### PR TITLE
Fix substep log line for reservoir coupling

### DIFF
--- a/opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
+++ b/opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
@@ -165,12 +165,29 @@ namespace Opm
     void AdaptiveSimulatorTimer::
     report(std::ostream& os) const
     {
-        os << "Sub steps started at time = " <<  unit::convert::to( start_time_, unit::day ) << " (days)" << std::endl;
+        os << "Sub steps started at time = "
+           << unit::convert::to(reportStepStartTime(), unit::day) << " (days)" << std::endl;
         for (std::size_t i = 0; i < steps_.size(); ++i)
         {
-            os << " step[ " << i << " ] = " << unit::convert::to( steps_[ i ], unit::day ) << " (days)" << std::endl;
+            os << " step[ " << (report_step_substep_offset_ + i) << " ] = "
+               << unit::convert::to(steps_[i], unit::day) << " (days)" << std::endl;
         }
         os << "sub steps end time = " << unit::convert::to( simulationTimeElapsed(), unit::day ) << " (days)" << std::endl;
+    }
+
+    double AdaptiveSimulatorTimer::reportStepStartTime() const
+    {
+        return report_step_start_time_.value_or(start_time_);
+    }
+
+    double AdaptiveSimulatorTimer::reportStepTotalTime() const
+    {
+        return report_step_total_time_.value_or(total_time_);
+    }
+
+    int AdaptiveSimulatorTimer::reportStepSubstepNum() const
+    {
+        return report_step_substep_offset_ + current_step_;
     }
 
     boost::posix_time::ptime AdaptiveSimulatorTimer::startDateTime() const

--- a/opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
+++ b/opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
@@ -167,9 +167,11 @@ namespace Opm
     {
         os << "Sub steps started at time = "
            << unit::convert::to(reportStepStartTime(), unit::day) << " (days)" << std::endl;
+        assert(report_step_substep_offset_ >= 0);
+        const auto offset = static_cast<std::size_t>(report_step_substep_offset_);
         for (std::size_t i = 0; i < steps_.size(); ++i)
         {
-            os << " step[ " << (report_step_substep_offset_ + i) << " ] = "
+            os << " step[ " << (offset + i) << " ] = "
                << unit::convert::to(steps_[i], unit::day) << " (days)" << std::endl;
         }
         os << "sub steps end time = " << unit::convert::to( simulationTimeElapsed(), unit::day ) << " (days)" << std::endl;

--- a/opm/simulators/timestepping/AdaptiveSimulatorTimer.hpp
+++ b/opm/simulators/timestepping/AdaptiveSimulatorTimer.hpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <memory>
 #include <numeric>
+#include <optional>
 
 #include <opm/simulators/timestepping/SimulatorTimerInterface.hpp>
 
@@ -112,6 +113,24 @@ namespace Opm
         /// \brief tell the timestepper whether timestep failed or not
         void setLastStepFailed(bool last_step_failed) { last_step_failed_ = last_step_failed; }
 
+        /// \brief Reservoir coupling constructs a fresh timer per sync chunk,
+        /// so `start_time_`, `total_time_`, and `current_step_` describe the
+        /// chunk rather than the enclosing report step. The accessors below
+        /// return a "report step view" that the rescoup outer loop populates
+        /// (via the setters) so that log lines can show the report-step start
+        /// and end and a substep counter that increments across chunks. When
+        /// the view is not set, they fall through to the per-timer fields, so
+        /// the non-rescoup path's behavior and output are unchanged.
+        double reportStepStartTime() const;
+        double reportStepTotalTime() const;
+        int reportStepSubstepNum() const;
+
+        void setReportStepStartTime(double t) { report_step_start_time_ = t; }
+        void setReportStepTotalTime(double t) { report_step_total_time_ = t; }
+        void setReportStepSubstepOffset(int n) { report_step_substep_offset_ = n; }
+
+        int reportStepSubstepOffset() const { return report_step_substep_offset_; }
+
         /// return copy of object
         std::unique_ptr<SimulatorTimerInterface> clone() const override;
 
@@ -128,6 +147,19 @@ namespace Opm
 
         std::vector< double > steps_;
         bool last_step_failed_;
+
+        /// \brief Optional report-step start time for the "report step view"
+        ///   accessors. Set by the rescoup outer loop on each per-sync-chunk
+        ///   timer; unset on a non-rescoup timer.
+        std::optional<double> report_step_start_time_;
+        /// \brief Optional report-step end time for the "report step view"
+        ///   accessors. Same population pattern as `report_step_start_time_`.
+        std::optional<double> report_step_total_time_;
+        /// \brief Number of substeps already taken in this report step before
+        ///   this timer was constructed (i.e. in earlier sync chunks). Added to
+        ///   `current_step_` by `reportStepSubstepNum()` to give a counter that
+        ///   increments across sync chunks. Zero on a non-rescoup timer.
+        int report_step_substep_offset_ = 0;
 
     };
 

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.cpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.cpp
@@ -25,10 +25,10 @@ void logTimer(const AdaptiveSimulatorTimer& substepTimer)
     std::ostringstream ss;
     boost::posix_time::time_facet* facet = new boost::posix_time::time_facet("%d-%b-%Y");
     ss.imbue(std::locale(std::locale::classic(), facet));
-    ss << "\nStarting time step " << substepTimer.currentStepNum() << ", stepsize "
+    ss << "\nStarting time step " << substepTimer.reportStepSubstepNum() << ", stepsize "
        << unit::convert::to(substepTimer.currentStepLength(), unit::day) << " days,"
        << " at day " << (double)unit::convert::to(substepTimer.simulationTimeElapsed(), unit::day)
-       << "/" << (double)unit::convert::to(substepTimer.totalTime(), unit::day);
+       << "/" << (double)unit::convert::to(substepTimer.reportStepTotalTime(), unit::day);
     if ((substepTimer.currentDateTime() <= boost::posix_time::ptime(boost::posix_time::max_date_time)) &&
         (boost::posix_time::ptime(boost::posix_time::min_date_time) <= substepTimer.currentDateTime())) {
         ss << ", date = " << substepTimer.currentDateTime();

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -716,6 +716,8 @@ runStepReservoirCouplingMaster_()
     const double original_time_step = this->simulator_timer_.currentStepLength();
     double current_time{this->simulator_timer_.simulationTimeElapsed()};
     double step_end_time = current_time + original_time_step;
+    const double report_step_start_time = current_time;
+    int report_step_substep_offset = 0;
     // In RSYNC mode this variable persists across outer iterations and
     // carries the previously-chopped sync span into the next iteration.  In
     // TSYNC mode it is overwritten each iteration by
@@ -750,6 +752,12 @@ runStepReservoirCouplingMaster_()
             /*reportStep=*/this->simulator_timer_.reportStepNum(),
             maxTimeStep_()
         };
+        // Make the per-chunk timer log the enclosing report step's span and a
+        // cumulative substep counter (see AdaptiveSimulatorTimer "report step
+        // view"). Without this, log lines would show one sync chunk only.
+        substep_timer.setReportStepStartTime(report_step_start_time);
+        substep_timer.setReportStepTotalTime(step_end_time);
+        substep_timer.setReportStepSubstepOffset(report_step_substep_offset);
         const bool final_step = ReservoirCoupling::Seconds::compare_gt_or_eq(
             current_time + current_step_length, step_end_time
         );
@@ -764,6 +772,7 @@ runStepReservoirCouplingMaster_()
         SubStepIteration<Solver> substepIteration{*this, substep_timer, current_step_length, final_step};
         const auto sub_steps_report = substepIteration.run();
         report += sub_steps_report;
+        report_step_substep_offset += substep_timer.currentStepNum();
         current_time += current_step_length;
         if (final_step) {
             break;
@@ -783,6 +792,8 @@ runStepReservoirCouplingSlave_()
     const double original_time_step = this->simulator_timer_.currentStepLength();
     double current_time{this->simulator_timer_.simulationTimeElapsed()};
     double step_end_time = current_time + original_time_step;
+    const double report_step_start_time = current_time;
+    int report_step_substep_offset = 0;
     SimulatorReport report;
     auto report_step_idx = this->simulator_timer_.currentStepNum();
     if (report_step_idx == 0 && iteration == 0) {
@@ -808,6 +819,12 @@ runStepReservoirCouplingSlave_()
             this->simulator_timer_.reportStepNum(),
             maxTimeStep_()
         };
+        // Make the per-chunk timer log the enclosing report step's span and a
+        // cumulative substep counter (see AdaptiveSimulatorTimer "report step
+        // view"). Without this, log lines would show one sync chunk only.
+        substep_timer.setReportStepStartTime(report_step_start_time);
+        substep_timer.setReportStepTotalTime(step_end_time);
+        substep_timer.setReportStepSubstepOffset(report_step_substep_offset);
         const bool final_step = ReservoirCoupling::Seconds::compare_gt_or_eq(
             current_time + timestep, step_end_time
         );
@@ -818,6 +835,7 @@ runStepReservoirCouplingSlave_()
         SubStepIteration<Solver> substepIteration{*this, substep_timer, timestep, final_step};
         const auto sub_steps_report = substepIteration.run();
         report += sub_steps_report;
+        report_step_substep_offset += substep_timer.currentStepNum();
         current_time += timestep;
         if (final_step) {
             break;


### PR DESCRIPTION
In a reservoir-coupling run, the per-substep `Starting time step N, stepsize ... days, at day X/Y` line emitted by `detail::logTimer` reset `N` to `0` on every sync chunk and showed `Y` as the end of the chunk instead of the end of the report step. The same problem applied to the debug output of `AdaptiveSimulatorTimer::report()`.

**Example — TSYNC, 31-day report step starting Oct 1.**
Before:

```
Starting time step 0, stepsize 1 days, at day 0/1,  date = 01-Oct-2018
Starting time step 0, stepsize 3 days, at day 1/4,  date = 02-Oct-2018
Starting time step 0, stepsize 9 days, at day 4/13, date = 05-Oct-2018
Starting time step 0, stepsize 18 days, at day 13/31, date = 14-Oct-2018
```

After:

```
Starting time step 0, stepsize 1 days, at day 0/31, date = 01-Oct-2018
Starting time step 1, stepsize 3 days, at day 1/31, date = 02-Oct-2018
Starting time step 2, stepsize 9 days, at day 4/31, date = 05-Oct-2018
Starting time step 3, stepsize 18 days, at day 13/31, date = 14-Oct-2018
```

#### Root cause

`runStepReservoirCouplingMaster_` and `runStepReservoirCouplingSlave_` construct a fresh `AdaptiveSimulatorTimer` for every sync chunk, so the timer's `current_step_` restarts at `0` and `total_time_` spans only the chunk. The non-coupled path (`runStepOriginal_`) constructs one timer per report step and is unaffected, which is why the bug only showed up in rescoup runs.

#### Fix

Add a small **"report step view"** to `AdaptiveSimulatorTimer` — three new optional members (`report_step_start_time_`, `report_step_total_time_`, `report_step_substep_offset_`) plus matching accessors (`reportStepStartTime()`, `reportStepTotalTime()`, `reportStepSubstepNum()`) that fall through to the per-timer fields when unset. The two rescoup outer loops set the view on each per-chunk timer and accumulate the substep offset across chunks. `detail::logTimer` and `AdaptiveSimulatorTimer::report()` switch to the new accessors.

#### Behavior matrix

| Mode | Master log | Slave logs |
|---|---|---|
| **TSYNC** (default) | **Fixed** — incrementing counter, report-step-end denominator | **Fixed** |
| **RSYNC** (`--rescoup-sync-at-report-steps=true`) | Unchanged (was already correct because chunk == report step) | Unchanged |
| Non-coupled (`runStepOriginal_`) | Byte-identical to before | n/a |

Defaults preserve existing semantics, so the non-rescoup output is unchanged.

