### PR TITLE
GPU assembly support on AMD and CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -775,6 +775,58 @@ macro(opm-simulators_targets_hook)
       opmsimulators
   )
 
+  # Flow GPU executables handled separately to avoid making flow dependent on CUDA/HIP
+  set(FLOW_GPU_MODELS
+    gpu_gaswater_thermal
+  )
+
+  if(CONVERT_CUDA_TO_HIP OR CUDA_FOUND)
+
+    if(CONVERT_CUDA_TO_HIP)
+      set(EXTENSION "hip")
+    else()
+      set(EXTENSION "cu")
+    endif()
+
+    foreach(OBJ ${FLOW_GPU_MODELS})
+
+      opm_add_library(
+        TARGET
+          flow_lib${OBJ}
+        TYPE
+          OBJECT
+        SOURCES
+          flow/flow_${OBJ}.${EXTENSION}
+      )
+
+      simulators_add_target_options(TARGET flow_lib${OBJ})
+      list(APPEND FLOW_GPU_TGTS $<TARGET_OBJECTS:flow_lib${OBJ}>)
+      list(APPEND FLOWMODELS_PREFIXED flow_${OBJ})
+
+      opm_add_executable(
+        TARGET
+          flow_${OBJ}
+        SOURCES
+          flow/flow_${OBJ}_main.cpp
+          $<TARGET_OBJECTS:moduleVersion>
+          $<TARGET_OBJECTS:flow_lib${OBJ}>
+        LIBRARIES
+          opmsimulators
+      )
+    endforeach()
+
+    opm_add_executable(
+      TARGET
+        flow_gpu
+      SOURCES
+        flow/flow_gpu_main.cpp
+        ${FLOW_GPU_TGTS}
+        $<TARGET_OBJECTS:moduleVersion>
+      LIBRARIES
+        opmsimulators
+    )
+  endif()
+
   if(OPM_ENABLE_PYTHON)
     set_target_properties(
       flow_libblackoil

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -593,6 +593,42 @@ if(CUDA_FOUND OR hip_FOUND)
   if(MPI_FOUND)
     ADD_CUDA_OR_HIP_FILE(TEST_SOURCE_FILES tests test_GpuOwnerOverlapCopy.cpp)
   endif()
+
+  # for loop providing the flag --expt-relaxed-constexpr to fix some cuda issues with constexpr
+  if(NOT CONVERT_CUDA_TO_HIP)
+    set(CU_FILES_NEEDING_RELAXED_CONSTEXPR
+      tests/gpuistl/test_gpu_ad.cu
+      tests/gpuistl/test_gpu_linear_two_phase_material.cu
+      tests/gpuistl/test_gpuPvt.cu
+      tests/gpuistl/test_gpuBlackOilFluidSystem.cu
+      tests/gpuistl/test_GpuSparseMatrix.cu
+      tests/gpuistl/test_GpuSparseTable.cu
+      tests/gpuistl/test_blackoilfluidstategpu.cu
+      flow/flow_gpu_gaswater_thermal.cu
+    )
+
+    foreach(file ${CU_FILES_NEEDING_RELAXED_CONSTEXPR})
+      set_source_files_properties(${file}
+        PROPERTIES
+        COMPILE_FLAGS
+          "--expt-relaxed-constexpr"
+      )
+    endforeach()
+
+    set(CU_FILES_NEEDING_FPERMISSIVE
+      tests/gpuistl/test_primary_variables_gpu.cu
+    )
+
+    foreach(file ${CU_FILES_NEEDING_FPERMISSIVE})
+      # Certain structures in OPM requires the -fpermissive flag to compile with nvcc,
+      # this enables this for the specific files
+      set_source_files_properties(${file}
+        PROPERTIES
+        COMPILE_FLAGS
+          "-fpermissive --expt-relaxed-constexpr -Xcompiler=-fpermissive"
+      )
+    endforeach()
+  endif()
 endif()
 
 if(USE_GPU_BRIDGE)
@@ -791,6 +827,9 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/models/discretization/common/linearizationtype.hh
   opm/models/discretization/common/restrictprolong.hh
   opm/models/discretization/common/tpfalinearizer.hh
+  opm/models/discretization/common/tpfalinearizergpukernels.hh
+  opm/models/discretization/common/tpfalinearizergpuparams.hh
+  opm/models/discretization/common/tpfalinearizerstructs.hh
   opm/models/discretization/common/tpsalinearizer.hpp
   opm/models/discretization/ecfv/ecfvbaseoutputmodule.hh
   opm/models/discretization/ecfv/ecfvdiscretization.hh
@@ -966,6 +1005,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/flow/FacePropertiesTPSA_impl.hpp
   opm/simulators/flow/FemCpGridCompat.hpp
   opm/simulators/flow/FIBlackoilModel.hpp
+  opm/simulators/flow/SimpleFIBlackOilModel.hpp
   opm/simulators/flow/FIPContainer.hpp
   opm/simulators/flow/FlowBaseProblemProperties.hpp
   opm/simulators/flow/FlowBaseVanguard.hpp
@@ -1022,6 +1062,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/flow/SimulatorSerializer.hpp
   opm/simulators/flow/SolutionContainers.hpp
   opm/simulators/flow/SubDomain.hpp
+  opm/simulators/flow/ThermalGasWaterFlowProblem.hpp
   opm/simulators/flow/TTagFlowProblemTPFA.hpp
   opm/simulators/flow/TTagFlowProblemTPSA.hpp
   opm/simulators/flow/TTagFlowProblemGasWater.hpp

--- a/flow/flow_gpu.hpp
+++ b/flow/flow_gpu.hpp
@@ -1,0 +1,79 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef FLOW_GPU_HPP
+#define FLOW_GPU_HPP
+
+#include <opm/simulators/flow/FlowGasWaterEnergyTypeTag.hpp>
+#include <opm/simulators/flow/SimpleFIBlackOilModel.hpp>
+/*
+    This file extracts typetag declarations that must be present in both the .CU and .HIP
+   executables for Flow to avoid double maintenance.
+*/
+
+namespace Opm
+{
+
+namespace Properties
+{
+    namespace TTag
+    {
+        // FlowGasWaterEnergyProblemGPU is declared in FlowGasWaterEnergyTypeTag.hpp
+        // (InheritsFrom = FlowGasWaterEnergyProblem).  The template below maps it
+        // to FlowGasWaterEnergyProblemGPUTrue<Storage> for GPU-storage variants.
+
+        template <template <class> class Storage>
+        struct FlowGasWaterEnergyProblemGPUTrue {
+            using InheritsFrom = std::tuple<FlowGasWaterEnergyProblemGPU>;
+        };
+
+        template <template <class> class Storage>
+        struct to_gpu_type<FlowGasWaterEnergyProblemGPU, Storage> {
+            using type = FlowGasWaterEnergyProblemGPUTrue<Storage>;
+        };
+    } // namespace TTag
+
+    template <class TypeTag>
+    struct RunAssemblyOnGpu<TypeTag, TTag::FlowGasWaterEnergyProblemGPU> {
+        static constexpr bool value = true;
+    };
+
+    template <class TypeTag>
+    struct Scalar<TypeTag, TTag::FlowGasWaterEnergyProblemGPU> {
+        using type = double;
+    };
+
+    template <class TypeTag>
+    struct GpuFIBlackOilModel<TypeTag, TTag::FlowGasWaterEnergyProblemGPU> {
+        using type = SimpleFIBlackOilModel<TypeTag>;
+    };
+
+    template <class TypeTag, template <class> class Storage>
+    struct FluidSystem<TypeTag, TTag::FlowGasWaterEnergyProblemGPUTrue<Storage>> {
+        using type = Opm::
+            BlackOilFluidSystemNonStatic<double, Opm::BlackOilDefaultFluidSystemIndices, Storage>;
+    };
+} // namespace Properties
+
+//! \brief Main function used in flow binary.
+int flowGasWaterEnergyMainGPU(int argc, char** argv, bool outputCout, bool outputFiles);
+
+//! \brief Main function used in flow_gaswater binary.
+int flowGasWaterEnergyMainGPUStandalone(int argc, char** argv);
+
+} // namespace Opm
+
+#endif // FLOW_GPU_HPP

--- a/flow/flow_gpu_gaswater_thermal.cu
+++ b/flow/flow_gpu_gaswater_thermal.cu
@@ -1,0 +1,70 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#undef HAVE_DUNE_ALUGRID // Disable ALUGRID if it is available as nvcc struggles with it
+#undef HAVE_DUNE_FEM // Disable DUNE-FEM if it is available as nvcc struggles with it
+
+// For now flow_gpu is developed to support SPE11 simulations, that is 2-phase gas-water flow with
+// thermal effects The goal is to support both property-evaluation and matrix assembly on the GPU,
+// in addition to the linear solver which already works on the GPU. The CPU would still have to
+// manage well contributions, although there are no wells in SPE11, only source-terms.
+
+#include <flow/flow_gpu.hpp>
+
+#include <opm/common/utility/gpuDecorators.hpp>
+
+#include <opm/material/common/ResetLocale.hpp>
+#include <opm/material/thermal/EnergyModuleType.hpp>
+#include <opm/models/blackoil/blackoiltwophaseindices.hh>
+
+#include <opm/grid/CpGrid.hpp>
+#include <opm/simulators/flow/FlowGasWaterEnergyTypeTag.hpp>
+#include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimpleFIBlackOilModel.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
+
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+#include <opm/models/discretization/common/tpfalinearizer.hh>
+
+namespace Opm
+{
+
+int
+flowGasWaterEnergyMainGPU(int argc, char** argv, bool outputCout, bool outputFiles)
+{
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    resetLocale();
+
+    FlowMain<Properties::TTag::FlowGasWaterEnergyProblemGPU> mainfunc {
+        argc, argv, outputCout, outputFiles};
+    return mainfunc.execute();
+}
+
+int
+flowGasWaterEnergyMainGPUStandalone(int argc, char** argv)
+{
+    using TypeTag = Properties::TTag::FlowGasWaterEnergyProblemGPU;
+    auto mainObject = std::make_unique<::Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
+}
+
+} // namespace Opm

--- a/flow/flow_gpu_gaswater_thermal.hip
+++ b/flow/flow_gpu_gaswater_thermal.hip
@@ -1,0 +1,67 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+// For now flow_gpu is developed to support SPE11 simulations, that is 2-phase gas-water flow with
+// thermal effects The goal is to support both property-evaluation and matrix assembly on the GPU,
+// in addition to the linear solver which already works on the GPU. The CPU would still have to
+// manage well contributions, although there are no wells in SPE11, only source-terms.
+
+#include <flow/flow_gpu.hpp>
+
+#include <opm/common/utility/gpuDecorators.hpp>
+
+#include <opm/material/common/ResetLocale.hpp>
+#include <opm/material/thermal/EnergyModuleType.hpp>
+
+#include <opm/grid/CpGrid.hpp>
+#include <opm/simulators/flow/FlowGasWaterEnergyTypeTag.hpp>
+#include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimpleFIBlackOilModel.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
+
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+#include <opm/models/blackoil/blackoiltwophaseindices.hh>
+#include <opm/models/discretization/common/tpfalinearizer.hh>
+
+namespace Opm
+{
+
+int
+flowGasWaterEnergyMainGPU(int argc, char** argv, bool outputCout, bool outputFiles)
+{
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    resetLocale();
+
+    FlowMain<Properties::TTag::FlowGasWaterEnergyProblemGPU> mainfunc {
+        argc, argv, outputCout, outputFiles};
+    return mainfunc.execute();
+}
+
+int
+flowGasWaterEnergyMainGPUStandalone(int argc, char** argv)
+{
+    using TypeTag = Properties::TTag::FlowGasWaterEnergyProblemGPU;
+    auto mainObject = std::make_unique<::Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
+}
+
+} // namespace Opm

--- a/flow/flow_gpu_gaswater_thermal_main.cpp
+++ b/flow/flow_gpu_gaswater_thermal_main.cpp
@@ -1,0 +1,25 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+#include <flow/flow_gpu.hpp>
+
+
+int
+main(int argc, char** argv)
+{
+    return Opm::flowGasWaterEnergyMainGPUStandalone(argc, argv);
+}

--- a/flow/flow_gpu_main.cpp
+++ b/flow/flow_gpu_main.cpp
@@ -1,0 +1,25 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+#include <flow/flow_gpu.hpp>
+
+
+int
+main(int argc, char** argv)
+{
+    return Opm::flowGasWaterEnergyMainGPUStandalone(argc, argv);
+}

--- a/opm/models/blackoil/blackoilconvectivemixingmodule.hh
+++ b/opm/models/blackoil/blackoilconvectivemixingmodule.hh
@@ -35,6 +35,7 @@
 
 #include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/common/Valgrind.hpp>
+#include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 
 #include <opm/models/blackoil/blackoilmodules.hpp>
 #include <opm/models/blackoil/blackoilconvectivemixingmoduleparam.hpp>
@@ -73,12 +74,10 @@ class BlackOilConvectiveMixingModule<TypeTag, /*enableConvectiveMixing=*/true>
     using Toolbox = MathToolbox<Evaluation>;
     using ConvectiveMixingModuleParamT = ConvectiveMixingModuleParam<Scalar>;
 
-    enum { conti0EqIdx = Indices::conti0EqIdx };
-    enum { dimWorld = GridView::dimensionworld };
-    enum { waterPhaseIdx = FluidSystem::waterPhaseIdx };
-    enum { oilPhaseIdx = FluidSystem::oilPhaseIdx };
+    static constexpr int conti0EqIdx = Indices::conti0EqIdx;
+    static constexpr int dimWorld = GridView::dimensionworld;
     static constexpr bool enableFullyImplicitThermal =
-        getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal;
+        (getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal);
     static constexpr unsigned contiEnergyEqIdx = Indices::contiEnergyEqIdx;
 
 public:
@@ -110,6 +109,10 @@ public:
                                                  const IntensiveQuantities& intQuantsEx,
                                                  const unsigned phaseIdx,
                                                  const CMMParam& info) {
+        // Local constexpr aliases avoid nvcc's failure to resolve class-scope
+        // static constexpr members in device code.
+        constexpr int waterPhaseIdx = FluidSystem::waterPhaseIdx;
+        constexpr int oilPhaseIdx = FluidSystem::oilPhaseIdx;
 
         if (info.active_.empty()) {
             return;
@@ -124,9 +127,9 @@ public:
         }
 
         const auto& liquidPhaseIdx =
-            fsys.phaseIsActive(fsys.waterPhaseIdx)
-               ? fsys.waterPhaseIdx
-               : fsys.oilPhaseIdx;
+            fsys.phaseIsActive(waterPhaseIdx)
+               ? waterPhaseIdx
+               : oilPhaseIdx;
 
         // Compute avg density based on pure water
         const auto& t_in = intQuantsIn.fluidState().temperature(liquidPhaseIdx);
@@ -219,6 +222,11 @@ public:
                                                         const Scalar faceArea,
                                                         const CMMParam& info)
     {
+        // Local constexpr aliases avoid nvcc's failure to resolve class-scope
+        // static constexpr members in device code.
+        constexpr int waterPhaseIdx = FluidSystem::waterPhaseIdx;
+        constexpr int oilPhaseIdx = FluidSystem::oilPhaseIdx;
+
         const FluidSystem& fsys = intQuantsIn.getFluidSystem();
 
         if (info.active_.empty()) {
@@ -230,9 +238,9 @@ public:
         }
 
         const auto& liquidPhaseIdx =
-            fsys.phaseIsActive(fsys.waterPhaseIdx)
-                ? fsys.waterPhaseIdx
-                : fsys.oilPhaseIdx;
+            fsys.phaseIsActive(waterPhaseIdx)
+                ? waterPhaseIdx
+                : oilPhaseIdx;
 
         // interiour
         const auto& t_in = intQuantsIn.fluidState().temperature(liquidPhaseIdx);
@@ -241,14 +249,14 @@ public:
         const auto& salt_in = intQuantsIn.fluidState().saltSaturation();
 
         const auto bLiquidSatIn =
-            fsys.phaseIsActive(fsys.waterPhaseIdx)
+            fsys.phaseIsActive(waterPhaseIdx)
                 ? fsys.waterPvt().inverseFormationVolumeFactor(intQuantsIn.pvtRegionIndex(),
                                                                        t_in, p_in, rssat_in, salt_in)
                 : fsys.oilPvt().inverseFormationVolumeFactor(intQuantsIn.pvtRegionIndex(),
                                                                      t_in, p_in, rssat_in);
 
         const auto& densityLiquidIn =
-            fsys.phaseIsActive(fsys.waterPhaseIdx)
+            fsys.phaseIsActive(waterPhaseIdx)
                 ? fsys.waterPvt().waterReferenceDensity(intQuantsIn.pvtRegionIndex())
                 : fsys.oilPvt().oilReferenceDensity(intQuantsIn.pvtRegionIndex());
 
@@ -264,14 +272,14 @@ public:
         const auto rssat_ex = Opm::getValue(intQuantsEx.saturatedDissolutionFactor());
         const auto salt_ex = Opm::getValue(intQuantsEx.fluidState().saltSaturation());
         const auto bLiquidSatEx =
-            fsys.phaseIsActive(fsys.waterPhaseIdx)
+            fsys.phaseIsActive(waterPhaseIdx)
                 ? fsys.waterPvt().inverseFormationVolumeFactor(intQuantsEx.pvtRegionIndex(),
                                                                        t_ex, p_ex, rssat_ex, salt_ex)
                 : fsys.oilPvt().inverseFormationVolumeFactor(intQuantsEx.pvtRegionIndex(),
                                                                      t_ex, p_ex, rssat_ex);
 
         const auto& densityLiquidEx =
-            fsys.phaseIsActive(fsys.waterPhaseIdx)
+            fsys.phaseIsActive(waterPhaseIdx)
                 ? fsys.waterPvt().waterReferenceDensity(intQuantsEx.pvtRegionIndex())
                 : fsys.oilPvt().oilReferenceDensity(intQuantsEx.pvtRegionIndex());
 
@@ -299,7 +307,7 @@ public:
             const auto& rssat_up = (upIdx == interiorDofIdx) ? rssat_in : rssat_ex;
             unsigned globalUpIndex = (upIdx == interiorDofIdx) ? globalIndexIn : globalIndexEx;
             const auto& Rsup =
-                fsys.phaseIsActive(fsys.waterPhaseIdx)
+                fsys.phaseIsActive(waterPhaseIdx)
                     ? up.fluidState().Rsw()
                     : up.fluidState().Rs();
 

--- a/opm/models/blackoil/blackoildiffusionmodule.hh
+++ b/opm/models/blackoil/blackoildiffusionmodule.hh
@@ -345,6 +345,12 @@ public:
         , diffusionCoefficient_(diffusionCoefficient)
     {}
 
+    template <class OtherTypeTag>
+    BlackOilDiffusionIntensiveQuantities(const BlackOilDiffusionIntensiveQuantities<OtherTypeTag, true>& other)
+        : tortuosity_(other.tortuosity())
+        , diffusionCoefficient_(other.diffusionCoefficients())
+    {}
+
     BlackOilDiffusionIntensiveQuantities&
     operator=(const BlackOilDiffusionIntensiveQuantities& rhs)
     {
@@ -367,11 +373,23 @@ public:
     { return diffusionCoefficient_[phaseIdx][compIdx]; }
 
     /*!
+     * \brief Returns all the diffusion coefficients
+     */
+    OPM_HOST_DEVICE const std::array<std::array<Evaluation, numComponents>, numPhases>& diffusionCoefficients() const
+    { return diffusionCoefficient_; }
+
+    /*!
      * \brief Returns the tortuousity of the sub-domain of a fluid
      *        phase in the porous medium.
      */
     OPM_HOST_DEVICE Evaluation tortuosity(unsigned phaseIdx) const
     { return tortuosity_[phaseIdx]; }
+
+    /*!
+     * \brief Returns all the tortuosities
+     */
+    OPM_HOST_DEVICE const std::array<Evaluation, numPhases>& tortuosities() const
+    { return tortuosity_; }
 
     /*!
      * \brief Returns the effective molecular diffusion coefficient of
@@ -540,9 +558,9 @@ protected:
     }
 
 public:
-    static void update(EvaluationArray& effectiveDiffusionCoefficient,
-                       const IntensiveQuantities& intQuantsInside,
-                       const IntensiveQuantities& intQuantsOutside)
+    OPM_HOST_DEVICE static void update(EvaluationArray& effectiveDiffusionCoefficient,
+                                       const IntensiveQuantities& intQuantsInside,
+                                       const IntensiveQuantities& intQuantsOutside)
     {
         const FluidSystem& fsys = intQuantsInside.getFluidSystem();
 

--- a/opm/models/blackoil/blackoilenergymodules.hh
+++ b/opm/models/blackoil/blackoilenergymodules.hh
@@ -380,6 +380,14 @@ public:
     {
     }
 
+    template <class OtherTypeTag>
+    BlackOilEnergyIntensiveQuantities(
+        const BlackOilEnergyIntensiveQuantities<OtherTypeTag, EnergyModules::FullyImplicitThermal>& other)
+        : rockInternalEnergy_(other.rockInternalEnergy())
+        , totalThermalConductivity_(other.totalThermalConductivity())
+        , rockFraction_(other.rockFraction())
+    {}
+
     BlackOilEnergyIntensiveQuantities() = default;
 
     /*!

--- a/opm/models/blackoil/blackoilextbomodules.hh
+++ b/opm/models/blackoil/blackoilextbomodules.hh
@@ -179,7 +179,7 @@ public:
             storage[contiZfracEqIdx - 1] += regWghtFactor*Toolbox::template decay<LhsEval>(intQuants.zFraction());
         }
         else {
-            throw std::runtime_error("Only component conservation in terms of surface volumes is implemented. ");
+            OPM_THROW(std::runtime_error, "Only component conservation in terms of surface volumes is implemented. ");
         }
     }
 

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -174,9 +174,8 @@ public:
             fluidState_.setRsw(0.0);
         }
     }
-    BlackOilIntensiveQuantities(const BlackOilIntensiveQuantities& other) = default;
 
-    BlackOilIntensiveQuantities& operator=(const BlackOilIntensiveQuantities& other) = default;
+    OPM_HOST_DEVICE BlackOilIntensiveQuantities& operator=(const BlackOilIntensiveQuantities& other) = default;
 
     template<class OtherTypeTag>
     friend class BlackOilIntensiveQuantities;
@@ -185,25 +184,18 @@ public:
     template<class OtherTypeTag>
     explicit BlackOilIntensiveQuantities(
         const BlackOilIntensiveQuantities<OtherTypeTag>& other, const FluidSystem& fsystem)
-        : fluidState_(other.fluidState_.withOtherFluidSystem(fsystem))
-        , BlackOilEnergyIntensiveQuantities<TypeTag, energyModuleType>(
-            other.rockInternalEnergy_, other.totalThermalConductivity_, other.rockFraction_)
-        , BlackOilDiffusionIntensiveQuantities<TypeTag, enableDiffusion>(
-            other.tortuosities(), other.diffusionCoefficients())
+        : fluidState_(other.fluidState_.template withOtherFluidSystem<FluidSystem>(fsystem))
+        , BlackOilEnergyIntensiveQuantities<TypeTag, energyModuleType>(other)
+        , DiffusionIntensiveQuantities(other)
         , referencePorosity_(other.referencePorosity_)
         , porosity_(other.porosity_)
         , rockCompTransMultiplier_(other.rockCompTransMultiplier_)
         , mobility_(other.mobility_)
         , dirMob_(/*NOT YET SUPPORTED ON GPU*/)
     {
-        static_assert(!enableSolvent);
-        static_assert(!enableExtbo);
-        static_assert(!enablePolymer);
-        static_assert(!enableFoam);
-        static_assert(!enableMICP);
-        static_assert(!enableBrine);
-        static_assert(!enableDispersion);
     }
+
+    BlackOilIntensiveQuantities(const BlackOilIntensiveQuantities& other) = default;
 
     /**
      * \brief Create a copy of this intensive quantities object
@@ -431,17 +423,16 @@ public:
             }
             else {
                 if (getFluidSystem().enableDissolvedGas()) { // Add So > 0? i.e. if only water set rs = 0)
+                    Evaluation RsSat;
                     if constexpr (enableExtbo) {
-                        fluidState_.setRs(min(RsMax, asImp_().rs()));
+                        RsSat = asImp_().rs();
+                    } else {
+                        RsSat = getFluidSystem().saturatedDissolutionFactor(fluidState_,
+                                                                            oilPhaseIdx,
+                                                                            pvtRegionIdx,
+                                                                            SoMax);
                     }
-                    else {
-                        const Evaluation& RsSat =
-                            getFluidSystem().saturatedDissolutionFactor(fluidState_,
-                                                                        oilPhaseIdx,
-                                                                        pvtRegionIdx,
-                                                                        SoMax);
-                        fluidState_.setRs(min(RsMax, RsSat));
-                    }
+                    fluidState_.setRs(min(RsMax, RsSat));
                 }
                 else {
                     fluidState_.setRs(0.0);
@@ -454,17 +445,16 @@ public:
             }
             else {
                 if (getFluidSystem().enableVaporizedOil() ) { // Add Sg > 0? i.e. if only water set rv = 0)
+                    Evaluation RvSat;
                     if constexpr (enableExtbo) {
-                        fluidState_.setRv(min(RvMax, asImp_().rv()));
+                        RvSat = asImp_().rv();
+                    } else {
+                        RvSat = getFluidSystem().saturatedDissolutionFactor(fluidState_,
+                                                                            gasPhaseIdx,
+                                                                            pvtRegionIdx,
+                                                                            SoMax);
                     }
-                    else {
-                        const Evaluation& RvSat =
-                            getFluidSystem().saturatedDissolutionFactor(fluidState_,
-                                                                        gasPhaseIdx,
-                                                                        pvtRegionIdx,
-                                                                        SoMax);
-                        fluidState_.setRv(min(RvMax, RvSat));
-                    }
+                    fluidState_.setRv(min(RvMax, RvSat));
                 }
                 else {
                     fluidState_.setRv(0.0);
@@ -861,7 +851,7 @@ public:
                     case Dir::ZPlus:
                         return dirMob_->getArray(2)[phaseIdx];
                     default:
-                        throw std::runtime_error("Unexpected face direction");
+                        OPM_THROW(std::runtime_error, "Unexpected face direction");
                 }
             }
             else{
@@ -922,7 +912,7 @@ public:
             return BrineIntQua::permFactor();
         }
         else {
-            throw std::logic_error("permFactor() called but salt precipitation or bioeffects are disabled");
+            OPM_THROW(std::logic_error, "permFactor() called but salt precipitation and bioeffects are disabled");
         }
     }
 

--- a/opm/models/blackoil/blackoillocalresidualtpfa.hh
+++ b/opm/models/blackoil/blackoillocalresidualtpfa.hh
@@ -45,9 +45,11 @@
 #include <opm/models/blackoil/blackoilpolymermodules.hh>
 #include <opm/models/blackoil/blackoilproperties.hh>
 #include <opm/models/blackoil/blackoilsolventmodules.hh>
+#include <opm/models/blackoil/blackoilmoduleparams.hh>
 
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/gpuDecorators.hpp>
+#include <opm/common/utility/gpuistl_if_available.hpp>
 
 #include <array>
 #include <cassert>
@@ -582,49 +584,6 @@ public:
         }
     }
 
-    template <class BoundaryConditionData, class RateVectorLocal, class LocalProblem>
-    OPM_HOST_DEVICE static void computeBoundaryFlux(RateVectorLocal& bdyFlux,
-                                                    const LocalProblem& problem,
-                                                    const BoundaryConditionData& bdyInfo,
-                                                    const IntensiveQuantities& insideIntQuants,
-                                                    unsigned globalSpaceIdx)
-    {
-#if OPM_IS_INSIDE_HOST_FUNCTION
-        switch (bdyInfo.type) {
-        case BCType::NONE:
-            bdyFlux = 0.0;
-            break;
-        case BCType::RATE:
-            computeBoundaryFluxRate(bdyFlux, bdyInfo);
-            break;
-        case BCType::FREE:
-        case BCType::DIRICHLET:
-            computeBoundaryFluxFree(problem, bdyFlux, bdyInfo, insideIntQuants, globalSpaceIdx);
-            break;
-        case BCType::THERMAL:
-            computeBoundaryThermal(problem, bdyFlux, bdyInfo, insideIntQuants, globalSpaceIdx);
-            break;
-        default:
-            throw std::logic_error("Unknown boundary condition type "
-                                   + std::to_string(static_cast<int>(bdyInfo.type))
-                                   + " in computeBoundaryFlux().");
-        }
-#else // TODO: support all boundary conditions on GPU as well to unify this code
-        switch (bdyInfo.type) {
-        case BCType::NONE:
-            bdyFlux = 0.0;
-            break;
-        case BCType::THERMAL:
-            computeBoundaryThermal(problem, bdyFlux, bdyInfo, insideIntQuants, globalSpaceIdx);
-            break;
-        default:
-            OPM_THROW(std::logic_error,
-                      "Boundary condition type " + std::to_string(static_cast<int>(bdyInfo.type))
-                          + " is not supported for GPU fluid systems in computeBoundaryFlux().");
-        }
-#endif
-    }
-
     template <class BoundaryConditionData>
     static void computeBoundaryFluxRate(RateVector& bdyFlux, const BoundaryConditionData& bdyInfo)
     {
@@ -759,17 +718,12 @@ public:
         if constexpr (enableFullyImplicitThermal) {
             Evaluation heatFlux;
             // avoid overload of functions with same numeber of elements in eclproblem
-
             Scalar alpha;
-            if constexpr (runAssemblyOnGpu) {
-                // This path is currently only intended for the SimplifiedBlackoilModel for GPUs
-                // which currently does not aim to reproduce the full problem object on the GPU.
+            if constexpr (!std::is_empty_v<GetPropType<TypeTag, Properties::FluidSystem>>) {
                 alpha = problem.getAlpha(globalSpaceIdx, bdyInfo.boundaryFaceIndex);
             } else {
-                alpha = problem.eclTransmissibilities().thermalHalfTransBoundary(
-                    globalSpaceIdx, bdyInfo.boundaryFaceIndex);
+                alpha = problem.eclTransmissibilities().thermalHalfTransBoundary(globalSpaceIdx, bdyInfo.boundaryFaceIndex);
             }
-
             unsigned inIdx = 0; // dummy
             // always calculated with derivatives of this cell
             EnergyModule::ExtensiveQuantities::updateEnergyBoundary(heatFlux,
@@ -787,6 +741,49 @@ public:
         }
         Valgrind::CheckDefined(bdyFlux);
 #endif
+    }
+
+    template <class BoundaryConditionData, class RateVectorLocal, class LocalProblem>
+    OPM_HOST_DEVICE static void computeBoundaryFlux(RateVectorLocal& bdyFlux,
+                                                    const LocalProblem& problem,
+                                                    const BoundaryConditionData& bdyInfo,
+                                                    const IntensiveQuantities& insideIntQuants,
+                                                    unsigned globalSpaceIdx)
+    {
+        if constexpr (std::is_empty_v<GetPropType<TypeTag, Properties::FluidSystem>>) {
+            switch (bdyInfo.type) {
+            case BCType::NONE:
+                bdyFlux = 0.0;
+                break;
+            case BCType::RATE:
+                computeBoundaryFluxRate(bdyFlux, bdyInfo);
+                break;
+            case BCType::FREE:
+            case BCType::DIRICHLET:
+                computeBoundaryFluxFree(problem, bdyFlux, bdyInfo, insideIntQuants, globalSpaceIdx);
+                break;
+            case BCType::THERMAL:
+                computeBoundaryThermal(problem, bdyFlux, bdyInfo, insideIntQuants, globalSpaceIdx);
+                break;
+            default:
+                OPM_THROW(std::logic_error, "Unknown boundary condition type "
+                              + std::to_string(static_cast<int>(bdyInfo.type))
+                              + " in computeBoundaryFlux().");
+            }
+        } else { // Non-static fluid system used in GPU assembly
+            switch (bdyInfo.type) {
+            case BCType::NONE:
+                bdyFlux = 0.0;
+                break;
+            case BCType::THERMAL:
+                computeBoundaryThermal(problem, bdyFlux, bdyInfo, insideIntQuants, globalSpaceIdx);
+                break;
+            default:
+                OPM_THROW(std::logic_error,
+                          "Boundary condition type " + std::to_string(static_cast<int>(bdyInfo.type))
+                              + " is not supported for GPU fluid systems in computeBoundaryFlux().");
+            }
+        }
     }
 
     static void computeSource(RateVector& source,
@@ -950,18 +947,15 @@ public:
     }
 
     /*!
-     * \brief Helper function to convert the mass-related parts of a Dune::FieldVector
-     *        that stores conservation quantities in terms of "surface-volume" to the
-     *        conservation quantities used by the model.
-     *
-     * Convenience overload for CPU code that uses the static FluidSystem. Delegates to
-     * the FsysType overload below, constructing a default FluidSystem instance.
+     * Wrapper of adaptMassConservationQuantities_ that does not take a fluid system instance.
      */
-    template <class Scalar>
-    static void adaptMassConservationQuantities_(Dune::FieldVector<Scalar, numEq>& container,
-                                                 unsigned pvtRegionIdx)
+    template <class ScalarVector>
+    OPM_HOST_DEVICE static void adaptMassConservationQuantities_(ScalarVector& container,
+                                                                 unsigned pvtRegionIdx)
     {
-        adaptMassConservationQuantities_(container, pvtRegionIdx, FluidSystem {});
+        // Delegate to the generic overload using a default-constructed static FluidSystem
+        // instance. Valid because the static FluidSystem is stateless (std::is_empty_v).
+        adaptMassConservationQuantities_(container, pvtRegionIdx, FluidSystem{});
     }
 
     /*!

--- a/opm/models/blackoil/blackoilmodules.hpp
+++ b/opm/models/blackoil/blackoilmodules.hpp
@@ -37,7 +37,13 @@ namespace Opm {
     template<class TypeTag, bool enable> class T##IntensiveQuantities;  \
     template<class TypeTag, bool enable> class T##ExtensiveQuantities; \
     template<class TypeTag> struct T##Params; \
-    template<class TypeTag> class T##IntensiveQuantities<TypeTag, false> {}; \
+    template<class TypeTag> class T##IntensiveQuantities<TypeTag, false> { \
+        public: \
+        T##IntensiveQuantities() = default; \
+        template <class OtherTypeTag> \
+        T##IntensiveQuantities(const T##IntensiveQuantities<OtherTypeTag, false>& other) \
+        {} \
+    }; \
     template<class TypeTag> class T##ExtensiveQuantities<TypeTag, false> {};
 
 DECLARE_MODULE(BlackOilBioeffects)

--- a/opm/models/blackoil/blackoilmodules.hpp
+++ b/opm/models/blackoil/blackoilmodules.hpp
@@ -41,7 +41,7 @@ namespace Opm {
         public: \
         T##IntensiveQuantities() = default; \
         template <class OtherTypeTag> \
-        T##IntensiveQuantities(const T##IntensiveQuantities<OtherTypeTag, false>& other) \
+        T##IntensiveQuantities(const T##IntensiveQuantities<OtherTypeTag, false>&) \
         {} \
     }; \
     template<class TypeTag> class T##ExtensiveQuantities<TypeTag, false> {};

--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -660,6 +660,9 @@ public:
         return &intensiveQuantityCache_[timeIdx][globalIdx];
     }
 
+    const auto& intensiveQuantityCache() const
+    { return intensiveQuantityCache_; }
+
     /*!
      * \brief Update the intensive quantity cache for a entity on the grid at given time.
      *
@@ -1203,6 +1206,9 @@ public:
      */
     bool isLocalDof(unsigned globalIdx) const
     { return isLocalDof_[globalIdx]; }
+
+    size_t numDof() const
+    { return asImp_().numGridDof(); }
 
     /*!
      * \brief Returns the volume \f$\mathrm{[m^3]}\f$ of the whole grid which represents

--- a/opm/models/discretization/common/fvbaseproperties.hh
+++ b/opm/models/discretization/common/fvbaseproperties.hh
@@ -46,6 +46,12 @@ namespace TTag {
 struct FvBaseDiscretization
 { using InheritsFrom = std::tuple<FvBaseNewtonMethod, ImplicitModel>; };
 
+template<class TypeTag, template<class> class Storage>
+struct to_gpu_type {};
+
+template<class TypeTag, template <class> class Storage>
+using to_gpu_type_t = typename to_gpu_type<TypeTag, Storage>::type;
+
 } // namespace TTag
 
 
@@ -131,6 +137,11 @@ struct PrimaryVariables { using type = UndefinedProperty; };
 //! The secondary variables within a sub-control volume
 template<class TypeTag, class MyTypeTag>
 struct IntensiveQuantities { using type = UndefinedProperty; };
+
+//! The blackoilmodel that is tailored for GPU compatibility
+template<class TypeTag, class MyTypeTag>
+struct GpuFIBlackOilModel { using type = UndefinedProperty; };
+
 //! The discretization specific part of the intensive quantities
 
 template<class TypeTag, class MyTypeTag>

--- a/opm/models/discretization/common/tpfalinearizer.hh
+++ b/opm/models/discretization/common/tpfalinearizer.hh
@@ -47,7 +47,12 @@
 #include <opm/models/discretization/common/baseauxiliarymodule.hh>
 #include <opm/models/discretization/common/fvbaseproperties.hh>
 #include <opm/models/discretization/common/linearizationtype.hh>
+#include <opm/models/discretization/common/tpfalinearizerstructs.hh>
+
 #include <opm/simulators/linalg/exportSystem.hpp>
+
+#include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
+#include <opm/material/fluidsystems/BlackOilFluidSystemNonStatic.hpp>
 
 #include <cassert>
 #include <cstddef>
@@ -59,22 +64,33 @@
 #include <set>
 #include <stdexcept>
 #include <unordered_map>
+#include <utility>
 #include <vector>
+
+#if HAVE_OPENMP
+#include <omp.h>
+#endif
 
 #include <fmt/format.h>
 
 #include <opm/common/utility/gpuDecorators.hpp>
+#include <opm/common/utility/gpuistl_if_available.hpp>
+#include <opm/common/utility/pointerArithmetic.hpp>
 #if HAVE_CUDA
+#include <opm/models/discretization/common/tpfalinearizergpukernels.hh>
+#include <opm/simulators/flow/SimpleFIBlackOilModel.hpp>
+#include <opm/simulators/flow/ThermalGasWaterFlowProblem.hpp>
+#include <opm/models/discretization/common/tpfalinearizergpuparams.hh>
 #if USE_HIP
-#include <opm/simulators/linalg/gpuistl_hip/GpuBuffer.hpp>
-#include <opm/simulators/linalg/gpuistl_hip/GpuView.hpp>
+#include <opm/simulators/linalg/gpuistl_hip/GpuSparseMatrixWrapper.hpp>
 #include <opm/simulators/linalg/gpuistl_hip/MiniMatrix.hpp>
 #include <opm/simulators/linalg/gpuistl_hip/MiniVector.hpp>
+#include <opm/simulators/linalg/gpuistl_hip/detail/gpusparse_matrix_operations.hpp>
 #else
-#include <opm/simulators/linalg/gpuistl/GpuBuffer.hpp>
-#include <opm/simulators/linalg/gpuistl/GpuView.hpp>
+#include <opm/simulators/linalg/gpuistl/GpuSparseMatrixWrapper.hpp>
 #include <opm/simulators/linalg/gpuistl/MiniMatrix.hpp>
 #include <opm/simulators/linalg/gpuistl/MiniVector.hpp>
+#include <opm/simulators/linalg/gpuistl/detail/gpusparse_matrix_operations.hpp>
 #endif
 #endif
 
@@ -89,91 +105,6 @@ namespace Opm {
 // forward declarations
 template<class TypeTag>
 class EcfvDiscretization;
-
-// Moved these structs out of the class to make them visible in the GPU code.
-template<class Storage = std::vector<int>>
-struct FullDomain
-{
-    Storage cells;
-};
-
-#if HAVE_CUDA && OPM_IS_COMPILING_WITH_GPU_COMPILER
-    inline FullDomain<gpuistl::GpuBuffer<int>> copy_to_gpu(FullDomain<> CPUDomain)
-    {
-        if (CPUDomain.cells.size() == 0) {
-            OPM_THROW(std::runtime_error, "Cannot copy empty full domain to GPU.");
-        }
-        return FullDomain<gpuistl::GpuBuffer<int>>{
-            gpuistl::GpuBuffer<int>(CPUDomain.cells)
-        };
-    };
-
-    inline FullDomain<gpuistl::GpuView<int>> make_view(FullDomain<gpuistl::GpuBuffer<int>>& buffer)
-    {
-        if (buffer.cells.size() == 0) {
-            OPM_THROW(std::runtime_error, "Cannot make view of empty full domain buffer.");
-        }
-        return FullDomain<gpuistl::GpuView<int>>{
-            gpuistl::make_view(buffer.cells)
-        };
-    };
-#endif
-
-template <class ResidualNBInfoType,class BlockType>
-struct NeighborInfoStruct
-{
-    unsigned int neighbor;
-    ResidualNBInfoType res_nbinfo;
-    BlockType* matBlockAddress;
-
-    template <class OtherBlockType>
-    NeighborInfoStruct(const NeighborInfoStruct<ResidualNBInfoType,OtherBlockType>& other)
-        : neighbor(other.neighbor)
-        , res_nbinfo(other.res_nbinfo)
-        , matBlockAddress(nullptr)
-    {
-        if (other.matBlockAddress) {
-            matBlockAddress = reinterpret_cast<BlockType*>(other.matBlockAddress);
-        }
-    }
-
-    template <class PtrType>
-    NeighborInfoStruct(unsigned int n, const ResidualNBInfoType& r, PtrType ptr)
-        : neighbor(n)
-        , res_nbinfo(r)
-        , matBlockAddress(static_cast<BlockType*>(ptr))
-    {
-    }
-
-    // Add a default constructor
-    NeighborInfoStruct()
-        : neighbor(0)
-        , res_nbinfo()
-        , matBlockAddress(nullptr)
-    {
-    }
-};
-
-#if HAVE_CUDA && OPM_IS_COMPILING_WITH_GPU_COMPILER
-namespace  gpuistl {
-    template<class MiniMatrixType, class MatrixBlockType, class ResidualNBInfoType>
-    auto copy_to_gpu(const SparseTable<NeighborInfoStruct<ResidualNBInfoType, MatrixBlockType>>& cpuNeighborInfoTable)
-    {
-        // Convert the DUNE FieldMatrix/MatrixBlock to MiniMatrix types
-        using StructWithMinimatrix = NeighborInfoStruct<ResidualNBInfoType, MiniMatrixType>;
-        std::vector<StructWithMinimatrix> minimatrices(cpuNeighborInfoTable.dataSize());
-        size_t idx = 0;
-        for (auto e : cpuNeighborInfoTable.dataStorage()) {
-            minimatrices[idx++] = StructWithMinimatrix(e);
-        }
-
-        return SparseTable<StructWithMinimatrix, gpuistl::GpuBuffer>(
-            gpuistl::GpuBuffer<StructWithMinimatrix>(minimatrices),
-            gpuistl::GpuBuffer<int>(cpuNeighborInfoTable.rowStarts())
-        );
-    }
-}
-#endif
 
 /*!
  * \ingroup FiniteVolumeDiscretizations
@@ -210,17 +141,29 @@ class TpfaLinearizer
 
     using Vector = GlobalEqVector;
 
+    using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
+
     enum { numEq = getPropValue<TypeTag, Properties::NumEq>() };
     enum { historySize = getPropValue<TypeTag, Properties::TimeDiscHistorySize>() };
     enum { dimWorld = GridView::dimensionworld };
 
-    using MatrixBlock = typename SparseMatrixAdapter::MatrixBlock;
-    using VectorBlock = Dune::FieldVector<Scalar, numEq>;
-    using ADVectorBlock = GetPropType<TypeTag, Properties::RateVector>;
+    constexpr static bool runAssemblyOnGpu = getPropValue<TypeTag, Properties::RunAssemblyOnGpu>();
 
-#if HAVE_CUDA && OPM_IS_COMPILING_WITH_GPU_COMPILER
-    using MatrixBlockGPU = gpuistl::MiniMatrix<Scalar, numEq * numEq>;
+    using MatrixBlockCPU = typename SparseMatrixAdapter::MatrixBlock;
+    using VectorBlockCPU = Dune::FieldVector<Scalar, numEq>;
+    using ADVectorBlockCPU = GetPropType<TypeTag, Properties::RateVector>;
+
+#if HAVE_CUDA
+    using MatrixBlockGPU = gpuistl::MiniMatrix<Scalar, numEq>;
     using VectorBlockGPU = gpuistl::MiniVector<Scalar, numEq>;
+    using ADVectorBlockGPU = gpuistl::MiniVector<Evaluation, numEq>;
+    using MatrixBlock = std::conditional_t<runAssemblyOnGpu, MatrixBlockGPU, MatrixBlockCPU>;
+    using VectorBlock = std::conditional_t<runAssemblyOnGpu, VectorBlockGPU, VectorBlockCPU>;
+    using ADVectorBlock = std::conditional_t<runAssemblyOnGpu, ADVectorBlockGPU, ADVectorBlockCPU>;
+#else
+    using MatrixBlock = MatrixBlockCPU;
+    using VectorBlock = VectorBlockCPU;
+    using ADVectorBlock = ADVectorBlockCPU;
 #endif
 
     static constexpr bool linearizeNonLocalElements =
@@ -484,7 +427,7 @@ public:
             const auto [type, massrateAD] = problem_().boundaryCondition(bdyInfo.cell, bdyInfo.dir);
 
             // Strip the unnecessary (and zero anyway) derivatives off massrate.
-            VectorBlock massrate(0.0);
+            VectorBlockCPU massrate(0.0);
             for (std::size_t ii = 0; ii < massrate.size(); ++ii) {
                 massrate[ii] = massrateAD[ii].value();
             }
@@ -570,7 +513,7 @@ private:
         std::vector<NeighborSet> sparsityPattern(model.numTotalDof());
         const Scalar gravity = problem_().gravity()[dimWorld - 1];
         unsigned numCells = model.numTotalDof();
-        neighborInfo_.reserve(numCells, 6 * numCells);
+        neighborInfo_.reserve(numCells, 6 * numCells); // Expect ~6 neighbors per cell
         std::vector<NeighborInfoCPU> loc_nbinfo;
         for (const auto& elem : elements(gridView_())) {
             stencil.update(elem);
@@ -633,18 +576,18 @@ private:
                         }
                         const auto [type, massrateAD] = problem_().boundaryCondition(myIdx, dir_id);
                         // Strip the unnecessary (and zero anyway) derivatives off massrate.
-                        VectorBlock massrate(0.0);
+                        VectorBlockCPU massrate(0.0);
                         for (std::size_t ii = 0; ii < massrate.size(); ++ii) {
                             massrate[ii] = massrateAD[ii].value();
                         }
                         const auto& exFluidState = problem_().boundaryFluidState(myIdx, dir_id);
-                        BoundaryConditionData bcdata{type,
-                                                     massrate,
-                                                     exFluidState.pvtRegionIndex(),
-                                                     bfIndex,
-                                                     bf.area(),
-                                                     bf.integrationPos()[dimWorld - 1],
-                                                     exFluidState};
+                        BoundaryConditionDataCPU bcdata {type,
+                                                         massrate,
+                                                         exFluidState.pvtRegionIndex(),
+                                                         bfIndex,
+                                                         bf.area(),
+                                                         bf.integrationPos()[dimWorld - 1],
+                                                         exFluidState};
                         boundaryInfo_.push_back({myIdx, dir_id, bfIndex, bcdata});
                     }
                 }
@@ -671,6 +614,13 @@ private:
             }
         }
 
+#if HAVE_CUDA && OPM_IS_COMPILING_WITH_GPU_COMPILER
+        gpuJacobian_.reset(new gpuistl::GpuSparseMatrixWrapper<Scalar>(
+            gpuistl::GpuSparseMatrixWrapper<Scalar>::fromMatrix(jacobian_->istlMatrix())));
+        gpuBufferDiagMatAddress_.reset(new gpuistl::GpuBuffer<MatrixBlockGPU*>(
+            gpuistl::detail::getDiagPtrsTyped<MatrixBlockGPU>(*gpuJacobian_)));
+#endif
+
         // Create dummy full domain.
         fullDomain_.cells.resize(numCells);
         std::iota(fullDomain_.cells.begin(), fullDomain_.cells.end(), 0);
@@ -682,6 +632,10 @@ private:
         residual_ = 0.0;
         // zero all matrix entries
         jacobian_->clear();
+
+#if HAVE_CUDA && OPM_IS_COMPILING_WITH_GPU_COMPILER
+        gpuJacobian_->setToZero();
+#endif
     }
 
     // Initialize the flows, flores, and velocity sparse tables
@@ -810,7 +764,9 @@ private:
     }
 
 public:
-    void setResAndJacobi(VectorBlock& res, MatrixBlock& bMat, const ADVectorBlock& resid) const
+    template <class VectorBlockType, class MatrixBlockType, class ADVectorBlockType>
+    OPM_HOST_DEVICE static void
+    setResAndJacobi(VectorBlockType& res, MatrixBlockType& bMat, const ADVectorBlockType& resid)
     {
         for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
             res[eqIdx] = resid[eqIdx].value();
@@ -891,7 +847,7 @@ public:
                 continue;
             }
 
-            ADVectorBlock adres(0.0);
+            ADVectorBlockCPU adres(0.0);
             const unsigned globI = bdyInfo.cell;
             const auto& nbInfos = neighborInfo_[globI];
             const IntensiveQuantities& insideIntQuants = model_().intensiveQuantities(globI, /*timeIdx*/ 0);
@@ -911,6 +867,8 @@ private:
     template <class SubDomainType>
     void linearize_(const SubDomainType& domain)
     {
+        constexpr bool run_assembly_on_gpu = getPropValue<TypeTag, Properties::RunAssemblyOnGpu>();
+
         // This check should be removed once this is addressed by
         // for example storing the previous timesteps' values for
         // rsmax (for DRSDT) and similar.
@@ -920,123 +878,170 @@ private:
             }
         }
 
+        const double dt = simulator_().timeStepSize();
+
         OPM_TIMEBLOCK(linearize);
 
         // We do not call resetSystem_() here, since that will set
         // the full system to zero, not just our part.
         // Instead, that must be called before starting the linearization.
         const bool dispersionActive = simulator_().vanguard().eclState().getSimulationConfig().rock_config().dispersion();
-        const auto& blockVelocity = simulator_().problem().eclWriter().outputModule().getFlows().blockVelocity();
         const unsigned int numCells = domain.cells.size();
 
-        // Fetch timestepsize used later in accumulation term.
-        const double dt = simulator_().timeStepSize();
+        if constexpr (!run_assembly_on_gpu) {
+            linearize_parallelization_wrapper<run_assembly_on_gpu, LocalResidual>(
+                numCells /*numCells*/,
+                domain,
+                neighborInfo_,
+                diagMatAddress_,
+                residual_,
+                model_(),
+                dt,
+                dispersionActive,
+                problem_());
 
+            linearize_bc<IntensiveQuantities, Model, LocalResidual>(
+                diagMatAddress_, residual_, boundaryInfo_);
+        } else {
+#if HAVE_CUDA && OPM_IS_COMPILING_WITH_GPU_COMPILER
+            // Make sure we have can have the domain on the GPU.
+            if constexpr (std::is_same_v<SubDomainType, FullDomain<>>) {
+
+                using GpuParams = TpfaLinearizerGpuParams<TypeTag>;
+
+                int constexpr blockSize = 256; // Experimentally this is a good value for multiple
+                                               // GPUs. Autotune this later.
+
+                GpuParams gpuParams(domain,
+                                    neighborInfo_,
+                                    *gpuJacobian_,
+                                    *gpuBufferDiagMatAddress_,
+                                    jacobian_->istlMatrix(),
+                                    residual_,
+                                    boundaryInfo_,
+                                    model_(),
+                                    problem_(),
+                                    numCells);
+
+                linearize_parallelization_wrapper<run_assembly_on_gpu,
+                                                  typename GpuParams::LocalResidualGPU>(
+                    numCells,
+                    gpuParams.domainView(),
+                    gpuParams.neighborInfoView(),
+                    gpuParams.diagMatAddressView(),
+                    gpuParams.residualView(),
+                    gpuParams.modelView(),
+                    dt,
+                    dispersionActive,
+                    gpuParams.flowProblemView());
+
+                if (gpuParams.boundaryInfoSize() > 0) {
+                    auto boundaryInfoView = gpuParams.boundaryInfoView();
+                    linearize_bc_threadsafe<TpfaLinearizer<TypeTag>,
+                                            typename GpuParams::GPUBOIQ,
+                                            decltype(gpuParams.modelView()),
+                                            typename GpuParams::LocalResidualGPU>
+                        <<<((gpuParams.boundaryInfoSize() + blockSize - 1) / blockSize),
+                           blockSize>>>(gpuParams.diagMatAddressView(),
+                                        gpuParams.residualView(),
+                                        boundaryInfoView,
+                                        gpuParams.modelView(),
+                                        gpuParams.flowProblemView());
+                }
+
+                // The memory copies here are synchronous and in the default stream,
+                // guaranteeing that the GPU kernels have completed.
+                gpuParams.copyResidualToHost(residual_, numCells);
+                gpuParams.copyJacobianToHost(*jacobian_, *gpuJacobian_);
+            } else {
+                OPM_THROW(std::logic_error, "Only FullDomain is supported on GPU");
+            }
+#else
+            OPM_THROW(std::logic_error,
+                      "Trying to run GPU assembly without compiling with GPU support");
+#endif
+        }
+
+        // Handle source terms separately as we want the functionality for CPU and GPU cases
+        // but for now we cannot handle this inside gpu kernels due to the use of problem_()
+        linearize_source_terms(numCells, domain);
+    }
+
+    template <bool useGPU,
+              class LocalResidualT,
+              class ModelClass,
+              class DiagPtrType,
+              class DomainType,
+              class NeighborSparseTable,
+              class ResidualType,
+              class ProblemT>
+    void linearize_parallelization_wrapper(const unsigned int numCells,
+                                           const DomainType& domain,
+                                           const NeighborSparseTable& neighborInfo,
+                                           DiagPtrType& diagMatAddress,
+                                           ResidualType& residual,
+                                           const ModelClass& model,
+                                           Scalar dt,
+                                           bool dispersionActive,
+                                           const ProblemT& problem)
+    {
+        if constexpr (useGPU) {
+            static_assert(!enableBioeffects && "Bioeffects not yet supported on GPU");
+            assert(!dispersionActive && "Dispersion not yet supported on GPU");
+#if HAVE_CUDA && OPM_IS_COMPILING_WITH_GPU_COMPILER
+            int constexpr blockSize = 256;
+            kernel_linearize<TpfaLinearizer<TypeTag>,
+                             ModelClass,
+                             LocalResidualT,
+                             DiagPtrType,
+                             Scalar,
+                             DomainType,
+                             NeighborSparseTable,
+                             ResidualType,
+                             ProblemT>
+                <<<((numCells + blockSize - 1) / blockSize), blockSize>>>(numCells,
+                                                                          domain,
+                                                                          neighborInfo,
+                                                                          diagMatAddress,
+                                                                          residual,
+                                                                          model,
+                                                                          dt,
+                                                                          problem);
+#else
+            OPM_THROW(std::runtime_error, "Trying to run GPU code without GPU support");
+#endif
+        } else {
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+            for (unsigned ii = 0; ii < numCells; ++ii) {
+                linearize_cell<false, LocalResidual>(ii,
+                                                     domain,
+                                                     neighborInfo,
+                                                     diagMatAddress,
+                                                     residual,
+                                                     model,
+                                                     velocityInfo_,
+                                                     dt,
+                                                     problem);
+            }
+        }
+    }
+
+    template <class SubDomainType>
+    void linearize_source_terms(unsigned int numCells, const SubDomainType& domain)
+    {
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
         for (unsigned ii = 0; ii < numCells; ++ii) {
             OPM_TIMEBLOCK_LOCAL(linearizationForEachCell, Subsystem::Assembly);
             const unsigned globI = domain.cells[ii];
-            const auto& nbInfos = neighborInfo_[globI];
-            VectorBlock res(0.0);
-            MatrixBlock bMat(0.0);
-            ADVectorBlock adres(0.0);
-            ADVectorBlock darcyFlux(0.0);
+            VectorBlockCPU res(0.0);
+            MatrixBlockCPU bMat(0.0);
+            ADVectorBlockCPU adres(0.0);
             const IntensiveQuantities& intQuantsIn = model_().intensiveQuantities(globI, /*timeIdx*/ 0);
-
-            // Flux term.
-            {
-                OPM_TIMEBLOCK_LOCAL(fluxCalculationForEachCell, Subsystem::Assembly);
-                short loc = 0;
-                for (const auto& nbInfo : nbInfos) {
-                    OPM_TIMEBLOCK_LOCAL(fluxCalculationForEachFace, Subsystem::Assembly);
-                    const unsigned globJ = nbInfo.neighbor;
-                    assert(globJ != globI);
-                    res = 0.0;
-                    bMat = 0.0;
-                    adres = 0.0;
-                    darcyFlux = 0.0;
-                    const IntensiveQuantities& intQuantsEx = model_().intensiveQuantities(globJ, /*timeIdx*/ 0);
-                    LocalResidual::computeFlux(adres, darcyFlux, globI, globJ, intQuantsIn, intQuantsEx,
-                                               nbInfo.res_nbinfo, problem_().moduleParams());
-                    adres *= nbInfo.res_nbinfo.faceArea;
-                    if (dispersionActive || enableBioeffects) {
-                        for (unsigned phaseIdx = 0; phaseIdx < numEq; ++phaseIdx) {
-                            velocityInfo_[globI][loc].velocity[phaseIdx] =
-                                darcyFlux[phaseIdx].value() / nbInfo.res_nbinfo.faceArea;
-                        }
-                    }
-                    else if (!blockVelocity.empty()) {
-                        if (std::ranges::binary_search(blockVelocity,
-                                                       simulator_().vanguard().cartesianIndex(globI))) {
-                            for (unsigned phaseIdx = 0; phaseIdx < numEq; ++phaseIdx) {
-                                velocityInfo_[globI][loc].velocity[phaseIdx] =
-                                    darcyFlux[phaseIdx].value() / nbInfo.res_nbinfo.faceArea;
-                            }
-                        }
-                    }
-                    setResAndJacobi(res, bMat, adres);
-                    residual_[globI] += res;
-                    //SparseAdapter syntax:  jacobian_->addToBlock(globI, globI, bMat);
-                    *diagMatAddress_[globI] += bMat;
-                    bMat *= -1.0;
-                    //SparseAdapter syntax: jacobian_->addToBlock(globJ, globI, bMat);
-                    *nbInfo.matBlockAddress += bMat;
-                    ++loc;
-                }
-            }
-
-            // Accumulation term.
             const double volume = model_().dofTotalVolume(globI);
-            const Scalar storefac = volume / dt;
-            adres = 0.0;
-            {
-                OPM_TIMEBLOCK_LOCAL(computeStorage, Subsystem::Assembly);
-                LocalResidual::template computeStorage<Evaluation>(adres, intQuantsIn);
-            }
-            setResAndJacobi(res, bMat, adres);
-            // Either use cached storage term, or compute it on the fly.
-            if (model_().enableStorageCache()) {
-                // The cached storage for timeIdx 0 (current time) is not
-                // used, but after storage cache is shifted at the end of the
-                // timestep, it will become cached storage for timeIdx 1.
-                model_().updateCachedStorage(globI, /*timeIdx=*/0, res);
-                // We should not update the storage cache here for NLDD local solves.
-                // This will reset the start-of-step storage to incorrect numbers when
-                // we do local solves, where the iteration number will start from 0,
-                // but the starting state may not be identical to the start-of-step state.
-                // Note that a full assembly must be done before local solves
-                // otherwise this will be left un-updated.
-                if (problem_().iterationContext().isFirstGlobalIteration()) {
-                    // Need to update the storage cache.
-                    if (problem_().recycleFirstIterationStorage()) {
-                        // Assumes nothing have changed in the system which
-                        // affects masses calculated from primary variables.
-                        model_().updateCachedStorage(globI, /*timeIdx=*/1, res);
-                    }
-                    else {
-                        Dune::FieldVector<Scalar, numEq> tmp;
-                        const IntensiveQuantities intQuantOld = model_().intensiveQuantities(globI, 1);
-                        LocalResidual::template computeStorage<Scalar>(tmp, intQuantOld);
-                        model_().updateCachedStorage(globI, /*timeIdx=*/1, tmp);
-                    }
-                }
-                res -= model_().cachedStorage(globI, 1);
-            }
-            else {
-                OPM_TIMEBLOCK_LOCAL(computeStorage0, Subsystem::Assembly);
-                Dune::FieldVector<Scalar, numEq> tmp;
-                const IntensiveQuantities intQuantOld = model_().intensiveQuantities(globI, 1);
-                LocalResidual::template computeStorage<Scalar>(tmp, intQuantOld);
-                // assume volume do not change
-                res -= tmp;
-            }
-            res *= storefac;
-            bMat *= storefac;
-            residual_[globI] += res;
-            //SparseAdapter syntax: jacobian_->addToBlock(globI, globI, bMat);
-            *diagMatAddress_[globI] += bMat;
 
             // Cell-wise source terms.
             // This will include well sources if SeparateSparseSourceTerms is false.
@@ -1045,14 +1050,13 @@ private:
             adres = 0.0;
             if (separateSparseSourceTerms_) {
                 LocalResidual::computeSourceDense(adres, problem_(), intQuantsIn, globI, 0);
-            }
-            else {
+            } else {
                 LocalResidual::computeSource(adres, problem_(), intQuantsIn, globI, 0);
             }
             adres *= -volume;
             setResAndJacobi(res, bMat, adres);
             residual_[globI] += res;
-            //SparseAdapter syntax: jacobian_->addToBlock(globI, globI, bMat);
+            // SparseAdapter syntax: jacobian_->addToBlock(globI, globI, bMat);
             *diagMatAddress_[globI] += bMat;
         } // end of loop for cell globI.
 
@@ -1060,24 +1064,223 @@ private:
         if (separateSparseSourceTerms_) {
             problem_().wellModel().addReservoirSourceTerms(residual_, diagMatAddress_);
         }
+    }
 
+public:
+    template <bool useGPU,
+              class LocalResidualT,
+              class ProblemType,
+              class VelocityInfoType,
+              class ModelClass,
+              class DiagPtrType,
+              class DomainType,
+              class NeighborSparseTable,
+              class ResidualType>
+    OPM_HOST_DEVICE static void linearize_cell(const unsigned int ii,
+                                               const DomainType& domain,
+                                               const NeighborSparseTable& neighborInfo,
+                                               const DiagPtrType& diagMatAddress,
+                                               ResidualType& residual,
+                                               const ModelClass& model,
+                                               VelocityInfoType& velocityInfo,
+                                               const Scalar dt,
+                                               const ProblemType& problem)
+    {
+#if OPM_IS_INSIDE_HOST_FUNCTION
+        OPM_TIMEBLOCK_LOCAL(linearizationForEachCell, Subsystem::Assembly);
+#endif
+        const unsigned globI = domain.cells[ii];
+        const auto& nbInfos = neighborInfo[globI];
+        VectorBlock res(0.0);
+        MatrixBlock bMat(0.0);
+        ADVectorBlock adres(0.0);
+        ADVectorBlock darcyFlux(0.0);
+        const auto& intQuantsIn = model.intensiveQuantities(globI, /*timeIdx*/ 0);
+
+        // Flux term.
+        {
+#if OPM_IS_INSIDE_HOST_FUNCTION
+            OPM_TIMEBLOCK_LOCAL(fluxCalculationForEachCell, Subsystem::Assembly);
+#endif
+            short loc = 0;
+            for (const auto& nbInfo : nbInfos) {
+                const unsigned globJ = nbInfo.neighbor;
+                res = 0.0;
+                bMat = 0.0;
+                adres = 0.0;
+                darcyFlux = 0.0;
+
+                const auto& intQuantsEx = model.intensiveQuantities(globJ, /*timeIdx*/ 0);
+
+                LocalResidualT::computeFlux(adres,
+                                            darcyFlux,
+                                            globI,
+                                            globJ,
+                                            intQuantsIn,
+                                            intQuantsEx,
+                                            nbInfo.res_nbinfo,
+                                            problem.moduleParams());
+
+                adres *= nbInfo.res_nbinfo.faceArea;
+
+                // currently not supported on GPU
+                if constexpr (!useGPU) {
+                    // Use std::cmp_less because sparseTable.size() returns signed integer, and globI is unsigned
+                    if (std::cmp_less(globI, velocityInfo.size())) {
+                        if (velocityInfo.rowSize(globI) > 0) {
+                            for (unsigned phaseIdx = 0; phaseIdx < numEq; ++phaseIdx) {
+                                velocityInfo[globI][loc].velocity[phaseIdx]
+                                    = darcyFlux[phaseIdx].value() / nbInfo.res_nbinfo.faceArea;
+                            }
+                        }
+                    }
+                }
+
+                setResAndJacobi(res, bMat, adres);
+                residual[globI] += res;
+                // SparseAdapter syntax:  jacobian_->addToBlock(globI, globI, bMat);
+                *diagMatAddress[globI] += bMat;
+                bMat *= -1.0;
+                // SparseAdapter syntax: jacobian_->addToBlock(globJ, globI, bMat);
+                *nbInfo.matBlockAddress += bMat;
+                ++loc;
+            }
+        }
+
+        // Accumulation term.
+        adres = 0.0;
+        {
+            LocalResidualT::template computeStorage<Evaluation>(adres, intQuantsIn);
+        }
+        setResAndJacobi(res, bMat, adres);
+
+        if constexpr (!useGPU) { // Cached storage not enabled for GPU
+            // Either use cached storage term, or compute it on the fly.
+            if (model.enableStorageCache()) {
+                // The cached storage for timeIdx 0 (current time) is not
+                // used, but after storage cache is shifted at the end of the
+                // timestep, it will become cached storage for timeIdx 1.
+                model.updateCachedStorage(globI, /*timeIdx=*/0, res);
+                // We should not update the storage cache here for NLDD local solves.
+                // This will reset the start-of-step storage to incorrect numbers when
+                // we do local solves, where the iteration number will start from 0,
+                // but the starting state may not be identical to the start-of-step state.
+                // Note that a full assembly must be done before local solves
+                // otherwise this will be left un-updated.
+                if (problem.iterationContext().isFirstGlobalIteration()) {
+                    // Need to update the storage cache.
+                    if (problem.recycleFirstIterationStorage()) {
+                        // Assumes nothing have changed in the system which
+                        // affects masses calculated from primary variables.
+                        model.updateCachedStorage(globI, 1, res);
+                    } else {
+                        VectorBlock tmp;
+                        const auto& intQuantOld = model.intensiveQuantities(globI, 1);
+                        LocalResidualT::template computeStorage<Scalar>(tmp, intQuantOld);
+                        model.updateCachedStorage(globI, 1, tmp);
+                    }
+                }
+                res -= model.cachedStorage(globI, 1);
+            } else {
+#if OPM_IS_INSIDE_HOST_FUNCTION
+                OPM_TIMEBLOCK_LOCAL(computeStorage0, Subsystem::Assembly);
+#endif
+                VectorBlock tmp;
+                const auto& intQuantOld = model.intensiveQuantities(globI, 1);
+                LocalResidualT::template computeStorage<Scalar>(tmp, intQuantOld);
+                // assume volume do not change
+                res -= tmp;
+            }
+        } else {
+            VectorBlock tmp;
+            const auto& intQuantOld = model.intensiveQuantities(globI, 1);
+            LocalResidualT::template computeStorage<Scalar>(tmp, intQuantOld);
+            // assume volume do not change
+            res -= tmp;
+        }
+
+        const Scalar volume = model.dofTotalVolume(globI);
+        const Scalar storefac = volume / dt;
+        res *= storefac;
+        bMat *= storefac;
+        residual[globI] += res;
+        // SparseAdapter syntax: jacobian_->addToBlock(globI, globI, bMat);
+        *diagMatAddress[globI] += bMat;
+    }
+
+#if HAVE_CUDA && OPM_IS_COMPILING_WITH_GPU_COMPILER
+    template <class LocalIntensiveQuantities,
+              class LocalResidualT,
+              class ModelT,
+              class DiagPtrType,
+              class ResidualT,
+              class BoundaryInfoT,
+              class ProblemT>
+    OPM_HOST_DEVICE static void linearize_bc_threadsafe_single_cell(DiagPtrType diagMatAdress,
+                                                               ResidualT residual,
+                                                               const BoundaryInfoT boundaryInfoElement,
+                                                               ModelT model,
+                                                               ProblemT problem)
+    {
+        using Scalar = GetPropType<TypeTag, Properties::Scalar>;
+        constexpr int numEq = getPropValue<TypeTag, Properties::NumEq>();
+        if (boundaryInfoElement.bcdata.type != BCType::NONE) {
+            VectorBlock res(0.0);
+            MatrixBlock bMat(0.0);
+            ADVectorBlock adres(0.0);
+            const unsigned globI = boundaryInfoElement.cell;
+            const LocalIntensiveQuantities& insideIntQuants
+                = model.intensiveQuantities(globI, /*timeIdx*/ 0);
+            if constexpr (!std::is_empty_v<GetPropType<TypeTag, Properties::FluidSystem>>) {
+                LocalResidualT::computeBoundaryFlux(
+                    adres, problem, boundaryInfoElement.bcdata, insideIntQuants, globI);
+            }
+            adres *= boundaryInfoElement.bcdata.faceArea;
+            TpfaLinearizer<TypeTag>::setResAndJacobi(res, bMat, adres);
+            auto* residualPtr = &(residual.data()[globI]);
+            for (int i = 0; i < numEq; ++i) {
+                atomicAdd(&((*residualPtr)[i]), res[i]);
+            }
+            auto* matPtr = diagMatAdress[globI];
+            for (int row = 0; row < bMat.size(); ++row) {
+                for (int col = 0; col < bMat.size(); ++col) {
+                    Scalar* elemPtr = &((*matPtr)[row][col]);
+                    atomicAdd(elemPtr, bMat[row][col]);
+                }
+            }
+        }
+    }
+#endif
+
+private:
+    template <class LocalIntensiveQuantities,
+              class ModelClass,
+              class LocalResidualT,
+              class DiagPtrType,
+              class ResidualType,
+              class BoundaryInfoT>
+    void linearize_bc(DiagPtrType& diagMatAdress,
+                      ResidualType& residual,
+                      const BoundaryInfoT& boundaryInfo)
+    {
         // Boundary terms. Only looping over cells with nontrivial bcs.
-        for (const auto& bdyInfo : boundaryInfo_) {
+        for (const auto& bdyInfo : boundaryInfo) {
             if (bdyInfo.bcdata.type == BCType::NONE) {
                 continue;
             }
-
             VectorBlock res(0.0);
             MatrixBlock bMat(0.0);
             ADVectorBlock adres(0.0);
             const unsigned globI = bdyInfo.cell;
-            const IntensiveQuantities& insideIntQuants = model_().intensiveQuantities(globI, /*timeIdx*/ 0);
-            LocalResidual::computeBoundaryFlux(adres, problem_(), bdyInfo.bcdata, insideIntQuants, globI);
+            const LocalIntensiveQuantities& insideIntQuants
+                = model_().intensiveQuantities(globI, /*timeIdx*/ 0);
+            LocalResidual::computeBoundaryFlux(
+                adres, problem_(), bdyInfo.bcdata, insideIntQuants, globI);
             adres *= bdyInfo.bcdata.faceArea;
             setResAndJacobi(res, bMat, adres);
-            residual_[globI] += res;
+            residual[globI] += res;
             ////SparseAdapter syntax: jacobian_->addToBlock(globI, globI, bMat);
-            *diagMatAddress_[globI] += bMat;
+            *diagMatAdress[globI] += bMat;
         }
     }
 
@@ -1107,6 +1310,10 @@ private:
 
     // the jacobian matrix
     std::unique_ptr<SparseMatrixAdapter> jacobian_{};
+#if HAVE_CUDA
+    std::unique_ptr<gpuistl::GpuSparseMatrixWrapper<Scalar>> gpuJacobian_;
+    std::unique_ptr<gpuistl::GpuBuffer<MatrixBlockGPU*>> gpuBufferDiagMatAddress_;
+#endif
 
     // the right-hand side
     GlobalEqVector residual_;
@@ -1114,10 +1321,10 @@ private:
     LinearizationType linearizationType_{};
 
     using ResidualNBInfo = typename LocalResidual::ResidualNBInfo;
-    using NeighborInfoCPU = NeighborInfoStruct<ResidualNBInfo, MatrixBlock>;
+    using NeighborInfoCPU = NeighborInfoStruct<ResidualNBInfo, MatrixBlockCPU>;
 
     SparseTable<NeighborInfoCPU> neighborInfo_{};
-    std::vector<MatrixBlock*> diagMatAddress_{};
+    std::vector<MatrixBlockCPU*> diagMatAddress_ {};
 
     struct FlowInfo
     {
@@ -1136,25 +1343,12 @@ private:
     SparseTable<VelocityInfo> velocityInfo_;
 
     using ScalarFluidState = typename IntensiveQuantities::ScalarFluidState;
-    struct BoundaryConditionData
-    {
-        BCType type;
-        VectorBlock massRate;
-        unsigned pvtRegionIdx;
-        unsigned boundaryFaceIndex;
-        double faceArea;
-        double faceZCoord;
-        ScalarFluidState exFluidState;
-    };
 
-    struct BoundaryInfo
-    {
-        unsigned int cell;
-        int dir;
-        unsigned int bfIndex;
-        BoundaryConditionData bcdata;
-    };
-    std::vector<BoundaryInfo> boundaryInfo_;
+    using BoundaryConditionDataCPU = BoundaryConditionData<VectorBlockCPU, ScalarFluidState>;
+
+    using BoundaryInfoCPU = BoundaryInfo<BoundaryConditionDataCPU>;
+
+    std::vector<BoundaryInfoCPU> boundaryInfo_;
 
     bool separateSparseSourceTerms_ = false;
 

--- a/opm/models/discretization/common/tpfalinearizergpukernels.hh
+++ b/opm/models/discretization/common/tpfalinearizergpukernels.hh
@@ -1,0 +1,91 @@
+/*
+  Copyright 2026 Equinor ASA
+  This file is part of the Open Porous Media project (OPM).
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef TPFA_LINEARIZER_GPUKERNELS_HH
+#define TPFA_LINEARIZER_GPUKERNELS_HH
+
+/*
+    This file contains the GPU kernels that handles the GPU parallelization of the linearization.
+    This is effectively just the GPU alternative to what is a for-loop on the CPU
+*/
+
+namespace Opm
+{
+
+#if HAVE_CUDA && OPM_IS_COMPILING_WITH_GPU_COMPILER
+template <class TpfaLinearizerType,
+          class ModelClass,
+          class LocalResidualT,
+          class DiagPtrType,
+          class ScalarType,
+          class DomainType,
+          class NeighborSparseTable,
+          class ResidualType,
+          class ProblemT>
+__global__ __launch_bounds__(256) void kernel_linearize(const unsigned int numCells,
+                                                        const DomainType domain,
+                                                        const NeighborSparseTable neighborInfo,
+                                                        DiagPtrType diagMatAddress,
+                                                        ResidualType residual,
+                                                        ModelClass model,
+                                                        ScalarType dt,
+                                                        ProblemT problem)
+{
+    const unsigned int ii = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (ii < numCells) {
+        // velocityInfo is unused on GPU (guarded by if constexpr (!useGPU)),
+        // but the parameter is T& so we need an lvalue to bind to.
+        std::nullptr_t dummyVelocityInfo = nullptr;
+        TpfaLinearizerType::template linearize_cell<true, LocalResidualT>(ii,
+                                                                          domain,
+                                                                          neighborInfo,
+                                                                          diagMatAddress,
+                                                                          residual,
+                                                                          model,
+                                                                          dummyVelocityInfo,
+                                                                          dt,
+                                                                          problem);
+    }
+}
+
+template <class TpfaLinearizerType,
+          class IntensiveQuantities,
+          class ModelT,
+          class LocalResidualT,
+          class DiagPtrType,
+          class ResidualT,
+          class BoundaryInfo,
+          class ProblemT>
+__global__ void
+linearize_bc_threadsafe(DiagPtrType diagMatAddress,
+                        ResidualT residual,
+                        const BoundaryInfo boundaryInfo,
+                        ModelT model,
+                        ProblemT gpuProblem)
+{
+    const unsigned int ii = blockIdx.x * blockDim.x + threadIdx.x;
+    if (ii < boundaryInfo.size()) {
+        TpfaLinearizerType::template linearize_bc_threadsafe_single_cell<IntensiveQuantities,
+                                                                         LocalResidualT>(
+            diagMatAddress, residual, boundaryInfo[ii], model, gpuProblem);
+    }
+}
+
+#endif
+
+} // namespace Opm
+
+#endif // TPFA_LINEARIZER_GPUKERNELS_HH

--- a/opm/models/discretization/common/tpfalinearizergpuparams.hh
+++ b/opm/models/discretization/common/tpfalinearizergpuparams.hh
@@ -1,0 +1,300 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+
+  Copyright 2026 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*!
+ * \file
+ *
+ * \brief GPU parameter setup class for TpfaLinearizer.
+ *
+ * \note This file is designed to be included from tpfalinearizer.hh inside a
+ *       \c #if HAVE_CUDA block.  It is self-contained: all required GPU headers,
+ *       model headers, and forward declarations are included below.
+ */
+#ifndef TPFA_LINEARIZER_GPU_PARAMS_HH
+#define TPFA_LINEARIZER_GPU_PARAMS_HH
+
+#if HAVE_CUDA && OPM_IS_COMPILING_WITH_GPU_COMPILER
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <opm/common/utility/gpuistl_if_available.hpp>
+
+#if USE_HIP
+#include <opm/simulators/linalg/gpuistl_hip/GpuSparseMatrixWrapper.hpp>
+#include <opm/simulators/linalg/gpuistl_hip/MiniMatrix.hpp>
+#include <opm/simulators/linalg/gpuistl_hip/MiniVector.hpp>
+#else
+#include <opm/simulators/linalg/gpuistl/GpuSparseMatrixWrapper.hpp>
+#include <opm/simulators/linalg/gpuistl/MiniMatrix.hpp>
+#include <opm/simulators/linalg/gpuistl/MiniVector.hpp>
+#endif
+
+#include <opm/grid/utility/SparseTable.hpp>
+#include <opm/models/blackoil/blackoilintensivequantities.hh>
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+#include <opm/simulators/flow/SimpleFIBlackOilModel.hpp>
+#include <opm/simulators/flow/ThermalGasWaterFlowProblem.hpp>
+
+#include <opm/models/discretization/common/tpfalinearizerstructs.hh>
+
+namespace Opm {
+
+/*!
+ * \ingroup FiniteVolumeDiscretizations
+ *
+ * \brief Manages GPU buffer allocation and view setup for one linearization pass.
+ *
+ * Constructed once per call to TpfaLinearizer::linearize_() when the GPU assembly
+ * path is active.  The constructor performs all CPU-to-GPU copies and stores the
+ * resulting GPU buffers as members.  Callers retrieve lightweight GpuView objects
+ * via the accessor methods and pass them directly to the GPU kernels.  After the
+ * kernels complete, copyResidualToHost() and copyJacobianToHost() transfer the
+ * computed results back to the CPU.
+ */
+template <class TypeTag>
+class TpfaLinearizerGpuParams
+{
+    using Scalar = GetPropType<TypeTag, Properties::Scalar>;
+    using GlobalEqVector = GetPropType<TypeTag, Properties::GlobalEqVector>;
+    using SparseMatrixAdapter = GetPropType<TypeTag, Properties::SparseMatrixAdapter>;
+    using LocalResidual = GetPropType<TypeTag, Properties::LocalResidual>;
+    using IntensiveQuantities = GetPropType<TypeTag, Properties::IntensiveQuantities>;
+    using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
+    using Model = GetPropType<TypeTag, Properties::Model>;
+    using Problem = GetPropType<TypeTag, Properties::Problem>;
+
+    enum { numEq = getPropValue<TypeTag, Properties::NumEq>() };
+
+    using MatrixBlockCPU = typename SparseMatrixAdapter::MatrixBlock;
+    using VectorBlockCPU = Dune::FieldVector<Scalar, numEq>;
+    using MatrixBlockGPU = gpuistl::MiniMatrix<Scalar, numEq>;
+    using VectorBlockGPU = gpuistl::MiniVector<Scalar, numEq>;
+
+    using ResidualNBInfo = typename LocalResidual::ResidualNBInfo;
+    using NeighborInfoCPU = NeighborInfoStruct<ResidualNBInfo, MatrixBlockCPU>;
+    using NeighborInfoGPU = NeighborInfoStruct<ResidualNBInfo, MatrixBlockGPU>;
+
+    using ScalarFluidState = typename IntensiveQuantities::ScalarFluidState;
+    using BoundaryConditionDataCPU = BoundaryConditionData<VectorBlockCPU, ScalarFluidState>;
+    using BoundaryInfoCPU = BoundaryInfo<BoundaryConditionDataCPU>;
+
+    // Fluid system buffer/view/ptr types derived without spelling out the fluid-system
+    // template parameters explicitly.
+    using NonStaticFluidSystem = std::decay_t<decltype(FluidSystem::getNonStaticInstance())>;
+    using GpuFluidSystemBuffer = std::decay_t<decltype(::Opm::gpuistl::copy_to_gpu(
+        std::declval<NonStaticFluidSystem&>()))>;
+    using GpuFluidSystemView
+        = std::decay_t<decltype(::Opm::gpuistl::make_view(std::declval<GpuFluidSystemBuffer&>()))>;
+    using GpuFluidSystemPtr = std::shared_ptr<GpuFluidSystemView>;
+
+public:
+    // Type aliases required by callers to instantiate the GPU kernel templates.
+    using CorrectTypeTagView =
+        typename ::Opm::Properties::TTag::to_gpu_type_t<TypeTag, gpuistl::GpuView>;
+
+    // GPUBOIQ and LocalResidualGPU are not taken from typetag as we need the
+    // outer class to template correctly here
+    using GPUBOIQ = BlackOilIntensiveQuantities<CorrectTypeTagView>;
+    using LocalResidualGPU = BlackOilLocalResidualTPFA<CorrectTypeTagView>;
+
+private:
+    using GpuScalarFluidState = typename GPUBOIQ::ScalarFluidState;
+    using BoundaryConditionDataGPU = BoundaryConditionData<VectorBlockGPU, GpuScalarFluidState>;
+    using BoundaryInfoGPU = BoundaryInfo<BoundaryConditionDataGPU>;
+
+    using GpuModelBufferType = SimpleFIBlackOilModel<CorrectTypeTagView, gpuistl::GpuBuffer>;
+    using GpuFlowProblemBufferType = ThermalGasWaterFlowProblem<Scalar, gpuistl::GpuBuffer>;
+
+    using GpuModel = GetPropType<TypeTag, Properties::GpuFIBlackOilModel>;
+
+    FullDomain<gpuistl::GpuBuffer<int>> domainBuffer_;
+    SparseTable<NeighborInfoGPU, gpuistl::GpuBuffer> neighborInfoBuffer_;
+    // diagMatAddressView_ is non-owning: the underlying buffer lives in TpfaLinearizer.
+    gpuistl::GpuView<MatrixBlockGPU*> diagMatAddressView_;
+    gpuistl::GpuBuffer<VectorBlockGPU> residualBuffer_;
+    gpuistl::GpuView<VectorBlockGPU>
+        residualView_; // stored as lvalue because mutable ref must be provided
+    // dynamicGpuFluidSystemBuffer_ must be declared before dynamicGpuFluidSystemPtr_
+    // because the ptr holds a GpuView into the buffer's GPU memory.
+    GpuFluidSystemBuffer dynamicGpuFluidSystemBuffer_;
+    // The fluid-system ptr is kept alive because gpuModelBuffer_ and
+    // boundaryInfoBuffer_ store raw GPU pointers into it.
+    GpuFluidSystemPtr dynamicGpuFluidSystemPtr_;
+    GpuModelBufferType gpuModelBuffer_;
+    GpuFlowProblemBufferType gpuFlowProblemBuffer_;
+    gpuistl::GpuBuffer<BoundaryInfoGPU> boundaryInfoBuffer_;
+
+public:
+    /*!
+     * \brief Construct and populate all GPU buffers needed for one linearization pass.
+        To avoid optionals we use initializerlists, although some are a bit ugly
+        with the lambdas
+     *
+     * \param domain                  The full domain (CPU).
+     * \param neighborInfo            CPU neighbor-info sparse table.
+     * \param gpuJacobian             Persistent GPU sparse-matrix wrapper (owned by
+     * TpfaLinearizer).
+     * \param gpuBufferDiagMatAddress Persistent GPU diagonal-pointer buffer (owned by
+     * TpfaLinearizer).
+     * \param cpuJacobian             CPU ISTL matrix (used to compute GPU pointer offsets).
+     * \param residual                CPU residual vector (read to initialise the GPU residual
+     * buffer).
+     * \param boundaryInfo            CPU boundary-condition info.
+     * \param model                   CPU model (provides intensive quantities and volumes).
+     * \param problem                 CPU problem (provides thermal transmissibilities and module
+     * params).
+     * \param numCells                Number of cells in the domain.
+     */
+    TpfaLinearizerGpuParams(const FullDomain<>& domain,
+                            const SparseTable<NeighborInfoCPU>& neighborInfo,
+                            gpuistl::GpuSparseMatrixWrapper<Scalar>& gpuJacobian,
+                            gpuistl::GpuBuffer<MatrixBlockGPU*>& gpuBufferDiagMatAddress,
+                            typename SparseMatrixAdapter::IstlMatrix& cpuJacobian,
+                            GlobalEqVector& residual,
+                            const std::vector<BoundaryInfoCPU>& boundaryInfo,
+                            Model& model,
+                            const Problem& problem,
+                            unsigned int numCells)
+        : domainBuffer_(copy_to_gpu(domain))
+        , neighborInfoBuffer_(
+              gpuistl::copy_to_gpu<MatrixBlockGPU>(neighborInfo, gpuJacobian, cpuJacobian))
+        , diagMatAddressView_(gpuistl::make_view(gpuBufferDiagMatAddress))
+        , residualBuffer_(gpuistl::copy_to_gpu_residual<GlobalEqVector, VectorBlockGPU>(residual))
+        , residualView_(gpuistl::make_view(residualBuffer_))
+        , dynamicGpuFluidSystemBuffer_(
+              ::Opm::gpuistl::copy_to_gpu(FluidSystem::getNonStaticInstance()))
+        , dynamicGpuFluidSystemPtr_(
+              gpuistl::make_gpu_shared_ptr(::Opm::gpuistl::make_view(dynamicGpuFluidSystemBuffer_)))
+        , gpuModelBuffer_([&]() -> GpuModelBufferType {
+            std::vector<Scalar> volumes(numCells);
+            for (unsigned i = 0; i < numCells; ++i) {
+                volumes[domain.cells[i]] = model.dofTotalVolume(domain.cells[i]);
+            }
+            GpuModel gpuModel(
+                model.intensiveQuantityCache()[0], model.intensiveQuantityCache()[1], volumes);
+            return gpuistl::copy_to_gpu(gpuModel, *dynamicGpuFluidSystemPtr_.get());
+        }())
+        , gpuFlowProblemBuffer_([&]() -> GpuFlowProblemBufferType {
+            std::vector<Scalar> alpha0(numCells);
+            std::vector<Scalar> alpha1(numCells);
+            std::vector<Scalar> alpha2(numCells);
+            const auto& thermalHalfTransBoundary
+                = problem.eclTransmissibilities().getThermalHalfTransBoundary();
+            for (const auto& [key, value] : thermalHalfTransBoundary) {
+                const unsigned cell = key.first;
+                const unsigned dir = key.second;
+                if (dir == 0) {
+                    alpha0[cell] = value;
+                } else if (dir == 1) {
+                    alpha1[cell] = value;
+                } else if (dir == 2) {
+                    alpha2[cell] = value;
+                } else {
+                    OPM_THROW(std::logic_error,
+                              "Invalid direction for thermal half transmissibility: "
+                                  + std::to_string(dir));
+                }
+            }
+            ThermalGasWaterFlowProblem<Scalar> gpuFlowProblem(
+                alpha0, alpha1, alpha2, problem.moduleParams());
+            return gpuistl::copy_to_gpu(gpuFlowProblem);
+        }())
+        , boundaryInfoBuffer_(
+              gpuistl::copy_to_gpu<VectorBlockGPU, GpuScalarFluidState, BoundaryInfoGPU>(
+                  boundaryInfo, *dynamicGpuFluidSystemPtr_.get()))
+    {
+    }
+
+    auto domainView()
+    {
+        return make_view(domainBuffer_);
+    }
+
+    auto neighborInfoView()
+    {
+        return gpuistl::make_view(neighborInfoBuffer_);
+    }
+
+    auto& diagMatAddressView()
+    {
+        return diagMatAddressView_;
+    }
+
+    auto& residualView()
+    {
+        return residualView_;
+    }
+
+    auto modelView()
+    {
+        return gpuistl::make_view(gpuModelBuffer_);
+    }
+
+    auto flowProblemView()
+    {
+        return gpuistl::make_view(gpuFlowProblemBuffer_);
+    }
+
+    auto boundaryInfoView()
+    {
+        return gpuistl::make_view(boundaryInfoBuffer_);
+    }
+
+    std::size_t boundaryInfoSize() const
+    {
+        return boundaryInfoBuffer_.size();
+    }
+
+    /*!
+     * \brief Copy the GPU residual buffer back to the CPU residual vector.
+     *
+     * Must be called after all GPU kernels have completed (the synchronous cudaMemcpy
+     * inside guarantees the GPU has finished).
+     */
+    void copyResidualToHost(GlobalEqVector& residual, unsigned numCells)
+    {
+        auto cpuResidualFromGpu = residualBuffer_.asStdVector();
+        std::memcpy(residual.data(), cpuResidualFromGpu.data(), numCells * numEq * sizeof(Scalar));
+    }
+
+    /*!
+     * \brief Copy the GPU Jacobian non-zero values back to the CPU ISTL matrix.
+     *
+     * Must be called after all GPU kernels have completed.
+     */
+    void copyJacobianToHost(SparseMatrixAdapter& jacobian,
+                            gpuistl::GpuSparseMatrixWrapper<Scalar>& gpuJacobian)
+    {
+        auto gpuJacobianNonZeroes = gpuJacobian.getNonZeroValues().asStdVector();
+        auto& cpuJacobian = jacobian.istlMatrix();
+        const std::size_t totalMatrixSize = cpuJacobian.nonzeroes() * numEq * numEq;
+        std::memcpy(&(cpuJacobian[0][0][0][0]),
+                    gpuJacobianNonZeroes.data(),
+                    totalMatrixSize * sizeof(Scalar));
+    }
+};
+
+} // namespace Opm
+
+#endif // HAVE_CUDA && OPM_IS_COMPILING_WITH_GPU_COMPILER
+
+#endif // TPFA_LINEARIZER_GPU_PARAMS_HH

--- a/opm/models/discretization/common/tpfalinearizerstructs.hh
+++ b/opm/models/discretization/common/tpfalinearizerstructs.hh
@@ -1,0 +1,206 @@
+/*
+  Copyright 2026 Equinor ASA
+  This file is part of the Open Porous Media project (OPM).
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef TPFA_LINEARIZER_STRUCTS_HH
+#define TPFA_LINEARIZER_STRUCTS_HH
+
+/*!
+ * Structs needed for tpfalinearizer and its gpuparams struct extracted
+ * to be defined in one place that both can include.
+ */
+
+#include <cassert>
+#include <vector>
+
+#include <opm/common/Exceptions.hpp>
+#include <opm/grid/utility/SparseTable.hpp>
+#include <opm/input/eclipse/Schedule/BCProp.hpp>
+
+#include <opm/common/utility/gpuistl_if_available.hpp>
+#include <opm/common/utility/pointerArithmetic.hpp>
+
+namespace Opm {
+
+template <class Storage = std::vector<int>>
+struct FullDomain
+{
+    Storage cells;
+};
+
+#if HAVE_CUDA && OPM_IS_COMPILING_WITH_GPU_COMPILER
+inline FullDomain<gpuistl::GpuBuffer<int>> copy_to_gpu(FullDomain<> CPUDomain)
+{
+    if (CPUDomain.cells.size() == 0) {
+        OPM_THROW(std::runtime_error, "Cannot copy empty full domain to GPU.");
+    }
+    return FullDomain<gpuistl::GpuBuffer<int>>{
+        gpuistl::GpuBuffer<int>(CPUDomain.cells)
+    };
+};
+
+inline FullDomain<gpuistl::GpuView<int>> make_view(FullDomain<gpuistl::GpuBuffer<int>>& buffer)
+{
+    if (buffer.cells.size() == 0) {
+        OPM_THROW(std::runtime_error, "Cannot make view of empty full domain buffer.");
+    }
+    return FullDomain<gpuistl::GpuView<int>>{
+        gpuistl::make_view(buffer.cells)
+    };
+};
+#endif
+
+template <class ResidualNBInfoType, class BlockType>
+struct NeighborInfoStruct
+{
+    unsigned int neighbor;
+    ResidualNBInfoType res_nbinfo;
+    BlockType* matBlockAddress;
+
+    template <class PtrType>
+    NeighborInfoStruct(unsigned int n, const ResidualNBInfoType& r, PtrType ptr)
+        : neighbor(n)
+        , res_nbinfo(r)
+        , matBlockAddress(static_cast<BlockType*>(ptr))
+    {
+    }
+
+    // Add a default constructor
+    NeighborInfoStruct()
+        : neighbor(0)
+        , res_nbinfo()
+        , matBlockAddress(nullptr)
+    {
+    }
+};
+
+template <class VectorBlock, class ScalarFluidState>
+struct BoundaryConditionData {
+    BCType type;
+    VectorBlock massRate;
+    unsigned pvtRegionIdx;
+    unsigned boundaryFaceIndex;
+    double faceArea;
+    double faceZCoord;
+    ScalarFluidState exFluidState;
+};
+
+template <class BoundaryConditionData>
+struct BoundaryInfo {
+    unsigned int cell;
+    int dir;
+    unsigned int bfIndex;
+    BoundaryConditionData bcdata;
+};
+
+#if HAVE_CUDA && OPM_IS_COMPILING_WITH_GPU_COMPILER
+namespace gpuistl {
+
+    template <class MiniMatrixType,
+              class GpuMatrixType,
+              class CpuMatrixType,
+              class MatrixBlockType,
+              class ResidualNBInfoType>
+    auto copy_to_gpu(const SparseTable<NeighborInfoStruct<ResidualNBInfoType, MatrixBlockType>>&
+                         cpuNeighborInfoTable,
+                     GpuMatrixType& gpuJacobian,
+                     CpuMatrixType& cpuJacobian)
+    {
+        // Convert the DUNE FieldVectors to MiniMatrix types
+        using StructWithMinimatrix = NeighborInfoStruct<ResidualNBInfoType, MiniMatrixType>;
+        using Scalar = typename GpuMatrixType::field_type;
+        std::vector<StructWithMinimatrix> minimatrices(cpuNeighborInfoTable.dataSize());
+        Scalar* gpuBufStart = gpuJacobian.getNonZeroValues().data();
+        Scalar* cpuBufStart = &(cpuJacobian[0][0][0][0]);
+
+        // To compute the length of the buffer of the cpuJacobian we here assume we have a blocked
+        // BCRS matrix with square blocks and that the blocks are stored as Dune::FieldMatrix
+        using CpuBlockType = typename CpuMatrixType::block_type::BaseType;
+
+        const size_t gpuBufferSize
+            = gpuJacobian.nonzeroes() * gpuJacobian.blockSize() * gpuJacobian.blockSize();
+        const size_t cpuBufferSize
+            = cpuJacobian.nonzeroes() * CpuBlockType::rows * CpuBlockType::cols;
+        assert(gpuBufferSize == cpuBufferSize);
+
+        const auto& dataStorage = cpuNeighborInfoTable.dataStorage();
+        const size_t dataSize = cpuNeighborInfoTable.dataSize();
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+        for (size_t idx = 0; idx < dataSize; ++idx) {
+            const auto& e = dataStorage[idx];
+            Scalar* cpuPtr = &((*e.matBlockAddress)[0][0]);
+
+            // convert the pointer from CPU to GPU pointer based on offset in CPU jacobian
+            Scalar* gpuPtr = ComputePtrBasedOnOffsetInOtherBuffer(
+                gpuBufStart, gpuBufferSize, cpuBufStart, cpuBufferSize, cpuPtr);
+
+            minimatrices[idx] = StructWithMinimatrix(
+                e.neighbor, e.res_nbinfo, reinterpret_cast<MiniMatrixType*>(gpuPtr));
+        }
+
+        return SparseTable<StructWithMinimatrix, gpuistl::GpuBuffer>(
+            gpuistl::GpuBuffer<StructWithMinimatrix>(minimatrices),
+            gpuistl::GpuBuffer<int>(cpuNeighborInfoTable.rowStarts())
+        );
+    }
+
+    // Handle the BoundaryInfo structs
+    template <class GpuVecBlock,
+              class GpuFluidState,
+              class BoundaryInfoTypeGPU,
+              class BoundaryInfoTypeCPU,
+              typename GpuFluidSystemPtr>
+    auto copy_to_gpu(const std::vector<BoundaryInfoTypeCPU>& cpu_boundary_info,
+                     const GpuFluidSystemPtr& dynamicGpuFluidSystemPtr)
+    {
+        std::vector<BoundaryInfoTypeGPU> gpu_boundary_info;
+        for (const auto& info : cpu_boundary_info) {
+            gpu_boundary_info.push_back(BoundaryInfoTypeGPU {
+                info.cell,
+                info.dir,
+                info.bfIndex,
+                BoundaryConditionData<GpuVecBlock, GpuFluidState> {
+                    info.bcdata.type,
+                    GpuVecBlock(info.bcdata.massRate),
+                    info.bcdata.pvtRegionIdx,
+                    info.bcdata.boundaryFaceIndex,
+                    info.bcdata.faceArea,
+                    info.bcdata.faceZCoord,
+                    info.bcdata.exFluidState.withOtherFluidSystem(dynamicGpuFluidSystemPtr)}});
+        }
+
+        return gpuistl::GpuBuffer<BoundaryInfoTypeGPU>(gpu_boundary_info);
+    }
+
+    // Implemented for residual_, which is a vector of FieldVectors.
+    // We then make a GpuBuffer of MiniVectors.
+    template <class CPUResidualType, class GpuMiniVector>
+    auto copy_to_gpu_residual(CPUResidualType& residual)
+    {
+        std::vector<GpuMiniVector> vectorOfMiniVectors;
+        for (const auto& minivec : residual) {
+            vectorOfMiniVectors.emplace_back(minivec);
+        }
+
+        return gpuistl::GpuBuffer<GpuMiniVector>(vectorOfMiniVectors);
+    }
+
+} // namespace gpuistl
+#endif
+
+} // namespace Opm
+
+#endif // TPFA_LINEARIZER_STRUCTS_HH

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -835,6 +835,9 @@ public:
     std::shared_ptr<const EclMaterialLawManager> materialLawManager() const
     { return materialLawManager_; }
 
+    std::shared_ptr<const EclThermalLawManager> thermalLawManager() const
+    { return thermalLawManager_; }
+
     template <class FluidState, class ...Args>
     void updateRelperms(
         std::array<Evaluation,numPhases> &mobility,

--- a/opm/simulators/flow/NewTranFluxModule.hpp
+++ b/opm/simulators/flow/NewTranFluxModule.hpp
@@ -36,6 +36,7 @@
 
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/utility/gpuDecorators.hpp>
 
 #include <opm/input/eclipse/EclipseState/Grid/FaceDir.hpp>
 
@@ -50,7 +51,6 @@
 #include <opm/models/utils/signum.hh>
 #include <opm/models/blackoil/blackoilmoduleparams.hh>
 
-#include <opm/common/utility/gpuDecorators.hpp>
 
 #include <array>
 
@@ -239,12 +239,12 @@ protected:
 public:
 
     OPM_HOST_DEVICE static void volumeAndPhasePressureDifferences(std::array<short, numPhases>& upIdx,
-                                                  std::array<short, numPhases>& dnIdx,
-                                                  Evaluation (&volumeFlux)[numPhases],
-                                                  Evaluation (&pressureDifferences)[numPhases],
-                                                  const ElementContext& elemCtx,
-                                                  unsigned scvfIdx,
-                                                  unsigned timeIdx)
+                                                                  std::array<short, numPhases>& dnIdx,
+                                                                  Evaluation (&volumeFlux)[numPhases],
+                                                                  Evaluation (&pressureDifferences)[numPhases],
+                                                                  const ElementContext& elemCtx,
+                                                                  unsigned scvfIdx,
+                                                                  unsigned timeIdx)
     {
         const auto& problem = elemCtx.problem();
         const auto& stencil = elemCtx.stencil(timeIdx);
@@ -324,23 +324,23 @@ public:
         }
     }
 
-    template<class EvalType>
+    template<class EvalType, class ModuleParamsT = ModuleParams>
     OPM_HOST_DEVICE static void calculatePhasePressureDiff_(short& upIdx,
-                                            short& dnIdx,
-                                            EvalType& pressureDifference,
-                                            const IntensiveQuantities& intQuantsIn,
-                                            const IntensiveQuantities& intQuantsEx,
-                                            const unsigned phaseIdx,
-                                            const unsigned interiorDofIdx,
-                                            const unsigned exteriorDofIdx,
-                                            const Scalar Vin,
-                                            const Scalar Vex,
-                                            const unsigned globalIndexIn,
-                                            const unsigned globalIndexEx,
-                                            const Scalar distZg,
-                                            const Scalar thpresInToEx,
-                                            const Scalar thpresExToIn,
-                                            const ModuleParams& moduleParams)
+                                                            short& dnIdx,
+                                                            EvalType& pressureDifference,
+                                                            const IntensiveQuantities& intQuantsIn,
+                                                            const IntensiveQuantities& intQuantsEx,
+                                                            const unsigned phaseIdx,
+                                                            const unsigned interiorDofIdx,
+                                                            const unsigned exteriorDofIdx,
+                                                            const Scalar Vin,
+                                                            const Scalar Vex,
+                                                            const unsigned globalIndexIn,
+                                                            const unsigned globalIndexEx,
+                                                            const Scalar distZg,
+                                                            const Scalar thpresInToEx,
+                                                            const Scalar thpresExToIn,
+                                                            const ModuleParamsT& moduleParams)
     {
 
         // check shortcut: if the mobility of the phase is zero in the interior as
@@ -446,9 +446,9 @@ protected:
      */
     template <class FluidState>
     OPM_HOST_DEVICE void calculateBoundaryGradients_(const ElementContext& elemCtx,
-                                     unsigned scvfIdx,
-                                     unsigned timeIdx,
-                                     const FluidState& exFluidState)
+                                                     unsigned scvfIdx,
+                                                     unsigned timeIdx,
+                                                     const FluidState& exFluidState)
     {
         const auto& scvf = elemCtx.stencil(timeIdx).boundaryFace(scvfIdx);
         const Scalar faceArea = scvf.area();
@@ -490,16 +490,16 @@ public:
      */
     template <class Problem, class FluidState, class EvaluationContainer>
     OPM_HOST_DEVICE static void calculateBoundaryGradients_(const Problem& problem,
-                                            const unsigned globalSpaceIdx,
-                                            const IntensiveQuantities& intQuantsIn,
-                                            const unsigned bfIdx,
-                                            const double faceArea,
-                                            const double zEx,
-                                            const FluidState& exFluidState,
-                                            std::array<short, numPhases>& upIdx,
-                                            std::array<short, numPhases>& dnIdx,
-                                            EvaluationContainer& volumeFlux,
-                                            EvaluationContainer& pressureDifference)
+                                                            const unsigned globalSpaceIdx,
+                                                            const IntensiveQuantities& intQuantsIn,
+                                                            const unsigned bfIdx,
+                                                            const double faceArea,
+                                                            const double zEx,
+                                                            const FluidState& exFluidState,
+                                                            std::array<short, numPhases>& upIdx,
+                                                            std::array<short, numPhases>& dnIdx,
+                                                            EvaluationContainer& volumeFlux,
+                                                            EvaluationContainer& pressureDifference)
     {
 
         bool enableBoundaryMassFlux = problem.nonTrivialBoundaryConditions();

--- a/opm/simulators/flow/SimpleFIBlackOilModel.hpp
+++ b/opm/simulators/flow/SimpleFIBlackOilModel.hpp
@@ -1,0 +1,203 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \copydoc Opm::FIBlackOilModel
+ */
+#ifndef SIMPLE_FI_BLACK_OIL_MODEL_HPP
+#define SIMPLE_FI_BLACK_OIL_MODEL_HPP
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+#include <opm/models/blackoil/blackoilmodel.hh>
+#include <opm/models/blackoil/blackoilmoduleparams.hh>
+#include <opm/models/parallel/threadmanager.hpp>
+#include <opm/models/utils/propertysystem.hh>
+
+#include <opm/common/ErrorMacros.hpp>
+
+#include <opm/grid/CpGrid.hpp>
+#include <opm/grid/utility/ElementChunks.hpp>
+
+#include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
+
+#include <opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp>
+
+#include <cassert>
+#include <cstddef>
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+/*
+    This file implements a simplified version of the FIBlackOilModel
+    which can be used in a GPU environment.
+    This is developed while parallelizing the tpfa matrix assembly, so
+    only functionality needed there is implemented.
+    To start with this means just being able to access intensiveQuantities.
+*/
+
+namespace Opm
+{
+
+template <typename TypeTag, template <class> class Storage = Opm::VectorWithDefaultAllocator>
+class SimpleFIBlackOilModel
+{
+public:
+    using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
+    using TypeTagPublic = TypeTag;
+    using Scalar = GetPropType<TypeTag, Properties::Scalar>;
+
+    SimpleFIBlackOilModel(
+        const Storage<BlackOilIntensiveQuantities<TypeTag>>& cachedIntensiveQuantities0,
+        const Storage<BlackOilIntensiveQuantities<TypeTag>>& cachedIntensiveQuantities1,
+        const Storage<Scalar>& volumes)
+        : cachedIntensiveQuantities0_(cachedIntensiveQuantities0)
+        , cachedIntensiveQuantities1_(cachedIntensiveQuantities1)
+        , volumes_(volumes)
+    {
+    }
+
+    // Special ctor because fvbasediscretization stores BOIQs with a custom allocator.
+    // OtherIQContainer can be any container (e.g. std::vector with a non-default allocator).
+    // Could this be using refs instead of making the copy? Then the copy-to-gpu would have to be
+    // rewritten a bit
+    template <typename OtherIQContainer>
+    SimpleFIBlackOilModel(const OtherIQContainer& cachedIntensiveQuantities0,
+                          const OtherIQContainer& cachedIntensiveQuantities1,
+                          const Storage<Scalar>& volumes)
+        : cachedIntensiveQuantities0_(cachedIntensiveQuantities0.begin(),
+                                      cachedIntensiveQuantities0.end())
+        , cachedIntensiveQuantities1_(cachedIntensiveQuantities1.begin(),
+                                      cachedIntensiveQuantities1.end())
+        , volumes_(volumes)
+    {
+    }
+
+    SimpleFIBlackOilModel() = delete;
+
+    OPM_HOST_DEVICE Scalar dofTotalVolume(unsigned int globalIdx) const
+    {
+        return volumes_[globalIdx];
+    }
+
+    OPM_HOST_DEVICE const auto& intensiveQuantities(unsigned int globalIdx,
+                                                    unsigned int timeIdx) const
+    {
+        assert(timeIdx == 0
+               || timeIdx
+                   == 1); // TODO: do not use assert for this because it can be run in GPU kernel...
+        if (timeIdx == 0) {
+            return cachedIntensiveQuantities0_[globalIdx];
+        } else {
+            return cachedIntensiveQuantities1_[globalIdx];
+        }
+    }
+
+public:
+    // assumes --enable-storage-cache=false so that we need not worry about updating cpu-caches from
+    // gpu kernels
+    Storage<BlackOilIntensiveQuantities<TypeTag>> cachedIntensiveQuantities0_;
+    Storage<BlackOilIntensiveQuantities<TypeTag>> cachedIntensiveQuantities1_;
+    Storage<Scalar> volumes_;
+};
+
+#if HAVE_CUDA && OPM_IS_COMPILING_WITH_GPU_COMPILER
+namespace gpuistl
+{
+    // For now we make a copy of the simplified CPU model because we need to set the fluid system
+    // pointer without breaking copy semantics
+    template <class TypeTag, typename GpuFluidSystem>
+    auto copy_to_gpu(const SimpleFIBlackOilModel<TypeTag>& cpuModel, const GpuFluidSystem& fsys)
+    {
+        using Scalar = typename SimpleFIBlackOilModel<TypeTag>::Scalar;
+        // In this copy_to_gpu we need to take care of two things:
+        // 1) Copy the cachedIntensiveQuantities_ to GPU (go from vector to GpuBuffer to allocate
+        // things on GPU) 2) Ensure that the FluidSystem pointer inside each IntensiveQuantities
+        // points to a GPU FluidSystem
+        //    The pointer should be set before we move the entire thing to the GPU.
+
+        // set pointers
+        using CorrectTypeTagView =
+            typename ::Opm::Properties::TTag::to_gpu_type_t<TypeTag, GpuView>;
+        using CorrectBOIQ = BlackOilIntensiveQuantities<CorrectTypeTagView>;
+        using SimplifiedGpuBufferModel = SimpleFIBlackOilModel<CorrectTypeTagView, GpuBuffer>;
+
+        assert(cpuModel.cachedIntensiveQuantities0_.size() == cpuModel.cachedIntensiveQuantities1_.size());
+        const std::size_t nCells = cpuModel.cachedIntensiveQuantities0_.size();
+        assert(nCells > 0);
+        // CorrectBOIQ is not default-constructible (non-static FluidSystem requires a pointer at
+        // construction time). To enable parallel fill, we create a prototype from the first element
+        // and use it to pre-size the vector with valid objects, then overwrite in parallel.
+        // Assumption: all cells share the same fsys pointer, so the prototype object is a valid
+        // stand-in until it is overwritten.
+        std::vector<CorrectBOIQ> cpuIntQuantsWithGpuPtr0;
+        std::vector<CorrectBOIQ> cpuIntQuantsWithGpuPtr1;
+        CorrectBOIQ proto0 = cpuModel.cachedIntensiveQuantities0_[0]
+                                    .template withOtherFluidSystem<CorrectTypeTagView>(fsys);
+        CorrectBOIQ proto1 = cpuModel.cachedIntensiveQuantities1_[0]
+                                    .template withOtherFluidSystem<CorrectTypeTagView>(fsys);
+        cpuIntQuantsWithGpuPtr0.resize(nCells, proto0);
+        cpuIntQuantsWithGpuPtr1.resize(nCells, proto1);
+
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+        for (std::size_t i = 1; i < nCells; ++i) {
+            cpuIntQuantsWithGpuPtr0[i]
+                = cpuModel.cachedIntensiveQuantities0_[i]
+                        .template withOtherFluidSystem<CorrectTypeTagView>(fsys);
+            cpuIntQuantsWithGpuPtr1[i]
+                = cpuModel.cachedIntensiveQuantities1_[i]
+                        .template withOtherFluidSystem<CorrectTypeTagView>(fsys);
+        }
+
+        GpuBuffer<CorrectBOIQ> gpuBuf0(cpuIntQuantsWithGpuPtr0);
+        GpuBuffer<CorrectBOIQ> gpuBuf1(cpuIntQuantsWithGpuPtr1);
+        GpuBuffer<Scalar> gpuVolumes(cpuModel.volumes_);
+
+        // create new blackoil model providing a gpubuffer allocated version of the intQuants
+        auto result = SimplifiedGpuBufferModel(
+            std::move(gpuBuf0), std::move(gpuBuf1), std::move(gpuVolumes));
+
+        return result;
+    }
+
+    template <typename LocalTypeTag>
+    auto make_view(SimpleFIBlackOilModel<LocalTypeTag, GpuBuffer>& gpuSimpleFIBlackOilModel)
+    {
+        return SimpleFIBlackOilModel<LocalTypeTag, gpuistl::GpuView>(
+            make_view(gpuSimpleFIBlackOilModel.cachedIntensiveQuantities0_),
+            make_view(gpuSimpleFIBlackOilModel.cachedIntensiveQuantities1_),
+            make_view(gpuSimpleFIBlackOilModel.volumes_));
+    }
+} // namespace gpuistl
+#endif
+
+} // namespace Opm
+
+#endif // SIMPLE_FI_BLACK_OIL_MODEL_HPP

--- a/opm/simulators/flow/ThermalGasWaterFlowProblem.hpp
+++ b/opm/simulators/flow/ThermalGasWaterFlowProblem.hpp
@@ -1,0 +1,125 @@
+/*
+  Copyright 2026 Equinor ASA
+  This file is part of the Open Porous Media project (OPM).
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef THERMAL_GASWATER_FLOW_PROBLEM_HPP
+#define THERMAL_GASWATER_FLOW_PROBLEM_HPP
+
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/utility/VectorWithDefaultAllocator.hpp>
+#include <opm/common/utility/gpuDecorators.hpp>
+#include <opm/common/utility/gpuistl_if_available.hpp>
+
+/*
+    A simple gas-water flow problem with thermal effects that is GPU compatible
+*/
+
+namespace Opm
+{
+
+template <class Scalar, template <class> class Storage = Opm::VectorWithDefaultAllocator>
+class ThermalGasWaterFlowProblem
+{
+public:
+    using ModuleParams = BlackoilModuleParams<ConvectiveMixingModuleParam<Scalar, Storage>>;
+
+    ThermalGasWaterFlowProblem() = default;
+
+    ThermalGasWaterFlowProblem(Storage<Scalar> alpha0,
+                               Storage<Scalar> alpha1,
+                               Storage<Scalar> alpha2,
+                               ModuleParams moduleParams)
+        : alpha0_(alpha0)
+        , alpha1_(alpha1)
+        , alpha2_(alpha2)
+        , moduleParams_(moduleParams)
+    {
+    }
+
+    OPM_HOST_DEVICE Scalar getAlpha(unsigned globalIndex, unsigned boundaryFaceIndex) const
+    {
+        if (boundaryFaceIndex == 0) {
+            return alpha0_[globalIndex];
+        } else if (boundaryFaceIndex == 1) {
+            return alpha1_[globalIndex];
+        } else if (boundaryFaceIndex == 2) {
+            return alpha2_[globalIndex];
+        } else {
+            OPM_THROW(std::logic_error, "Invalid boundary face index");
+        }
+    }
+
+    OPM_HOST_DEVICE const ModuleParams& moduleParams() const
+    {
+        return moduleParams_;
+    }
+    OPM_HOST_DEVICE ModuleParams& moduleParams()
+    {
+        return moduleParams_;
+    }
+
+    Storage<Scalar>& alpha0()
+    {
+        return alpha0_;
+    }
+
+    Storage<Scalar>& alpha1()
+    {
+        return alpha1_;
+    }
+
+    Storage<Scalar>& alpha2()
+    {
+        return alpha2_;
+    }
+
+private:
+    Storage<Scalar> alpha0_;
+    Storage<Scalar> alpha1_;
+    Storage<Scalar> alpha2_;
+    ModuleParams moduleParams_;
+};
+
+namespace gpuistl
+{
+
+    template <class Scalar>
+    ThermalGasWaterFlowProblem<Scalar, GpuBuffer>
+    copy_to_gpu(ThermalGasWaterFlowProblem<Scalar, Opm::VectorWithDefaultAllocator>& cpuProblem)
+    {
+        using ModuleParams = BlackoilModuleParams<ConvectiveMixingModuleParam<Scalar, GpuBuffer>>;
+        return ThermalGasWaterFlowProblem<Scalar, GpuBuffer>(
+            GpuBuffer<Scalar>(cpuProblem.alpha0()),
+            GpuBuffer<Scalar>(cpuProblem.alpha1()),
+            GpuBuffer<Scalar>(cpuProblem.alpha2()),
+            ModuleParams {copy_to_gpu(cpuProblem.moduleParams().convectiveMixingModuleParam)});
+    }
+
+    template <class Scalar>
+    ThermalGasWaterFlowProblem<Scalar, GpuView>
+    make_view(ThermalGasWaterFlowProblem<Scalar, GpuBuffer>& buffer)
+    {
+        using ModuleParams = BlackoilModuleParams<ConvectiveMixingModuleParam<Scalar, GpuView>>;
+        return ThermalGasWaterFlowProblem<Scalar, GpuView>(
+            make_view(buffer.alpha0()),
+            make_view(buffer.alpha1()),
+            make_view(buffer.alpha2()),
+            ModuleParams {make_view(buffer.moduleParams().convectiveMixingModuleParam)});
+    }
+
+} // namespace gpuistl
+
+} // namespace Opm
+
+#endif // THERMAL_GASWATER_FLOW_PROBLEM_HPP

--- a/opm/simulators/flow/Transmissibility.hpp
+++ b/opm/simulators/flow/Transmissibility.hpp
@@ -102,6 +102,8 @@ public:
 
     Scalar thermalHalfTransBoundary(unsigned insideElemIdx, unsigned boundaryFaceIdx) const;
 
+    const std::map<std::pair<unsigned, unsigned>, Scalar>& getThermalHalfTransBoundary() const;
+
     /*!
      * \brief Return the diffusivity for the intersection between two elements.
      */

--- a/opm/simulators/flow/Transmissibility_impl.hpp
+++ b/opm/simulators/flow/Transmissibility_impl.hpp
@@ -146,6 +146,13 @@ thermalHalfTransBoundary(unsigned insideElemIdx, unsigned boundaryFaceIdx) const
 }
 
 template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>
+const std::map<std::pair<unsigned, unsigned>, Scalar>& Transmissibility<Grid,GridView,ElementMapper,CartesianIndexMapper,Scalar>::
+getThermalHalfTransBoundary() const
+{
+    return thermalHalfTransBoundary_;
+}
+
+template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>
 Scalar Transmissibility<Grid,GridView,ElementMapper,CartesianIndexMapper,Scalar>::
 diffusivity(unsigned elemIdx1, unsigned elemIdx2) const
 {

--- a/opm/simulators/linalg/gpuistl/GpuBuffer.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuBuffer.hpp
@@ -88,6 +88,42 @@ public:
     }
 
     /**
+     * @brief Move constructor: transfers ownership of GPU memory without copying.
+     *
+     * The source buffer is left in a valid, empty state (size 0, null pointer) so
+     * that its destructor's cudaFree(nullptr) is a harmless no-op.
+     *
+     * @param other the GpuBuffer to move from
+     */
+    GpuBuffer(GpuBuffer<T>&& other) noexcept
+        : m_dataOnDevice(other.m_dataOnDevice)
+        , m_numberOfElements(other.m_numberOfElements)
+    {
+        other.m_dataOnDevice = nullptr;
+        other.m_numberOfElements = 0;
+    }
+
+    /**
+     * @brief Move assignment: frees current GPU memory, then takes ownership from other.
+     *
+     * The source buffer is left in a valid, empty state after the transfer.
+     *
+     * @param other the GpuBuffer to move from
+     * @return *this
+     */
+    GpuBuffer<T>& operator=(GpuBuffer<T>&& other) noexcept
+    {
+        if (this != &other) {
+            OPM_GPU_WARN_IF_ERROR(cudaFree(m_dataOnDevice));
+            m_dataOnDevice = other.m_dataOnDevice;
+            m_numberOfElements = other.m_numberOfElements;
+            other.m_dataOnDevice = nullptr;
+            other.m_numberOfElements = 0;
+        }
+        return *this;
+    }
+
+    /**
      * @brief GpuBuffer allocates new GPU memory of the same size as data and copies the content of the data vector to
      * this newly allocated memory.
      *

--- a/opm/simulators/linalg/gpuistl/GpuView.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuView.hpp
@@ -80,7 +80,7 @@ public:
      *
      * @param idx The index of the element
      */
-    __host__ __device__ T operator[](size_t idx) const {
+    __host__ __device__ const T& operator[](size_t idx) const {
 #ifndef NDEBUG
         assertInRange(idx);
 #endif

--- a/opm/simulators/linalg/gpuistl/MiniVector.hpp
+++ b/opm/simulators/linalg/gpuistl/MiniVector.hpp
@@ -181,6 +181,12 @@ public:
         return Dimension;
     }
 
+    /** @return Always \c false; a fixed‑size vector is never empty. */
+    OPM_HOST_DEVICE static constexpr bool empty() noexcept
+    {
+        return Dimension == 0;
+    }
+
 
     /**
      * @brief Fill every component with the supplied value.

--- a/opm/simulators/linalg/gpuistl/detail/gpusparse_matrix_operations.cu
+++ b/opm/simulators/linalg/gpuistl/detail/gpusparse_matrix_operations.cu
@@ -21,6 +21,7 @@
 #include <opm/simulators/linalg/gpuistl/detail/gpusparse_matrix_operations.hpp>
 #include <opm/simulators/linalg/gpuistl/detail/deviceBlockOperations.hpp>
 #include <opm/simulators/linalg/gpuistl/detail/gpuThreadUtils.hpp>
+#include <opm/simulators/linalg/gpuistl/MiniMatrix.hpp>
 
 namespace Opm::gpuistl::detail
 {
@@ -97,13 +98,13 @@ namespace
         }
     }
 
-    template <class T>
-    __global__ void cuComputeDiagPtrs(const int* rowIndices,
-                                      const int* colIndices,
-                                      int rows,
-                                      T** diagPtrs,
-                                      T* values,
-                                      size_t blocksize)
+    template <class MatrixBlockType, class T>
+    __global__ void cuComputeDiagPtrsTyped(const int* rowIndices,
+                                           const int* colIndices,
+                                           int rows,
+                                           MatrixBlockType** diagPtrs,
+                                           T* values,
+                                           size_t blocksize)
     {
         const auto rawIdx = blockDim.x * blockIdx.x + threadIdx.x;
         if (rawIdx < rows) {
@@ -114,8 +115,7 @@ namespace
                 ++diagIdx;
             }
 
-            // Pointer arithmetic based on first element is sufficient here
-            diagPtrs[rawIdx] = values + diagIdx*blocksize*blocksize;
+            diagPtrs[rawIdx] = reinterpret_cast<MatrixBlockType*>(values + diagIdx * blocksize * blocksize);
         }
     }
 } // namespace
@@ -166,23 +166,6 @@ copyMatDataToReorderedSplit(const T* srcMatrix,
                                                                                  numberOfRows);
 }
 
-template <class T>
-GpuBuffer<T*>
-getDiagPtrs(GpuSparseMatrixWrapper<T>& matrix)
-{
-    GpuBuffer<T*> diagPtrs(matrix.N());
-
-    // Have cuda/hip automatically pick a reasonable block size for this kernel based on static analysis
-    int threadBlockSize = ::Opm::gpuistl::detail::getCudaRecomendedThreadBlockSize(cuComputeDiagPtrs<T>);
-    // Calculate the number of blocks needed
-    int nThreadBlocks = ::Opm::gpuistl::detail::getNumberOfBlocks(matrix.N(), threadBlockSize);
-
-    cuComputeDiagPtrs<T>
-        <<<nThreadBlocks, threadBlockSize>>>(
-            matrix->getRowIndices().data(), matrix->getColumnIndices().data(), matrix.N(), diagPtrs.data(), matrix->getNonZeroValues().data(), matrix.blockSize());
-    return diagPtrs;
-}
-
 #define INSTANTIATE_KERNEL_WRAPPERS_WITH_SCALAR_AND_BLOCKSIZE(T, blocksize)                                                                      \
     template void copyMatDataToReordered<T, blocksize>(const T*, const int*, T*, int*, int*, size_t, int);                         \
     template void copyMatDataToReorderedSplit<T, blocksize>(const T*, const int*, const int*, T*, int*, T*, int*, T*, int*, size_t, int);
@@ -202,11 +185,46 @@ INSTANTIATE_KERNEL_WRAPPERS_WITH_SCALAR_AND_BLOCKSIZE(double, 5);
 INSTANTIATE_KERNEL_WRAPPERS_WITH_SCALAR_AND_BLOCKSIZE(double, 6);
 INSTANTIATE_KERNEL_WRAPPERS_WITH_SCALAR_AND_BLOCKSIZE(double, 7);
 
-#define INSTANTIATE_KERNEL_WRAPPER_WITH_SCALAR(T) \
-    template Opm::gpuistl::GpuBuffer<T*> Opm::gpuistl::detail::getDiagPtrs<T>(                           \
+template <class MatrixBlockType, class T>
+GpuBuffer<MatrixBlockType*>
+getDiagPtrsTyped(GpuSparseMatrixWrapper<T>& matrix)
+{
+    GpuBuffer<MatrixBlockType*> diagPtrs(matrix.N());
+
+    int threadBlockSize = ::Opm::gpuistl::detail::getCudaRecomendedThreadBlockSize(cuComputeDiagPtrsTyped<MatrixBlockType, T>);
+    int nThreadBlocks = ::Opm::gpuistl::detail::getNumberOfBlocks(matrix.N(), threadBlockSize);
+
+    cuComputeDiagPtrsTyped<MatrixBlockType, T>
+        <<<nThreadBlocks, threadBlockSize>>>(
+            matrix->getRowIndices().data(), matrix->getColumnIndices().data(), matrix.N(),
+            diagPtrs.data(), matrix->getNonZeroValues().data(), matrix.blockSize());
+    return diagPtrs;
+}
+
+#define INSTANTIATE_GET_DIAG_PTRS_TYPED(T, blocksize) \
+    template Opm::gpuistl::GpuBuffer<Opm::gpuistl::MiniMatrix<T, blocksize>*>                \
+    Opm::gpuistl::detail::getDiagPtrsTyped<Opm::gpuistl::MiniMatrix<T, blocksize>, T>(        \
         Opm::gpuistl::GpuSparseMatrixWrapper<T>&);
 
-INSTANTIATE_KERNEL_WRAPPER_WITH_SCALAR(float)
-INSTANTIATE_KERNEL_WRAPPER_WITH_SCALAR(double)
+INSTANTIATE_GET_DIAG_PTRS_TYPED(float, 1)
+INSTANTIATE_GET_DIAG_PTRS_TYPED(float, 2)
+INSTANTIATE_GET_DIAG_PTRS_TYPED(float, 3)
+INSTANTIATE_GET_DIAG_PTRS_TYPED(float, 4)
+INSTANTIATE_GET_DIAG_PTRS_TYPED(float, 5)
+INSTANTIATE_GET_DIAG_PTRS_TYPED(float, 6)
+INSTANTIATE_GET_DIAG_PTRS_TYPED(float, 7)
+INSTANTIATE_GET_DIAG_PTRS_TYPED(double, 1)
+INSTANTIATE_GET_DIAG_PTRS_TYPED(double, 2)
+INSTANTIATE_GET_DIAG_PTRS_TYPED(double, 3)
+INSTANTIATE_GET_DIAG_PTRS_TYPED(double, 4)
+INSTANTIATE_GET_DIAG_PTRS_TYPED(double, 5)
+INSTANTIATE_GET_DIAG_PTRS_TYPED(double, 6)
+INSTANTIATE_GET_DIAG_PTRS_TYPED(double, 7)
+
+#define INSTANTIATE_GET_DIAG_PTRS(T) \
+    template Opm::gpuistl::GpuBuffer<T*> Opm::gpuistl::detail::getDiagPtrsTyped<T, T>(GpuSparseMatrixWrapper<T>&);
+
+INSTANTIATE_GET_DIAG_PTRS(float)
+INSTANTIATE_GET_DIAG_PTRS(double)
 
 } // namespace Opm::gpuistl::detail

--- a/opm/simulators/linalg/gpuistl/detail/gpusparse_matrix_operations.hpp
+++ b/opm/simulators/linalg/gpuistl/detail/gpusparse_matrix_operations.hpp
@@ -78,12 +78,18 @@ void copyMatDataToReorderedSplit(const T* srcMatrix,
                                  int threadBlockSize);
 
 /**
- * @brief Return the pointers to diagonal elements in a GpuBuffer
+ * @brief Return typed pointers to diagonal block elements in a GpuBuffer
+ *
+ * Like getDiagPtrs, but returns pointers typed as MatrixBlockType* instead of T*,
+ * avoiding the need for reinterpret_cast at the call sites.
+ *
+ * @tparam MatrixBlockType The block matrix type (e.g. MiniMatrix<T, N>) whose size
+ *         must match T[blockSize^2] in the underlying storage.
  * @param matrix The matrix to extract diagonal pointers from
- * @return GpuBuffer containing pointers to the diagonal elements
+ * @return GpuBuffer containing typed pointers to the diagonal block elements
  */
-template <class T>
-GpuBuffer<T*> getDiagPtrs(GpuSparseMatrixWrapper<T>& matrix);
+template <class MatrixBlockType, class T>
+GpuBuffer<MatrixBlockType*> getDiagPtrsTyped(GpuSparseMatrixWrapper<T>& matrix);
 
 } // namespace Opm::gpuistl::detail
 

--- a/tests/gpuistl/test_GpuSparseMatrix.cu
+++ b/tests/gpuistl/test_GpuSparseMatrix.cu
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(TestGetDiagPtrs)
     BOOST_CHECK_EQUAL(cpuValues[4], 5.0);
     BOOST_CHECK_EQUAL(cpuValues[5], 6.0);
 
-    auto diagPtrs = Opm::gpuistl::detail::getDiagPtrs(gpuSparseMatrix);
+    auto diagPtrs = Opm::gpuistl::detail::getDiagPtrsTyped<double>(gpuSparseMatrix);
     auto diagPtrsView = Opm::gpuistl::GpuView<double*>(diagPtrs.data(), diagPtrs.size());
 
     auto d_result = Opm::gpuistl::make_gpu_unique_ptr<std::array<double, 3>>({-1});
@@ -199,12 +199,12 @@ __global__ void checkDiagBlocksKernel (double** diagPtrs, std::array<double, 12>
         (*values)[1] = diagPtrs[0][1];  // B[0][0][0][1]
         (*values)[2] = diagPtrs[0][2];  // B[0][0][1][0]
         (*values)[3] = diagPtrs[0][3];  // B[0][0][1][1]
-        
+
         (*values)[4] = diagPtrs[1][0];  // B[1][1][0][0]
         (*values)[5] = diagPtrs[1][1];  // B[1][1][0][1]
         (*values)[6] = diagPtrs[1][2];  // B[1][1][1][0]
         (*values)[7] = diagPtrs[1][3];  // B[1][1][1][1]
-        
+
         (*values)[8] = diagPtrs[2][0];  // B[2][2][0][0]
         (*values)[9] = diagPtrs[2][1];  // B[2][2][0][1]
         (*values)[10] = diagPtrs[2][2]; // B[2][2][1][0]
@@ -251,27 +251,27 @@ BOOST_AUTO_TEST_CASE(TestGetDiagPtrsBlockedNonScalar)
     B[0][0][0][1] = 1.1;
     B[0][0][1][0] = 1.2;
     B[0][0][1][1] = 1.3;
-    
+
     B[0][1][0][0] = 2.0;
     B[0][1][0][1] = 2.1;
     B[0][1][1][0] = 2.2;
     B[0][1][1][1] = 2.3;
-    
+
     B[0][2][0][0] = 3.0;
     B[0][2][0][1] = 3.1;
     B[0][2][1][0] = 3.2;
     B[0][2][1][1] = 3.3;
-    
+
     B[1][1][0][0] = 4.0;
     B[1][1][0][1] = 4.1;
     B[1][1][1][0] = 4.2;
     B[1][1][1][1] = 4.3;
-    
+
     B[2][0][0][0] = 5.0;
     B[2][0][0][1] = 5.1;
     B[2][0][1][0] = 5.2;
     B[2][0][1][1] = 5.3;
-    
+
     B[2][2][0][0] = 6.0;
     B[2][2][0][1] = 6.1;
     B[2][2][1][0] = 6.2;
@@ -279,8 +279,8 @@ BOOST_AUTO_TEST_CASE(TestGetDiagPtrsBlockedNonScalar)
 
     auto gpuSparseMatrix = Opm::gpuistl::GpuSparseMatrixWrapper<double>::fromMatrix(B);
 
-    auto diagPtrs = Opm::gpuistl::detail::getDiagPtrs(gpuSparseMatrix);
-    
+    auto diagPtrs = Opm::gpuistl::detail::getDiagPtrsTyped<double>(gpuSparseMatrix);
+
     // Check that we have the correct number of diagonal pointers
     BOOST_CHECK_EQUAL(diagPtrs.size(), N);
 
@@ -291,18 +291,18 @@ BOOST_AUTO_TEST_CASE(TestGetDiagPtrsBlockedNonScalar)
     checkDiagBlocksKernel<<<1, 1>>>(diagPtrsView.data(), d_result.get());
 
     std::array<double, 12> h_result = Opm::gpuistl::copyFromGPU(d_result);
-    
+
     // Verify diagonal block elements
     BOOST_CHECK_EQUAL(h_result[0], 1.0);
     BOOST_CHECK_EQUAL(h_result[1], 1.1);
     BOOST_CHECK_EQUAL(h_result[2], 1.2);
     BOOST_CHECK_EQUAL(h_result[3], 1.3);
-    
+
     BOOST_CHECK_EQUAL(h_result[4], 4.0);
     BOOST_CHECK_EQUAL(h_result[5], 4.1);
     BOOST_CHECK_EQUAL(h_result[6], 4.2);
     BOOST_CHECK_EQUAL(h_result[7], 4.3);
-    
+
     BOOST_CHECK_EQUAL(h_result[8], 6.0);
     BOOST_CHECK_EQUAL(h_result[9], 6.1);
     BOOST_CHECK_EQUAL(h_result[10], 6.2);


### PR DESCRIPTION
The GPU assembly support extracted from https://github.com/OPM/opm-simulators/pull/7018
Still contains more code than necessary from that branch to support the assembly, but the goal is to reduce this PR to be as small as possible yet support the new GPU linearization.