### PR TITLE
faster checking of blackout cases

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -11,6 +11,183 @@
 # Define some paths
 set(BASE_RESULT_PATH ${PROJECT_BINARY_DIR}/tests/results)
 
+# Select which executable should be used for blackoil cases that currently
+# register the generic flow simulator.
+set(OPM_BLACKOIL_TEST_SIMULATOR "flow" CACHE STRING
+    "Simulator executable used for blackoil test cases")
+set_property(CACHE OPM_BLACKOIL_TEST_SIMULATOR PROPERTY STRINGS flow flow_blackoil)
+
+set(OPM_BLACKOIL_ALLOWED_RUNSPEC_MODEL_KEYWORDS
+  OIL GAS WATER DISGAS DISOIL VAPOIL)
+set(OPM_BLACKOIL_DISALLOWED_RUNSPEC_MODEL_KEYWORDS
+  COMPS DISGASW VAPWAT TEMP THERMAL BRINE PRECSALT POLYMER FOAM SOLVENT WSOLVENT
+  CO2SOL H2SOL CO2STORE H2STORE MICP DIFFUSE MECH)
+
+function(get_blackoil_reference_simulator simulator reference_simulator_var)
+  if("${simulator}" STREQUAL "${OPM_BLACKOIL_TEST_SIMULATOR}")
+    set(${reference_simulator_var} "flow" PARENT_SCOPE)
+  else()
+    set(${reference_simulator_var} "${simulator}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+function(resolve_test_deck_file deck_dir deck_name resolved_deck_var)
+  set(deck_root "${OPM_TESTS_ROOT}/${deck_dir}")
+  foreach(suffix "" ".DATA" ".data" ".BASE" ".base" ".INC" ".inc")
+    set(candidate "${deck_root}/${deck_name}${suffix}")
+    if(EXISTS "${candidate}")
+      set(${resolved_deck_var} "${candidate}" PARENT_SCOPE)
+      return()
+    endif()
+  endforeach()
+  set(${resolved_deck_var} "" PARENT_SCOPE)
+endfunction()
+
+function(collect_runspec_blackoil_keywords deck_path inherited_section visited_var keywords_var)
+  get_filename_component(abs_deck "${deck_path}" ABSOLUTE)
+  set(visited ${${visited_var}})
+  list(FIND visited "${abs_deck}" visited_index)
+  if(NOT visited_index EQUAL -1)
+    set(${visited_var} "${visited}" PARENT_SCOPE)
+    set(${keywords_var} "" PARENT_SCOPE)
+    return()
+  endif()
+
+  list(APPEND visited "${abs_deck}")
+  if(NOT EXISTS "${abs_deck}")
+    set(${visited_var} "${visited}" PARENT_SCOPE)
+    set(${keywords_var} "" PARENT_SCOPE)
+    return()
+  endif()
+
+  file(READ "${abs_deck}" deck_content)
+  string(REGEX REPLACE "--[^\n]*" "" deck_content "${deck_content}")
+  string(REGEX MATCHALL "'[^']*'|\"[^\"]*\"|/|[^ \t\r\n/]+" tokens "${deck_content}")
+
+  set(current_section "${inherited_section}")
+  set(local_keywords "")
+  list(LENGTH tokens token_count)
+  set(index 0)
+
+  while(index LESS token_count)
+    list(GET tokens ${index} token)
+    if(token STREQUAL "/")
+      math(EXPR index "${index} + 1")
+      continue()
+    endif()
+
+    string(REGEX REPLACE "^[\"']|[\"']$" "" bare_token "${token}")
+    string(TOUPPER "${bare_token}" upper_token)
+
+    if(upper_token STREQUAL "RUNSPEC" OR
+       upper_token STREQUAL "GRID" OR
+       upper_token STREQUAL "EDIT" OR
+       upper_token STREQUAL "PROPS" OR
+       upper_token STREQUAL "REGIONS" OR
+       upper_token STREQUAL "SOLUTION" OR
+       upper_token STREQUAL "SUMMARY" OR
+       upper_token STREQUAL "SCHEDULE")
+      set(current_section "${upper_token}")
+      math(EXPR index "${index} + 1")
+      continue()
+    endif()
+
+    if(current_section STREQUAL "RUNSPEC" AND upper_token STREQUAL "INCLUDE")
+      math(EXPR index "${index} + 1")
+      while(index LESS token_count)
+        list(GET tokens ${index} include_token)
+        if(include_token STREQUAL "/")
+          break()
+        endif()
+
+        string(REGEX REPLACE "^[\"']|[\"']$" "" include_name "${include_token}")
+        if(NOT include_name MATCHES "[$<>]")
+          get_filename_component(deck_dirname "${abs_deck}" DIRECTORY)
+          if(IS_ABSOLUTE "${include_name}")
+            set(include_path "${include_name}")
+          else()
+            set(include_path "${deck_dirname}/${include_name}")
+          endif()
+          if(EXISTS "${include_path}")
+            collect_runspec_blackoil_keywords("${include_path}" "${current_section}" visited include_keywords)
+            list(APPEND local_keywords ${include_keywords})
+          endif()
+        endif()
+
+        math(EXPR index "${index} + 1")
+      endwhile()
+      math(EXPR index "${index} + 1")
+      continue()
+    endif()
+
+    if(current_section STREQUAL "RUNSPEC")
+      list(FIND OPM_BLACKOIL_ALLOWED_RUNSPEC_MODEL_KEYWORDS "${upper_token}" allowed_index)
+      list(FIND OPM_BLACKOIL_DISALLOWED_RUNSPEC_MODEL_KEYWORDS "${upper_token}" disallowed_index)
+      if(NOT "${allowed_index}" STREQUAL "-1" OR NOT "${disallowed_index}" STREQUAL "-1")
+        list(APPEND local_keywords "${upper_token}")
+      endif()
+    endif()
+
+    math(EXPR index "${index} + 1")
+  endwhile()
+
+  list(REMOVE_DUPLICATES local_keywords)
+  set(${visited_var} "${visited}" PARENT_SCOPE)
+  set(${keywords_var} "${local_keywords}" PARENT_SCOPE)
+endfunction()
+
+function(test_supports_blackoil_simulator deck_dir deck_name supports_var)
+  resolve_test_deck_file("${deck_dir}" "${deck_name}" resolved_deck)
+  if(NOT resolved_deck)
+    set(${supports_var} FALSE PARENT_SCOPE)
+    return()
+  endif()
+
+  set(visited "")
+  collect_runspec_blackoil_keywords("${resolved_deck}" "" visited keywords)
+  foreach(phase IN ITEMS OIL GAS WATER)
+    list(FIND keywords "${phase}" phase_index)
+    if(phase_index EQUAL -1)
+      set(${supports_var} FALSE PARENT_SCOPE)
+      return()
+    endif()
+  endforeach()
+
+  foreach(disallowed_keyword IN LISTS OPM_BLACKOIL_DISALLOWED_RUNSPEC_MODEL_KEYWORDS)
+    list(FIND keywords "${disallowed_keyword}" disallowed_index)
+    if(NOT disallowed_index EQUAL -1)
+      set(${supports_var} FALSE PARENT_SCOPE)
+      return()
+    endif()
+  endforeach()
+
+  set(${supports_var} TRUE PARENT_SCOPE)
+endfunction()
+
+function(resolve_blackoil_test_simulator simulator is_blackoil_data resolved_simulator_var)
+  if(("${simulator}" STREQUAL "flow" OR "${simulator}" STREQUAL "flow_blackoil") AND NOT ${is_blackoil_data})
+    set(${resolved_simulator_var} "flow" PARENT_SCOPE)
+  else()
+    set(${resolved_simulator_var} "${simulator}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+function(resolve_unlabeled_test_simulator simulator resolved_simulator_var)
+  if("${simulator}" STREQUAL "flow" OR "${simulator}" STREQUAL "flow_blackoil")
+    set(${resolved_simulator_var} "flow" PARENT_SCOPE)
+  else()
+    set(${resolved_simulator_var} "${simulator}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+function(label_blackoil_test test_name simulator is_blackoil)
+  if(${is_blackoil})
+    if("${simulator}" STREQUAL "flow" OR "${simulator}" STREQUAL "flow_blackoil")
+      set_property(TEST ${test_name} APPEND PROPERTY LABELS ${ARGN})
+    endif()
+  endif()
+endfunction()
+
 ###########################################################################
 # TEST: runSim
 ###########################################################################
@@ -27,7 +204,8 @@ function(add_test_runSimulator)
   if(NOT PARAM_DIR)
     set(PARAM_DIR ${PARAM_CASENAME})
   endif()
-  set(RESULT_PATH ${BASE_RESULT_PATH}${PARAM_DIR_PREFIX}/${PARAM_SIMULATOR}+${PARAM_CASENAME})
+  resolve_unlabeled_test_simulator("${PARAM_SIMULATOR}" TEST_SIMULATOR)
+  set(RESULT_PATH ${BASE_RESULT_PATH}${PARAM_DIR_PREFIX}/${TEST_SIMULATOR}+${PARAM_CASENAME})
   set(TEST_ARGS ${PARAM_TEST_ARGS})
   set(DRIVER_ARGS -i ${OPM_TESTS_ROOT}/${PARAM_DIR}
                   -r ${RESULT_PATH}
@@ -40,7 +218,7 @@ function(add_test_runSimulator)
    list(APPEND DRIVER_ARGS -p "${PARAM_POST_COMMAND}")
  endif()
   opm_add_test(runSimulator/${PARAM_CASENAME} NO_COMPILE
-               EXE_NAME ${PARAM_SIMULATOR}
+            EXE_NAME ${TEST_SIMULATOR}
                DRIVER_ARGS ${DRIVER_ARGS}
                TEST_ARGS ${TEST_ARGS}
                CONFIGURATION ${PARAM_CONFIGURATION})
@@ -68,7 +246,12 @@ function(add_test_compareECLFiles)
   if(NOT PARAM_PREFIX)
     set(PARAM_PREFIX compareECLFiles)
   endif()
-  set(RESULT_PATH ${BASE_RESULT_PATH}${PARAM_DIR_PREFIX}/${PARAM_SIMULATOR}+${PARAM_CASENAME})
+
+  test_supports_blackoil_simulator("${PARAM_DIR}" "${PARAM_FILENAME}" IS_BLACKOIL_DATA)
+  resolve_blackoil_test_simulator("${PARAM_SIMULATOR}" ${IS_BLACKOIL_DATA} TEST_SIMULATOR)
+  get_blackoil_reference_simulator("${TEST_SIMULATOR}" REFERENCE_SIMULATOR)
+
+  set(RESULT_PATH ${BASE_RESULT_PATH}${PARAM_DIR_PREFIX}/${TEST_SIMULATOR}+${PARAM_CASENAME})
   set(TEST_ARGS ${PARAM_TEST_ARGS})
   set(DRIVER_ARGS -i ${OPM_TESTS_ROOT}/${PARAM_DIR}
                   -r ${RESULT_PATH}
@@ -77,22 +260,29 @@ function(add_test_compareECLFiles)
                   -a ${PARAM_ABS_TOL}
                   -t ${PARAM_REL_TOL}
                   -c $<TARGET_FILE:compareECL>
-                  -d $<TARGET_FILE:rst_deck>)
+                  -d $<TARGET_FILE:rst_deck>
+                  -u ${REFERENCE_SIMULATOR})
   if(PARAM_RESTART_STEP)
     list(APPEND DRIVER_ARGS -s ${PARAM_RESTART_STEP})
   endif()
   if(PARAM_RESTART_SCHED STREQUAL "false" OR PARAM_RESTART_SCHED STREQUAL "true")
     list(APPEND DRIVER_ARGS -h ${PARAM_RESTART_SCHED})
   endif()
-  opm_add_test(${PARAM_PREFIX}_${PARAM_SIMULATOR}+${PARAM_FILENAME} NO_COMPILE
-               EXE_NAME ${PARAM_SIMULATOR}
+  opm_add_test(${PARAM_PREFIX}_${TEST_SIMULATOR}+${PARAM_FILENAME} NO_COMPILE
+               EXE_NAME ${TEST_SIMULATOR}
                DRIVER_ARGS ${DRIVER_ARGS}
                TEST_ARGS ${TEST_ARGS})
-  set_tests_properties(${PARAM_PREFIX}_${PARAM_SIMULATOR}+${PARAM_FILENAME} PROPERTIES
+  set_tests_properties(${PARAM_PREFIX}_${TEST_SIMULATOR}+${PARAM_FILENAME} PROPERTIES
                         DIRNAME ${PARAM_DIR}
                         FILENAME ${PARAM_FILENAME}
-                        SIMULATOR ${PARAM_SIMULATOR}
+                        SIMULATOR ${TEST_SIMULATOR}
                         TESTNAME ${PARAM_CASENAME})
+
+  if(PARAM_PREFIX STREQUAL "compareECLFiles")
+    label_blackoil_test(${PARAM_PREFIX}_${TEST_SIMULATOR}+${PARAM_FILENAME} "${TEST_SIMULATOR}" ${IS_BLACKOIL_DATA} blackoil blackoil-regression)
+  elseif(PARAM_PREFIX STREQUAL "compareECLInitFiles" OR PARAM_PREFIX STREQUAL "comparePORV")
+    label_blackoil_test(${PARAM_PREFIX}_${TEST_SIMULATOR}+${PARAM_FILENAME} "${TEST_SIMULATOR}" ${IS_BLACKOIL_DATA} blackoil blackoil-reference)
+  endif()
 endfunction()
 
 ###########################################################################
@@ -121,7 +311,17 @@ function(add_test_compareSeparateECLFiles)
   if(NOT PARAM_DIR)
     set(PARAM_DIR ${PARAM_CASENAME})
   endif()
-  set(RESULT_PATH ${BASE_RESULT_PATH}${PARAM_DIR_PREFIX}/${PARAM_SIMULATOR}+${PARAM_CASENAME})
+
+  test_supports_blackoil_simulator("${PARAM_DIR1}" "${PARAM_FILENAME1}" IS_BLACKOIL_DATA_1)
+  test_supports_blackoil_simulator("${PARAM_DIR2}" "${PARAM_FILENAME2}" IS_BLACKOIL_DATA_2)
+  if(IS_BLACKOIL_DATA_1 AND IS_BLACKOIL_DATA_2)
+    set(IS_BLACKOIL_DATA TRUE)
+  else()
+    set(IS_BLACKOIL_DATA FALSE)
+  endif()
+  resolve_blackoil_test_simulator("${PARAM_SIMULATOR}" ${IS_BLACKOIL_DATA} TEST_SIMULATOR)
+
+  set(RESULT_PATH ${BASE_RESULT_PATH}${PARAM_DIR_PREFIX}/${TEST_SIMULATOR}+${PARAM_CASENAME})
   set(TEST_ARGS ${PARAM_TEST_ARGS})
   set(DRIVER_ARGS -i ${OPM_TESTS_ROOT}/${PARAM_DIR1}
                   -j ${OPM_TESTS_ROOT}/${PARAM_DIR2}
@@ -136,20 +336,24 @@ function(add_test_compareSeparateECLFiles)
   if(PARAM_IGNORE_EXTRA_KW)
     list(APPEND DRIVER_ARGS -y ${PARAM_IGNORE_EXTRA_KW})
   endif()
-  opm_add_test(${PARAM_PREFIX}_${PARAM_SIMULATOR}+${PARAM_CASENAME} NO_COMPILE
-               EXE_NAME ${PARAM_SIMULATOR}
+  opm_add_test(${PARAM_PREFIX}_${TEST_SIMULATOR}+${PARAM_CASENAME} NO_COMPILE
+               EXE_NAME ${TEST_SIMULATOR}
                DRIVER_ARGS ${DRIVER_ARGS}
                TEST_ARGS ${TEST_ARGS})
-  set_tests_properties(${PARAM_PREFIX}_${PARAM_SIMULATOR}+${PARAM_CASENAME} PROPERTIES
+  set_tests_properties(${PARAM_PREFIX}_${TEST_SIMULATOR}+${PARAM_CASENAME} PROPERTIES
                         DIRNAME ${PARAM_DIR}
                         FILENAME1 ${PARAM_FILENAME1}
                         FILENAME2 ${PARAM_FILENAME2}
-                        SIMULATOR ${PARAM_SIMULATOR}
+                        SIMULATOR ${TEST_SIMULATOR}
                         TESTNAME ${PARAM_CASENAME}
                         PROCESSORS ${MPI_PROCS})
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.22)
-    set_tests_properties(${PARAM_PREFIX}_${PARAM_SIMULATOR}+${PARAM_CASENAME} PROPERTIES
+    set_tests_properties(${PARAM_PREFIX}_${TEST_SIMULATOR}+${PARAM_CASENAME} PROPERTIES
                          ENVIRONMENT_MODIFICATION PYTHONPATH=path_list_append:${opm-common_DIR}/python)
+  endif()
+
+  if(IS_BLACKOIL_DATA)
+    label_blackoil_test(${PARAM_PREFIX}_${TEST_SIMULATOR}+${PARAM_CASENAME} "${TEST_SIMULATOR}" TRUE blackoil blackoil-comparison)
   endif()
 endfunction()
 
@@ -170,15 +374,19 @@ function(add_test_compare_restarted_simulation)
   if(NOT PARAM_DIR)
     set(PARAM_DIR ${PARAM_CASENAME})
   endif()
+
+  test_supports_blackoil_simulator("${PARAM_DIR}" "${PARAM_FILENAME}" IS_BLACKOIL_DATA)
+  resolve_blackoil_test_simulator("${PARAM_SIMULATOR}" ${IS_BLACKOIL_DATA} TEST_SIMULATOR)
+
   if (PARAM_TEST_NAME)
     set(TEST_NAME ${PARAM_TEST_NAME})
   else()
-    set(TEST_NAME compareRestartedSim_${PARAM_SIMULATOR}+${PARAM_FILENAME})
+    set(TEST_NAME compareRestartedSim_${TEST_SIMULATOR}+${PARAM_FILENAME})
   endif()
 
-  set(RESULT_PATH ${BASE_RESULT_PATH}/restart/${PARAM_SIMULATOR}+${PARAM_CASENAME})
+  set(RESULT_PATH ${BASE_RESULT_PATH}/restart/${TEST_SIMULATOR}+${PARAM_CASENAME})
   opm_add_test(${TEST_NAME} NO_COMPILE
-               EXE_NAME ${PARAM_SIMULATOR}
+               EXE_NAME ${TEST_SIMULATOR}
                DRIVER_ARGS -i ${OPM_TESTS_ROOT}/${PARAM_DIR}
                            -r ${RESULT_PATH}
                            -b ${PROJECT_BINARY_DIR}/bin
@@ -189,6 +397,8 @@ function(add_test_compare_restarted_simulation)
                            -d $<TARGET_FILE:rst_deck>
                            -s ${PARAM_RESTART_STEP}
                TEST_ARGS ${PARAM_TEST_ARGS})
+
+  label_blackoil_test(${TEST_NAME} "${TEST_SIMULATOR}" ${IS_BLACKOIL_DATA} blackoil blackoil-restart blackoil-consistency)
 endfunction()
 
 ###########################################################################
@@ -222,9 +432,12 @@ function(add_test_compare_parallel_simulation)
     set(MPI_PROCS 4)
   endif()
 
+  test_supports_blackoil_simulator("${PARAM_DIR}" "${PARAM_FILENAME}" IS_BLACKOIL_DATA)
+  resolve_blackoil_test_simulator("${PARAM_SIMULATOR}" ${IS_BLACKOIL_DATA} TEST_SIMULATOR)
+
   if(MPIEXEC_MAX_NUMPROCS GREATER_EQUAL MPI_PROCS)
     # Local computer system has at least ${MPI_PROCS} CPUs. Register test.
-    set(RESULT_PATH ${BASE_RESULT_PATH}/parallel/${PARAM_SIMULATOR}+${PARAM_CASENAME})
+    set(RESULT_PATH ${BASE_RESULT_PATH}/parallel/${TEST_SIMULATOR}+${PARAM_CASENAME})
     set(TEST_ARGS ${OPM_TESTS_ROOT}/${PARAM_DIR}/${PARAM_FILENAME} ${PARAM_TEST_ARGS})
 
     set(DRIVER_ARGS -i ${OPM_TESTS_ROOT}/${PARAM_DIR}
@@ -237,12 +450,14 @@ function(add_test_compare_parallel_simulation)
                     -n ${MPI_PROCS})
 
     # Add test that runs flow_mpi and outputs the results to file
-    opm_add_test(compareParallelSim_${PARAM_SIMULATOR}+${PARAM_FILENAME}${PARAM_POSTFIX} NO_COMPILE
-                 EXE_NAME ${PARAM_SIMULATOR}
+    opm_add_test(compareParallelSim_${TEST_SIMULATOR}+${PARAM_FILENAME}${PARAM_POSTFIX} NO_COMPILE
+                 EXE_NAME ${TEST_SIMULATOR}
                  DRIVER_ARGS ${DRIVER_ARGS}
                  TEST_ARGS ${TEST_ARGS})
-    set_tests_properties(compareParallelSim_${PARAM_SIMULATOR}+${PARAM_FILENAME}${PARAM_POSTFIX}
+    set_tests_properties(compareParallelSim_${TEST_SIMULATOR}+${PARAM_FILENAME}${PARAM_POSTFIX}
                          PROPERTIES PROCESSORS ${MPI_PROCS})
+
+    label_blackoil_test(compareParallelSim_${TEST_SIMULATOR}+${PARAM_FILENAME}${PARAM_POSTFIX} "${TEST_SIMULATOR}" ${IS_BLACKOIL_DATA} blackoil blackoil-parallel blackoil-consistency)
   endif()
 endfunction()
 
@@ -278,9 +493,12 @@ function(add_test_compare_parallel_restarted_simulation)
     set(MPI_PROCS 4)
   endif()
 
+  test_supports_blackoil_simulator("${PARAM_DIR}" "${PARAM_FILENAME}" IS_BLACKOIL_DATA)
+  resolve_blackoil_test_simulator("${PARAM_SIMULATOR}" ${IS_BLACKOIL_DATA} TEST_SIMULATOR)
+
   if(MPIEXEC_MAX_NUMPROCS GREATER_EQUAL MPI_PROCS)
     # Local computer system has at least ${MPI_PROCS} CPUs. Register test.
-    set(RESULT_PATH ${BASE_RESULT_PATH}/parallelRestart/${PARAM_SIMULATOR}+${PARAM_CASENAME})
+    set(RESULT_PATH ${BASE_RESULT_PATH}/parallelRestart/${TEST_SIMULATOR}+${PARAM_CASENAME})
     set(DRIVER_ARGS -i ${OPM_TESTS_ROOT}/${PARAM_DIR}
                     -r ${RESULT_PATH}
                     -b ${PROJECT_BINARY_DIR}/bin
@@ -293,10 +511,12 @@ function(add_test_compare_parallel_restarted_simulation)
                     -n ${MPI_PROCS})
 
     opm_add_test(${TEST_NAME} NO_COMPILE
-                 EXE_NAME ${PARAM_SIMULATOR}
+                    EXE_NAME ${TEST_SIMULATOR}
                  DRIVER_ARGS ${DRIVER_ARGS}
                  TEST_ARGS ${PARAM_TEST_ARGS})
     set_tests_properties(${TEST_NAME} PROPERTIES PROCESSORS ${MPI_PROCS})
+
+    label_blackoil_test(${TEST_NAME} "${TEST_SIMULATOR}" ${IS_BLACKOIL_DATA} blackoil blackoil-parallel blackoil-restart blackoil-consistency)
   endif()
 endfunction()
 
@@ -326,7 +546,10 @@ function(add_test_split_comm)
     set(MPI_PROCS 4)
   endif()
 
-  set(RESULT_PATH ${BASE_RESULT_PATH}/parallelSplitComm/${PARAM_SIMULATOR}+${PARAM_CASENAME})
+  test_supports_blackoil_simulator("${PARAM_DIR}" "${PARAM_FILENAME}" IS_BLACKOIL_DATA)
+  resolve_blackoil_test_simulator("${PARAM_SIMULATOR}" ${IS_BLACKOIL_DATA} TEST_SIMULATOR)
+
+  set(RESULT_PATH ${BASE_RESULT_PATH}/parallelSplitComm/${TEST_SIMULATOR}+${PARAM_CASENAME})
   set(DRIVER_ARGS -i ${OPM_TESTS_ROOT}/${PARAM_DIR}
                   -r ${RESULT_PATH}
                   -b ${PROJECT_BINARY_DIR}/bin
@@ -336,12 +559,14 @@ function(add_test_split_comm)
                   -c $<TARGET_FILE:compareECL>
                   -n ${MPI_PROCS})
 
-  opm_add_test(compareParallelSplitComm_${PARAM_SIMULATOR}+${PARAM_FILENAME} NO_COMPILE
-               EXE_NAME ${PARAM_SIMULATOR}
+  opm_add_test(compareParallelSplitComm_${TEST_SIMULATOR}+${PARAM_FILENAME} NO_COMPILE
+               EXE_NAME ${TEST_SIMULATOR}
                DRIVER_ARGS ${DRIVER_ARGS}
                TEST_ARGS ${PARAM_TEST_ARGS})
-  set_tests_properties(compareParallelSplitComm_${PARAM_SIMULATOR}+${PARAM_FILENAME}
+  set_tests_properties(compareParallelSplitComm_${TEST_SIMULATOR}+${PARAM_FILENAME}
                        PROPERTIES PROCESSORS ${MPI_PROCS})
+
+  label_blackoil_test(compareParallelSplitComm_${TEST_SIMULATOR}+${PARAM_FILENAME} "${TEST_SIMULATOR}" ${IS_BLACKOIL_DATA} blackoil blackoil-parallel blackoil-consistency)
 endfunction()
 
 
@@ -371,7 +596,12 @@ function(add_test_compareDamarisFiles)
   else()
     set(MPI_PROCS 4)
   endif()
-  set(RESULT_PATH ${BASE_RESULT_PATH}${PARAM_DIR_PREFIX}/${PARAM_SIMULATOR}+${PARAM_CASENAME})
+
+  test_supports_blackoil_simulator("${PARAM_DIR}" "${PARAM_FILENAME}" IS_BLACKOIL_DATA)
+  resolve_blackoil_test_simulator("${PARAM_SIMULATOR}" ${IS_BLACKOIL_DATA} TEST_SIMULATOR)
+  get_blackoil_reference_simulator("${TEST_SIMULATOR}" REFERENCE_SIMULATOR)
+
+  set(RESULT_PATH ${BASE_RESULT_PATH}${PARAM_DIR_PREFIX}/${TEST_SIMULATOR}+${PARAM_CASENAME})
   set(TEST_ARGS ${PARAM_TEST_ARGS})
   set(DRIVER_ARGS -i ${OPM_TESTS_ROOT}/${PARAM_DIR}
                   -r ${RESULT_PATH}
@@ -380,17 +610,20 @@ function(add_test_compareDamarisFiles)
                   -a ${PARAM_ABS_TOL}
                   -t ${PARAM_REL_TOL}
                   -c ${HDF5_DIFF_EXECUTABLE}
-                  -n ${MPI_PROCS})
-  set(TEST_NAME ${PARAM_PREFIX}_${PARAM_SIMULATOR}+${PARAM_FILENAME})
+                  -n ${MPI_PROCS}
+                  -u ${REFERENCE_SIMULATOR})
+  set(TEST_NAME ${PARAM_PREFIX}_${TEST_SIMULATOR}+${PARAM_FILENAME})
   opm_add_test(${TEST_NAME} NO_COMPILE
-               EXE_NAME ${PARAM_SIMULATOR}
+               EXE_NAME ${TEST_SIMULATOR}
                DRIVER_ARGS ${DRIVER_ARGS}
                TEST_ARGS ${TEST_ARGS})
   set_tests_properties(${TEST_NAME} PROPERTIES PROCESSORS ${MPI_PROCS}
                                     DIRNAME ${PARAM_DIR}
                                     FILENAME ${PARAM_FILENAME}
-                                    SIMULATOR ${PARAM_SIMULATOR}
+                                    SIMULATOR ${TEST_SIMULATOR}
                                     TESTNAME ${PARAM_CASENAME})
+
+  label_blackoil_test(${TEST_NAME} "${TEST_SIMULATOR}" ${IS_BLACKOIL_DATA} blackoil blackoil-reference)
 endfunction()
 
 ###########################################################################
@@ -438,32 +671,32 @@ endif()
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-test.sh "")
 add_test_runSimulator(CASENAME norne
                       FILENAME NORNE_ATW2013
-                      SIMULATOR flow
+                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                       CONFIGURATION extra)
 
 add_test_runSimulator(CASENAME norne_parallel
                       FILENAME NORNE_ATW2013
-                      SIMULATOR flow
+                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                       DIR norne
                       PROCS 4
                       CONFIGURATION extra)
 
 add_test_runSimulator(CASENAME spe1case1_carfin
                       FILENAME SPE1CASE1_CARFIN
-                      SIMULATOR flow
+                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                       DIR lgr
                       TEST_ARGS --parsing-strictness=low --enable-ecl-output=true --enable-vtk-output=true)
 
 add_test_runSimulator(CASENAME spe1case1_carfin_gr
                       FILENAME SPE1CASE1_CARFIN_GR
-                      SIMULATOR flow
+                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                       DIR lgr
                       TEST_ARGS --parsing-strictness=low --enable-ecl-output=true --enable-vtk-output=true)
 
 if(MPI_FOUND)
   add_test_runSimulator(CASENAME spe1case1_carfin_parallel
                         FILENAME SPE1CASE1_CARFIN
-                        SIMULATOR flow
+                        SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                         DIR lgr
                         PROCS 4
                         TEST_ARGS --parsing-strictness=low --enable-ecl-output=false --enable-vtk-output=true)
@@ -471,21 +704,21 @@ endif()
 
 add_test_runSimulator(CASENAME dryrun
                       FILENAME CO2STORE_PRECSALT
-                      SIMULATOR flow
+                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                       DIR co2store
                       TEST_ARGS --enable-dry-run=true --enable-ecl-output=false --enable-vtk-output=true)
 
 # Tests that are run based on simulator results, but not necessarily direct comparison to reference results
 add_test_runSimulator(CASENAME tuning_trgmbe
                       FILENAME 01_TUNING_TRGMBE
-                      SIMULATOR flow
+                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
 											DIR tuning
                       TEST_ARGS --output-extra-convergence-info=iterations --enable-tuning=true
                       POST_COMMAND $<TARGET_FILE:test_tuning_trgmbe>)
 
 add_test_runSimulator(CASENAME notuning_trgmbe
                       FILENAME 01_TUNING_TRGMBE
-                      SIMULATOR flow
+                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
 											DIR tuning
                       TEST_ARGS --output-extra-convergence-info=iterations --enable-tuning=false
                       POST_COMMAND $<TARGET_FILE:test_tuning_trgmbe>)
@@ -494,7 +727,7 @@ set_tests_properties(runSimulator/notuning_trgmbe PROPERTIES WILL_FAIL TRUE)
 
 add_test_runSimulator(CASENAME tuning_tsinit_nextstep
                       FILENAME 02_TUNING_TSINIT_NEXTSTEP
-                      SIMULATOR flow
+                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
 											DIR tuning
                       TEST_ARGS --enable-tuning=true
                       POST_COMMAND $<TARGET_FILE:test_tuning_tsinit_nextstep>)
@@ -511,7 +744,7 @@ include (${CMAKE_CURRENT_SOURCE_DIR}/restartTests.cmake)
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-porv-acceptanceTest.sh "")
 add_test_compareECLFiles(CASENAME norne
                          FILENAME NORNE_ATW2013
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL 1e-5
                          REL_TOL 1e-8
                          PREFIX comparePORV
@@ -522,7 +755,7 @@ opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-init-regressionTest.sh "")
 
 add_test_compareECLFiles(CASENAME norne_init
                          FILENAME NORNE_ATW2013
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          PREFIX compareECLInitFiles
@@ -536,7 +769,7 @@ set(_operate_work_tests
 
 add_multiple_tests(_operate_work_tests
   "operate_work_"
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   PREFIX compareECLInitFiles
@@ -547,8 +780,9 @@ add_multiple_tests(_operate_work_tests
 # This is not a proper regression test; the test will load a norne case prepared
 # for restart and run one single timestep - of length one day. The results are not
 # verified in any way.
+resolve_unlabeled_test_simulator("${OPM_BLACKOIL_TEST_SIMULATOR}" NORNE_RESTART_SIMULATOR)
 add_test(NAME NORNE_RESTART
-         COMMAND flow --output-dir=${BASE_RESULT_PATH}/norne-restart ${OPM_TESTS_ROOT}/norne/NORNE_ATW2013_RESTART.DATA)
+         COMMAND ${NORNE_RESTART_SIMULATOR} --output-dir=${BASE_RESULT_PATH}/norne-restart ${OPM_TESTS_ROOT}/norne/NORNE_ATW2013_RESTART.DATA)
 
 
 if(MPI_FOUND)
@@ -558,7 +792,7 @@ if(MPI_FOUND)
   opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-split-comm-test.sh "")
   add_test_split_comm(CASENAME spe1
                       FILENAME SPE1CASE2
-                      SIMULATOR flow
+                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                       ABS_TOL 0.0
                       REL_TOL 0.0)
 
@@ -567,7 +801,7 @@ if(MPI_FOUND)
       opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-damaris-regressionTest.sh "")
       add_test_compareDamarisFiles(CASENAME spe1_damaris
                       FILENAME SPE1CASE1
-                      SIMULATOR flow
+                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                       ABS_TOL ${abs_tol}
                       REL_TOL 0.01
                       DIR spe1)

--- a/comparisonTests.cmake
+++ b/comparisonTests.cmake
@@ -12,7 +12,7 @@ add_test_compareSeparateECLFiles(CASENAME spe1_metric_vfp1_multiliner_vs_oneline
                                  FILENAME1 SPE1CASE1_METRIC_VFP1_MULTILINER
                                  DIR2 vfpprod_spe1_oneliner
                                  FILENAME2 SPE1CASE1_METRIC_VFP1_ONELINER
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH

--- a/parallelRestartTests.cmake
+++ b/parallelRestartTests.cmake
@@ -2,7 +2,7 @@
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-parallel-restart-regressionTest.sh "")
 add_test_compare_parallel_restarted_simulation(CASENAME spe1
                                                FILENAME SPE1CASE2_ACTNUM
-                                               SIMULATOR flow
+                                               SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                                ABS_TOL ${abs_tol_restart}
                                                REL_TOL ${rel_tol_restart}
                                                RESTART_STEP 6
@@ -10,7 +10,7 @@ add_test_compare_parallel_restarted_simulation(CASENAME spe1
 
 add_test_compare_parallel_restarted_simulation(CASENAME ctaquifer_2d_oilwater
                                                FILENAME 2D_OW_CTAQUIFER
-                                               SIMULATOR flow
+                                               SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                                ABS_TOL ${abs_tol_restart}
                                                REL_TOL ${rel_tol_restart}
                                                RESTART_STEP 15
@@ -19,7 +19,7 @@ add_test_compare_parallel_restarted_simulation(CASENAME ctaquifer_2d_oilwater
 
 add_test_compare_parallel_restarted_simulation(CASENAME fetkovich_2d
                                                FILENAME 2D_FETKOVICHAQUIFER
-                                               SIMULATOR flow
+                                               SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                                ABS_TOL ${abs_tol_restart}
                                                REL_TOL ${rel_tol_restart}
                                                RESTART_STEP 30
@@ -28,7 +28,7 @@ add_test_compare_parallel_restarted_simulation(CASENAME fetkovich_2d
 
 add_test_compare_parallel_restarted_simulation(CASENAME numerical_aquifer_3d_2aqu
                                                FILENAME 3D_2AQU_NUM
-                                               SIMULATOR flow
+                                               SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                                ABS_TOL 0.12
                                                REL_TOL 5.0e-2
                                                RESTART_STEP 3
@@ -37,7 +37,7 @@ add_test_compare_parallel_restarted_simulation(CASENAME numerical_aquifer_3d_2aq
 
 add_test_compare_parallel_restarted_simulation(CASENAME numerical_aquifer_3d_1aqu
                                                FILENAME 3D_1AQU_3CELLS
-                                               SIMULATOR flow
+                                               SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                                ABS_TOL 0.12
                                                REL_TOL 5.0e-2
                                                RESTART_STEP 3
@@ -46,7 +46,7 @@ add_test_compare_parallel_restarted_simulation(CASENAME numerical_aquifer_3d_1aq
 
 add_test_compare_parallel_restarted_simulation(CASENAME aquflux_01
                                                FILENAME AQUFLUX-01
-                                               SIMULATOR flow
+                                               SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                                ABS_TOL ${abs_tol_restart}
                                                REL_TOL 5.0e-2
                                                RESTART_STEP 3
@@ -55,7 +55,7 @@ add_test_compare_parallel_restarted_simulation(CASENAME aquflux_01
 
 add_test_compare_parallel_restarted_simulation(CASENAME aquflux_02
                                                FILENAME AQUFLUX-02
-                                               SIMULATOR flow
+                                               SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                                ABS_TOL ${abs_tol_restart}
                                                REL_TOL 5.0e-2
                                                RESTART_STEP 50
@@ -68,7 +68,7 @@ if(HDF5_FOUND)
   add_test_compare_parallel_restarted_simulation(CASENAME spe1_serialized
                                                  DIR spe1
                                                  FILENAME SPE1CASE1
-                                                 SIMULATOR flow
+                                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                                  TEST_NAME compareParallelSerializedSim_flow+spe1
                                                  ABS_TOL 2e-2
                                                  REL_TOL 1e-5

--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -7,14 +7,14 @@ set(coarse_rel_tol_parallel 1e-2)
 
 add_test_compare_parallel_simulation(CASENAME spe1
                                      FILENAME SPE1CASE2
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL ${rel_tol_parallel}
                                      TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
 
 add_test_compare_parallel_simulation(CASENAME spe1_gaswater
                                      FILENAME SPE1CASE2_GASWATER
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL ${rel_tol_parallel}
                                      DIR spe1
@@ -22,7 +22,7 @@ add_test_compare_parallel_simulation(CASENAME spe1_gaswater
 
 add_test_compare_parallel_simulation(CASENAME spe9
                                      FILENAME SPE9_CP_SHORT
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL ${rel_tol_parallel}
                                      TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
@@ -137,7 +137,7 @@ add_test_compare_parallel_simulation(CASENAME msw-model-1-short
 
 add_test_compare_parallel_simulation(CASENAME spe9group
                                      FILENAME SPE9_CP_GROUP
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL ${coarse_rel_tol_parallel}
                                      TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
@@ -146,7 +146,7 @@ add_test_compare_parallel_simulation(CASENAME spe3_partition_method_zoltan
                                      FILENAME SPE3CASE1
                                      POSTFIX partition_method_zoltan
                                      DIR spe3
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL ${coarse_rel_tol_parallel}
                                      TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --tolerance-wells=1e-7 --partition-method=zoltan)
@@ -155,34 +155,34 @@ add_test_compare_parallel_simulation(CASENAME spe3_partition_method_zoltanwell
                                      FILENAME SPE3CASE1
                                      POSTFIX partition_method_zoltanwell
                                      DIR spe3
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL ${coarse_rel_tol_parallel}
                                      TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --tolerance-wells=1e-7)
 
 add_test_compare_parallel_simulation(CASENAME spe1_solvent
                                      FILENAME SPE1CASE2_SOLVENT
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL ${coarse_rel_tol_parallel}
                                      TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
 
 add_test_compare_parallel_simulation(CASENAME polymer_simple2D
                                      FILENAME 2D_THREEPHASE_POLY_HETER
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol}
                                      REL_TOL ${coarse_rel_tol}
                                      TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
 
 add_test_compare_parallel_simulation(CASENAME spe1_foam
                                      FILENAME SPE1FOAM
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol}
                                      REL_TOL ${coarse_rel_tol_parallel})
 
 add_test_compare_parallel_simulation(CASENAME spe1_thermal
                                      FILENAME SPE1CASE2_THERMAL
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol}
                                      REL_TOL ${coarse_rel_tol_parallel}
                                      DIR spe1
@@ -190,7 +190,7 @@ add_test_compare_parallel_simulation(CASENAME spe1_thermal
 
 add_test_compare_parallel_simulation(CASENAME spe1_temp
                                      FILENAME SPE1CASE2_TEMP
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol}
                                      REL_TOL ${coarse_rel_tol_parallel}
                                      DIR spe1
@@ -199,7 +199,7 @@ add_test_compare_parallel_simulation(CASENAME spe1_temp
 
 add_test_compare_parallel_simulation(CASENAME spe1_thermal_onephase
                                      FILENAME SPE1CASE2_THERMAL_ONEPHASE
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol}
                                      REL_TOL ${rel_tol}
                                      DIR spe1
@@ -207,7 +207,7 @@ add_test_compare_parallel_simulation(CASENAME spe1_thermal_onephase
 
 add_test_compare_parallel_simulation(CASENAME spe1_water
                                      FILENAME SPE1CASE1_WATER
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol}
                                      REL_TOL ${rel_tol}
                                      DIR spe1
@@ -215,14 +215,14 @@ add_test_compare_parallel_simulation(CASENAME spe1_water
 
 add_test_compare_parallel_simulation(CASENAME spe1_brine
                                      FILENAME SPE1CASE1_BRINE
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL ${coarse_rel_tol_parallel}
                                      TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-6)
 
 add_test_compare_parallel_simulation(CASENAME fetkovich_2d
                                      FILENAME 2D_FETKOVICHAQUIFER
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL ${rel_tol_parallel}
                                      DIR aquifer-fetkovich
@@ -230,7 +230,7 @@ add_test_compare_parallel_simulation(CASENAME fetkovich_2d
 
 add_test_compare_parallel_simulation(CASENAME ctaquifer_2d_oilwater
                                      FILENAME 2D_OW_CTAQUIFER
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL ${rel_tol_parallel}
                                      DIR aquifer-oilwater
@@ -238,7 +238,7 @@ add_test_compare_parallel_simulation(CASENAME ctaquifer_2d_oilwater
 
 add_test_compare_parallel_simulation(CASENAME 3d_tran_operator
                                      FILENAME 3D_TRAN_OPERATOR
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL 0.0003
                                      DIR parallel_fieldprops
@@ -246,7 +246,7 @@ add_test_compare_parallel_simulation(CASENAME 3d_tran_operator
 
 add_test_compare_parallel_simulation(CASENAME numerical_aquifer_3d_2aqu
                                      FILENAME 3D_2AQU_NUM
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL 0.17
                                      REL_TOL ${coarse_rel_tol_parallel}
                                      DIR aquifer-num
@@ -254,7 +254,7 @@ add_test_compare_parallel_simulation(CASENAME numerical_aquifer_3d_2aqu
 
 add_test_compare_parallel_simulation(CASENAME aquflux_01
                                      FILENAME AQUFLUX-01
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol}
                                      REL_TOL 0.06
                                      DIR aquifers
@@ -262,7 +262,7 @@ add_test_compare_parallel_simulation(CASENAME aquflux_01
 
 add_test_compare_parallel_simulation(CASENAME aquflux_02
                                      FILENAME AQUFLUX-02
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol}
                                      REL_TOL ${coarse_rel_tol_parallel}
                                      DIR aquifers
@@ -270,7 +270,7 @@ add_test_compare_parallel_simulation(CASENAME aquflux_02
 
 add_test_compare_parallel_simulation(CASENAME network_balance_01
                                      FILENAME NETWORK-01
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol}
                                      REL_TOL ${coarse_rel_tol_parallel}
                                      DIR network
@@ -278,7 +278,7 @@ add_test_compare_parallel_simulation(CASENAME network_balance_01
 
 add_test_compare_parallel_simulation(CASENAME numerical_aquifer_3d_1aqu
                                      FILENAME 3D_1AQU_3CELLS
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL 0.05
                                      DIR aquifer-num
@@ -286,7 +286,7 @@ add_test_compare_parallel_simulation(CASENAME numerical_aquifer_3d_1aqu
 
 add_test_compare_parallel_simulation(CASENAME 6_uda_model5_stdw
   FILENAME 6_UDA_MODEL5_STDW
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol_parallel}
   REL_TOL ${rel_tol_parallel}
   DIR model5
@@ -295,7 +295,7 @@ add_test_compare_parallel_simulation(CASENAME 6_uda_model5_stdw
 
 add_test_compare_parallel_simulation(CASENAME GSATPROD6
   FILENAME GSATPROD6
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol_parallel}
   REL_TOL ${rel_tol_parallel}
   DIR satellite
@@ -305,7 +305,7 @@ add_test_compare_parallel_simulation(CASENAME GSATPROD6
 foreach(templ_case RANGE 1 6)
   add_test_compare_parallel_simulation(CASENAME actionx_well_templ_0${templ_case}
     FILENAME ACTIONX_WELL_TEMPL-0${templ_case}
-    SIMULATOR flow
+    SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
     ABS_TOL ${abs_tol_parallel}
     REL_TOL ${rel_tol_parallel}
     DIR actionx
@@ -314,7 +314,7 @@ endforeach()
 
 add_test_compare_parallel_simulation(CASENAME WCYCLE-0
                                      FILENAME WCYCLE-0
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL ${rel_tol_parallel}
                                      DIR wcycle
@@ -322,7 +322,7 @@ add_test_compare_parallel_simulation(CASENAME WCYCLE-0
 
 add_test_compare_parallel_simulation(CASENAME actionx_m1
                                      FILENAME ACTIONX_M1
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL ${coarse_rel_tol_parallel}
                                      DIR udq_actionx
@@ -330,7 +330,7 @@ add_test_compare_parallel_simulation(CASENAME actionx_m1
 
 add_test_compare_parallel_simulation(CASENAME reg_smry_in_fld_udq
                                      FILENAME UDQ_REG-01
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL ${coarse_rel_tol_parallel}
                                      DIR udq_actionx
@@ -338,7 +338,7 @@ add_test_compare_parallel_simulation(CASENAME reg_smry_in_fld_udq
 
 add_test_compare_parallel_simulation(CASENAME winjmult_msw
                                      FILENAME WINJMULT_MSW
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol}
                                      REL_TOL ${rel_tol}
                                      DIR winjmult
@@ -346,7 +346,7 @@ add_test_compare_parallel_simulation(CASENAME winjmult_msw
 
 add_test_compare_parallel_simulation(CASENAME winjdam_msw
                                      FILENAME WINJDAM_MSW
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol}
                                      REL_TOL ${rel_tol}
                                      DIR winjdam
@@ -354,7 +354,7 @@ add_test_compare_parallel_simulation(CASENAME winjdam_msw
 
 add_test_compare_parallel_simulation(CASENAME 3_a_mpi_multflt_mod2
                                      FILENAME 3_A_MPI_MULTFLT_SCHED_MODEL2
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL 1.0e-3
                                      DIR model2
@@ -362,7 +362,7 @@ add_test_compare_parallel_simulation(CASENAME 3_a_mpi_multflt_mod2
 
 add_test_compare_parallel_simulation(CASENAME rxft
                                      FILENAME TEST_RXFT
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL 1.0e-3
                                      DIR rxft_smry
@@ -370,7 +370,7 @@ add_test_compare_parallel_simulation(CASENAME rxft
 
 add_test_compare_parallel_simulation(CASENAME gconinje_resv_gas_01
                                      FILENAME GCONINJE_RESV_GAS-01
-                                     SIMULATOR flow
+                                     SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL ${rel_tol_parallel}
                                      DIR resv_ctrl
@@ -383,7 +383,7 @@ add_test_compareSeparateECLFiles(CASENAME actionx_compdat_1_proc
                                  FILENAME1 COMPDAT_SHORT
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_COMPDAT_SHORT
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH
@@ -394,7 +394,7 @@ add_test_compareSeparateECLFiles(CASENAME actionx_compdat_2_procs
                                  FILENAME1 COMPDAT_SHORT
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_COMPDAT_SHORT
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH
@@ -405,7 +405,7 @@ add_test_compareSeparateECLFiles(CASENAME actionx_compdat_nldd_1_proc
                                  FILENAME1 COMPDAT_SHORT
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_COMPDAT_SHORT
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH
@@ -417,7 +417,7 @@ add_test_compareSeparateECLFiles(CASENAME actionx_compdat_nldd_2_procs
                                  FILENAME1 COMPDAT_SHORT
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_COMPDAT_SHORT
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH

--- a/pyactionActionXComparisons.cmake
+++ b/pyactionActionXComparisons.cmake
@@ -10,7 +10,7 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_gconprod_insert_kw
                                  FILENAME1 PYACTION_GCONPROD_INSERT_KW
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_GCONPROD
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
@@ -20,7 +20,7 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_gconsump_insert_kw
                                  FILENAME1 PYACTION_GCONSUMP_INSERT_KW
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_GCONSUMP
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
@@ -30,7 +30,7 @@ add_test_compareSeparateECLFiles(CASENAME actionx_gefac
                                  FILENAME1 MOD4_GRP_GEFAC
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_GEFAC
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
@@ -40,7 +40,7 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_gefac_insert_kw
                                  FILENAME1 PYACTION_GEFAC_INSERT_KW
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_GEFAC
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
@@ -50,7 +50,7 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_gruptree_insert_kw
                                  FILENAME1 PYACTION_GRUPTREE_INSERT_KW
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_GRUPTREE
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
@@ -60,7 +60,7 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_include_insert_kw
                                  FILENAME1 PYACTION_INCLUDE_INSERT_KW
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_INCLUDE
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
@@ -70,7 +70,7 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_mult+_insert_kw
                                  FILENAME1 PYACTION_MULT+_INSERT_KW
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_MULT+
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
@@ -80,7 +80,7 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_multx+_insert_kw
                                  FILENAME1 PYACTION_MULTX+_INSERT_KW
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_MULTX+
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
@@ -90,7 +90,7 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_multx-_insert_kw
                                  FILENAME1 PYACTION_MULTX-_INSERT_KW
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_MULTX-
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
@@ -100,7 +100,7 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_next_insert_kw
                                  FILENAME1 PYACTION_NEXT_INSERT_KW
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_NEXT
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
@@ -110,7 +110,7 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_wconprod_insert_kw
                                  FILENAME1 PYACTION_WCONPROD_INSERT_KW
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_WCONPROD
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
@@ -120,7 +120,7 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_wefac_insert_kw
                                  FILENAME1 PYACTION_WEFAC_INSERT_KW
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_WEFAC
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
@@ -130,7 +130,7 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_welpi_insert_kw
                                  FILENAME1 PYACTION_WELPI_INSERT_KW
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_WELPI
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
@@ -140,7 +140,7 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_wpimult_insert_kw
                                  FILENAME1 PYACTION_WPIMULT_INSERT_KW
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_WPIMULT
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
@@ -150,7 +150,7 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_wsegvalv_insert_kw
                                  FILENAME1 PYACTION_WSEGVALV_INSERT_KW
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_WSEGVALV
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
@@ -160,7 +160,7 @@ add_test_compareSeparateECLFiles(CASENAME actionx_wlist
                                  FILENAME1 ACTIONX_M1
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_WLIST
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
@@ -170,7 +170,7 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_wlist_insert_kw
                                  FILENAME1 PYACTION_WLIST_INSERT_KW
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_WLIST
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
@@ -180,7 +180,7 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_wtest_insert_kw
                                  FILENAME1 PYACTION_WTEST_INSERT_KW
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_WTEST
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
@@ -190,7 +190,7 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_WTMULT_insert_kw
                                  FILENAME1 PYACTION_WTMULT_INSERT_KW
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_WTMULT
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
@@ -203,7 +203,7 @@ if(MPI_FOUND)
                                    FILENAME1 PYACTION_GCONPROD_INSERT_KW
                                    DIR2 actionx
                                    FILENAME2 ACTIONX_GCONPROD
-                                   SIMULATOR flow
+                                   SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                    ABS_TOL ${abs_tol}
                                    REL_TOL ${rel_tol}
                                    IGNORE_EXTRA_KW BOTH
@@ -215,7 +215,7 @@ if(MPI_FOUND)
                                    FILENAME1 PYACTION_GCONSUMP_INSERT_KW
                                    DIR2 actionx
                                    FILENAME2 ACTIONX_GCONSUMP
-                                   SIMULATOR flow
+                                   SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                    ABS_TOL ${abs_tol}
                                    REL_TOL ${rel_tol}
                                    IGNORE_EXTRA_KW BOTH
@@ -228,7 +228,7 @@ if(MPI_FOUND)
                                    FILENAME1 PYACTION_GRUPTREE_INSERT_KW
                                    DIR2 actionx
                                    FILENAME2 ACTIONX_GRUPTREE
-                                   SIMULATOR flow
+                                   SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                    ABS_TOL ${abs_tol}
                                    REL_TOL ${rel_tol}
                                    IGNORE_EXTRA_KW BOTH
@@ -240,7 +240,7 @@ if(MPI_FOUND)
                                    FILENAME1 MOD4_GRP_GEFAC
                                    DIR2 actionx
                                    FILENAME2 ACTIONX_GEFAC
-                                   SIMULATOR flow
+                                   SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                    ABS_TOL ${abs_tol}
                                    REL_TOL ${rel_tol}
                                    IGNORE_EXTRA_KW BOTH
@@ -251,7 +251,7 @@ if(MPI_FOUND)
                                    FILENAME1 PYACTION_GEFAC_INSERT_KW
                                    DIR2 actionx
                                    FILENAME2 ACTIONX_GEFAC
-                                   SIMULATOR flow
+                                   SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                    ABS_TOL ${abs_tol}
                                    REL_TOL ${rel_tol}
                                    IGNORE_EXTRA_KW BOTH
@@ -262,7 +262,7 @@ if(MPI_FOUND)
                                    FILENAME1 PYACTION_MULTX+_INSERT_KW
                                    DIR2 actionx
                                    FILENAME2 ACTIONX_MULTX+
-                                   SIMULATOR flow
+                                   SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                    ABS_TOL ${abs_tol}
                                    REL_TOL ${rel_tol}
                                    IGNORE_EXTRA_KW BOTH
@@ -273,7 +273,7 @@ if(MPI_FOUND)
                                    FILENAME1 PYACTION_MULT+_INSERT_KW
                                    DIR2 actionx
                                    FILENAME2 ACTIONX_MULT+
-                                   SIMULATOR flow
+                                   SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                    ABS_TOL ${abs_tol}
                                    REL_TOL ${rel_tol}
                                    IGNORE_EXTRA_KW BOTH
@@ -284,7 +284,7 @@ if(MPI_FOUND)
                                    FILENAME1 PYACTION_MULTX-_INSERT_KW
                                    DIR2 actionx
                                    FILENAME2 ACTIONX_MULTX-
-                                   SIMULATOR flow
+                                   SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                    ABS_TOL ${abs_tol}
                                    REL_TOL ${rel_tol}
                                    IGNORE_EXTRA_KW BOTH
@@ -295,7 +295,7 @@ if(MPI_FOUND)
                                    FILENAME1 PYACTION_NEXT_INSERT_KW
                                    DIR2 actionx
                                    FILENAME2 ACTIONX_NEXT
-                                   SIMULATOR flow
+                                   SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                    ABS_TOL ${abs_tol}
                                    REL_TOL ${rel_tol}
                                    IGNORE_EXTRA_KW BOTH
@@ -308,7 +308,7 @@ if(MPI_FOUND)
                                    FILENAME1 PYACTION_WCONPROD_INSERT_KW
                                    DIR2 actionx
                                    FILENAME2 ACTIONX_WCONPROD
-                                   SIMULATOR flow
+                                   SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                    ABS_TOL ${abs_tol}
                                    REL_TOL ${rel_tol}
                                    IGNORE_EXTRA_KW BOTH
@@ -320,7 +320,7 @@ if(MPI_FOUND)
                                    FILENAME1 PYACTION_WEFAC_INSERT_KW
                                    DIR2 actionx
                                    FILENAME2 ACTIONX_WEFAC
-                                   SIMULATOR flow
+                                   SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                    ABS_TOL ${abs_tol}
                                    REL_TOL ${rel_tol}
                                    IGNORE_EXTRA_KW BOTH
@@ -331,7 +331,7 @@ if(MPI_FOUND)
                                  FILENAME1 PYACTION_WELPI_INSERT_KW
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_WELPI
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH,
@@ -342,7 +342,7 @@ if(MPI_FOUND)
                                  FILENAME1 PYACTION_WPIMULT_INSERT_KW
                                  DIR2 actionx
                                  FILENAME2 ACTIONX_WPIMULT
-                                 SIMULATOR flow
+                                 SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH
@@ -353,7 +353,7 @@ if(MPI_FOUND)
                                    FILENAME1 PYACTION_WSEGVALV_INSERT_KW
                                    DIR2 actionx
                                    FILENAME2 ACTIONX_WSEGVALV
-                                   SIMULATOR flow
+                                   SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                    ABS_TOL ${abs_tol}
                                    REL_TOL ${rel_tol}
                                    IGNORE_EXTRA_KW BOTH
@@ -364,7 +364,7 @@ if(MPI_FOUND)
                                    FILENAME1 PYACTION_WTMULT_INSERT_KW
                                    DIR2 actionx
                                    FILENAME2 ACTIONX_WTMULT
-                                   SIMULATOR flow
+                                   SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                    ABS_TOL ${abs_tol}
                                    REL_TOL ${rel_tol}
                                    IGNORE_EXTRA_KW BOTH
@@ -375,7 +375,7 @@ if(MPI_FOUND)
                                    FILENAME1 ACTIONX_M1
                                    DIR2 actionx
                                    FILENAME2 ACTIONX_WLIST
-                                   SIMULATOR flow
+                                   SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                    ABS_TOL ${abs_tol}
                                    REL_TOL ${rel_tol}
                                    IGNORE_EXTRA_KW BOTH
@@ -386,7 +386,7 @@ if(MPI_FOUND)
                                    FILENAME1 PYACTION_WLIST_INSERT_KW
                                    DIR2 actionx
                                    FILENAME2 ACTIONX_WLIST
-                                   SIMULATOR flow
+                                   SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                    ABS_TOL ${abs_tol}
                                    REL_TOL ${rel_tol}
                                    IGNORE_EXTRA_KW BOTH
@@ -397,7 +397,7 @@ if(MPI_FOUND)
                                    FILENAME1 PYACTION_WTEST_INSERT_KW
                                    DIR2 actionx
                                    FILENAME2 ACTIONX_WTEST
-                                   SIMULATOR flow
+                                   SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                    ABS_TOL ${abs_tol}
                                    REL_TOL ${rel_tol}
                                    IGNORE_EXTRA_KW BOTH

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -22,7 +22,7 @@ add_test_compareECLFiles(CASENAME 1dcompositional
 
 add_test_compareECLFiles(CASENAME spe12
                          FILENAME SPE1CASE2
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${coarse_rel_tol}
                          RESTART_SCHED false
@@ -46,7 +46,7 @@ set(_spe1_tests
 add_multiple_tests(
   _spe1_tests
   ""
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR spe1
@@ -61,7 +61,7 @@ set(_spe1_coarse_tests
 add_multiple_tests(
   _spe1_coarse_tests
   ""
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${coarse_rel_tol}
   DIR spe1
@@ -76,7 +76,7 @@ set(_spe1_brine_tests
 add_multiple_tests(
   _spe1_brine_tests
   ""
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR spe1_brine
@@ -90,7 +90,7 @@ set(_spe1_precsalt_tests
 add_multiple_tests(
   _spe1_precsalt_tests
   ""
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR spe1_precsalt
@@ -98,7 +98,7 @@ add_multiple_tests(
 
 add_test_compareECLFiles(CASENAME gasoil_precsalt
                          FILENAME GASCONDENSATE_VAPWAT_PRECSALT_REGRESSION
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR spe1_precsalt
@@ -112,7 +112,7 @@ set(_network_tuning_tests
 add_multiple_tests(
   _network_tuning_tests
   ""
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR network
@@ -127,7 +127,7 @@ set(_network_tuning_local_switch_tests
 add_multiple_tests(
   _network_tuning_local_switch_tests
   ""
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR network
@@ -136,7 +136,7 @@ add_multiple_tests(
 
 add_test_compareECLFiles(CASENAME network_01_wtest
                          FILENAME NETWORK-01-WTEST
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR network
@@ -144,28 +144,28 @@ add_test_compareECLFiles(CASENAME network_01_wtest
 
 add_test_compareECLFiles(CASENAME spe1_metric_vfp1
                          FILENAME SPE1CASE1_METRIC_VFP1
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR vfpprod_spe1)
 
 add_test_compareECLFiles(CASENAME spe1_spider
                          FILENAME SPIDER_CAKESLICE
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR radial_grid)
 
 add_test_compareECLFiles(CASENAME spe1_radial
                          FILENAME RADIAL_CAKESLICE
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR radial_grid)
 
 add_test_compareECLFiles(CASENAME jfunc_01
                          FILENAME JFUNC-01
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR jfunc
@@ -173,21 +173,21 @@ add_test_compareECLFiles(CASENAME jfunc_01
 
 add_test_compareECLFiles(CASENAME ctaquifer_2d_oilwater
                          FILENAME 2D_OW_CTAQUIFER
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR aquifer-oilwater)
 
 add_test_compareECLFiles(CASENAME fetkovich_2d
                          FILENAME 2D_FETKOVICHAQUIFER
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR aquifer-fetkovich)
 
 add_test_compareECLFiles(CASENAME numerical_aquifer_3d_2aqu
                          FILENAME 3D_2AQU_NUM
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR aquifer-num
@@ -195,7 +195,7 @@ add_test_compareECLFiles(CASENAME numerical_aquifer_3d_2aqu
 
 add_test_compareECLFiles(CASENAME numerical_aquifer_3d_1aqu
                          FILENAME 3D_1AQU_3CELLS
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR aquifer-num
@@ -203,7 +203,7 @@ add_test_compareECLFiles(CASENAME numerical_aquifer_3d_1aqu
 
 add_test_compareECLFiles(CASENAME aquflux_01
                          FILENAME AQUFLUX-01
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR aquifers
@@ -211,7 +211,7 @@ add_test_compareECLFiles(CASENAME aquflux_01
 
 add_test_compareECLFiles(CASENAME aquflux_02
                          FILENAME AQUFLUX-02
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR aquifers
@@ -219,86 +219,86 @@ add_test_compareECLFiles(CASENAME aquflux_02
 
 add_test_compareECLFiles(CASENAME spe3
                          FILENAME SPE3CASE1
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${coarse_rel_tol}
                          TEST_ARGS --tolerance-wells=1e-6)
 
 add_test_compareECLFiles(CASENAME spe9
                          FILENAME SPE9_CP_SHORT
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          RESTART_STEP 10)
 
 add_test_compareECLFiles(CASENAME spe9group
                          FILENAME SPE9_CP_GROUP
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol})
 
 add_test_compareECLFiles(CASENAME spe9group_resv
                          FILENAME SPE9_CP_GROUP_RESV
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR spe9group)
 
 add_test_compareECLFiles(CASENAME msw_2d_h
                          FILENAME 2D_H__
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${coarse_rel_tol})
 
 add_test_compareECLFiles(CASENAME msw_3d_hfa
                          FILENAME 3D_MSW
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          TEST_ARGS --tolerance-pressure-ms-wells=10)
 
 add_test_compareECLFiles(CASENAME polymer_oilwater
                          FILENAME 2D_OILWATER_POLYMER
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          TEST_ARGS --solver-max-time-step-in-days=10)
 
 add_test_compareECLFiles(CASENAME polymer_injectivity
                          FILENAME 2D_POLYMER_INJECTIVITY
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          TEST_ARGS --tolerance-wells=1.e-6)
 
 add_test_compareECLFiles(CASENAME polymer_simple2D
                          FILENAME 2D_THREEPHASE_POLY_HETER
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${coarse_rel_tol}
                          TEST_ARGS --tolerance-mb-relaxed=1.e-7)
 
 add_test_compareECLFiles(CASENAME spe5
                          FILENAME SPE5CASE1
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${coarse_rel_tol})
 
 add_test_compareECLFiles(CASENAME spe5_co2eor
                          FILENAME SPE5CASE1_DYN
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${coarse_rel_tol})
 
 add_test_compareECLFiles(CASENAME wecon_wtest
                          FILENAME 3D_WECON
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${coarse_rel_tol})
 
 add_test_compareECLFiles(CASENAME msw_model_1
                          FILENAME MSW_MODEL_1
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR model1
@@ -306,14 +306,14 @@ add_test_compareECLFiles(CASENAME msw_model_1
 
 add_test_compareECLFiles(CASENAME base_model_1
                          FILENAME BASE_MODEL_1
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR model1)
 
 add_test_compareECLFiles(CASENAME faults_model_1
                          FILENAME FAULTS_MODEL_1
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR model1
@@ -321,7 +321,7 @@ add_test_compareECLFiles(CASENAME faults_model_1
 
 add_test_compareECLFiles(CASENAME base_model2_welpi
                          FILENAME 0B_WELPI_MODEL2
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR model2
@@ -329,7 +329,7 @@ add_test_compareECLFiles(CASENAME base_model2_welpi
 
 add_test_compareECLFiles(CASENAME 0a1_grpctl_msw_model2
                          FILENAME 0A1_GRCTRL_LRAT_ORAT_BASE_MODEL2_MSW
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR model2
@@ -337,7 +337,7 @@ add_test_compareECLFiles(CASENAME 0a1_grpctl_msw_model2
 
 add_test_compareECLFiles(CASENAME 0a2_grpctl_msw_model2
                          FILENAME 0A2_GRCTRL_LRAT_ORAT_GGR_BASE_MODEL2_MSW
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR model2
@@ -345,7 +345,7 @@ add_test_compareECLFiles(CASENAME 0a2_grpctl_msw_model2
 
 add_test_compareECLFiles(CASENAME 0a3_grpctl_msw_model2
                          FILENAME 0A3_GRCTRL_LRAT_LRAT_BASE_MODEL2_MSW
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR model2
@@ -353,7 +353,7 @@ add_test_compareECLFiles(CASENAME 0a3_grpctl_msw_model2
 
 add_test_compareECLFiles(CASENAME 0a4_grpctl_msw_model2
                          FILENAME 0A4_GRCTRL_LRAT_LRAT_GGR_BASE_MODEL2_MSW
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR model2
@@ -361,7 +361,7 @@ add_test_compareECLFiles(CASENAME 0a4_grpctl_msw_model2
 
 add_test_compareECLFiles(CASENAME udq_actionx
                          FILENAME UDQ_ACTIONX
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR udq_actionx
@@ -369,14 +369,14 @@ add_test_compareECLFiles(CASENAME udq_actionx
 
 add_test_compareECLFiles(CASENAME udq_wconprod
                          FILENAME UDQ_WCONPROD
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR udq_actionx)
 
 add_test_compareECLFiles(CASENAME actionx_m1
                          FILENAME ACTIONX_M1
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR udq_actionx
@@ -384,49 +384,49 @@ add_test_compareECLFiles(CASENAME actionx_m1
 
 add_test_compareECLFiles(CASENAME waghyst1
                          FILENAME WAGHYSTR-01
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR waghystr)
 
 add_test_compareECLFiles(CASENAME waghyst2
                          FILENAME WAGHYSTR-02
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR waghystr)
 
 add_test_compareECLFiles(CASENAME gpmaint11
                          FILENAME GPMAINT-11
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR gpmaint)
 
 add_test_compareECLFiles(CASENAME 3dwecon9
                          FILENAME 3D_WECON_9
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR wecon_wtest)
 
 add_test_compareECLFiles(CASENAME gconinje_resv_gas_01
                          FILENAME GCONINJE_RESV_GAS-01
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR resv_ctrl)
 
 add_test_compareECLFiles(CASENAME gconinje_resv1
                          FILENAME GCONINJE-01
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR gconinje)
 
 add_test_compareECLFiles(CASENAME gconinje_resv2
                          FILENAME GCONINJE-02
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR gconinje)
@@ -441,7 +441,7 @@ set(_gconprod_cases
 add_multiple_tests(
   _gconprod_cases
   gconprod_
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR gconprod
@@ -475,7 +475,7 @@ set(_pinch_cases
 add_multiple_tests(
   _pinch_cases
   pinch_
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR pinch
@@ -491,7 +491,7 @@ set(_udt_cases
 add_multiple_tests(
   _udt_cases
   ""
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   TEST_ARGS --enable-tuning=true
@@ -503,7 +503,7 @@ add_multiple_test_range(
   6
   EQUALREG-0
   equalreg_multy
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR mult
@@ -514,7 +514,7 @@ add_multiple_test_range(
   6
   ACTIONX_WELL_TEMPL-0
   actionx_well_templ
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR actionx
@@ -525,7 +525,7 @@ add_multiple_test_range(
   8
   WCYCLE-
   WCYCLE
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR wcycle
@@ -534,7 +534,7 @@ add_multiple_test_range(
 
 add_test_compareECLFiles(CASENAME udq_uadd
                          FILENAME UDQ_M1
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR udq_actionx
@@ -542,21 +542,21 @@ add_test_compareECLFiles(CASENAME udq_uadd
 
 add_test_compareECLFiles(CASENAME udq_undefined
                          FILENAME UDQ_M2
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR udq_actionx)
 
 add_test_compareECLFiles(CASENAME udq_in_actionx
                          FILENAME UDQ_M3
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR udq_actionx)
 
 add_test_compareECLFiles(CASENAME reg_smry_in_fld_udq
                          FILENAME UDQ_REG-01
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR udq_actionx
@@ -566,7 +566,7 @@ add_test_compareECLFiles(CASENAME reg_smry_in_fld_udq
 # ACTIONX blocks.
 add_test_compareECLFiles(CASENAME group_udq
                          FILENAME UDQ_GRP-01
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR udq_actionx
@@ -585,7 +585,7 @@ set(_actionx_tests
 add_multiple_tests(
   _actionx_tests
   ""
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR actionx
@@ -596,7 +596,7 @@ add_multiple_test_range(
   5
   CSKIN-0
   cskin
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR cskin
@@ -615,7 +615,7 @@ set(_co2store_cases
 add_multiple_tests(
   _co2store_cases
   ""
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR co2store
@@ -632,7 +632,7 @@ set(_h2store_cases
 add_multiple_tests(
   _h2store_cases
   ""
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR h2store
@@ -647,7 +647,7 @@ set(_tpsa_cases
 add_multiple_tests(
   _tpsa_cases
   ""
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR tpsa
@@ -656,7 +656,7 @@ add_multiple_tests(
 
 add_test_compareECLFiles(CASENAME ppcwmax
                          FILENAME PPCWMAX-01
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR ppcwmax)
@@ -665,7 +665,7 @@ get_property(opm-common_EMBEDDED_PYTHON TARGET opmcommon PROPERTY EMBEDDED_PYTHO
 if(opm-common_EMBEDDED_PYTHON)
   add_test_compareECLFiles(CASENAME udq_pyaction
                            FILENAME PYACTION_WCONPROD
-                           SIMULATOR flow
+                           SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                            ABS_TOL ${abs_tol}
                            REL_TOL ${rel_tol}
                            DIR udq_actionx
@@ -722,7 +722,7 @@ set(_model2_tests
 add_multiple_tests(
   _model2_tests
   ""
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR model2
@@ -730,7 +730,7 @@ add_multiple_tests(
 
 add_test_compareECLFiles(CASENAME multflt_model2
                         FILENAME 3_MULTFLT_MODEL2
-                        SIMULATOR flow
+                        SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                         ABS_TOL ${abs_tol}
                         REL_TOL ${rel_tol}
                         DIR model2
@@ -738,7 +738,7 @@ add_test_compareECLFiles(CASENAME multflt_model2
 
 add_test_compareECLFiles(CASENAME multpvv_model2
                          FILENAME 4_MINPVV_MODEL2
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR model2
@@ -746,7 +746,7 @@ add_test_compareECLFiles(CASENAME multpvv_model2
 
 add_test_compareECLFiles(CASENAME 9_3d_grpctl_stw_model2
                          FILENAME 9_3D_GINJ_GAS_MAX_EXPORT_STW
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR model2
@@ -754,53 +754,53 @@ add_test_compareECLFiles(CASENAME 9_3d_grpctl_stw_model2
 
 add_test_compareECLFiles(CASENAME model4_udq_group
                          FILENAME MOD4_UDQ_ACTIONX
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR model4)
 
 add_test_compareECLFiles(CASENAME model4_gefac
                          FILENAME MOD4_GRP_GEFAC
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR model4)
 
 add_test_compareECLFiles(CASENAME model6_msw
                          FILENAME 1_MSW_MODEL6
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR model6)
 
 add_test_compareECLFiles(CASENAME wsegsicd
                          FILENAME TEST_WSEGSICD
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol})
 
 add_test_compareECLFiles(CASENAME wsegaicd
                          FILENAME BASE_MSW_WSEGAICD
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol})
 
 add_test_compareECLFiles(CASENAME wsegvalv
                          FILENAME BASE_MSW_WSEGVALV
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol})
 
 add_test_compareECLFiles(CASENAME wsegvalv_2d_vert
                          FILENAME  MSW-2D-VERT-02
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR msw)
 
 add_test_compareECLFiles(CASENAME nnc
                          FILENAME NNC_AND_EDITNNC
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR editnnc
@@ -808,14 +808,14 @@ add_test_compareECLFiles(CASENAME nnc
 
 add_test_compareECLFiles(CASENAME nonnc
                          FILENAME NONNC
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR editnnc)
 
 add_test_compareECLFiles(CASENAME nnc_overlapping_editnnc
                          FILENAME NNC_OVERLAPPING_EDITNNC
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR editnnc
@@ -823,7 +823,7 @@ add_test_compareECLFiles(CASENAME nnc_overlapping_editnnc
 
 add_test_compareECLFiles(CASENAME nnc_overlapping_editnncr_multregt
                          FILENAME NNC_OVERLAPPING_EDITNNCR_MULTREGT
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR editnnc
@@ -831,28 +831,28 @@ add_test_compareECLFiles(CASENAME nnc_overlapping_editnncr_multregt
 
 add_test_compareECLFiles(CASENAME spe1_foam
                          FILENAME SPE1FOAM
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR spe1_foam)
 
 add_test_compareECLFiles(CASENAME spe1_solvent_foam
                          FILENAME SPE1CASE2_SOLVENT_FOAM
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR spe1_solvent)
 
 add_test_compareECLFiles(CASENAME spe1_gaswater_solvent
                          FILENAME SPE1CASE2_GASWATER_SOLVENT
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR spe1_solvent)
 
 add_test_compareECLFiles(CASENAME spe1_co2sol
                          FILENAME SPE1CASE2_CO2SOL
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR spe1_solvent
@@ -860,7 +860,7 @@ add_test_compareECLFiles(CASENAME spe1_co2sol
 
 add_test_compareECLFiles(CASENAME spe1_h2sol
                          FILENAME SPE1CASE2_H2SOL
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR spe1_solvent
@@ -868,14 +868,14 @@ add_test_compareECLFiles(CASENAME spe1_h2sol
 
 add_test_compareECLFiles(CASENAME bc_lab
                          FILENAME BC_LAB
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR bc_lab)
 
 add_test_compareECLFiles(CASENAME norne_reperf
                          FILENAME NORNE_ATW2013_B1H_RE-PERF
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR norne
@@ -883,14 +883,14 @@ add_test_compareECLFiles(CASENAME norne_reperf
 
 add_test_compareECLFiles(CASENAME compl_smry
                          FILENAME COMPL_SMRY
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR compl_smry)
 
 add_test_compareECLFiles(CASENAME 3d_tran_operator
                          FILENAME 3D_TRAN_OPERATOR
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR parallel_fieldprops
@@ -898,7 +898,7 @@ add_test_compareECLFiles(CASENAME 3d_tran_operator
 
 add_test_compareECLFiles(CASENAME h2store_biofilm
                          FILENAME H2STORE_BIOFILM
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR h2store
@@ -906,7 +906,7 @@ add_test_compareECLFiles(CASENAME h2store_biofilm
 
 add_test_compareECLFiles(CASENAME micp
                          FILENAME MICP
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR micp
@@ -914,28 +914,28 @@ add_test_compareECLFiles(CASENAME micp
 
 add_test_compareECLFiles(CASENAME 0_base_model6
                          FILENAME 0_BASE_MODEL6
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR model6)
 
 add_test_compareECLFiles(CASENAME 0a_aquct_model6
                          FILENAME 0A_AQUCT_MODEL6
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR model6)
 
 add_test_compareECLFiles(CASENAME 0b_rocktab_model6
                          FILENAME 0B_ROCKTAB_MODEL6
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR model6)
 
 add_test_compareECLFiles(CASENAME base_wt_tracer
                          FILENAME BASE_WT_TRACER
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR tracer
@@ -943,7 +943,7 @@ add_test_compareECLFiles(CASENAME base_wt_tracer
 
 add_test_compareECLFiles(CASENAME tracer_multiphase
                          FILENAME TRACER_2WT_2GT
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR tracer)
@@ -953,7 +953,7 @@ add_multiple_test_range(
   3
   MIN_BHP_
   min_bhp
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR wtest/bhp_min
@@ -962,7 +962,7 @@ add_multiple_test_range(
 
 add_test_compareECLFiles(CASENAME min_thp_1
                          FILENAME MIN_THP_1
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR wtest/thp_min
@@ -970,7 +970,7 @@ add_test_compareECLFiles(CASENAME min_thp_1
 
 add_test_compareECLFiles(CASENAME max_gor_1
                          FILENAME MAX_GOR_1
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR wtest/wecon_gor_max
@@ -978,7 +978,7 @@ add_test_compareECLFiles(CASENAME max_gor_1
 
 add_test_compareECLFiles(CASENAME min_gasrate_1
                          FILENAME MIN_GASRATE_1
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR wtest/wecon_qg_min
@@ -986,7 +986,7 @@ add_test_compareECLFiles(CASENAME min_gasrate_1
 
 add_test_compareECLFiles(CASENAME min_qoil_1
                          FILENAME MIN_QOIL_1
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR wtest/wecon_qo_min
@@ -997,7 +997,7 @@ add_multiple_test_range(
   4
   MAX_WATERCUT_
   max_watercut
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR wtest/wecon_wct_max
@@ -1006,7 +1006,7 @@ add_multiple_test_range(
 
 add_test_compareECLFiles(CASENAME max_wgr_1
                          FILENAME MAX_WGR_1
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR wtest/wecon_wgr_max
@@ -1014,7 +1014,7 @@ add_test_compareECLFiles(CASENAME max_wgr_1
 
 add_test_compareECLFiles(CASENAME rxft_smry
                          FILENAME TEST_RXFT
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR rxft_smry
@@ -1022,21 +1022,21 @@ add_test_compareECLFiles(CASENAME rxft_smry
 
 add_test_compareECLFiles(CASENAME bo_diffusion
                          FILENAME BO_DIFFUSE_CASE1
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR diffusion )
 
 add_test_compareECLFiles(CASENAME fpr_nonhc
                          FILENAME WATER2F
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR water-1ph)
 
 add_test_compareECLFiles(CASENAME actionx_wpimult
                          FILENAME ACTIONX_WPIMULT
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR actionx
@@ -1044,7 +1044,7 @@ add_test_compareECLFiles(CASENAME actionx_wpimult
 
 add_test_compareECLFiles(CASENAME wvfpexp_02
                          FILENAME WVFPEXP-02
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR wvfpexp)
@@ -1061,7 +1061,7 @@ set(_krnum_tests
 add_multiple_tests(
   _krnum_tests
   ""
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR krnum
@@ -1079,7 +1079,7 @@ set(_gridunit_tests
 add_multiple_tests(
   _gridunit_tests
   ""
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR gridunit
@@ -1087,7 +1087,7 @@ add_multiple_tests(
 
 add_test_compareECLFiles(CASENAME 01_wgrupcon
                          FILENAME 01-WGRUPCON
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR wgrupcon
@@ -1095,49 +1095,49 @@ add_test_compareECLFiles(CASENAME 01_wgrupcon
 
 add_test_compareECLFiles(CASENAME 02_wgrupcon
                          FILENAME 02-WGRUPCON
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR wgrupcon
                          TEST_ARGS --enable-tuning=true)
 add_test_compareECLFiles(CASENAME winjmult_stdw
                          FILENAME WINJMULT_STDW
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR winjmult
                          TEST_ARGS --enable-tuning=true)
 add_test_compareECLFiles(CASENAME winjmult_msw
                          FILENAME WINJMULT_MSW
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR winjmult
                          TEST_ARGS --enable-tuning=true)
 add_test_compareECLFiles(CASENAME winjdam_stdw
                          FILENAME WINJDAM_STDW
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR winjdam
                          TEST_ARGS --enable-tuning=true)
 add_test_compareECLFiles(CASENAME winjdam_msw
                          FILENAME WINJDAM_MSW
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR winjdam
                          TEST_ARGS --enable-tuning=true)
 add_test_compareECLFiles(CASENAME 01_vappars
                          FILENAME VAPPARS-01
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR vappars)
 
 add_test_compareECLFiles(CASENAME 6_uda_model5_stdw
   FILENAME 6_UDA_MODEL5_STDW
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR model5
@@ -1160,7 +1160,7 @@ set(_mult_cases
 add_multiple_tests(
   _mult_cases
   ""
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol}
   REL_TOL ${rel_tol}
   DIR mult
@@ -1168,14 +1168,14 @@ add_multiple_tests(
 
 add_test_compareECLFiles(CASENAME gsatprod
                          FILENAME GSATPROD2
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR satellite)
 
 add_test_compareECLFiles(CASENAME gsatprod6
                          FILENAME GSATPROD6
-                         SIMULATOR flow
+                         SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR satellite)

--- a/restartTests.cmake
+++ b/restartTests.cmake
@@ -6,7 +6,7 @@ set(rel_tol_restart 4e-4)
 
 add_test_compare_restarted_simulation(CASENAME spe1
                                       FILENAME SPE1CASE2_ACTNUM
-                                      SIMULATOR flow
+                                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                       ABS_TOL ${abs_tol_restart}
                                       REL_TOL ${rel_tol_restart}
                                       RESTART_STEP 6
@@ -14,7 +14,7 @@ add_test_compare_restarted_simulation(CASENAME spe1
 
 add_test_compare_restarted_simulation(CASENAME spe9
                                       FILENAME SPE9_CP_SHORT
-                                      SIMULATOR flow
+                                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                       ABS_TOL ${abs_tol_restart}
                                       REL_TOL ${rel_tol_restart}
                                       RESTART_STEP 15
@@ -22,7 +22,7 @@ add_test_compare_restarted_simulation(CASENAME spe9
 
 add_test_compare_restarted_simulation(CASENAME ctaquifer_2d_oilwater
                                       FILENAME 2D_OW_CTAQUIFER
-                                      SIMULATOR flow
+                                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                       ABS_TOL ${abs_tol_restart}
                                       REL_TOL ${rel_tol_restart}
                                       DIR aquifer-oilwater
@@ -31,7 +31,7 @@ add_test_compare_restarted_simulation(CASENAME ctaquifer_2d_oilwater
 
 add_test_compare_restarted_simulation(CASENAME fetkovich_2d
                                       FILENAME 2D_FETKOVICHAQUIFER
-                                      SIMULATOR flow
+                                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                       ABS_TOL ${abs_tol_restart}
                                       REL_TOL ${rel_tol_restart}
                                       RESTART_STEP 30
@@ -40,7 +40,7 @@ add_test_compare_restarted_simulation(CASENAME fetkovich_2d
 
 add_test_compare_restarted_simulation(CASENAME numerical_aquifer_3d_1aqu
                                       FILENAME 3D_1AQU_3CELLS
-                                      SIMULATOR flow
+                                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                       ABS_TOL 0.4
                                       REL_TOL 4.0e-3
                                       RESTART_STEP 3
@@ -49,7 +49,7 @@ add_test_compare_restarted_simulation(CASENAME numerical_aquifer_3d_1aqu
 
 add_test_compare_restarted_simulation(CASENAME numerical_aquifer_3d_2aqu
                                       FILENAME 3D_2AQU_NUM
-                                      SIMULATOR flow
+                                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                       ABS_TOL 0.4
                                       REL_TOL 4.0e-3
                                       RESTART_STEP 3
@@ -58,7 +58,7 @@ add_test_compare_restarted_simulation(CASENAME numerical_aquifer_3d_2aqu
 
 add_test_compare_restarted_simulation(CASENAME aquflux_01
                                       FILENAME AQUFLUX-01
-                                      SIMULATOR flow
+                                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                       ABS_TOL ${abs_tol_restart}
                                       REL_TOL 3.0e-3
                                       RESTART_STEP 3
@@ -67,7 +67,7 @@ add_test_compare_restarted_simulation(CASENAME aquflux_01
 
 add_test_compare_restarted_simulation(CASENAME aquflux_02
                                       FILENAME AQUFLUX-02
-                                      SIMULATOR flow
+                                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                       ABS_TOL ${abs_tol_restart}
                                       REL_TOL ${rel_tol_restart}
                                       RESTART_STEP 50
@@ -76,7 +76,7 @@ add_test_compare_restarted_simulation(CASENAME aquflux_02
 
 add_test_compare_restarted_simulation(CASENAME network_01_restart
                                       FILENAME NETWORK-01-RESTART
-                                      SIMULATOR flow
+                                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                       ABS_TOL ${abs_tol_restart}
                                       REL_TOL ${rel_tol_restart}
                                       RESTART_STEP 5
@@ -85,7 +85,7 @@ add_test_compare_restarted_simulation(CASENAME network_01_restart
 
 add_test_compare_restarted_simulation(CASENAME network_01_reroute_restart
                                       FILENAME NETWORK-01-REROUTE-RESTART
-                                      SIMULATOR flow
+                                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                       ABS_TOL ${abs_tol_restart}
                                       REL_TOL ${rel_tol_restart}
                                       RESTART_STEP 5
@@ -94,7 +94,7 @@ add_test_compare_restarted_simulation(CASENAME network_01_reroute_restart
 
 add_test_compare_restarted_simulation(CASENAME spe1_temp
                                       FILENAME SPE1CASE2_TEMP
-                                      SIMULATOR flow
+                                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                       ABS_TOL ${abs_tol_restart}
                                       REL_TOL 5.0e-2
                                       RESTART_STEP 3
@@ -106,7 +106,7 @@ add_test_compare_restarted_simulation(CASENAME spe1_temp
 # limit in restart files.
 add_test_compare_restarted_simulation(CASENAME udq_reg_02
   FILENAME UDQ_REG-02
-  SIMULATOR flow
+  SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
   ABS_TOL ${abs_tol_restart}
   REL_TOL ${rel_tol_restart}
   RESTART_STEP 2
@@ -123,7 +123,7 @@ set(rel_tol_restart_msw 1e-3)
 
 add_test_compare_restarted_simulation(CASENAME msw_3d_hfa
                                       FILENAME 3D_MSW
-                                      SIMULATOR flow
+                                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                       ABS_TOL ${abs_tol_restart_msw}
                                       REL_TOL ${rel_tol_restart_msw}
                                       RESTART_STEP 10
@@ -136,7 +136,7 @@ opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-summary-restart-regressionTe
 
 add_test_compare_restarted_simulation(CASENAME spe1_actnum
                                       FILENAME SPE1CASE2_ACTNUM
-                                      SIMULATOR flow
+                                      SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                       TEST_NAME restart_spe1_summary
                                       ABS_TOL ${abs_tol_restart}
                                       REL_TOL ${rel_tol_restart}
@@ -150,7 +150,7 @@ if(HDF5_FOUND)
   add_test_compare_restarted_simulation(CASENAME spe1_serialized
                                         DIR spe1
                                         FILENAME SPE1CASE1
-                                        SIMULATOR flow
+                                        SIMULATOR ${OPM_BLACKOIL_TEST_SIMULATOR}
                                         TEST_NAME compareSerializedSim_flow+spe1
                                         ABS_TOL 2e-2
                                         REL_TOL 1e-5

--- a/tests/run-damaris-regressionTest.sh
+++ b/tests/run-damaris-regressionTest.sh
@@ -17,12 +17,13 @@ then
   echo -e "\t\t -e <filename> Simulator binary to use"
   echo -e "\tOptional options:"
   echo -e "\t\t -n <procs>    Number of MPI processes to use"
+  echo -e "\t\t -u <name>     Reference simulator directory to compare against"
   exit 1
 fi
 
 MPI_PROCS=4
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:e:n:" OPT
+while getopts "i:r:b:f:a:t:c:e:n:u:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
@@ -34,10 +35,15 @@ do
     c) H5DIFF_COMMAND=${OPTARG} ;;
     e) EXE_NAME=${OPTARG} ;;
     n) MPI_PROCS=${OPTARG} ;;
+    u) REFERENCE_EXE_NAME=${OPTARG} ;;
   esac
 done
 shift $(($OPTIND-1))
 TEST_ARGS="$@"
+
+if [ -z "${REFERENCE_EXE_NAME}" ]; then
+  REFERENCE_EXE_NAME=${EXE_NAME}
+fi
 
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
@@ -49,10 +55,10 @@ echo "=== Executing comparison for files if these exists in reference folder ===
 for fname in `ls ${RESULT_PATH}/${FILENAME}*.h5`
 do
   fname=`basename $fname`
-  if test -f ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${fname}
+  if test -f ${INPUT_DATA_PATH}/opm-simulation-reference/${REFERENCE_EXE_NAME}/${fname}
   then
     echo -e "\t - ${fname}"
-    h5diffout=$(${H5DIFF_COMMAND} --relative=${REL_TOL} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${fname} ${RESULT_PATH}/${fname})
+    h5diffout=$(${H5DIFF_COMMAND} --relative=${REL_TOL} ${INPUT_DATA_PATH}/opm-simulation-reference/${REFERENCE_EXE_NAME}/${fname} ${RESULT_PATH}/${fname})
     if [ -n "${h5diffout}" ]; then
         exit 1
     fi

--- a/tests/run-init-regressionTest.sh
+++ b/tests/run-init-regressionTest.sh
@@ -18,11 +18,12 @@ then
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
   echo -e "\t\t -c <path>     Path to comparison tool"
   echo -e "\t\t -e <filename> Simulator binary to use"
+  echo -e "\t\t -u <name>     Reference simulator directory to compare against"
   exit 1
 fi
 
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:e:d:h:" OPT
+while getopts "i:r:b:f:a:t:c:e:d:h:u:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
@@ -35,10 +36,15 @@ do
     e) EXE_NAME=${OPTARG} ;;
     d) ;; # Ignored
     h) ;; # Ignored#
+    u) REFERENCE_EXE_NAME=${OPTARG} ;;
   esac
 done
 shift $(($OPTIND-1))
 TEST_ARGS="$@"
+
+if [ -z "${REFERENCE_EXE_NAME}" ]; then
+  REFERENCE_EXE_NAME=${EXE_NAME}
+fi
 
 rm -Rf  ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
@@ -47,11 +53,11 @@ ${BINPATH}/${EXE_NAME} ${TEST_ARGS} --enable-dry-run=true --output-dir=${RESULT_
 cd ..
 
 ecode=0
-${COMPARE_ECL_COMMAND} -t INIT ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
+${COMPARE_ECL_COMMAND} -t INIT ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-simulation-reference/${REFERENCE_EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
 if [ $? -ne 0 ]
 then
   ecode=1
-  ${COMPARE_ECL_COMMAND} -a -t INIT ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  ${COMPARE_ECL_COMMAND} -a -t INIT ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-simulation-reference/${REFERENCE_EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
 fi
 
 exit $ecode

--- a/tests/run-porv-acceptanceTest.sh
+++ b/tests/run-porv-acceptanceTest.sh
@@ -18,11 +18,12 @@ then
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
   echo -e "\t\t -c <path>     Path to comparison tool"
   echo -e "\t\t -e <filename> Simulator binary to use"
+  echo -e "\t\t -u <name>     Reference simulator directory to compare against"
   exit 1
 fi
 
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:e:d:h:" OPT
+while getopts "i:r:b:f:a:t:c:e:d:h:u:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
@@ -35,10 +36,15 @@ do
     e) EXE_NAME=${OPTARG} ;;
     d) ;; # Ignored
     h) ;; # Ignored
+    u) REFERENCE_EXE_NAME=${OPTARG} ;;
   esac
 done
 shift $(($OPTIND-1))
 TEST_ARGS="$@"
+
+if [ -z "${REFERENCE_EXE_NAME}" ]; then
+  REFERENCE_EXE_NAME=${EXE_NAME}
+fi
 
 rm -Rf  ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
@@ -47,11 +53,11 @@ ${BINPATH}/${EXE_NAME} ${TEST_ARGS} --enable-dry-run=true --output-dir=${RESULT_
 cd ..
 
 ecode=0
-${COMPARE_ECL_COMMAND} -t INIT -k PORV ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-porevolume-reference/${EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
+${COMPARE_ECL_COMMAND} -t INIT -k PORV ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-porevolume-reference/${REFERENCE_EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
 if [ $? -ne 0 ]
 then
   ecode=1
-  ${COMPARE_ECL_COMMAND} -a -t INIT -k PORV ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-porevolume-reference/${EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  ${COMPARE_ECL_COMMAND} -a -t INIT -k PORV ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-porevolume-reference/${REFERENCE_EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
 fi
 
 exit $ecode

--- a/tests/run-regressionTest.sh
+++ b/tests/run-regressionTest.sh
@@ -19,12 +19,13 @@ then
   echo -e "\tOptional options:"
   echo -e "\t\t -s <step>     Step to do restart testing from"
   echo -e "\t\t -h value      sched_restart value to use in restart test"
+  echo -e "\t\t -u <name>     Reference simulator directory to compare against"
   exit 1
 fi
 
 RESTART_STEP=""
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:d:s:e:h:" OPT
+while getopts "i:r:b:f:a:t:c:d:s:e:h:u:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
@@ -38,10 +39,15 @@ do
     s) RESTART_STEP=${OPTARG} ;;
     e) EXE_NAME=${OPTARG} ;;
     h) RESTART_SCHED=${OPTARG} ;;
+    u) REFERENCE_EXE_NAME=${OPTARG} ;;
   esac
 done
 shift $(($OPTIND-1))
 TEST_ARGS="$@"
+
+if [ -z "${REFERENCE_EXE_NAME}" ]; then
+  REFERENCE_EXE_NAME=${EXE_NAME}
+fi
 
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
@@ -81,11 +87,11 @@ else
   echo "=== Executing comparison for EGRID, INIT, UNRST, UNSMRY and RFT files if these exists in reference folder ==="
 fi
 
-${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${type} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${RESULT_PATH}/${FILENAME} ${ABS_TOL} ${REL_TOL}
+${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${type} ${INPUT_DATA_PATH}/opm-simulation-reference/${REFERENCE_EXE_NAME}/${FILENAME} ${RESULT_PATH}/${FILENAME} ${ABS_TOL} ${REL_TOL}
 if [ $? -ne 0 ]
 then
   ecode=1
-  ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${type} -a  ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${RESULT_PATH}/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${type} -a  ${INPUT_DATA_PATH}/opm-simulation-reference/${REFERENCE_EXE_NAME}/${FILENAME} ${RESULT_PATH}/${FILENAME} ${ABS_TOL} ${REL_TOL}
 fi
 
 RSTEPS=(${RESTART_STEP//,/ })
@@ -110,11 +116,11 @@ do
   else
     echo "=== Executing comparison for EGRID, INIT, UNRST, UNSMRY and RFT files for restarted run ==="
   fi
-  ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${type} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/restart/${FILENAME}_RESTART_${STEP} ${RESULT_PATH}/restart/${FILENAME}_RESTART_${STEP} ${ABS_TOL} ${REL_TOL}
+  ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${type} ${INPUT_DATA_PATH}/opm-simulation-reference/${REFERENCE_EXE_NAME}/restart/${FILENAME}_RESTART_${STEP} ${RESULT_PATH}/restart/${FILENAME}_RESTART_${STEP} ${ABS_TOL} ${REL_TOL}
   if [ $? -ne 0 ]
   then
     ecode=1
-    ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${type} -a ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/restart/${FILENAME}_RESTART_${STEP} ${RESULT_PATH}/restart/${FILENAME}_RESTART_${STEP} ${ABS_TOL} ${REL_TOL}
+    ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${type} -a ${INPUT_DATA_PATH}/opm-simulation-reference/${REFERENCE_EXE_NAME}/restart/${FILENAME}_RESTART_${STEP} ${RESULT_PATH}/restart/${FILENAME}_RESTART_${STEP} ${ABS_TOL} ${REL_TOL}
   fi
 done
 


### PR DESCRIPTION
This add:
- labeling of blackoil tests
- option for running blackout cases with flow_blackoil

This make recompilation and running test affecting blackoil faster. It is also easier to restrict the testing to what you work on. It is usefull for most of the development and in particular if one use agents.

This code is mostly generated by copilot.