### PR TITLE
Add option to use the development simulator binaries (e.g. flow_blackoil) in regression tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ option(USE_AMGX "Enable AMGX support?" OFF)
 option(USE_HYPRE "Use the Hypre library for linear solvers?" OFF)
 set(OPM_COMPILE_COMPONENTS "2;3;4;5;6;7" CACHE STRING "The components to compile support for")
 option(USE_OPENCL "Enable OpenCL support?" ON)
+option(USE_DEV_SIMULATOR_IN_TESTS "Use the development simulator binaries in tests?" OFF)
 
 # Wrapper for opm_add_target_options that also adds
 # compile definitions and target links from the library

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -136,7 +136,20 @@ endfunction()
 # Details:
 #   - This test class compares two separate simulations
 function(add_test_compareSeparateECLFiles)
-  set(oneValueArgs CASENAME FILENAME1 FILENAME2 DIR1 DIR2 SIMULATOR ABS_TOL REL_TOL IGNORE_EXTRA_KW DIR_PREFIX MPI_PROCS)
+  set(oneValueArgs
+    CASENAME
+    FILENAME1
+    FILENAME2
+    DIR1
+    DIR2
+    DEV_SIMULATOR
+    SIMULATOR
+    ABS_TOL
+    REL_TOL
+    IGNORE_EXTRA_KW
+    DIR_PREFIX
+    MPI_PROCS
+  )
   set(multiValueArgs TEST_ARGS)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
   if(NOT PARAM_PREFIX)
@@ -149,6 +162,9 @@ function(add_test_compareSeparateECLFiles)
   endif()
   if(NOT PARAM_DIR)
     set(PARAM_DIR ${PARAM_CASENAME})
+  endif()
+  if(USE_DEV_SIMULATOR_IN_TESTS AND PARAM_DEV_SIMULATOR)
+    set(PARAM_SIMULATOR ${PARAM_DEV_SIMULATOR})
   endif()
   set(RESULT_PATH ${BASE_RESULT_PATH}${PARAM_DIR_PREFIX}/${PARAM_SIMULATOR}+${PARAM_CASENAME})
   set(TEST_ARGS ${PARAM_TEST_ARGS})

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -314,12 +314,27 @@ endfunction()
 #   - This test class compares the output from a restarted parallel simulation
 #     to that of a non-restarted parallel simulation.
 function(add_test_compare_parallel_restarted_simulation)
-  set(oneValueArgs CASENAME FILENAME SIMULATOR ABS_TOL REL_TOL DIR MPI_PROCS RESTART_STEP TEST_NAME)
+  set(oneValueArgs
+    CASENAME
+    FILENAME
+    DEV_SIMULATOR
+    SIMULATOR
+    ABS_TOL
+    REL_TOL
+    DIR
+    MPI_PROCS
+    RESTART_STEP
+    TEST_NAME
+  )
   set(multiValueArgs TEST_ARGS)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
   if(NOT PARAM_DIR)
     set(PARAM_DIR ${PARAM_CASENAME})
+  endif()
+
+  if(USE_DEV_SIMULATOR_IN_TESTS AND PARAM_DEV_SIMULATOR)
+    set(PARAM_SIMULATOR ${PARAM_DEV_SIMULATOR})
   endif()
 
   if (PARAM_TEST_NAME)

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -807,12 +807,22 @@ if(MPI_FOUND)
   # Single test for damaris
   if(Damaris_FOUND AND USE_DAMARIS_LIB)
       opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-damaris-regressionTest.sh "")
-      add_test_compareDamarisFiles(CASENAME spe1_damaris
-                      FILENAME SPE1CASE1
-                      SIMULATOR flow
-                      ABS_TOL ${abs_tol}
-                      REL_TOL 0.01
-                      DIR spe1)
+      add_test_compareDamarisFiles(
+        CASENAME
+          spe1_damaris
+        FILENAME
+          SPE1CASE1
+        SIMULATOR
+          flow
+        DEV_SIMULATOR
+          flow_blackoil
+        ABS_TOL
+          ${abs_tol}
+        REL_TOL
+          0.01
+        DIR
+          spe1
+      )
     endif()
 
   include (${CMAKE_CURRENT_SOURCE_DIR}/parallelTests.cmake)

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -525,40 +525,70 @@ include (${CMAKE_CURRENT_SOURCE_DIR}/restartTests.cmake)
 
 # PORV test
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-porv-acceptanceTest.sh "")
-add_test_compareECLFiles(CASENAME norne
-                         FILENAME NORNE_ATW2013
-                         SIMULATOR flow
-                         DEV_SIMULATOR flow_blackoil
-                         ABS_TOL 1e-5
-                         REL_TOL 1e-8
-                         PREFIX comparePORV
-                         DIR_PREFIX /porv)
+add_test_compareECLFiles(
+  CASENAME
+    norne
+  FILENAME
+    NORNE_ATW2013
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    1e-5
+  REL_TOL
+    1e-8
+  PREFIX
+    comparePORV
+  DIR_PREFIX
+    /porv
+)
 
 # Init tests
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-init-regressionTest.sh "")
-
-add_test_compareECLFiles(CASENAME norne_init
-                         FILENAME NORNE_ATW2013
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         PREFIX compareECLInitFiles
-                         DIR norne
-                         DIR_PREFIX /init)
+add_test_compareECLFiles(
+  CASENAME
+    norne_init
+  FILENAME
+    NORNE_ATW2013
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  PREFIX
+    compareECLInitFiles
+  DIR
+    norne
+  DIR_PREFIX
+    /init
+)
 
 set(_operate_work_tests
   OPERATE_ENDPOINTS-01
   OPERATER_ENDPOINTS-01
 )
 
-add_multiple_tests(_operate_work_tests
+add_multiple_tests(
+  _operate_work_tests
   "operate_work_"
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  PREFIX compareECLInitFiles
-  DIR operate
-  DIR_PREFIX /init
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  PREFIX
+    compareECLInitFiles
+  DIR
+    operate
+  DIR_PREFIX
+    /init
 )
 
 # This is not a proper regression test; the test will load a norne case prepared

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -775,11 +775,20 @@ if(MPI_FOUND)
 
   # Single test to verify that we treat custom communicators correctly.
   opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-split-comm-test.sh "")
-  add_test_split_comm(CASENAME spe1
-                      FILENAME SPE1CASE2
-                      SIMULATOR flow
-                      ABS_TOL 0.0
-                      REL_TOL 0.0)
+  add_test_split_comm(
+    CASENAME
+      spe1
+    FILENAME
+      SPE1CASE2
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    ABS_TOL
+      0.0
+    REL_TOL
+      0.0
+  )
 
   # Single test for damaris
   if(Damaris_FOUND AND USE_DAMARIS_LIB)

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -21,7 +21,17 @@ set(BASE_RESULT_PATH ${PROJECT_BINARY_DIR}/tests/results)
 # Details:
 #   - This test class simply runs a simulation.
 function(add_test_runSimulator)
-  set(oneValueArgs CASENAME FILENAME SIMULATOR DIR DIR_PREFIX PROCS CONFIGURATION POST_COMMAND)
+  set(oneValueArgs
+    CASENAME
+    FILENAME
+    DEV_SIMULATOR
+    SIMULATOR
+    DIR
+    DIR_PREFIX
+    PROCS
+    CONFIGURATION
+    POST_COMMAND
+  )
   set(multiValueArgs TEST_ARGS)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
   if(NOT PARAM_DIR)
@@ -39,11 +49,14 @@ function(add_test_runSimulator)
  if(PARAM_POST_COMMAND)
    list(APPEND DRIVER_ARGS -p "${PARAM_POST_COMMAND}")
  endif()
-  opm_add_test(runSimulator/${PARAM_CASENAME} NO_COMPILE
-               EXE_NAME ${PARAM_SIMULATOR}
-               DRIVER_ARGS ${DRIVER_ARGS}
-               TEST_ARGS ${TEST_ARGS}
-               CONFIGURATION ${PARAM_CONFIGURATION})
+ if(USE_DEV_SIMULATOR_IN_TESTS AND PARAM_DEV_SIMULATOR)
+   set(PARAM_SIMULATOR ${PARAM_DEV_SIMULATOR})
+ endif()
+ opm_add_test(runSimulator/${PARAM_CASENAME} NO_COMPILE
+              EXE_NAME ${PARAM_SIMULATOR}
+              DRIVER_ARGS ${DRIVER_ARGS}
+              TEST_ARGS ${TEST_ARGS}
+              CONFIGURATION ${PARAM_CONFIGURATION})
  if(PARAM_PROCS)
     set_tests_properties(runSimulator/${PARAM_CASENAME} PROPERTIES PROCESSORS ${PARAM_PROCS})
   endif()

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -59,7 +59,19 @@ endfunction()
 # Details:
 #   - This test class compares output from a simulation to reference files.
 function(add_test_compareECLFiles)
-  set(oneValueArgs CASENAME FILENAME SIMULATOR ABS_TOL REL_TOL DIR DIR_PREFIX PREFIX RESTART_STEP RESTART_SCHED)
+  set(oneValueArgs
+    CASENAME
+    FILENAME
+    DEV_SIMULATOR
+    SIMULATOR
+    ABS_TOL
+    REL_TOL
+    DIR
+    DIR_PREFIX
+    PREFIX
+    RESTART_STEP
+    RESTART_SCHED
+  )
   set(multiValueArgs TEST_ARGS)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
   if(NOT PARAM_DIR)
@@ -83,6 +95,10 @@ function(add_test_compareECLFiles)
   endif()
   if(PARAM_RESTART_SCHED STREQUAL "false" OR PARAM_RESTART_SCHED STREQUAL "true")
     list(APPEND DRIVER_ARGS -h ${PARAM_RESTART_SCHED})
+  endif()
+  list(APPEND DRIVER_ARGS -u ${PARAM_SIMULATOR})
+  if(USE_DEV_SIMULATOR_IN_TESTS AND PARAM_DEV_SIMULATOR)
+    set(PARAM_SIMULATOR ${PARAM_DEV_SIMULATOR})
   endif()
   opm_add_test(${PARAM_PREFIX}_${PARAM_SIMULATOR}+${PARAM_FILENAME} NO_COMPILE
                EXE_NAME ${PARAM_SIMULATOR}
@@ -512,6 +528,7 @@ opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-porv-acceptanceTest.sh "")
 add_test_compareECLFiles(CASENAME norne
                          FILENAME NORNE_ATW2013
                          SIMULATOR flow
+                         DEV_SIMULATOR flow_blackoil
                          ABS_TOL 1e-5
                          REL_TOL 1e-8
                          PREFIX comparePORV

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -399,7 +399,16 @@ endfunction()
 #   - This test class compares the output from a parallel simulation
 #     to that of a parallel simulation running with a custom communicator.
 function(add_test_split_comm)
-  set(oneValueArgs CASENAME FILENAME SIMULATOR ABS_TOL REL_TOL DIR MPI_PROCS)
+  set(oneValueArgs
+    CASENAME
+    FILENAME
+    DEV_SIMULATOR
+    SIMULATOR
+    ABS_TOL
+    REL_TOL
+    DIR
+    MPI_PROCS
+  )
   set(multiValueArgs TEST_ARGS)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
@@ -411,6 +420,10 @@ function(add_test_split_comm)
     set(MPI_PROCS ${PARAM_MPI_PROCS})
   else()
     set(MPI_PROCS 4)
+  endif()
+
+  if(USE_DEV_SIMULATOR_IN_TESTS AND PARAM_DEV_SIMULATOR)
+    set(PARAM_SIMULATOR ${PARAM_DEV_SIMULATOR})
   endif()
 
   set(RESULT_PATH ${BASE_RESULT_PATH}/parallelSplitComm/${PARAM_SIMULATOR}+${PARAM_CASENAME})

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -244,7 +244,17 @@ endfunction()
 #   - This test class compares the output from a parallel simulation
 #     to the output from the serial instance of the same model.
 function(add_test_compare_parallel_simulation)
-  set(oneValueArgs CASENAME FILENAME SIMULATOR ABS_TOL REL_TOL DIR POSTFIX MPI_PROCS)
+  set(oneValueArgs
+    CASENAME
+    FILENAME
+    DEV_SIMULATOR
+    SIMULATOR
+    ABS_TOL
+    REL_TOL
+    DIR
+    POSTFIX
+    MPI_PROCS
+  )
   set(multiValueArgs TEST_ARGS)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
@@ -262,6 +272,10 @@ function(add_test_compare_parallel_simulation)
     set(MPI_PROCS ${PARAM_MPI_PROCS})
   else()
     set(MPI_PROCS 4)
+  endif()
+
+  if(USE_DEV_SIMULATOR_IN_TESTS AND PARAM_DEV_SIMULATOR)
+    set(PARAM_SIMULATOR ${PARAM_DEV_SIMULATOR})
   endif()
 
   if(MPIEXEC_MAX_NUMPROCS GREATER_EQUAL MPI_PROCS)

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -457,7 +457,18 @@ endfunction()
 # Details:
 #   - This test class compares output from a simulation to reference files.
 function(add_test_compareDamarisFiles)
-  set(oneValueArgs CASENAME FILENAME SIMULATOR ABS_TOL REL_TOL DIR DIR_PREFIX PREFIX MPI_PROCS)
+  set(oneValueArgs
+    CASENAME
+    FILENAME
+    DEV_SIMULATOR
+    SIMULATOR
+    ABS_TOL
+    REL_TOL
+    DIR
+    DIR_PREFIX
+    PREFIX
+    MPI_PROCS
+  )
   set(multiValueArgs TEST_ARGS)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
   if(NOT PARAM_DIR)
@@ -470,6 +481,9 @@ function(add_test_compareDamarisFiles)
     set(MPI_PROCS ${PARAM_MPI_PROCS})
   else()
     set(MPI_PROCS 4)
+  endif()
+  if(USE_DEV_SIMULATOR_IN_TESTS AND PARAM_DEV_SIMULATOR)
+    set(PARAM_SIMULATOR ${PARAM_DEV_SIMULATOR})
   endif()
   set(RESULT_PATH ${BASE_RESULT_PATH}${PARAM_DIR_PREFIX}/${PARAM_SIMULATOR}+${PARAM_CASENAME})
   set(TEST_ARGS ${PARAM_TEST_ARGS})

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -465,68 +465,163 @@ endif()
 
 # Simple execution tests
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-test.sh "")
-add_test_runSimulator(CASENAME norne
-                      FILENAME NORNE_ATW2013
-                      SIMULATOR flow
-                      CONFIGURATION extra)
+add_test_runSimulator(
+  CASENAME
+    norne
+  FILENAME
+    NORNE_ATW2013
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  CONFIGURATION
+    extra
+)
 
-add_test_runSimulator(CASENAME norne_parallel
-                      FILENAME NORNE_ATW2013
-                      SIMULATOR flow
-                      DIR norne
-                      PROCS 4
-                      CONFIGURATION extra)
+add_test_runSimulator(
+  CASENAME
+    norne_parallel
+  FILENAME
+    NORNE_ATW2013
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  DIR
+    norne
+  PROCS
+    4
+  CONFIGURATION
+    extra
+)
 
-add_test_runSimulator(CASENAME spe1case1_carfin
-                      FILENAME SPE1CASE1_CARFIN
-                      SIMULATOR flow
-                      DIR lgr
-                      TEST_ARGS --parsing-strictness=low --enable-ecl-output=true --enable-vtk-output=true)
+add_test_runSimulator(
+  CASENAME
+    spe1case1_carfin
+  FILENAME
+    SPE1CASE1_CARFIN
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  DIR
+    lgr
+  TEST_ARGS
+    --parsing-strictness=low
+    --enable-ecl-output=true
+    --enable-vtk-output=true
+)
 
-add_test_runSimulator(CASENAME spe1case1_carfin_gr
-                      FILENAME SPE1CASE1_CARFIN_GR
-                      SIMULATOR flow
-                      DIR lgr
-                      TEST_ARGS --parsing-strictness=low --enable-ecl-output=true --enable-vtk-output=true)
+add_test_runSimulator(
+  CASENAME
+    spe1case1_carfin_gr
+  FILENAME
+    SPE1CASE1_CARFIN_GR
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  DIR
+    lgr
+  TEST_ARGS
+    --parsing-strictness=low
+    --enable-ecl-output=true
+    --enable-vtk-output=true
+)
 
 if(MPI_FOUND)
-  add_test_runSimulator(CASENAME spe1case1_carfin_parallel
-                        FILENAME SPE1CASE1_CARFIN
-                        SIMULATOR flow
-                        DIR lgr
-                        PROCS 4
-                        TEST_ARGS --parsing-strictness=low --enable-ecl-output=false --enable-vtk-output=true)
+  add_test_runSimulator(
+    CASENAME
+      spe1case1_carfin_parallel
+    FILENAME
+      SPE1CASE1_CARFIN
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    DIR
+      lgr
+    PROCS
+      4
+    TEST_ARGS
+      --parsing-strictness=low
+      --enable-ecl-output=false
+      --enable-vtk-output=true
+  )
 endif()
 
-add_test_runSimulator(CASENAME dryrun
-                      FILENAME CO2STORE_PRECSALT
-                      SIMULATOR flow
-                      DIR co2store
-                      TEST_ARGS --enable-dry-run=true --enable-ecl-output=false --enable-vtk-output=true)
+add_test_runSimulator(
+  CASENAME
+    dryrun
+  FILENAME
+    CO2STORE_PRECSALT
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_brine_precsalt_vapwat
+  DIR
+    co2store
+  TEST_ARGS
+    --enable-dry-run=true
+    --enable-ecl-output=false
+    --enable-vtk-output=true
+)
 
 # Tests that are run based on simulator results, but not necessarily direct comparison to reference results
-add_test_runSimulator(CASENAME tuning_trgmbe
-                      FILENAME 01_TUNING_TRGMBE
-                      SIMULATOR flow
-											DIR tuning
-                      TEST_ARGS --output-extra-convergence-info=iterations --enable-tuning=true
-                      POST_COMMAND $<TARGET_FILE:test_tuning_trgmbe>)
+add_test_runSimulator(
+  CASENAME
+    tuning_trgmbe
+  FILENAME
+    01_TUNING_TRGMBE
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  DIR
+    tuning
+  TEST_ARGS
+    --output-extra-convergence-info=iterations
+    --enable-tuning=true
+  POST_COMMAND
+    $<TARGET_FILE:test_tuning_trgmbe>
+)
 
-add_test_runSimulator(CASENAME notuning_trgmbe
-                      FILENAME 01_TUNING_TRGMBE
-                      SIMULATOR flow
-											DIR tuning
-                      TEST_ARGS --output-extra-convergence-info=iterations --enable-tuning=false
-                      POST_COMMAND $<TARGET_FILE:test_tuning_trgmbe>)
+add_test_runSimulator(
+  CASENAME
+    notuning_trgmbe
+  FILENAME
+    01_TUNING_TRGMBE
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  DIR
+    tuning
+  TEST_ARGS
+    --output-extra-convergence-info=iterations
+    --enable-tuning=false
+  POST_COMMAND
+    $<TARGET_FILE:test_tuning_trgmbe>
+)
 
 set_tests_properties(runSimulator/notuning_trgmbe PROPERTIES WILL_FAIL TRUE)
 
-add_test_runSimulator(CASENAME tuning_tsinit_nextstep
-                      FILENAME 02_TUNING_TSINIT_NEXTSTEP
-                      SIMULATOR flow
-											DIR tuning
-                      TEST_ARGS --enable-tuning=true
-                      POST_COMMAND $<TARGET_FILE:test_tuning_tsinit_nextstep>)
+add_test_runSimulator(
+  CASENAME
+    tuning_tsinit_nextstep
+  FILENAME
+    02_TUNING_TSINIT_NEXTSTEP
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  DIR
+    tuning
+  TEST_ARGS
+    --enable-tuning=true
+  POST_COMMAND
+    $<TARGET_FILE:test_tuning_tsinit_nextstep>
+)
 
 get_property(opm-common_EMBEDDED_PYTHON TARGET opmcommon PROPERTY EMBEDDED_PYTHON)
 if (opm-common_EMBEDDED_PYTHON)

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -712,13 +712,6 @@ add_multiple_tests(
     /init
 )
 
-# This is not a proper regression test; the test will load a norne case prepared
-# for restart and run one single timestep - of length one day. The results are not
-# verified in any way.
-add_test(NAME NORNE_RESTART
-         COMMAND flow --output-dir=${BASE_RESULT_PATH}/norne-restart ${OPM_TESTS_ROOT}/norne/NORNE_ATW2013_RESTART.DATA)
-
-
 if(MPI_FOUND)
   include (${CMAKE_CURRENT_SOURCE_DIR}/parallelRestartTests.cmake)
 

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -193,11 +193,24 @@ endfunction()
 #   - This test class compares the output from a restarted simulation
 #     to that of a non-restarted simulation.
 function(add_test_compare_restarted_simulation)
-  set(oneValueArgs CASENAME FILENAME SIMULATOR TEST_NAME ABS_TOL REL_TOL DIR RESTART_STEP)
+  set(oneValueArgs
+    CASENAME
+    FILENAME
+    DEV_SIMULATOR
+    SIMULATOR
+    TEST_NAME
+    ABS_TOL
+    REL_TOL
+    DIR
+    RESTART_STEP
+  )
   set(multiValueArgs TEST_ARGS)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
   if(NOT PARAM_DIR)
     set(PARAM_DIR ${PARAM_CASENAME})
+  endif()
+  if(USE_DEV_SIMULATOR_IN_TESTS AND PARAM_DEV_SIMULATOR)
+    set(PARAM_SIMULATOR ${PARAM_DEV_SIMULATOR})
   endif()
   if (PARAM_TEST_NAME)
     set(TEST_NAME ${PARAM_TEST_NAME})

--- a/comparisonTests.cmake
+++ b/comparisonTests.cmake
@@ -7,14 +7,27 @@ set(rel_tol 1e-5)
 set(coarse_rel_tol 1e-2)
 
 # Tests comparing VFPTABLE oneliner vs multiliner lift curves (constant delta pressure)
-add_test_compareSeparateECLFiles(CASENAME spe1_metric_vfp1_multiliner_vs_oneliner
-                                 DIR1 vfpprod_spe1_oneliner
-                                 FILENAME1 SPE1CASE1_METRIC_VFP1_MULTILINER
-                                 DIR2 vfpprod_spe1_oneliner
-                                 FILENAME2 SPE1CASE1_METRIC_VFP1_ONELINER
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH
-                                 MPI_PROCS 1)
-
+add_test_compareSeparateECLFiles(
+  CASENAME
+    spe1_metric_vfp1_multiliner_vs_oneliner
+  DIR1
+    vfpprod_spe1_oneliner
+  FILENAME1
+    SPE1CASE1_METRIC_VFP1_MULTILINER
+  DIR2
+    vfpprod_spe1_oneliner
+  FILENAME2
+    SPE1CASE1_METRIC_VFP1_ONELINER
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+  MPI_PROCS
+    1
+)

--- a/parallelRestartTests.cmake
+++ b/parallelRestartTests.cmake
@@ -1,78 +1,198 @@
 # Parallel tests
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-parallel-restart-regressionTest.sh "")
-add_test_compare_parallel_restarted_simulation(CASENAME spe1
-                                               FILENAME SPE1CASE2_ACTNUM
-                                               SIMULATOR flow
-                                               ABS_TOL ${abs_tol_restart}
-                                               REL_TOL ${rel_tol_restart}
-                                               RESTART_STEP 6
-                                               TEST_ARGS --sched-restart=false --enable-adaptive-time-stepping=false)
+add_test_compare_parallel_restarted_simulation(
+  CASENAME
+    spe1
+  FILENAME
+    SPE1CASE2_ACTNUM
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_restart}
+  REL_TOL
+    ${rel_tol_restart}
+  RESTART_STEP
+    6
+  TEST_ARGS
+    --sched-restart=false
+    --enable-adaptive-time-stepping=false
+)
 
-add_test_compare_parallel_restarted_simulation(CASENAME ctaquifer_2d_oilwater
-                                               FILENAME 2D_OW_CTAQUIFER
-                                               SIMULATOR flow
-                                               ABS_TOL ${abs_tol_restart}
-                                               REL_TOL ${rel_tol_restart}
-                                               RESTART_STEP 15
-                                               DIR aquifer-oilwater
-                                               TEST_ARGS --enable-tuning=true --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-6 --enable-adaptive-time-stepping=false)
+add_test_compare_parallel_restarted_simulation(
+  CASENAME
+    ctaquifer_2d_oilwater
+  FILENAME
+    2D_OW_CTAQUIFER
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater
+  ABS_TOL
+    ${abs_tol_restart}
+  REL_TOL
+    ${rel_tol_restart}
+  RESTART_STEP
+    15
+  DIR
+    aquifer-oilwater
+  TEST_ARGS
+    --enable-tuning=true
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=5e-6
+    --tolerance-mb=1e-6
+    --enable-adaptive-time-stepping=false
+)
 
-add_test_compare_parallel_restarted_simulation(CASENAME fetkovich_2d
-                                               FILENAME 2D_FETKOVICHAQUIFER
-                                               SIMULATOR flow
-                                               ABS_TOL ${abs_tol_restart}
-                                               REL_TOL ${rel_tol_restart}
-                                               RESTART_STEP 30
-                                               DIR aquifer-fetkovich
-                                               TEST_ARGS --enable-tuning=true --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-6 --enable-adaptive-time-stepping=false)
+add_test_compare_parallel_restarted_simulation(
+  CASENAME
+    fetkovich_2d
+  FILENAME
+    2D_FETKOVICHAQUIFER
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater
+  ABS_TOL
+    ${abs_tol_restart}
+  REL_TOL
+    ${rel_tol_restart}
+  RESTART_STEP
+    30
+  DIR
+    aquifer-fetkovich
+  TEST_ARGS
+    --enable-tuning=true
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=5e-6
+    --tolerance-mb=1e-6
+    --enable-adaptive-time-stepping=false
+)
 
-add_test_compare_parallel_restarted_simulation(CASENAME numerical_aquifer_3d_2aqu
-                                               FILENAME 3D_2AQU_NUM
-                                               SIMULATOR flow
-                                               ABS_TOL 0.12
-                                               REL_TOL 5.0e-2
-                                               RESTART_STEP 3
-                                               DIR aquifer-num
-                                               TEST_ARGS --enable-tuning=true --tolerance-cnv=0.00003 --time-step-control=pid --linear-solver=cpr_trueimpes --enable-adaptive-time-stepping=false)
+add_test_compare_parallel_restarted_simulation(
+  CASENAME
+    numerical_aquifer_3d_2aqu
+  FILENAME
+    3D_2AQU_NUM
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    0.12
+  REL_TOL
+    5.0e-2
+  RESTART_STEP
+    3
+  DIR
+    aquifer-num
+  TEST_ARGS
+    --enable-tuning=true
+    --tolerance-cnv=0.00003
+    --time-step-control=pid
+    --linear-solver=cpr_trueimpes
+    --enable-adaptive-time-stepping=false
+)
 
-add_test_compare_parallel_restarted_simulation(CASENAME numerical_aquifer_3d_1aqu
-                                               FILENAME 3D_1AQU_3CELLS
-                                               SIMULATOR flow
-                                               ABS_TOL 0.12
-                                               REL_TOL 5.0e-2
-                                               RESTART_STEP 3
-                                               DIR aquifer-num
-                                               TEST_ARGS --enable-tuning=true --tolerance-cnv=0.00003 --time-step-control=pid --linear-solver=cpr_trueimpes --enable-adaptive-time-stepping=false)
+add_test_compare_parallel_restarted_simulation(
+  CASENAME
+    numerical_aquifer_3d_1aqu
+  FILENAME
+    3D_1AQU_3CELLS
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    0.12
+  REL_TOL
+    5.0e-2
+  RESTART_STEP
+    3
+  DIR
+    aquifer-num
+  TEST_ARGS
+    --enable-tuning=true
+    --tolerance-cnv=0.00003
+    --time-step-control=pid
+    --linear-solver=cpr_trueimpes
+    --enable-adaptive-time-stepping=false
+)
 
-add_test_compare_parallel_restarted_simulation(CASENAME aquflux_01
-                                               FILENAME AQUFLUX-01
-                                               SIMULATOR flow
-                                               ABS_TOL ${abs_tol_restart}
-                                               REL_TOL 5.0e-2
-                                               RESTART_STEP 3
-                                               DIR aquifers
-                                               TEST_ARGS --solver-max-time-step-in-days=1)
+add_test_compare_parallel_restarted_simulation(
+  CASENAME
+    aquflux_01
+  FILENAME
+    AQUFLUX-01
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_restart}
+  REL_TOL
+    5.0e-2
+  RESTART_STEP
+    3
+  DIR
+    aquifers
+  TEST_ARGS
+    --solver-max-time-step-in-days=1
+)
 
-add_test_compare_parallel_restarted_simulation(CASENAME aquflux_02
-                                               FILENAME AQUFLUX-02
-                                               SIMULATOR flow
-                                               ABS_TOL ${abs_tol_restart}
-                                               REL_TOL 5.0e-2
-                                               RESTART_STEP 50
-                                               DIR aquifers
-                                               TEST_ARGS --solver-max-time-step-in-days=1)
+add_test_compare_parallel_restarted_simulation(
+  CASENAME
+    aquflux_02
+  FILENAME
+    AQUFLUX-02
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater
+  ABS_TOL
+    ${abs_tol_restart}
+  REL_TOL
+    5.0e-2
+  RESTART_STEP
+    50
+  DIR
+    aquifers
+  TEST_ARGS
+    --solver-max-time-step-in-days=1
+)
 
 # Serialized restart tests
 if(HDF5_FOUND)
   opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-serialization-regressionTest.sh "")
-  add_test_compare_parallel_restarted_simulation(CASENAME spe1_serialized
-                                                 DIR spe1
-                                                 FILENAME SPE1CASE1
-                                                 SIMULATOR flow
-                                                 TEST_NAME compareParallelSerializedSim_flow+spe1
-                                                 ABS_TOL 2e-2
-                                                 REL_TOL 1e-5
-                                                 RESTART_STEP 94
-                                                 TEST_ARGS --tolerance-mb=1e-7 --linear-solver=ilu0
-                                                 MPI_PROCS 4)
+  if(USE_DEV_SIMULATOR_IN_TESTS)
+    set(RESTART_SIM flow_blackoil)
+  else()
+    set(RESTART_SIM flow)
+  endif()
+  add_test_compare_parallel_restarted_simulation(
+    CASENAME
+      spe1_serialized
+    DIR
+      spe1
+    FILENAME
+      SPE1CASE1
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    TEST_NAME
+      compareParallelSerializedSim_${RESTART_SIM}+spe1
+    ABS_TOL
+      2e-2
+    REL_TOL
+      1e-5
+    RESTART_STEP
+      94
+    MPI_PROCS
+      4
+    TEST_ARGS
+      --tolerance-mb=1e-7
+      --linear-solver=ilu0
+  )
 endif()

--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -5,376 +5,946 @@ set(abs_tol_parallel 0.02)
 set(rel_tol_parallel 8e-5)
 set(coarse_rel_tol_parallel 1e-2)
 
-add_test_compare_parallel_simulation(CASENAME spe1
-                                     FILENAME SPE1CASE2
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL ${rel_tol_parallel}
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
-
-add_test_compare_parallel_simulation(CASENAME spe1_gaswater
-                                     FILENAME SPE1CASE2_GASWATER
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL ${rel_tol_parallel}
-                                     DIR spe1
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
-
-add_test_compare_parallel_simulation(CASENAME spe9
-                                     FILENAME SPE9_CP_SHORT
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL ${rel_tol_parallel}
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
-
-# A test for distributed standard wells. We load distribute only along the z-axis
-add_test_compare_parallel_simulation(CASENAME spe9_dist_z
-                                     FILENAME SPE9_CP_SHORT
-                                     DIR spe9
-                                     SIMULATOR flow_distribute_z
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL ${rel_tol_parallel}
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
-
-# A test for distributed standard wells with 8 processes. We load distribute only along the z-axis
-add_test_compare_parallel_simulation(CASENAME spe9_dist_z_8
-                                     FILENAME SPE9_CP_SHORT
-                                     POSTFIX 8
-                                     DIR spe9
-                                     SIMULATOR flow_distribute_z
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL ${rel_tol_parallel}
-                                     MPI_PROCS 8
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
-
-# A test for distributed multisegment wells. We load distribute only along the z-axis
-add_test_compare_parallel_simulation(CASENAME msw-simple
-                                     FILENAME MSW-SIMPLE # this file contains one Multisegment well without branches that is distributed across several processes
-                                     DIR msw
-                                     SIMULATOR flow_distribute_z
-                                     ABS_TOL 1e4 # the absolute tolerance is pretty high here, yet in this case, we are only interested in the relative tolerance
-                                     REL_TOL 1e-5
-                                     MPI_PROCS 4
-                                     TEST_ARGS --solver-max-time-step-in-days=15 --allow-distributed-wells=true)
-
-# A test for distributed multisegment wells. We load distribute only along the z-axis
-add_test_compare_parallel_simulation(CASENAME msw-simple-9-perfs-1-seg
-                                     FILENAME MSW-SIMPLE-9-PERFS-1-SEG # this file contains one Multisegment well without branches where 9 perforations belong to the same segment
-                                     DIR msw
-                                     SIMULATOR flow_distribute_z
-                                     ABS_TOL 1e4 # the absolute tolerance is pretty high here, yet in this case, we are only interested in the relative tolerance
-                                     REL_TOL 1e-5
-                                     MPI_PROCS 4
-                                     TEST_ARGS --solver-max-time-step-in-days=10 --allow-distributed-wells=true)
-
-# A test for distributed multisegment wells with one shut perforation at the process border. We load distribute only along the z-axis
-add_test_compare_parallel_simulation(CASENAME msw-simple-1-shut-perforation-border
-                                     FILENAME MSW-SIMPLE-1-SHUT-PERFORATION-BORDER # this file contains one Multisegment well without branches that is distributed across several processes
-                                     DIR msw
-                                     SIMULATOR flow_distribute_z
-                                     ABS_TOL 1e4 # the absolute tolerance is pretty high here, yet in this case, we are only interested in the relative tolerance
-                                     REL_TOL 1e-5
-                                     MPI_PROCS 4
-                                     TEST_ARGS --solver-max-time-step-in-days=15 --allow-distributed-wells=true)
-
-
-# A test for distributed multisegment wells with only one open perforation. We load distribute only along the z-axis
-add_test_compare_parallel_simulation(CASENAME msw-simple-shut-perforations
-                                     FILENAME MSW-SIMPLE-SHUT-PERFORATIONS # this file contains one Multisegment well without branches that is distributed across several processes
-                                     DIR msw
-                                     SIMULATOR flow_distribute_z
-                                     ABS_TOL 1e4 # the absolute tolerance is pretty high here, yet in this case, we are only interested in the relative tolerance
-                                     REL_TOL 1e-5
-                                     MPI_PROCS 4
-                                     TEST_ARGS --solver-max-time-step-in-days=15 --allow-distributed-wells=true)
-
-# A test for distributed multisegment wells with only shut perforations on rank 0, where the well is distributed across ranks 0 and 1. We load distribute only along the z-axis
-add_test_compare_parallel_simulation(CASENAME msw-simple-5-shut-perforations
-                                     FILENAME MSW-SIMPLE-5-SHUT-PERFORATIONS # this file contains one Multisegment well without branches that is distributed across several processes
-                                     DIR msw
-                                     SIMULATOR flow_distribute_z
-                                     ABS_TOL 1e4 # the absolute tolerance is pretty high here, yet in this case, we are only interested in the relative tolerance
-                                     REL_TOL 1e-5
-                                     MPI_PROCS 4
-                                     TEST_ARGS --solver-max-time-step-in-days=10 --allow-distributed-wells=true)
-
-# A test for distributed multisegment wells with only shut perforations on rank 1, where the well is distributed across ranks 0 and 1. We load distribute only along the z-axis
-add_test_compare_parallel_simulation(CASENAME msw-simple-7-shut-perforations
-                                     FILENAME MSW-SIMPLE-7-SHUT-PERFORATIONS # this file contains one Multisegment well without branches that is distributed across several processes
-                                     DIR msw
-                                     SIMULATOR flow_distribute_z
-                                     ABS_TOL 1e4 # the absolute tolerance is pretty high here, yet in this case, we are only interested in the relative tolerance
-                                     REL_TOL 1e-5
-                                     MPI_PROCS 4
-                                     TEST_ARGS --solver-max-time-step-in-days=15 --allow-distributed-wells=true)
-
-add_test_compare_parallel_simulation(CASENAME msw-3d
-                                     FILENAME MSW-3D # this file contains one Multisegment well with branches that is distributed across several processes
-                                     DIR msw
-                                     SIMULATOR flow_distribute_z
-                                     ABS_TOL 1e4 # the absolute tolerance is pretty high here, yet in this case, we are only interested in the relative tolerance
-                                     REL_TOL 1e-4
-                                     MPI_PROCS 4
-                                     TEST_ARGS --allow-distributed-wells=true)
-
-add_test_compare_parallel_simulation(CASENAME msw-3d-two-producers
-                                     FILENAME MSW-3D-TWO-PRODUCERS # this file contains two Multisegment wells with branches that are distributed across several processes
-                                     DIR msw
-                                     SIMULATOR flow_distribute_z
-                                     ABS_TOL 1e4 # the absolute tolerance is pretty high here, yet in this case, we are only interested in the relative tolerance
-                                     REL_TOL 1e-4
-                                     MPI_PROCS 4
-                                     TEST_ARGS --allow-distributed-wells=true)
-
-add_test_compare_parallel_simulation(CASENAME msw-model-1-short
-                                     FILENAME MSW_MODEL_1_SHORT
-                                     DIR model1
-                                     SIMULATOR flow_distribute_z
-                                     ABS_TOL 1e4 # the absolute tolerance is pretty high here, yet in this case, we are only interested in the relative tolerance
-                                     REL_TOL 1e-4
-                                     MPI_PROCS 4
-                                     TEST_ARGS --allow-distributed-wells=true)
-
-add_test_compare_parallel_simulation(CASENAME spe9group
-                                     FILENAME SPE9_CP_GROUP
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL ${coarse_rel_tol_parallel}
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
-
-add_test_compare_parallel_simulation(CASENAME spe3_partition_method_zoltan
-                                     FILENAME SPE3CASE1
-                                     POSTFIX partition_method_zoltan
-                                     DIR spe3
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL ${coarse_rel_tol_parallel}
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --tolerance-wells=1e-7 --partition-method=zoltan)
-
-add_test_compare_parallel_simulation(CASENAME spe3_partition_method_zoltanwell
-                                     FILENAME SPE3CASE1
-                                     POSTFIX partition_method_zoltanwell
-                                     DIR spe3
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL ${coarse_rel_tol_parallel}
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --tolerance-wells=1e-7)
-
-add_test_compare_parallel_simulation(CASENAME spe1_solvent
-                                     FILENAME SPE1CASE2_SOLVENT
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL ${coarse_rel_tol_parallel}
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
-
-add_test_compare_parallel_simulation(CASENAME polymer_simple2D
-                                     FILENAME 2D_THREEPHASE_POLY_HETER
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol}
-                                     REL_TOL ${coarse_rel_tol}
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
-
-add_test_compare_parallel_simulation(CASENAME spe1_foam
-                                     FILENAME SPE1FOAM
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol}
-                                     REL_TOL ${coarse_rel_tol_parallel})
-
-add_test_compare_parallel_simulation(CASENAME spe1_thermal
-                                     FILENAME SPE1CASE2_THERMAL
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol}
-                                     REL_TOL ${coarse_rel_tol_parallel}
-                                     DIR spe1
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
-
-add_test_compare_parallel_simulation(CASENAME spe1_temp
-                                     FILENAME SPE1CASE2_TEMP
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol}
-                                     REL_TOL ${coarse_rel_tol_parallel}
-                                     DIR spe1
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
-
-
-add_test_compare_parallel_simulation(CASENAME spe1_thermal_onephase
-                                     FILENAME SPE1CASE2_THERMAL_ONEPHASE
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol}
-                                     REL_TOL ${rel_tol}
-                                     DIR spe1
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
-
-add_test_compare_parallel_simulation(CASENAME spe1_water
-                                     FILENAME SPE1CASE1_WATER
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol}
-                                     REL_TOL ${rel_tol}
-                                     DIR spe1
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --tolerance-wells=1e-7)
-
-add_test_compare_parallel_simulation(CASENAME spe1_brine
-                                     FILENAME SPE1CASE1_BRINE
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL ${coarse_rel_tol_parallel}
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-6)
-
-add_test_compare_parallel_simulation(CASENAME fetkovich_2d
-                                     FILENAME 2D_FETKOVICHAQUIFER
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL ${rel_tol_parallel}
-                                     DIR aquifer-fetkovich
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-6)
-
-add_test_compare_parallel_simulation(CASENAME ctaquifer_2d_oilwater
-                                     FILENAME 2D_OW_CTAQUIFER
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL ${rel_tol_parallel}
-                                     DIR aquifer-oilwater
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-6)
-
-add_test_compare_parallel_simulation(CASENAME 3d_tran_operator
-                                     FILENAME 3D_TRAN_OPERATOR
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL 0.0003
-                                     DIR parallel_fieldprops
-                                     TEST_ARGS --enable-tuning=true --relaxed-max-pv-fraction=0)
-
-add_test_compare_parallel_simulation(CASENAME numerical_aquifer_3d_2aqu
-                                     FILENAME 3D_2AQU_NUM
-                                     SIMULATOR flow
-                                     ABS_TOL 0.17
-                                     REL_TOL ${coarse_rel_tol_parallel}
-                                     DIR aquifer-num
-                                     TEST_ARGS --tolerance-cnv=0.000003 --time-step-control=pid --linear-solver=cpr_trueimpes --relaxed-max-pv-fraction=0.0)
-
-add_test_compare_parallel_simulation(CASENAME aquflux_01
-                                     FILENAME AQUFLUX-01
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol}
-                                     REL_TOL 0.06
-                                     DIR aquifers
-                                     TEST_ARGS --enable-tuning=true --relaxed-max-pv-fraction=0)
-
-add_test_compare_parallel_simulation(CASENAME aquflux_02
-                                     FILENAME AQUFLUX-02
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol}
-                                     REL_TOL ${coarse_rel_tol_parallel}
-                                     DIR aquifers
-                                     TEST_ARGS --enable-tuning=true)
-
-add_test_compare_parallel_simulation(CASENAME network_balance_01
-                                     FILENAME NETWORK-01
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol}
-                                     REL_TOL ${coarse_rel_tol_parallel}
-                                     DIR network
-                                     TEST_ARGS --enable-tuning=true)
-
-add_test_compare_parallel_simulation(CASENAME numerical_aquifer_3d_1aqu
-                                     FILENAME 3D_1AQU_3CELLS
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL 0.05
-                                     DIR aquifer-num
-                                     TEST_ARGS --enable-tuning=true --tolerance-cnv=0.00003 --time-step-control=pid --linear-solver=cpr_trueimpes --relaxed-max-pv-fraction=0.0)
-
-add_test_compare_parallel_simulation(CASENAME 6_uda_model5_stdw
-  FILENAME 6_UDA_MODEL5_STDW
-  SIMULATOR flow
-  ABS_TOL ${abs_tol_parallel}
-  REL_TOL ${rel_tol_parallel}
-  DIR model5
-  TEST_ARGS --enable-tuning=true
+add_test_compare_parallel_simulation(
+  CASENAME
+    spe1
+  FILENAME
+    SPE1CASE2
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    ${rel_tol_parallel}
+  TEST_ARGS
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=5e-6
+    --tolerance-mb=1e-8
 )
 
-add_test_compare_parallel_simulation(CASENAME GSATPROD6
-  FILENAME GSATPROD6
-  SIMULATOR flow
-  ABS_TOL ${abs_tol_parallel}
-  REL_TOL ${rel_tol_parallel}
-  DIR satellite
-  TEST_ARGS --enable-tuning=true --linear-solver-reduction=1e-7
+add_test_compare_parallel_simulation(
+  CASENAME
+    spe1_gaswater
+  FILENAME
+    SPE1CASE2_GASWATER
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gaswater
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    ${rel_tol_parallel}
+  DIR
+    spe1
+  TEST_ARGS
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=5e-6
+    --tolerance-mb=1e-8
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    spe9
+  FILENAME
+    SPE9_CP_SHORT
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    ${rel_tol_parallel}
+  TEST_ARGS
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=5e-6
+    --tolerance-mb=1e-8
+)
+
+# A test for distributed standard wells. We load distribute only along the z-axis
+add_test_compare_parallel_simulation(
+  CASENAME
+    spe9_dist_z
+  FILENAME
+    SPE9_CP_SHORT
+  DIR
+    spe9
+  SIMULATOR
+    flow_distribute_z
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    ${rel_tol_parallel}
+  TEST_ARGS
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=5e-6
+    --tolerance-mb=1e-8
+)
+
+# A test for distributed standard wells with 8 processes. We load distribute only along the z-axis
+add_test_compare_parallel_simulation(
+  CASENAME
+    spe9_dist_z_8
+  FILENAME
+    SPE9_CP_SHORT
+  POSTFIX
+    8
+  DIR
+    spe9
+  SIMULATOR
+    flow_distribute_z
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    ${rel_tol_parallel}
+  MPI_PROCS
+    8
+  TEST_ARGS
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=5e-6
+    --tolerance-mb=1e-8
+)
+
+# A test for distributed multisegment wells.
+# We load distribute only along the z-axis
+# This file contains one Multisegment well
+# without branches that is distributed across several processes.
+# The absolute tolerance is pretty high here,
+# we are only interested in the relative tolerance.
+add_test_compare_parallel_simulation(
+  CASENAME
+    msw-simple
+  FILENAME
+    MSW-SIMPLE
+  DIR
+    msw
+  SIMULATOR
+    flow_distribute_z
+  ABS_TOL
+    1e4
+  REL_TOL
+    1e-5
+  MPI_PROCS
+    4
+  TEST_ARGS
+    --solver-max-time-step-in-days=15
+    --allow-distributed-wells=true
+)
+
+# A test for distributed multisegment wells.
+# We load distribute only along the z-axis,
+# this file contains one Multisegment well without
+# branches where 9 perforations belong to the same segment
+# The absolute tolerance is pretty high here,
+# we are only interested in the relative tolerance.
+add_test_compare_parallel_simulation(
+  CASENAME
+    msw-simple-9-perfs-1-seg
+  FILENAME
+    MSW-SIMPLE-9-PERFS-1-SEG
+  DIR
+    msw
+  SIMULATOR
+    flow_distribute_z
+  ABS_TOL
+    1e4
+  REL_TOL
+    1e-5
+  MPI_PROCS
+    4
+  TEST_ARGS
+    --solver-max-time-step-in-days=10
+    --allow-distributed-wells=true
+)
+
+# A test for distributed multisegment wells with one shut perforation
+# at the process border. We load distribute only along the z-axis.
+# This file contains one Multisegment well without branches that
+# is distributed across several processes.
+# The absolute tolerance is pretty high here,
+# we are only interested in the relative tolerance.
+add_test_compare_parallel_simulation(
+  CASENAME
+    msw-simple-1-shut-perforation-border
+  FILENAME
+    MSW-SIMPLE-1-SHUT-PERFORATION-BORDER
+  DIR
+    msw
+  SIMULATOR
+    flow_distribute_z
+  ABS_TOL
+    1e4
+  REL_TOL
+    1e-5
+  MPI_PROCS
+    4
+  TEST_ARGS
+    --solver-max-time-step-in-days=15
+    --allow-distributed-wells=true
+)
+
+# A test for distributed multisegment wells with only one open perforation
+# . We load distribute only along the z-axis
+# This file contains one Multisegment well without branches that is
+# distributed across several processes.
+# The absolute tolerance is pretty high here,
+# we are only interested in the relative tolerance.
+add_test_compare_parallel_simulation(
+  CASENAME
+    msw-simple-shut-perforations
+  FILENAME
+    MSW-SIMPLE-SHUT-PERFORATIONS
+  DIR
+    msw
+  SIMULATOR
+    flow_distribute_z
+  ABS_TOL
+    1e4
+  REL_TOL
+    1e-5
+  MPI_PROCS
+    4
+  TEST_ARGS
+    --solver-max-time-step-in-days=15
+    --allow-distributed-wells=true
+)
+
+# A test for distributed multisegment wells with only shut perforations on rank 0,
+# where the well is distributed across ranks 0 and 1.
+# We load distribute only along the z-axis.
+# This file contains one Multisegment well without branches that
+# is distributed across several processes.
+# The absolute tolerance is pretty high here,
+# we are only interested in the relative tolerance.
+add_test_compare_parallel_simulation(
+  CASENAME
+    msw-simple-5-shut-perforations
+  FILENAME
+    MSW-SIMPLE-5-SHUT-PERFORATIONS
+  DIR
+    msw
+  SIMULATOR
+    flow_distribute_z
+  ABS_TOL
+    1e4
+  REL_TOL
+    1e-5
+  MPI_PROCS
+    4
+  TEST_ARGS
+    --solver-max-time-step-in-days=10
+    --allow-distributed-wells=true
+)
+
+# A test for distributed multisegment wells with only shut perforations on rank 1,
+# where the well is distributed across ranks 0 and 1.
+# We load distribute only along the z-axis.
+# This file contains one Multisegment well without branches
+# that is distributed across several processes.
+# The absolute tolerance is pretty high here,
+# we are only interested in the relative tolerance.
+add_test_compare_parallel_simulation(
+  CASENAME
+    msw-simple-7-shut-perforations
+  FILENAME
+    MSW-SIMPLE-7-SHUT-PERFORATIONS
+  DIR
+    msw
+  SIMULATOR
+    flow_distribute_z
+  ABS_TOL
+    1e4
+  REL_TOL
+    1e-5
+  MPI_PROCS
+    4
+  TEST_ARGS
+    --solver-max-time-step-in-days=15
+    --allow-distributed-wells=true
+)
+
+# This file contains one Multisegment well with branches that
+# is distributed across several processes.
+# The absolute tolerance is pretty high here,
+# we are only interested in the relative tolerance.
+add_test_compare_parallel_simulation(
+  CASENAME
+    msw-3d
+  FILENAME
+    MSW-3D
+  DIR
+    msw
+  SIMULATOR
+    flow_distribute_z
+  ABS_TOL
+    1e4
+  REL_TOL
+    1e-4
+  MPI_PROCS
+    4
+  TEST_ARGS
+    --allow-distributed-wells=true
+)
+
+# this file contains two Multisegment wells with branches that
+# are distributed across several processes.
+# The absolute tolerance is pretty high here,
+# we are only interested in the relative tolerance.
+add_test_compare_parallel_simulation(
+  CASENAME
+    msw-3d-two-producers
+  FILENAME
+    MSW-3D-TWO-PRODUCERS
+  DIR
+    msw
+  SIMULATOR
+    flow_distribute_z
+  ABS_TOL
+    1e4
+  REL_TOL
+    1e-4
+  MPI_PROCS
+    4
+  TEST_ARGS
+    --allow-distributed-wells=true
+)
+
+# The absolute tolerance is pretty high here,
+# we are only interested in the relative tolerance.
+add_test_compare_parallel_simulation(
+  CASENAME
+    msw-model-1-short
+  FILENAME
+    MSW_MODEL_1_SHORT
+  DIR
+    model1
+  SIMULATOR
+    flow_distribute_z
+  ABS_TOL
+    1e4
+  REL_TOL
+    1e-4
+  MPI_PROCS
+    4
+  TEST_ARGS
+    --allow-distributed-wells=true
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    spe9group
+  FILENAME
+    SPE9_CP_GROUP
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    ${coarse_rel_tol_parallel}
+  TEST_ARGS
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=5e-6
+    --tolerance-mb=1e-8
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    spe3_partition_method_zoltan
+  FILENAME
+    SPE3CASE1
+  POSTFIX
+    partition_method_zoltan
+  DIR
+    spe3
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    ${coarse_rel_tol_parallel}
+  TEST_ARGS
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=5e-6
+    --tolerance-mb=1e-8
+    --tolerance-wells=1e-7
+    --partition-method=zoltan
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    spe3_partition_method_zoltanwell
+  FILENAME
+    SPE3CASE1
+  POSTFIX
+    partition_method_zoltanwell
+  DIR
+    spe3
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    ${coarse_rel_tol_parallel}
+  TEST_ARGS
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=5e-6
+    --tolerance-mb=1e-8
+    --tolerance-wells=1e-7
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    spe1_solvent
+  FILENAME
+    SPE1CASE2_SOLVENT
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_solvent
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    ${coarse_rel_tol_parallel}
+  TEST_ARGS
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=5e-6
+    --tolerance-mb=1e-8
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    polymer_simple2D
+  FILENAME
+    2D_THREEPHASE_POLY_HETER
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_polymer
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${coarse_rel_tol}
+  TEST_ARGS
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=5e-6
+    --tolerance-mb=1e-8
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    spe1_foam
+  FILENAME
+    SPE1FOAM
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_foam
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${coarse_rel_tol_parallel}
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    spe1_thermal
+  FILENAME
+    SPE1CASE2_THERMAL
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_energy
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${coarse_rel_tol_parallel}
+  DIR
+    spe1
+  TEST_ARGS
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=5e-6
+    --tolerance-mb=1e-8
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    spe1_temp
+  FILENAME
+    SPE1CASE2_TEMP
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil_temp
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${coarse_rel_tol_parallel}
+  DIR
+    spe1
+  TEST_ARGS
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=5e-6
+    --tolerance-mb=1e-8
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    spe1_thermal_onephase
+  FILENAME
+    SPE1CASE2_THERMAL_ONEPHASE
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_onephase_energy
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe1
+  TEST_ARGS
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=5e-6
+    --tolerance-mb=1e-8
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    spe1_water
+  FILENAME
+    SPE1CASE1_WATER
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_onephase
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe1
+  TEST_ARGS
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=5e-6
+    --tolerance-mb=1e-8
+    --tolerance-wells=1e-7
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    spe1_brine
+  FILENAME
+    SPE1CASE1_BRINE
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_brine
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    ${coarse_rel_tol_parallel}
+  TEST_ARGS
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=5e-6
+    --tolerance-mb=1e-6
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    fetkovich_2d
+  FILENAME
+    2D_FETKOVICHAQUIFER
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    ${rel_tol_parallel}
+  DIR
+    aquifer-fetkovich
+  TEST_ARGS
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=5e-6
+    --tolerance-mb=1e-6
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    ctaquifer_2d_oilwater
+  FILENAME
+    2D_OW_CTAQUIFER
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    ${rel_tol_parallel}
+  DIR
+    aquifer-oilwater
+  TEST_ARGS
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=5e-6
+    --tolerance-mb=1e-6
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    3d_tran_operator
+  FILENAME
+    3D_TRAN_OPERATOR
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    0.0003
+  DIR
+    parallel_fieldprops
+  TEST_ARGS
+    --enable-tuning=true
+    --relaxed-max-pv-fraction=0
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    numerical_aquifer_3d_2aqu
+  FILENAME
+    3D_2AQU_NUM
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    0.17
+  REL_TOL
+    ${coarse_rel_tol_parallel}
+  DIR
+    aquifer-num
+  TEST_ARGS
+    --tolerance-cnv=0.000003
+    --time-step-control=pid
+    --linear-solver=cpr_trueimpes
+    --relaxed-max-pv-fraction=0.0
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    aquflux_01
+  FILENAME
+    AQUFLUX-01
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    0.06
+  DIR
+    aquifers
+  TEST_ARGS
+    --enable-tuning=true
+    --relaxed-max-pv-fraction=0
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    aquflux_02
+  FILENAME
+    AQUFLUX-02
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${coarse_rel_tol_parallel}
+  DIR
+    aquifers
+  TEST_ARGS
+    --enable-tuning=true
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    network_balance_01
+  FILENAME
+    NETWORK-01
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${coarse_rel_tol_parallel}
+  DIR
+    network
+  TEST_ARGS
+    --enable-tuning=true
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    numerical_aquifer_3d_1aqu
+  FILENAME
+    3D_1AQU_3CELLS
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    0.05
+  DIR
+    aquifer-num
+  TEST_ARGS
+    --enable-tuning=true
+    --tolerance-cnv=0.00003
+    --time-step-control=pid
+    --linear-solver=cpr_trueimpes
+    --relaxed-max-pv-fraction=0.0
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    6_uda_model5_stdw
+  FILENAME
+    6_UDA_MODEL5_STDW
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    ${rel_tol_parallel}
+  DIR
+    model5
+  TEST_ARGS
+    --enable-tuning=true
+)
+
+add_test_compare_parallel_simulation(
+  CASENAME
+    GSATPROD6
+  FILENAME
+    GSATPROD6
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    ${rel_tol_parallel}
+  DIR
+    satellite
+  TEST_ARGS
+    --enable-tuning=true
+    --linear-solver-reduction=1e-7
 )
 
 foreach(templ_case RANGE 1 6)
-  add_test_compare_parallel_simulation(CASENAME actionx_well_templ_0${templ_case}
-    FILENAME ACTIONX_WELL_TEMPL-0${templ_case}
-    SIMULATOR flow
-    ABS_TOL ${abs_tol_parallel}
-    REL_TOL ${rel_tol_parallel}
-    DIR actionx
+  add_test_compare_parallel_simulation(
+    CASENAME
+      actionx_well_templ_0${templ_case}
+    FILENAME
+      ACTIONX_WELL_TEMPL-0${templ_case}
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    ABS_TOL
+      ${abs_tol_parallel}
+    REL_TOL
+      ${rel_tol_parallel}
+    DIR
+      actionx
   )
 endforeach()
 
-add_test_compare_parallel_simulation(CASENAME WCYCLE-0
-                                     FILENAME WCYCLE-0
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL ${rel_tol_parallel}
-                                     DIR wcycle
-                                     TEST_ARGS --enable-tuning=true)
+add_test_compare_parallel_simulation(
+  CASENAME
+    WCYCLE-0
+  FILENAME
+    WCYCLE-0
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    ${rel_tol_parallel}
+  DIR
+    wcycle
+  TEST_ARGS
+    --enable-tuning=true
+)
 
-add_test_compare_parallel_simulation(CASENAME actionx_m1
-                                     FILENAME ACTIONX_M1
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL ${coarse_rel_tol_parallel}
-                                     DIR udq_actionx
-                                     TEST_ARGS --solver-max-time-step-in-days=0.2 --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-6)
+add_test_compare_parallel_simulation(
+  CASENAME
+    actionx_m1
+  FILENAME
+    ACTIONX_M1
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    ${coarse_rel_tol_parallel}
+  DIR
+    udq_actionx
+  TEST_ARGS
+    --solver-max-time-step-in-days=0.2
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=5e-6
+    --tolerance-mb=1e-6
+)
 
-add_test_compare_parallel_simulation(CASENAME reg_smry_in_fld_udq
-                                     FILENAME UDQ_REG-01
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL ${coarse_rel_tol_parallel}
-                                     DIR udq_actionx
-                                     TEST_ARGS --enable-tuning=true --time-step-control=pid)
+add_test_compare_parallel_simulation(
+  CASENAME
+    reg_smry_in_fld_udq
+  FILENAME
+    UDQ_REG-01
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    ${coarse_rel_tol_parallel}
+  DIR
+    udq_actionx
+  TEST_ARGS
+    --enable-tuning=true
+    --time-step-control=pid
+)
 
-add_test_compare_parallel_simulation(CASENAME winjmult_msw
-                                     FILENAME WINJMULT_MSW
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol}
-                                     REL_TOL ${rel_tol}
-                                     DIR winjmult
-                                     TEST_ARGS --enable-tuning=true --linear-solver-reduction=1e-7)
+add_test_compare_parallel_simulation(
+  CASENAME
+    winjmult_msw
+  FILENAME
+    WINJMULT_MSW
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    winjmult
+  TEST_ARGS
+    --enable-tuning=true
+    --linear-solver-reduction=1e-7
+)
 
-add_test_compare_parallel_simulation(CASENAME winjdam_msw
-                                     FILENAME WINJDAM_MSW
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol}
-                                     REL_TOL ${rel_tol}
-                                     DIR winjdam
-                                     TEST_ARGS --enable-tuning=true --linear-solver-reduction=1e-7)
+add_test_compare_parallel_simulation(
+  CASENAME
+    winjdam_msw
+  FILENAME
+    WINJDAM_MSW
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    winjdam
+  TEST_ARGS
+    --enable-tuning=true
+    --linear-solver-reduction=1e-7
+)
 
-add_test_compare_parallel_simulation(CASENAME 3_a_mpi_multflt_mod2
-                                     FILENAME 3_A_MPI_MULTFLT_SCHED_MODEL2
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL 1.0e-3
-                                     DIR model2
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=1.0e-3 --tolerance-cnv-relaxed=1.0e-3 --tolerance-mb=1e-8  --tolerance-mb-relaxed=1.0e-8 --newton-max-iterations=30)
+add_test_compare_parallel_simulation(
+  CASENAME
+    3_a_mpi_multflt_mod2
+  FILENAME
+    3_A_MPI_MULTFLT_SCHED_MODEL2
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    1.0e-3
+  DIR
+    model2
+  TEST_ARGS
+    --linear-solver-reduction=1e-7
+    --tolerance-cnv=1.0e-3
+    --tolerance-cnv-relaxed=1.0e-3
+    --tolerance-mb=1e-8
+    --tolerance-mb-relaxed=1.0e-8
+    --newton-max-iterations=30
+)
 
-add_test_compare_parallel_simulation(CASENAME rxft
-                                     FILENAME TEST_RXFT
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL 1.0e-3
-                                     DIR rxft_smry
-                                     TEST_ARGS --enable-tuning=true --linear-solver-reduction=1e-7)
+add_test_compare_parallel_simulation(
+  CASENAME
+    rxft
+  FILENAME
+    TEST_RXFT
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    1.0e-3
+  DIR
+    rxft_smry
+  TEST_ARGS
+    --enable-tuning=true
+    --linear-solver-reduction=1e-7
+)
 
-add_test_compare_parallel_simulation(CASENAME gconinje_resv_gas_01
-                                     FILENAME GCONINJE_RESV_GAS-01
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL ${rel_tol_parallel}
-                                     DIR resv_ctrl
-                                     TEST_ARGS --enable-tuning=true --linear-solver-reduction=1e-7)
+add_test_compare_parallel_simulation(
+  CASENAME
+    gconinje_resv_gas_01
+  FILENAME
+    GCONINJE_RESV_GAS-01
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_parallel}
+  REL_TOL
+    ${rel_tol_parallel}
+  DIR
+    resv_ctrl
+  TEST_ARGS
+    --enable-tuning=true
+    --linear-solver-reduction=1e-7
+)
 
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-comparison.sh "")
 

--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -948,48 +948,66 @@ add_test_compare_parallel_simulation(
 
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-comparison.sh "")
 
-add_test_compareSeparateECLFiles(CASENAME actionx_compdat_1_proc
-                                 DIR1 actionx
-                                 FILENAME1 COMPDAT_SHORT
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_COMPDAT_SHORT
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH
-                                 MPI_PROCS 1)
+add_test_compareSeparateECLFiles(
+  CASENAME actionx_compdat_1_proc
+  DIR1 actionx
+  FILENAME1 COMPDAT_SHORT
+  DIR2 actionx
+  FILENAME2 ACTIONX_COMPDAT_SHORT
+  SIMULATOR flow
+  DEV_SIMULATOR flow_blackoil
+  ABS_TOL ${abs_tol}
+  REL_TOL ${rel_tol}
+  IGNORE_EXTRA_KW BOTH
+  MPI_PROCS 1
+)
 
-add_test_compareSeparateECLFiles(CASENAME actionx_compdat_2_procs
-                                 DIR1 actionx
-                                 FILENAME1 COMPDAT_SHORT
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_COMPDAT_SHORT
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH
-                                 MPI_PROCS 2)
+add_test_compareSeparateECLFiles(
+  CASENAME actionx_compdat_2_procs
+  DIR1 actionx
+  FILENAME1 COMPDAT_SHORT
+  DIR2 actionx
+  FILENAME2 ACTIONX_COMPDAT_SHORT
+  SIMULATOR flow
+  DEV_SIMULATOR flow_blackoil
+  ABS_TOL ${abs_tol}
+  REL_TOL ${rel_tol}
+  IGNORE_EXTRA_KW BOTH
+  MPI_PROCS 2
+)
 
-add_test_compareSeparateECLFiles(CASENAME actionx_compdat_nldd_1_proc
-                                 DIR1 actionx
-                                 FILENAME1 COMPDAT_SHORT
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_COMPDAT_SHORT
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH
-                                 MPI_PROCS 1
-                                 TEST_ARGS --nonlinear-solver=nldd --matrix-add-well-contributions=true --linear-solver=ilu0)
+add_test_compareSeparateECLFiles(
+  CASENAME actionx_compdat_nldd_1_proc
+  DIR1 actionx
+  FILENAME1 COMPDAT_SHORT
+  DIR2 actionx
+  FILENAME2 ACTIONX_COMPDAT_SHORT
+  SIMULATOR flow
+  DEV_SIMULATOR flow_blackoil
+  ABS_TOL ${abs_tol}
+  REL_TOL ${rel_tol}
+  IGNORE_EXTRA_KW BOTH
+  MPI_PROCS 1
+  TEST_ARGS
+    --nonlinear-solver=nldd
+    --matrix-add-well-contributions=true
+    --linear-solver=ilu0
+)
 
-add_test_compareSeparateECLFiles(CASENAME actionx_compdat_nldd_2_procs
-                                 DIR1 actionx
-                                 FILENAME1 COMPDAT_SHORT
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_COMPDAT_SHORT
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH
-                                 MPI_PROCS 2
-                                 TEST_ARGS --nonlinear-solver=nldd --matrix-add-well-contributions=true --linear-solver=ilu0)
+add_test_compareSeparateECLFiles(
+  CASENAME actionx_compdat_nldd_2_procs
+  DIR1 actionx
+  FILENAME1 COMPDAT_SHORT
+  DIR2 actionx
+  FILENAME2 ACTIONX_COMPDAT_SHORT
+  SIMULATOR flow
+  DEV_SIMULATOR flow_blackoil
+  ABS_TOL ${abs_tol}
+  REL_TOL ${rel_tol}
+  IGNORE_EXTRA_KW BOTH
+  MPI_PROCS 2
+  TEST_ARGS
+    --nonlinear-solver=nldd
+    --matrix-add-well-contributions=true
+    --linear-solver=ilu0
+)

--- a/pyactionActionXComparisons.cmake
+++ b/pyactionActionXComparisons.cmake
@@ -5,401 +5,903 @@ opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-comparison.sh "")
 set(abs_tol 1e+5)
 set(rel_tol 2e-5)
 set(coarse_rel_tol 1e-2)
-add_test_compareSeparateECLFiles(CASENAME pyaction_gconprod_insert_kw
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_GCONPROD_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_GCONPROD
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+add_test_compareSeparateECLFiles(
+  CASENAME
+    pyaction_gconprod_insert_kw
+  DIR1
+    pyaction
+  FILENAME1
+    PYACTION_GCONPROD_INSERT_KW
+  DIR2
+    actionx
+  FILENAME2
+    ACTIONX_GCONPROD
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_gconsump_insert_kw
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_GCONSUMP_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_GCONSUMP
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+add_test_compareSeparateECLFiles(
+  CASENAME
+    pyaction_gconsump_insert_kw
+  DIR1
+    pyaction
+  FILENAME1
+    PYACTION_GCONSUMP_INSERT_KW
+  DIR2
+    actionx
+  FILENAME2
+    ACTIONX_GCONSUMP
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+)
 
-add_test_compareSeparateECLFiles(CASENAME actionx_gefac
-                                 DIR1 model4
-                                 FILENAME1 MOD4_GRP_GEFAC
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_GEFAC
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+add_test_compareSeparateECLFiles(
+  CASENAME
+    actionx_gefac
+  DIR1
+    model4
+  FILENAME1
+    MOD4_GRP_GEFAC
+  DIR2
+    actionx
+  FILENAME2
+    ACTIONX_GEFAC
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_gefac_insert_kw
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_GEFAC_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_GEFAC
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+add_test_compareSeparateECLFiles(
+  CASENAME
+    pyaction_gefac_insert_kw
+  DIR1
+    pyaction
+  FILENAME1
+    PYACTION_GEFAC_INSERT_KW
+  DIR2
+    actionx
+  FILENAME2
+    ACTIONX_GEFAC
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_gruptree_insert_kw
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_GRUPTREE_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_GRUPTREE
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+add_test_compareSeparateECLFiles(
+  CASENAME
+    pyaction_gruptree_insert_kw
+  DIR1
+    pyaction
+  FILENAME1
+    PYACTION_GRUPTREE_INSERT_KW
+  DIR2
+    actionx
+  FILENAME2
+    ACTIONX_GRUPTREE
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_include_insert_kw
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_INCLUDE_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_INCLUDE
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+add_test_compareSeparateECLFiles(
+  CASENAME
+    pyaction_include_insert_kw
+  DIR1
+    pyaction
+  FILENAME1
+    PYACTION_INCLUDE_INSERT_KW
+  DIR2
+    actionx
+  FILENAME2
+    ACTIONX_INCLUDE
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_mult+_insert_kw
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_MULT+_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_MULT+
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+add_test_compareSeparateECLFiles(
+  CASENAME
+    pyaction_mult+_insert_kw
+  DIR1
+    pyaction
+  FILENAME1
+    PYACTION_MULT+_INSERT_KW
+  DIR2
+    actionx
+  FILENAME2
+    ACTIONX_MULT+
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_multx+_insert_kw
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_MULTX+_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_MULTX+
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+add_test_compareSeparateECLFiles(
+  CASENAME
+    pyaction_multx+_insert_kw
+  DIR1
+    pyaction
+  FILENAME1
+    PYACTION_MULTX+_INSERT_KW
+  DIR2
+    actionx
+  FILENAME2
+    ACTIONX_MULTX+
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_multx-_insert_kw
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_MULTX-_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_MULTX-
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+add_test_compareSeparateECLFiles(
+  CASENAME
+    pyaction_multx-_insert_kw
+  DIR1
+    pyaction
+  FILENAME1
+    PYACTION_MULTX-_INSERT_KW
+  DIR2
+    actionx
+  FILENAME2
+    ACTIONX_MULTX-
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_next_insert_kw
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_NEXT_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_NEXT
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+add_test_compareSeparateECLFiles(
+  CASENAME
+    pyaction_next_insert_kw
+  DIR1
+    pyaction
+  FILENAME1
+    PYACTION_NEXT_INSERT_KW
+  DIR2
+    actionx
+  FILENAME2
+    ACTIONX_NEXT
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_wconprod_insert_kw
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_WCONPROD_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_WCONPROD
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+add_test_compareSeparateECLFiles(
+  CASENAME
+    pyaction_wconprod_insert_kw
+  DIR1
+    pyaction
+  FILENAME1
+    PYACTION_WCONPROD_INSERT_KW
+  DIR2
+    actionx
+  FILENAME2
+    ACTIONX_WCONPROD
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_wefac_insert_kw
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_WEFAC_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_WEFAC
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+add_test_compareSeparateECLFiles(
+  CASENAME
+    pyaction_wefac_insert_kw
+  DIR1
+    pyaction
+  FILENAME1
+    PYACTION_WEFAC_INSERT_KW
+  DIR2
+    actionx
+  FILENAME2
+    ACTIONX_WEFAC
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_welpi_insert_kw
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_WELPI_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_WELPI
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+add_test_compareSeparateECLFiles(
+  CASENAME
+    pyaction_welpi_insert_kw
+  DIR1
+    pyaction
+  FILENAME1
+    PYACTION_WELPI_INSERT_KW
+  DIR2
+    actionx
+  FILENAME2
+    ACTIONX_WELPI
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_wpimult_insert_kw
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_WPIMULT_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_WPIMULT
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+add_test_compareSeparateECLFiles(
+  CASENAME
+    pyaction_wpimult_insert_kw
+  DIR1
+    pyaction
+  FILENAME1
+    PYACTION_WPIMULT_INSERT_KW
+  DIR2
+    actionx
+  FILENAME2
+    ACTIONX_WPIMULT
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_wsegvalv_insert_kw
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_WSEGVALV_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_WSEGVALV
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+add_test_compareSeparateECLFiles(
+  CASENAME
+    pyaction_wsegvalv_insert_kw
+  DIR1
+    pyaction
+  FILENAME1
+    PYACTION_WSEGVALV_INSERT_KW
+  DIR2
+    actionx
+  FILENAME2
+    ACTIONX_WSEGVALV
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+)
 
-add_test_compareSeparateECLFiles(CASENAME actionx_wlist
-                                 DIR1 udq_actionx
-                                 FILENAME1 ACTIONX_M1
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_WLIST
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+add_test_compareSeparateECLFiles(
+  CASENAME
+    actionx_wlist
+  DIR1
+    udq_actionx
+  FILENAME1
+    ACTIONX_M1
+  DIR2
+    actionx
+  FILENAME2
+    ACTIONX_WLIST
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_wlist_insert_kw
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_WLIST_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_WLIST
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+add_test_compareSeparateECLFiles(
+  CASENAME
+    pyaction_wlist_insert_kw
+  DIR1
+    pyaction
+  FILENAME1
+    PYACTION_WLIST_INSERT_KW
+  DIR2
+    actionx
+  FILENAME2
+    ACTIONX_WLIST
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_wtest_insert_kw
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_WTEST_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_WTEST
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+add_test_compareSeparateECLFiles(
+  CASENAME
+    pyaction_wtest_insert_kw
+  DIR1
+    pyaction
+  FILENAME1
+    PYACTION_WTEST_INSERT_KW
+  DIR2
+    actionx
+  FILENAME2
+    ACTIONX_WTEST
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_WTMULT_insert_kw
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_WTMULT_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_WTMULT
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+add_test_compareSeparateECLFiles(
+  CASENAME
+    pyaction_WTMULT_insert_kw
+  DIR1
+    pyaction
+  FILENAME1
+    PYACTION_WTMULT_INSERT_KW
+  DIR2
+    actionx
+  FILENAME2
+    ACTIONX_WTMULT
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+)
 
 if(MPI_FOUND)
   # We pass allow-distributed-wells=true, because wells appear inactive with
   # with PYACTION but active with ACTIONX
-  add_test_compareSeparateECLFiles(CASENAME pyaction_gconprod_insert_kw_4_procs
-                                   DIR1 pyaction
-                                   FILENAME1 PYACTION_GCONPROD_INSERT_KW
-                                   DIR2 actionx
-                                   FILENAME2 ACTIONX_GCONPROD
-                                   SIMULATOR flow
-                                   ABS_TOL ${abs_tol}
-                                   REL_TOL ${rel_tol}
-                                   IGNORE_EXTRA_KW BOTH
-                                   MPI_PROCS 4
-                                   TEST_ARGS --allow-distributed-wells=true)
+  add_test_compareSeparateECLFiles(
+    CASENAME
+      pyaction_gconprod_insert_kw_4_procs
+    DIR1
+      pyaction
+    FILENAME1
+      PYACTION_GCONPROD_INSERT_KW
+    DIR2
+      actionx
+    FILENAME2
+      ACTIONX_GCONPROD
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${rel_tol}
+    IGNORE_EXTRA_KW
+      BOTH
+    MPI_PROCS
+      4
+    TEST_ARGS
+      --allow-distributed-wells=true
+  )
 
-  add_test_compareSeparateECLFiles(CASENAME pyaction_gconsump_insert_kw_4_procs
-                                   DIR1 pyaction
-                                   FILENAME1 PYACTION_GCONSUMP_INSERT_KW
-                                   DIR2 actionx
-                                   FILENAME2 ACTIONX_GCONSUMP
-                                   SIMULATOR flow
-                                   ABS_TOL ${abs_tol}
-                                   REL_TOL ${rel_tol}
-                                   IGNORE_EXTRA_KW BOTH
-                                   MPI_PROCS 4)
-
-  # We pass allow-distributed-wells=true, because wells appear inactive with
-  # with PYACTION but active with ACTIONX
-  add_test_compareSeparateECLFiles(CASENAME pyaction_gruptree_insert_kw_4_procs
-                                   DIR1 pyaction
-                                   FILENAME1 PYACTION_GRUPTREE_INSERT_KW
-                                   DIR2 actionx
-                                   FILENAME2 ACTIONX_GRUPTREE
-                                   SIMULATOR flow
-                                   ABS_TOL ${abs_tol}
-                                   REL_TOL ${rel_tol}
-                                   IGNORE_EXTRA_KW BOTH
-                                   MPI_PROCS 4
-                                   TEST_ARGS --allow-distributed-wells=true)
-
-  add_test_compareSeparateECLFiles(CASENAME actionx_gefac_4_procs
-                                   DIR1 model4
-                                   FILENAME1 MOD4_GRP_GEFAC
-                                   DIR2 actionx
-                                   FILENAME2 ACTIONX_GEFAC
-                                   SIMULATOR flow
-                                   ABS_TOL ${abs_tol}
-                                   REL_TOL ${rel_tol}
-                                   IGNORE_EXTRA_KW BOTH
-                                   MPI_PROCS 4)
-
-  add_test_compareSeparateECLFiles(CASENAME pyaction_gefac_insert_kw_4_procs
-                                   DIR1 pyaction
-                                   FILENAME1 PYACTION_GEFAC_INSERT_KW
-                                   DIR2 actionx
-                                   FILENAME2 ACTIONX_GEFAC
-                                   SIMULATOR flow
-                                   ABS_TOL ${abs_tol}
-                                   REL_TOL ${rel_tol}
-                                   IGNORE_EXTRA_KW BOTH
-                                   MPI_PROCS 4)
-
-  add_test_compareSeparateECLFiles(CASENAME pyaction_multx+_insert_kw_4_procs
-                                   DIR1 pyaction
-                                   FILENAME1 PYACTION_MULTX+_INSERT_KW
-                                   DIR2 actionx
-                                   FILENAME2 ACTIONX_MULTX+
-                                   SIMULATOR flow
-                                   ABS_TOL ${abs_tol}
-                                   REL_TOL ${rel_tol}
-                                   IGNORE_EXTRA_KW BOTH
-                                   MPI_PROCS 4)
-
-  add_test_compareSeparateECLFiles(CASENAME pyaction_mult+_insert_kw_4_procs
-                                   DIR1 pyaction
-                                   FILENAME1 PYACTION_MULT+_INSERT_KW
-                                   DIR2 actionx
-                                   FILENAME2 ACTIONX_MULT+
-                                   SIMULATOR flow
-                                   ABS_TOL ${abs_tol}
-                                   REL_TOL ${rel_tol}
-                                   IGNORE_EXTRA_KW BOTH
-                                   MPI_PROCS 4)
-
-  add_test_compareSeparateECLFiles(CASENAME pyaction_multx-_insert_kw_4_procs
-                                   DIR1 pyaction
-                                   FILENAME1 PYACTION_MULTX-_INSERT_KW
-                                   DIR2 actionx
-                                   FILENAME2 ACTIONX_MULTX-
-                                   SIMULATOR flow
-                                   ABS_TOL ${abs_tol}
-                                   REL_TOL ${rel_tol}
-                                   IGNORE_EXTRA_KW BOTH
-                                   MPI_PROCS 4)
-
-  add_test_compareSeparateECLFiles(CASENAME pyaction_next_insert_kw_4_procs
-                                   DIR1 pyaction
-                                   FILENAME1 PYACTION_NEXT_INSERT_KW
-                                   DIR2 actionx
-                                   FILENAME2 ACTIONX_NEXT
-                                   SIMULATOR flow
-                                   ABS_TOL ${abs_tol}
-                                   REL_TOL ${rel_tol}
-                                   IGNORE_EXTRA_KW BOTH
-                                   MPI_PROCS 4)
+  add_test_compareSeparateECLFiles(
+    CASENAME
+      pyaction_gconsump_insert_kw_4_procs
+    DIR1
+      pyaction
+    FILENAME1
+      PYACTION_GCONSUMP_INSERT_KW
+    DIR2
+      actionx
+    FILENAME2
+      ACTIONX_GCONSUMP
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${rel_tol}
+    IGNORE_EXTRA_KW
+      BOTH
+    MPI_PROCS
+      4
+  )
 
   # We pass allow-distributed-wells=true, because wells appear inactive with
   # with PYACTION but active with ACTIONX
-  add_test_compareSeparateECLFiles(CASENAME pyaction_wconprod_insert_kw_4_procs
-                                   DIR1 pyaction
-                                   FILENAME1 PYACTION_WCONPROD_INSERT_KW
-                                   DIR2 actionx
-                                   FILENAME2 ACTIONX_WCONPROD
-                                   SIMULATOR flow
-                                   ABS_TOL ${abs_tol}
-                                   REL_TOL ${rel_tol}
-                                   IGNORE_EXTRA_KW BOTH
-                                   MPI_PROCS 4
-                                   TEST_ARGS --allow-distributed-wells=true)
+  add_test_compareSeparateECLFiles(
+    CASENAME
+      pyaction_gruptree_insert_kw_4_procs
+    DIR1
+      pyaction
+    FILENAME1
+      PYACTION_GRUPTREE_INSERT_KW
+    DIR2
+      actionx
+    FILENAME2
+      ACTIONX_GRUPTREE
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${rel_tol}
+    IGNORE_EXTRA_KW
+      BOTH
+    MPI_PROCS
+      4
+    TEST_ARGS
+      --allow-distributed-wells=true
+  )
 
-  add_test_compareSeparateECLFiles(CASENAME pyaction_wefac_insert_kw_4_procs
-                                   DIR1 pyaction
-                                   FILENAME1 PYACTION_WEFAC_INSERT_KW
-                                   DIR2 actionx
-                                   FILENAME2 ACTIONX_WEFAC
-                                   SIMULATOR flow
-                                   ABS_TOL ${abs_tol}
-                                   REL_TOL ${rel_tol}
-                                   IGNORE_EXTRA_KW BOTH
-                                   MPI_PROCS 4)
+  add_test_compareSeparateECLFiles(
+    CASENAME
+      actionx_gefac_4_procs
+    DIR1
+      model4
+    FILENAME1
+      MOD4_GRP_GEFAC
+    DIR2
+      actionx
+    FILENAME2
+      ACTIONX_GEFAC
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${rel_tol}
+    IGNORE_EXTRA_KW
+      BOTH
+    MPI_PROCS
+      4
+  )
 
-  add_test_compareSeparateECLFiles(CASENAME pyaction_welpi_insert_kw_4_procs
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_WELPI_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_WELPI
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH,
-                                 MPI_PROCS 4)
+  add_test_compareSeparateECLFiles(
+    CASENAME
+      pyaction_gefac_insert_kw_4_procs
+    DIR1
+      pyaction
+    FILENAME1
+      PYACTION_GEFAC_INSERT_KW
+    DIR2
+      actionx
+    FILENAME2
+      ACTIONX_GEFAC
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${rel_tol}
+    IGNORE_EXTRA_KW
+      BOTH
+    MPI_PROCS
+      4
+  )
 
-  add_test_compareSeparateECLFiles(CASENAME pyaction_wpimult_insert_kw_4_procs
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_WPIMULT_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_WPIMULT
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH
-                                 MPI_PROCS 4)
+  add_test_compareSeparateECLFiles(
+    CASENAME
+      pyaction_multx+_insert_kw_4_procs
+    DIR1
+      pyaction
+    FILENAME1
+      PYACTION_MULTX+_INSERT_KW
+    DIR2
+      actionx
+    FILENAME2
+      ACTIONX_MULTX+
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${rel_tol}
+    IGNORE_EXTRA_KW
+      BOTH
+    MPI_PROCS
+      4
+  )
 
-  add_test_compareSeparateECLFiles(CASENAME pyaction_wsegvalv_insert_kw_4_procs
-                                   DIR1 pyaction
-                                   FILENAME1 PYACTION_WSEGVALV_INSERT_KW
-                                   DIR2 actionx
-                                   FILENAME2 ACTIONX_WSEGVALV
-                                   SIMULATOR flow
-                                   ABS_TOL ${abs_tol}
-                                   REL_TOL ${rel_tol}
-                                   IGNORE_EXTRA_KW BOTH
-                                   MPI_PROCS 4)
+  add_test_compareSeparateECLFiles(
+    CASENAME
+      pyaction_mult+_insert_kw_4_procs
+    DIR1
+      pyaction
+    FILENAME1
+      PYACTION_MULT+_INSERT_KW
+    DIR2
+      actionx
+    FILENAME2
+      ACTIONX_MULT+
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${rel_tol}
+    IGNORE_EXTRA_KW
+      BOTH
+    MPI_PROCS
+      4
+  )
 
-  add_test_compareSeparateECLFiles(CASENAME pyaction_WTMULT_insert_kw_4_procs
-                                   DIR1 pyaction
-                                   FILENAME1 PYACTION_WTMULT_INSERT_KW
-                                   DIR2 actionx
-                                   FILENAME2 ACTIONX_WTMULT
-                                   SIMULATOR flow
-                                   ABS_TOL ${abs_tol}
-                                   REL_TOL ${rel_tol}
-                                   IGNORE_EXTRA_KW BOTH
-                                   MPI_PROCS 4)
+  add_test_compareSeparateECLFiles(
+    CASENAME
+      pyaction_multx-_insert_kw_4_procs
+    DIR1
+      pyaction
+    FILENAME1
+      PYACTION_MULTX-_INSERT_KW
+    DIR2
+      actionx
+    FILENAME2
+      ACTIONX_MULTX-
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${rel_tol}
+    IGNORE_EXTRA_KW
+      BOTH
+    MPI_PROCS
+      4
+  )
 
-  add_test_compareSeparateECLFiles(CASENAME actionx_wlist_4_procs
-                                   DIR1 udq_actionx
-                                   FILENAME1 ACTIONX_M1
-                                   DIR2 actionx
-                                   FILENAME2 ACTIONX_WLIST
-                                   SIMULATOR flow
-                                   ABS_TOL ${abs_tol}
-                                   REL_TOL ${rel_tol}
-                                   IGNORE_EXTRA_KW BOTH
-                                   MPI_PROCS 4)
+  add_test_compareSeparateECLFiles(
+    CASENAME
+      pyaction_next_insert_kw_4_procs
+    DIR1
+      pyaction
+    FILENAME1
+      PYACTION_NEXT_INSERT_KW
+    DIR2
+      actionx
+    FILENAME2
+      ACTIONX_NEXT
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${rel_tol}
+    IGNORE_EXTRA_KW
+      BOTH
+    MPI_PROCS
+      4
+  )
 
-  add_test_compareSeparateECLFiles(CASENAME pyaction_wlist_insert_kw_4_procs
-                                   DIR1 pyaction
-                                   FILENAME1 PYACTION_WLIST_INSERT_KW
-                                   DIR2 actionx
-                                   FILENAME2 ACTIONX_WLIST
-                                   SIMULATOR flow
-                                   ABS_TOL ${abs_tol}
-                                   REL_TOL ${rel_tol}
-                                   IGNORE_EXTRA_KW BOTH
-                                   MPI_PROCS 4)
+  # We pass allow-distributed-wells=true, because wells appear inactive with
+  # with PYACTION but active with ACTIONX
+  add_test_compareSeparateECLFiles(
+    CASENAME
+      pyaction_wconprod_insert_kw_4_procs
+    DIR1
+      pyaction
+    FILENAME1
+      PYACTION_WCONPROD_INSERT_KW
+    DIR2
+      actionx
+    FILENAME2
+      ACTIONX_WCONPROD
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${rel_tol}
+    IGNORE_EXTRA_KW
+      BOTH
+    MPI_PROCS
+      4
+    TEST_ARGS
+      --allow-distributed-wells=true
+  )
 
-  add_test_compareSeparateECLFiles(CASENAME pyaction_wtest_insert_kw_4_procs
-                                   DIR1 pyaction
-                                   FILENAME1 PYACTION_WTEST_INSERT_KW
-                                   DIR2 actionx
-                                   FILENAME2 ACTIONX_WTEST
-                                   SIMULATOR flow
-                                   ABS_TOL ${abs_tol}
-                                   REL_TOL ${rel_tol}
-                                   IGNORE_EXTRA_KW BOTH
-                                   MPI_PROCS 4)
+  add_test_compareSeparateECLFiles(
+    CASENAME
+      pyaction_wefac_insert_kw_4_procs
+    DIR1
+      pyaction
+    FILENAME1
+      PYACTION_WEFAC_INSERT_KW
+    DIR2
+      actionx
+    FILENAME2
+      ACTIONX_WEFAC
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${rel_tol}
+    IGNORE_EXTRA_KW
+      BOTH
+    MPI_PROCS
+      4
+  )
+
+  add_test_compareSeparateECLFiles(
+    CASENAME
+      pyaction_welpi_insert_kw_4_procs
+    DIR1
+      pyaction
+    FILENAME1
+      PYACTION_WELPI_INSERT_KW
+    DIR2
+      actionx
+    FILENAME2
+      ACTIONX_WELPI
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${rel_tol}
+    IGNORE_EXTRA_KW
+      BOTH
+    MPI_PROCS
+      4
+  )
+
+  add_test_compareSeparateECLFiles(
+    CASENAME
+      pyaction_wpimult_insert_kw_4_procs
+    DIR1
+      pyaction
+    FILENAME1
+      PYACTION_WPIMULT_INSERT_KW
+    DIR2
+      actionx
+    FILENAME2
+      ACTIONX_WPIMULT
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${rel_tol}
+    IGNORE_EXTRA_KW
+      BOTH
+    MPI_PROCS
+      4
+  )
+
+  add_test_compareSeparateECLFiles(
+    CASENAME
+      pyaction_wsegvalv_insert_kw_4_procs
+    DIR1
+      pyaction
+    FILENAME1
+      PYACTION_WSEGVALV_INSERT_KW
+    DIR2
+      actionx
+    FILENAME2
+      ACTIONX_WSEGVALV
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${rel_tol}
+    IGNORE_EXTRA_KW
+      BOTH
+    MPI_PROCS
+      4
+  )
+
+  add_test_compareSeparateECLFiles(
+    CASENAME
+      pyaction_WTMULT_insert_kw_4_procs
+    DIR1
+      pyaction
+    FILENAME1
+      PYACTION_WTMULT_INSERT_KW
+    DIR2
+      actionx
+    FILENAME2
+      ACTIONX_WTMULT
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${rel_tol}
+    IGNORE_EXTRA_KW
+      BOTH
+    MPI_PROCS
+      4
+  )
+
+  add_test_compareSeparateECLFiles(
+    CASENAME
+      actionx_wlist_4_procs
+    DIR1
+      udq_actionx
+    FILENAME1
+      ACTIONX_M1
+    DIR2
+      actionx
+    FILENAME2
+      ACTIONX_WLIST
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${rel_tol}
+    IGNORE_EXTRA_KW
+      BOTH
+    MPI_PROCS
+      4
+  )
+
+  add_test_compareSeparateECLFiles(
+    CASENAME
+      pyaction_wlist_insert_kw_4_procs
+    DIR1
+      pyaction
+    FILENAME1
+      PYACTION_WLIST_INSERT_KW
+    DIR2
+      actionx
+    FILENAME2
+      ACTIONX_WLIST
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${rel_tol}
+    IGNORE_EXTRA_KW
+      BOTH
+    MPI_PROCS
+      4
+  )
+
+  add_test_compareSeparateECLFiles(
+    CASENAME
+      pyaction_wtest_insert_kw_4_procs
+    DIR1
+      pyaction
+    FILENAME1
+      PYACTION_WTEST_INSERT_KW
+    DIR2
+      actionx
+    FILENAME2
+      ACTIONX_WTEST
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${rel_tol}
+    IGNORE_EXTRA_KW
+      BOTH
+    MPI_PROCS
+      4
+  )
 endif()

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -6,103 +6,308 @@ set(abs_tol 2e-2)
 set(rel_tol 1e-5)
 set(coarse_rel_tol 1e-2)
 
-add_test_compareECLFiles(CASENAME spe1flowexp
-                         FILENAME SPE1CASE2
-                         SIMULATOR flowexp_blackoil
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR spe1)
+add_test_compareECLFiles(
+  CASENAME
+    spe1flowexp
+  FILENAME
+    SPE1CASE2
+  SIMULATOR
+    flowexp_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe1
+)
 
-add_test_compareECLFiles(CASENAME 1dcompositional
-                         FILENAME 1D_COMP
-                         SIMULATOR flowexp_comp
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR compositional)
+add_test_compareECLFiles(
+  CASENAME
+    1dcompositional
+  FILENAME
+    1D_COMP
+  SIMULATOR
+    flowexp_comp
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    compositional
+)
 
-add_test_compareECLFiles(CASENAME spe12
-                         FILENAME SPE1CASE2
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${coarse_rel_tol}
-                         RESTART_SCHED false
-                         RESTART_STEP 60
-                         DIR spe1)
+add_test_compareECLFiles(
+  CASENAME
+    spe12
+  FILENAME
+    SPE1CASE2
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${coarse_rel_tol}
+  RESTART_SCHED
+    false
+  RESTART_STEP
+    60
+  DIR
+    spe1
+)
+
+add_test_compareECLFiles(
+  CASENAME
+    spe1case1_water
+  FILENAME
+    SPE1CASE1_WATER
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_onephase
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe1
+)
+
+add_test_compareECLFiles(
+  CASENAME
+    spe1case2_thermal_onephase
+  FILENAME
+    SPE1CASE2_THERMAL_ONEPHASE
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_onephase_energy
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe1
+)
+
+add_test_compareECLFiles(
+  CASENAME
+    spe1case2_temp
+  FILENAME
+    SPE1CASE2_TEMP
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil_temp
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe1
+)
+
+add_test_compareECLFiles(
+  CASENAME
+    spe1case2_2p
+  FILENAME
+    SPE1CASE2_2P
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe1
+)
+
+set(_spe1_tests_energy
+  SPE1CASE2_THERMAL
+  SPE1CASE2_THERMAL_WATVISC
+)
+
+add_multiple_tests(
+  _spe1_tests_energy
+  ""
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_energy
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe1
+)
 
 set(_spe1_tests
   SPE1CASE1
   SPE1CASE1_IMPORT
-  SPE1CASE1_WATER
   SPE1CASE2_KRNUM
   SPE1CASE2_NOWELLS
   SPE1CASE2_ROCK2DTR
-  SPE1CASE2_THERMAL
-  SPE1CASE2_THERMAL_ONEPHASE
-  SPE1CASE2_THERMAL_WATVISC
-  SPE1CASE2_2P
-  SPE1CASE2_TEMP
 )
 
 add_multiple_tests(
   _spe1_tests
   ""
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR spe1
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe1
 )
 
-set(_spe1_coarse_tests
+add_test_compareECLFiles(
+  CASENAME
+    spe1case2_oilgas
+  FILENAME
+    SPE1CASE2_OILGAS
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gasoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${coarse_rel_tol}
+  DIR
+    spe1
+)
+
+set(_spe1_coarse_tests_gw
   SPE1CASE2_GASWATER
   SPE1CASE2_GASWATER_MSW
-  SPE1CASE2_OILGAS
 )
 
 add_multiple_tests(
-  _spe1_coarse_tests
+  _spe1_coarse_tests_gw
   ""
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${coarse_rel_tol}
-  DIR spe1
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gaswater
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${coarse_rel_tol}
+  DIR
+    spe1
 )
 
-set(_spe1_brine_tests
-  SPE1CASE1_BRINE
-  SPE1CASE2_BRINE_GASWATER
-  SPE1CASE1_BRINE_THERMAL
+add_test_compareECLFiles(
+  CASENAME
+    spe1case1_brine
+  FILENAME
+    SPE1CASE1_BRINE
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_brine
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe1_brine
 )
 
-add_multiple_tests(
-  _spe1_brine_tests
-  ""
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR spe1_brine
+add_test_compareECLFiles(
+  CASENAME
+    spe1case2_brine_gaswater
+  FILENAME
+    SPE1CASE2_BRINE_GASWATER
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gaswater_brine
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe1_brine
 )
 
-set(_spe1_precsalt_tests
-  GASWATER_VAPWAT_PRECSALT
-  SPE1CASE1_PRECSALT
+add_test_compareECLFiles(
+  CASENAME
+    spe1case1_brine_thermal
+  FILENAME
+    SPE1CASE1_BRINE_THERMAL
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_brine_energy
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe1_brine
 )
 
-add_multiple_tests(
-  _spe1_precsalt_tests
-  ""
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR spe1_precsalt
+add_test_compareECLFiles(
+  CASENAME
+    spe1case1_precsalt
+  FILENAME
+    SPE1CASE1_PRECSALT
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_brine_saltprecipitation
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe1_precsalt
 )
 
-add_test_compareECLFiles(CASENAME gasoil_precsalt
-                         FILENAME GASCONDENSATE_VAPWAT_PRECSALT_REGRESSION
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR spe1_precsalt
-                         TEST_ARGS --solver-max-time-step-in-days=0.05)
+add_test_compareECLFiles(
+  CASENAME
+    gaswater_vapwat_precsalt
+  FILENAME
+    GASWATER_VAPWAT_PRECSALT
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gaswater_saltprec_vapwat
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe1_precsalt
+)
+
+add_test_compareECLFiles(
+  CASENAME
+    gasoil_precsalt
+  FILENAME
+    GASCONDENSATE_VAPWAT_PRECSALT_REGRESSION
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_brine_precsalt_vapwat
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe1_precsalt
+  TEST_ARGS
+    --solver-max-time-step-in-days=0.05
+)
 
 set(_network_tuning_tests
   NETWORK-01
@@ -112,11 +317,18 @@ set(_network_tuning_tests
 add_multiple_tests(
   _network_tuning_tests
   ""
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR network
-  TEST_ARGS --enable-tuning=true
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    network
+  TEST_ARGS
+    --enable-tuning=true
 )
 
 set(_network_tuning_local_switch_tests
@@ -127,309 +339,742 @@ set(_network_tuning_local_switch_tests
 add_multiple_tests(
   _network_tuning_local_switch_tests
   ""
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR network
-  TEST_ARGS --enable-tuning=true --local-well-solve-control-switching=true
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    network
+  TEST_ARGS
+    --enable-tuning=true
+    --local-well-solve-control-switching=true
 )
 
-add_test_compareECLFiles(CASENAME network_01_wtest
-                         FILENAME NETWORK-01-WTEST
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR network
-                         TEST_ARGS --enable-tuning=true)
+add_test_compareECLFiles(
+  CASENAME
+    network_01_wtest
+  FILENAME
+    NETWORK-01-WTEST
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    network
+  TEST_ARGS
+    --enable-tuning=true
+)
 
-add_test_compareECLFiles(CASENAME spe1_metric_vfp1
-                         FILENAME SPE1CASE1_METRIC_VFP1
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR vfpprod_spe1)
+add_test_compareECLFiles(
+  CASENAME
+    spe1_metric_vfp1
+  FILENAME
+    SPE1CASE1_METRIC_VFP1
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    vfpprod_spe1
+)
 
-add_test_compareECLFiles(CASENAME spe1_spider
-                         FILENAME SPIDER_CAKESLICE
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR radial_grid)
+add_test_compareECLFiles(
+  CASENAME
+    spe1_spider
+  FILENAME
+    SPIDER_CAKESLICE
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    radial_grid
+)
 
-add_test_compareECLFiles(CASENAME spe1_radial
-                         FILENAME RADIAL_CAKESLICE
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR radial_grid)
+add_test_compareECLFiles(
+  CASENAME
+    spe1_radial
+  FILENAME
+    RADIAL_CAKESLICE
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    radial_grid
+)
 
-add_test_compareECLFiles(CASENAME jfunc_01
-                         FILENAME JFUNC-01
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR jfunc
-                         TEST_ARGS --enable-tuning=true)
+add_test_compareECLFiles(
+  CASENAME
+    jfunc_01
+  FILENAME
+    JFUNC-01
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    jfunc
+  TEST_ARGS
+    --enable-tuning=true
+)
 
-add_test_compareECLFiles(CASENAME ctaquifer_2d_oilwater
-                         FILENAME 2D_OW_CTAQUIFER
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR aquifer-oilwater)
+add_test_compareECLFiles(
+  CASENAME
+    ctaquifer_2d_oilwater
+  FILENAME
+    2D_OW_CTAQUIFER
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    aquifer-oilwater
+)
 
-add_test_compareECLFiles(CASENAME fetkovich_2d
-                         FILENAME 2D_FETKOVICHAQUIFER
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR aquifer-fetkovich)
+add_test_compareECLFiles(
+  CASENAME
+    fetkovich_2d
+  FILENAME
+    2D_FETKOVICHAQUIFER
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    aquifer-fetkovich
+)
 
-add_test_compareECLFiles(CASENAME numerical_aquifer_3d_2aqu
-                         FILENAME 3D_2AQU_NUM
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR aquifer-num
-                         TEST_ARGS --tolerance-cnv=0.00003 --time-step-control=pid --linear-solver=cpr_trueimpes)
+add_test_compareECLFiles(
+  CASENAME
+    numerical_aquifer_3d_2aqu
+  FILENAME
+    3D_2AQU_NUM
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    aquifer-num
+  TEST_ARGS
+    --tolerance-cnv=0.00003
+    --time-step-control=pid
+    --linear-solver=cpr_trueimpes
+)
 
-add_test_compareECLFiles(CASENAME numerical_aquifer_3d_1aqu
-                         FILENAME 3D_1AQU_3CELLS
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR aquifer-num
-                         TEST_ARGS --tolerance-cnv=0.00003 --time-step-control=pid --linear-solver=cpr_trueimpes)
+add_test_compareECLFiles(
+  CASENAME
+    numerical_aquifer_3d_1aqu
+  FILENAME
+    3D_1AQU_3CELLS
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    aquifer-num
+  TEST_ARGS
+    --tolerance-cnv=0.00003
+    --time-step-control=pid
+    --linear-solver=cpr_trueimpes
+)
 
-add_test_compareECLFiles(CASENAME aquflux_01
-                         FILENAME AQUFLUX-01
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR aquifers
-                         TEST_ARGS --enable-tuning=true --relaxed-max-pv-fraction=0)
+add_test_compareECLFiles(
+  CASENAME
+    aquflux_01
+  FILENAME
+    AQUFLUX-01
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    aquifers
+  TEST_ARGS
+    --enable-tuning=true
+    --relaxed-max-pv-fraction=0
+)
 
-add_test_compareECLFiles(CASENAME aquflux_02
-                         FILENAME AQUFLUX-02
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR aquifers
-                         TEST_ARGS --solver-max-time-step-in-days=1)
+add_test_compareECLFiles(
+  CASENAME
+    aquflux_02
+  FILENAME
+    AQUFLUX-02
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    aquifers
+  TEST_ARGS
+    --solver-max-time-step-in-days=1
+)
 
-add_test_compareECLFiles(CASENAME spe3
-                         FILENAME SPE3CASE1
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${coarse_rel_tol}
-                         TEST_ARGS --tolerance-wells=1e-6)
+add_test_compareECLFiles(
+  CASENAME
+    spe3
+  FILENAME
+    SPE3CASE1
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${coarse_rel_tol}
+  TEST_ARGS
+    --tolerance-wells=1e-6
+)
 
-add_test_compareECLFiles(CASENAME spe9
-                         FILENAME SPE9_CP_SHORT
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         RESTART_STEP 10)
+add_test_compareECLFiles(
+  CASENAME
+    spe9
+  FILENAME
+    SPE9_CP_SHORT
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  RESTART_STEP
+    10
+)
 
-add_test_compareECLFiles(CASENAME spe9group
-                         FILENAME SPE9_CP_GROUP
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol})
+add_test_compareECLFiles(
+  CASENAME
+    spe9group
+  FILENAME
+    SPE9_CP_GROUP
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+)
 
-add_test_compareECLFiles(CASENAME spe9group_resv
-                         FILENAME SPE9_CP_GROUP_RESV
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR spe9group)
+add_test_compareECLFiles(
+  CASENAME
+    spe9group_resv
+  FILENAME
+    SPE9_CP_GROUP_RESV
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe9group
+)
 
-add_test_compareECLFiles(CASENAME msw_2d_h
-                         FILENAME 2D_H__
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${coarse_rel_tol})
+add_test_compareECLFiles(
+  CASENAME
+    msw_2d_h
+  FILENAME
+    2D_H__
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${coarse_rel_tol}
+)
 
-add_test_compareECLFiles(CASENAME msw_3d_hfa
-                         FILENAME 3D_MSW
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         TEST_ARGS --tolerance-pressure-ms-wells=10)
+add_test_compareECLFiles(
+  CASENAME
+    msw_3d_hfa
+  FILENAME
+    3D_MSW
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  TEST_ARGS
+    --tolerance-pressure-ms-wells=10
+)
 
-add_test_compareECLFiles(CASENAME polymer_oilwater
-                         FILENAME 2D_OILWATER_POLYMER
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         TEST_ARGS --solver-max-time-step-in-days=10)
+add_test_compareECLFiles(
+  CASENAME
+    polymer_oilwater
+  FILENAME
+    2D_OILWATER_POLYMER
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater_polymer
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  TEST_ARGS
+    --solver-max-time-step-in-days=10
+)
 
-add_test_compareECLFiles(CASENAME polymer_injectivity
-                         FILENAME 2D_POLYMER_INJECTIVITY
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         TEST_ARGS --tolerance-wells=1.e-6)
+add_test_compareECLFiles(
+  CASENAME
+    polymer_injectivity
+  FILENAME
+    2D_POLYMER_INJECTIVITY
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater_polymer_injectivity
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  TEST_ARGS
+    --tolerance-wells=1.e-6
+)
 
-add_test_compareECLFiles(CASENAME polymer_simple2D
-                         FILENAME 2D_THREEPHASE_POLY_HETER
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${coarse_rel_tol}
-                         TEST_ARGS --tolerance-mb-relaxed=1.e-7)
+add_test_compareECLFiles(
+  CASENAME
+    polymer_simple2D
+  FILENAME
+    2D_THREEPHASE_POLY_HETER
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_polymer
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${coarse_rel_tol}
+  TEST_ARGS
+    --tolerance-mb-relaxed=1.e-7
+)
 
-add_test_compareECLFiles(CASENAME spe5
-                         FILENAME SPE5CASE1
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${coarse_rel_tol})
+add_test_compareECLFiles(
+  CASENAME
+    spe5
+  FILENAME
+    SPE5CASE1
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_solvent
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${coarse_rel_tol}
+)
 
-add_test_compareECLFiles(CASENAME spe5_co2eor
-                         FILENAME SPE5CASE1_DYN
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${coarse_rel_tol})
+add_test_compareECLFiles(
+  CASENAME
+    spe5_co2eor
+  FILENAME
+    SPE5CASE1_DYN
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_extbo
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${coarse_rel_tol}
+)
 
-add_test_compareECLFiles(CASENAME wecon_wtest
-                         FILENAME 3D_WECON
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${coarse_rel_tol})
+add_test_compareECLFiles(
+  CASENAME
+    wecon_wtest
+  FILENAME
+    3D_WECON
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+   ABS_TOL
+    ${abs_tol}
+   REL_TOL
+    ${coarse_rel_tol}
+)
 
-add_test_compareECLFiles(CASENAME msw_model_1
-                         FILENAME MSW_MODEL_1
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR model1
-                         TEST_ARGS --solver-max-time-step-in-days=5.0)
+add_test_compareECLFiles(
+  CASENAME
+    msw_model_1
+  FILENAME
+    MSW_MODEL_1
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    model1
+  TEST_ARGS
+    --solver-max-time-step-in-days=5.0
+)
 
-add_test_compareECLFiles(CASENAME base_model_1
-                         FILENAME BASE_MODEL_1
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR model1)
+add_test_compareECLFiles(
+  CASENAME
+    base_model_1
+  FILENAME
+    BASE_MODEL_1
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    model1
+)
 
-add_test_compareECLFiles(CASENAME faults_model_1
-                         FILENAME FAULTS_MODEL_1
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR model1
-                         TEST_ARGS --solver-max-time-step-in-days=5.0)
+add_test_compareECLFiles(
+  CASENAME
+    faults_model_1
+  FILENAME
+    FAULTS_MODEL_1
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    model1
+  TEST_ARGS
+    --solver-max-time-step-in-days=5.0
+)
 
-add_test_compareECLFiles(CASENAME base_model2_welpi
-                         FILENAME 0B_WELPI_MODEL2
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR model2
-                         TEST_ARGS --enable-tuning=true)
+add_test_compareECLFiles(
+  CASENAME
+    base_model2_welpi
+  FILENAME
+    0B_WELPI_MODEL2
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    model2
+  TEST_ARGS
+    --enable-tuning=true
+)
 
-add_test_compareECLFiles(CASENAME 0a1_grpctl_msw_model2
-                         FILENAME 0A1_GRCTRL_LRAT_ORAT_BASE_MODEL2_MSW
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR model2
-                         TEST_ARGS --solver-max-time-step-in-days=3)
+add_test_compareECLFiles(
+  CASENAME
+    0a1_grpctl_msw_model2
+  FILENAME
+    0A1_GRCTRL_LRAT_ORAT_BASE_MODEL2_MSW
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    model2
+  TEST_ARGS
+    --solver-max-time-step-in-days=3
+)
 
-add_test_compareECLFiles(CASENAME 0a2_grpctl_msw_model2
-                         FILENAME 0A2_GRCTRL_LRAT_ORAT_GGR_BASE_MODEL2_MSW
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR model2
-                         TEST_ARGS --solver-max-time-step-in-days=3)
+add_test_compareECLFiles(
+  CASENAME
+    0a2_grpctl_msw_model2
+  FILENAME
+    0A2_GRCTRL_LRAT_ORAT_GGR_BASE_MODEL2_MSW
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    model2
+  TEST_ARGS
+    --solver-max-time-step-in-days=3
+)
 
-add_test_compareECLFiles(CASENAME 0a3_grpctl_msw_model2
-                         FILENAME 0A3_GRCTRL_LRAT_LRAT_BASE_MODEL2_MSW
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR model2
-                         TEST_ARGS --solver-max-time-step-in-days=3)
+add_test_compareECLFiles(
+  CASENAME
+    0a3_grpctl_msw_model2
+  FILENAME
+    0A3_GRCTRL_LRAT_LRAT_BASE_MODEL2_MSW
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    model2
+  TEST_ARGS
+    --solver-max-time-step-in-days=3
+)
 
-add_test_compareECLFiles(CASENAME 0a4_grpctl_msw_model2
-                         FILENAME 0A4_GRCTRL_LRAT_LRAT_GGR_BASE_MODEL2_MSW
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR model2
-                         TEST_ARGS --solver-max-time-step-in-days=3)
+add_test_compareECLFiles(
+  CASENAME
+    0a4_grpctl_msw_model2
+  FILENAME
+    0A4_GRCTRL_LRAT_LRAT_GGR_BASE_MODEL2_MSW
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    model2
+  TEST_ARGS
+    --solver-max-time-step-in-days=3
+)
 
-add_test_compareECLFiles(CASENAME udq_actionx
-                         FILENAME UDQ_ACTIONX
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR udq_actionx
-                         TEST_ARGS --solver-max-time-step-in-days=5)
+add_test_compareECLFiles(
+  CASENAME
+    udq_actionx
+  FILENAME
+    UDQ_ACTIONX
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    udq_actionx
+  TEST_ARGS
+    --solver-max-time-step-in-days=5
+)
 
-add_test_compareECLFiles(CASENAME udq_wconprod
-                         FILENAME UDQ_WCONPROD
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR udq_actionx)
+add_test_compareECLFiles(
+  CASENAME
+    udq_wconprod
+  FILENAME
+    UDQ_WCONPROD
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    udq_actionx
+)
 
-add_test_compareECLFiles(CASENAME actionx_m1
-                         FILENAME ACTIONX_M1
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR udq_actionx
-                         TEST_ARGS --solver-max-time-step-in-days=0.2)
+add_test_compareECLFiles(
+  CASENAME
+    actionx_m1
+  FILENAME
+    ACTIONX_M1
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    udq_actionx
+  TEST_ARGS
+    --solver-max-time-step-in-days=0.2
+)
 
-add_test_compareECLFiles(CASENAME waghyst1
-                         FILENAME WAGHYSTR-01
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR waghystr)
+add_test_compareECLFiles(
+  CASENAME
+    waghyst1
+  FILENAME
+    WAGHYSTR-01
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    waghystr
+)
 
-add_test_compareECLFiles(CASENAME waghyst2
-                         FILENAME WAGHYSTR-02
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR waghystr)
+add_test_compareECLFiles(
+  CASENAME
+    waghyst2
+  FILENAME
+    WAGHYSTR-02
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    waghystr
+)
 
-add_test_compareECLFiles(CASENAME gpmaint11
-                         FILENAME GPMAINT-11
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR gpmaint)
+add_test_compareECLFiles(
+  CASENAME
+    gpmaint11
+  FILENAME
+    GPMAINT-11
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    gpmaint
+)
 
-add_test_compareECLFiles(CASENAME 3dwecon9
-                         FILENAME 3D_WECON_9
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR wecon_wtest)
+add_test_compareECLFiles(
+  CASENAME
+    3dwecon9
+  FILENAME
+    3D_WECON_9
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    wecon_wtest
+)
 
-add_test_compareECLFiles(CASENAME gconinje_resv_gas_01
-                         FILENAME GCONINJE_RESV_GAS-01
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR resv_ctrl)
+add_test_compareECLFiles(
+  CASENAME
+    gconinje_resv_gas_01
+  FILENAME
+    GCONINJE_RESV_GAS-01
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    resv_ctrl
+)
 
-add_test_compareECLFiles(CASENAME gconinje_resv1
-                         FILENAME GCONINJE-01
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR gconinje)
+add_test_compareECLFiles(
+  CASENAME
+    gconinje_resv1
+  FILENAME
+    GCONINJE-01
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    gconinje
+)
 
-add_test_compareECLFiles(CASENAME gconinje_resv2
-                         FILENAME GCONINJE-02
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR gconinje)
+add_test_compareECLFiles(
+  CASENAME
+    gconinje_resv2
+  FILENAME
+    GCONINJE-02
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    gconinje
+)
 
 set(_gconprod_cases
   T1L
@@ -441,10 +1086,16 @@ set(_gconprod_cases
 add_multiple_tests(
   _gconprod_cases
   gconprod_
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR gconprod
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    gconprod
 )
 
 set(_pinch_cases
@@ -475,10 +1126,16 @@ set(_pinch_cases
 add_multiple_tests(
   _pinch_cases
   pinch_
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR pinch
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    pinch
 )
 
 set(_udt_cases
@@ -491,11 +1148,18 @@ set(_udt_cases
 add_multiple_tests(
   _udt_cases
   ""
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  TEST_ARGS --enable-tuning=true
-  DIR udt
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    udt
+  TEST_ARGS
+    --enable-tuning=true
 )
 
 add_multiple_test_range(
@@ -503,10 +1167,16 @@ add_multiple_test_range(
   6
   EQUALREG-0
   equalreg_multy
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR mult
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    mult
 )
 
 add_multiple_test_range(
@@ -514,10 +1184,16 @@ add_multiple_test_range(
   6
   ACTIONX_WELL_TEMPL-0
   actionx_well_templ
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR actionx
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    actionx
 )
 
 add_multiple_test_range(
@@ -525,52 +1201,113 @@ add_multiple_test_range(
   8
   WCYCLE-
   WCYCLE
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR wcycle
-  TEST_ARGS --enable-tuning=true
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    wcycle
+  TEST_ARGS
+    --enable-tuning=true
 )
 
-add_test_compareECLFiles(CASENAME udq_uadd
-                         FILENAME UDQ_M1
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR udq_actionx
-                         TEST_ARGS --tolerance-wells=1.e-8)
+add_test_compareECLFiles(
+  CASENAME
+    udq_uadd
+  FILENAME
+    UDQ_M1
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    udq_actionx
+  TEST_ARGS
+    --tolerance-wells=1.e-8
+)
 
-add_test_compareECLFiles(CASENAME udq_undefined
-                         FILENAME UDQ_M2
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR udq_actionx)
+add_test_compareECLFiles(
+  CASENAME
+    udq_undefined
+  FILENAME
+    UDQ_M2
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    udq_actionx
+)
 
-add_test_compareECLFiles(CASENAME udq_in_actionx
-                         FILENAME UDQ_M3
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR udq_actionx)
+add_test_compareECLFiles(
+  CASENAME
+    udq_in_actionx
+  FILENAME
+    UDQ_M3
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    udq_actionx
+)
 
-add_test_compareECLFiles(CASENAME reg_smry_in_fld_udq
-                         FILENAME UDQ_REG-01
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR udq_actionx
-                         TEST_ARGS --enable-tuning=true --time-step-control=pid)
+add_test_compareECLFiles(
+  CASENAME
+    reg_smry_in_fld_udq
+  FILENAME
+    UDQ_REG-01
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    udq_actionx
+  TEST_ARGS
+    --enable-tuning=true
+    --time-step-control=pid
+)
 
 # UDQ ASSIGN for subsets of group level UDQs.  Updates triggered from
 # ACTIONX blocks.
-add_test_compareECLFiles(CASENAME group_udq
-                         FILENAME UDQ_GRP-01
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR udq_actionx
-                         TEST_ARGS --solver-max-time-step-in-days=0.25)
+add_test_compareECLFiles(
+  CASENAME
+    group_udq
+  FILENAME
+    UDQ_GRP-01
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    udq_actionx
+  TEST_ARGS
+    --solver-max-time-step-in-days=0.25
+)
 
 set(_actionx_tests
   ACTIONX_GCONINJE
@@ -585,10 +1322,16 @@ set(_actionx_tests
 add_multiple_tests(
   _actionx_tests
   ""
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR actionx
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    actionx
 )
 
 add_multiple_test_range(
@@ -596,47 +1339,202 @@ add_multiple_test_range(
   5
   CSKIN-0
   cskin
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR cskin
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    cskin
 )
 
-set(_co2store_cases
+set(_co2store_gasoil_cases
   CO2STORE
-  CO2STORE_DIFFUSIVE
   CO2STORE_DRSDTCON
-  CO2STORE_ENERGY
-  CO2STORE_GASWAT
+)
+
+add_multiple_tests(
+  _co2store_gasoil_cases
+  ""
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gasoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    co2store
+)
+
+set(_co2store_gaswater_d_cases
   CO2STORE_GW
   CO2STORE_GW_DIRICHLET
 )
 
 add_multiple_tests(
-  _co2store_cases
+  _co2store_gaswater_d_cases
   ""
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR co2store
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gaswater_dissolution
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    co2store
 )
 
-set(_h2store_cases
-  H2STORE
-  H2STORE_DIFFUSIVE
-  H2STORE_ENERGY
-  H2STORE_GASWAT
-  H2STORE_GW
+add_test_compareECLFiles(
+  CASENAME
+    co2store_gaswat
+  FILENAME
+    CO2STORE_GASWAT
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gaswater
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    co2store
 )
 
-add_multiple_tests(
-  _h2store_cases
-  ""
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR h2store
-  TEST_ARGS --tolerance-cnv-relaxed=0.01
+add_test_compareECLFiles(
+  CASENAME
+    co2store_energy
+  FILENAME
+    CO2STORE_ENERGY
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gasoil_energy
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    co2store
+)
+
+add_test_compareECLFiles(
+  CASENAME
+    co2store_diffusive
+  FILENAME
+    CO2STORE_DIFFUSIVE
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gasoildiffuse
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    co2store
+)
+
+add_test_compareECLFiles(
+  CASENAME
+    h2store
+  FILENAME
+    H2STORE
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gasoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    h2store
+  TEST_ARGS
+    --tolerance-cnv-relaxed=0.01
+)
+
+add_test_compareECLFiles(
+  CASENAME
+    h2store_gaswat
+  FILENAME
+    H2STORE_GASWAT
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gaswater
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    h2store
+  TEST_ARGS
+    --tolerance-cnv-relaxed=0.01
+)
+
+add_test_compareECLFiles(
+  CASENAME
+    h2store_gw
+  FILENAME
+    H2STORE_GW
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gaswater_dissolution
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    h2store
+  TEST_ARGS
+    --tolerance-cnv-relaxed=0.01
+)
+
+add_test_compareECLFiles(
+  CASENAME
+    h2store_diffusive
+  FILENAME
+    H2STORE_DIFFUSIVE
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gasoildiffuse
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    h2store
+  TEST_ARGS
+    --tolerance-cnv-relaxed=0.01
+)
+
+add_test_compareECLFiles(
+  CASENAME
+    h2store_energy
+  FILENAME
+    H2STORE_ENERGY
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gasoil_energy
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    h2store
+  TEST_ARGS
+    --tolerance-cnv-relaxed=0.01
 )
 
 set(_tpsa_cases
@@ -647,31 +1545,64 @@ set(_tpsa_cases
 add_multiple_tests(
   _tpsa_cases
   ""
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR tpsa
-  TEST_ARGS --enable-opm-rst-file=1
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_onephase_tpsa
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    tpsa
+  TEST_ARGS
+    --enable-opm-rst-file=1
 )
 
-add_test_compareECLFiles(CASENAME ppcwmax
-                         FILENAME PPCWMAX-01
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR ppcwmax)
+add_test_compareECLFiles(
+  CASENAME
+    ppcwmax
+  FILENAME
+    PPCWMAX-01
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    ppcwmax
+)
 
 get_property(opm-common_EMBEDDED_PYTHON TARGET opmcommon PROPERTY EMBEDDED_PYTHON)
 if(opm-common_EMBEDDED_PYTHON)
-  add_test_compareECLFiles(CASENAME udq_pyaction
-                           FILENAME PYACTION_WCONPROD
-                           SIMULATOR flow
-                           ABS_TOL ${abs_tol}
-                           REL_TOL ${rel_tol}
-                           DIR udq_actionx
-                           TEST_ARGS --solver-max-time-step-in-days=10)
+  add_test_compareECLFiles(
+    CASENAME
+      udq_pyaction
+    FILENAME
+      PYACTION_WCONPROD
+    DEV_SIMULATOR
+      flow_blackoil
+    SIMULATOR
+      flow
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${rel_tol}
+    DIR
+      udq_actionx
+    TEST_ARGS
+      --solver-max-time-step-in-days=10
+  )
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.22)
-    set_tests_properties(compareECLFiles_flow+PYACTION_WCONPROD PROPERTIES
+    if(USE_DEV_SIMULATOR_IN_TESTS)
+      set(test_name compareECLFiles_flow_blackoil+PYACTION_WCONPROD)
+    else()
+      set(test_name compareECLFiles_flow+PYACTION_WCONPROD)
+    endif()
+    set_tests_properties(${test_name} PROPERTIES
                           ENVIRONMENT_MODIFICATION PYTHONPATH=path_list_append:${opm-common_DIR}/python)
   endif()
 endif()
@@ -722,332 +1653,772 @@ set(_model2_tests
 add_multiple_tests(
   _model2_tests
   ""
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR model2
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    model2
 )
 
-add_test_compareECLFiles(CASENAME multflt_model2
-                        FILENAME 3_MULTFLT_MODEL2
-                        SIMULATOR flow
-                        ABS_TOL ${abs_tol}
-                        REL_TOL ${rel_tol}
-                        DIR model2
-                        TEST_ARGS --solver-max-time-step-in-days=10)
+add_test_compareECLFiles(
+  CASENAME
+    multflt_model2
+  FILENAME
+    3_MULTFLT_MODEL2
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    model2
+  TEST_ARGS
+    --solver-max-time-step-in-days=10
+)
 
-add_test_compareECLFiles(CASENAME multpvv_model2
-                         FILENAME 4_MINPVV_MODEL2
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR model2
-                         TEST_ARGS --solver-max-time-step-in-days=10)
+add_test_compareECLFiles(
+  CASENAME
+    multpvv_model2
+  FILENAME
+    4_MINPVV_MODEL2
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    model2
+  TEST_ARGS
+    --solver-max-time-step-in-days=10
+)
 
-add_test_compareECLFiles(CASENAME 9_3d_grpctl_stw_model2
-                         FILENAME 9_3D_GINJ_GAS_MAX_EXPORT_STW
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR model2
-                         TEST_ARGS --time-step-after-event-in-days=1)
+add_test_compareECLFiles(
+  CASENAME
+    9_3d_grpctl_stw_model2
+  FILENAME
+    9_3D_GINJ_GAS_MAX_EXPORT_STW
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    model2
+  TEST_ARGS
+    --time-step-after-event-in-days=1
+)
 
-add_test_compareECLFiles(CASENAME model4_udq_group
-                         FILENAME MOD4_UDQ_ACTIONX
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR model4)
+add_test_compareECLFiles(
+  CASENAME
+    model4_udq_group
+  FILENAME
+    MOD4_UDQ_ACTIONX
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    model4
+)
 
-add_test_compareECLFiles(CASENAME model4_gefac
-                         FILENAME MOD4_GRP_GEFAC
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR model4)
+add_test_compareECLFiles(
+  CASENAME
+    model4_gefac
+  FILENAME
+    MOD4_GRP_GEFAC
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    model4
+)
 
-add_test_compareECLFiles(CASENAME model6_msw
-                         FILENAME 1_MSW_MODEL6
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR model6)
+add_test_compareECLFiles(
+  CASENAME
+    model6_msw
+  FILENAME
+    1_MSW_MODEL6
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    model6
+)
 
-add_test_compareECLFiles(CASENAME wsegsicd
-                         FILENAME TEST_WSEGSICD
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol})
+add_test_compareECLFiles(
+  CASENAME
+    wsegsicd
+  FILENAME
+    TEST_WSEGSICD
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+)
 
-add_test_compareECLFiles(CASENAME wsegaicd
-                         FILENAME BASE_MSW_WSEGAICD
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol})
+add_test_compareECLFiles(
+  CASENAME
+    wsegaicd
+  FILENAME
+    BASE_MSW_WSEGAICD
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+)
 
-add_test_compareECLFiles(CASENAME wsegvalv
-                         FILENAME BASE_MSW_WSEGVALV
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol})
+add_test_compareECLFiles(
+  CASENAME
+    wsegvalv
+  FILENAME
+    BASE_MSW_WSEGVALV
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+)
 
-add_test_compareECLFiles(CASENAME wsegvalv_2d_vert
-                         FILENAME  MSW-2D-VERT-02
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR msw)
+add_test_compareECLFiles(
+  CASENAME
+    wsegvalv_2d_vert
+  FILENAME
+    MSW-2D-VERT-02
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    msw
+)
 
-add_test_compareECLFiles(CASENAME nnc
-                         FILENAME NNC_AND_EDITNNC
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR editnnc
-                         TEST_ARGS --enable-opm-rst-file=1)
+add_test_compareECLFiles(
+  CASENAME
+    nnc
+  FILENAME
+    NNC_AND_EDITNNC
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    editnnc
+  TEST_ARGS
+    --enable-opm-rst-file=1
+)
 
-add_test_compareECLFiles(CASENAME nonnc
-                         FILENAME NONNC
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR editnnc)
+add_test_compareECLFiles(
+  CASENAME
+    nonnc
+  FILENAME
+    NONNC
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    editnnc
+)
 
-add_test_compareECLFiles(CASENAME nnc_overlapping_editnnc
-                         FILENAME NNC_OVERLAPPING_EDITNNC
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR editnnc
-                         TEST_ARGS --enable-opm-rst-file=1)
+add_test_compareECLFiles(
+  CASENAME
+    nnc_overlapping_editnnc
+  FILENAME
+    NNC_OVERLAPPING_EDITNNC
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gaswater
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    editnnc
+  TEST_ARGS
+    --enable-opm-rst-file=1
+)
 
-add_test_compareECLFiles(CASENAME nnc_overlapping_editnncr_multregt
-                         FILENAME NNC_OVERLAPPING_EDITNNCR_MULTREGT
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR editnnc
-                         TEST_ARGS --enable-opm-rst-file=1)
+add_test_compareECLFiles(
+  CASENAME
+    nnc_overlapping_editnncr_multregt
+  FILENAME
+    NNC_OVERLAPPING_EDITNNCR_MULTREGT
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gaswater
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    editnnc
+  TEST_ARGS
+    --enable-opm-rst-file=1
+)
 
-add_test_compareECLFiles(CASENAME spe1_foam
-                         FILENAME SPE1FOAM
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR spe1_foam)
+add_test_compareECLFiles(
+  CASENAME
+    spe1_foam
+  FILENAME
+    SPE1FOAM
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_foam
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe1_foam
+)
 
-add_test_compareECLFiles(CASENAME spe1_solvent_foam
-                         FILENAME SPE1CASE2_SOLVENT_FOAM
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR spe1_solvent)
+add_test_compareECLFiles(
+  CASENAME
+    spe1_solvent_foam
+  FILENAME
+    SPE1CASE2_SOLVENT_FOAM
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_solvent_foam
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe1_solvent
+)
 
-add_test_compareECLFiles(CASENAME spe1_gaswater_solvent
-                         FILENAME SPE1CASE2_GASWATER_SOLVENT
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR spe1_solvent)
+add_test_compareECLFiles(
+  CASENAME
+    spe1_gaswater_solvent
+  FILENAME
+    SPE1CASE2_GASWATER_SOLVENT
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gaswater_solvent
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe1_solvent
+)
 
-add_test_compareECLFiles(CASENAME spe1_co2sol
-                         FILENAME SPE1CASE2_CO2SOL
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR spe1_solvent
-                         TEST_ARGS --enable-opm-rst-file=1)
+add_test_compareECLFiles(
+  CASENAME
+    spe1_co2sol
+  FILENAME
+    SPE1CASE2_CO2SOL
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_solvent
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe1_solvent
+  TEST_ARGS
+    --enable-opm-rst-file=1
+)
 
-add_test_compareECLFiles(CASENAME spe1_h2sol
-                         FILENAME SPE1CASE2_H2SOL
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR spe1_solvent
-                         TEST_ARGS --enable-opm-rst-file=1)
+add_test_compareECLFiles(
+  CASENAME
+    spe1_h2sol
+  FILENAME
+    SPE1CASE2_H2SOL
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_solvent
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    spe1_solvent
+  TEST_ARGS
+    --enable-opm-rst-file=1
+)
 
-add_test_compareECLFiles(CASENAME bc_lab
-                         FILENAME BC_LAB
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR bc_lab)
+add_test_compareECLFiles(
+  CASENAME
+    bc_lab
+  FILENAME
+    BC_LAB
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    bc_lab
+)
 
-add_test_compareECLFiles(CASENAME norne_reperf
-                         FILENAME NORNE_ATW2013_B1H_RE-PERF
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR norne
-                         TEST_ARGS --tolerance-wells=1.e-8)
+add_test_compareECLFiles(
+  CASENAME
+    norne_reperf
+  FILENAME
+    NORNE_ATW2013_B1H_RE-PERF
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    norne
+  TEST_ARGS
+    --tolerance-wells=1.e-8
+)
 
-add_test_compareECLFiles(CASENAME compl_smry
-                         FILENAME COMPL_SMRY
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR compl_smry)
+add_test_compareECLFiles(
+  CASENAME
+    compl_smry
+  FILENAME
+    COMPL_SMRY
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    compl_smry
+)
 
-add_test_compareECLFiles(CASENAME 3d_tran_operator
-                         FILENAME 3D_TRAN_OPERATOR
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR parallel_fieldprops
-                         TEST_ARGS --enable-tuning=true --relaxed-max-pv-fraction=0)
+add_test_compareECLFiles(
+  CASENAME
+    3d_tran_operator
+  FILENAME
+    3D_TRAN_OPERATOR
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    parallel_fieldprops
+  TEST_ARGS
+    --enable-tuning=true
+    --relaxed-max-pv-fraction=0
+)
 
-add_test_compareECLFiles(CASENAME h2store_biofilm
-                         FILENAME H2STORE_BIOFILM
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR h2store
-                         TEST_ARGS --enable-opm-rst-file=true --initial-time-step-in-days=0.01)
+add_test_compareECLFiles(
+  CASENAME
+    h2store_biofilm
+  FILENAME
+    H2STORE_BIOFILM
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_biofilm
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    h2store
+  TEST_ARGS
+    --enable-opm-rst-file=true
+    --initial-time-step-in-days=0.01
+)
 
-add_test_compareECLFiles(CASENAME micp
-                         FILENAME MICP
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR micp
-                         TEST_ARGS --enable-opm-rst-file=true)
+add_test_compareECLFiles(
+  CASENAME
+    micp
+  FILENAME
+    MICP
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_micp
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    micp
+  TEST_ARGS
+    --enable-opm-rst-file=true
+)
 
-add_test_compareECLFiles(CASENAME 0_base_model6
-                         FILENAME 0_BASE_MODEL6
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR model6)
+add_test_compareECLFiles(
+  CASENAME
+    0_base_model6
+  FILENAME
+    0_BASE_MODEL6
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    model6
+)
 
-add_test_compareECLFiles(CASENAME 0a_aquct_model6
-                         FILENAME 0A_AQUCT_MODEL6
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR model6)
+add_test_compareECLFiles(
+  CASENAME
+    0a_aquct_model6
+  FILENAME
+    0A_AQUCT_MODEL6
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    model6
+)
 
-add_test_compareECLFiles(CASENAME 0b_rocktab_model6
-                         FILENAME 0B_ROCKTAB_MODEL6
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR model6)
+add_test_compareECLFiles(
+  CASENAME
+    0b_rocktab_model6
+  FILENAME
+    0B_ROCKTAB_MODEL6
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    model6
+)
 
-add_test_compareECLFiles(CASENAME base_wt_tracer
-                         FILENAME BASE_WT_TRACER
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR tracer
-                         RESTART_STEP 1,3,7)
+add_test_compareECLFiles(
+  CASENAME
+    base_wt_tracer
+  FILENAME
+    BASE_WT_TRACER
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    tracer
+  RESTART_STEP
+    1,3,7
+)
 
-add_test_compareECLFiles(CASENAME tracer_multiphase
-                         FILENAME TRACER_2WT_2GT
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR tracer)
+add_test_compareECLFiles(
+  CASENAME
+    tracer_multiphase
+  FILENAME
+    TRACER_2WT_2GT
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    tracer
+)
 
 add_multiple_test_range(
   1
   3
   MIN_BHP_
   min_bhp
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR wtest/bhp_min
-  TEST_ARGS --enable-tuning=true
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    wtest/bhp_min
+  TEST_ARGS
+    --enable-tuning=true
 )
 
-add_test_compareECLFiles(CASENAME min_thp_1
-                         FILENAME MIN_THP_1
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR wtest/thp_min
-                         TEST_ARGS --enable-tuning=true)
+add_test_compareECLFiles(
+  CASENAME
+    min_thp_1
+  FILENAME
+    MIN_THP_1
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    wtest/thp_min
+  TEST_ARGS
+    --enable-tuning=true
+)
 
-add_test_compareECLFiles(CASENAME max_gor_1
-                         FILENAME MAX_GOR_1
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR wtest/wecon_gor_max
-                         TEST_ARGS --enable-tuning=true)
+add_test_compareECLFiles(
+  CASENAME
+    max_gor_1
+  FILENAME
+    MAX_GOR_1
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    wtest/wecon_gor_max
+  TEST_ARGS
+    --enable-tuning=true
+)
 
-add_test_compareECLFiles(CASENAME min_gasrate_1
-                         FILENAME MIN_GASRATE_1
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR wtest/wecon_qg_min
-                         TEST_ARGS --enable-tuning=true)
+add_test_compareECLFiles(
+  CASENAME
+    min_gasrate_1
+  FILENAME
+    MIN_GASRATE_1
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    wtest/wecon_qg_min
+  TEST_ARGS
+    --enable-tuning=true
+)
 
-add_test_compareECLFiles(CASENAME min_qoil_1
-                         FILENAME MIN_QOIL_1
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR wtest/wecon_qo_min
-                         TEST_ARGS --enable-tuning=true)
+add_test_compareECLFiles(
+  CASENAME
+    min_qoil_1
+  FILENAME
+    MIN_QOIL_1
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    wtest/wecon_qo_min
+  TEST_ARGS
+    --enable-tuning=true
+)
 
 add_multiple_test_range(
   1
   4
   MAX_WATERCUT_
   max_watercut
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR wtest/wecon_wct_max
-  TEST_ARGS --enable-tuning=true
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    wtest/wecon_wct_max
+  TEST_ARGS
+    --enable-tuning=true
 )
 
-add_test_compareECLFiles(CASENAME max_wgr_1
-                         FILENAME MAX_WGR_1
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR wtest/wecon_wgr_max
-                         TEST_ARGS --enable-tuning=true)
+add_test_compareECLFiles(
+  CASENAME
+    max_wgr_1
+  FILENAME
+    MAX_WGR_1
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    wtest/wecon_wgr_max
+  TEST_ARGS
+    --enable-tuning=true
+)
 
-add_test_compareECLFiles(CASENAME rxft_smry
-                         FILENAME TEST_RXFT
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR rxft_smry
-                         TEST_ARGS --enable-tuning=true --linear-solver-reduction=1e-7)
+add_test_compareECLFiles(
+  CASENAME
+    rxft_smry
+  FILENAME
+    TEST_RXFT
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    rxft_smry
+  TEST_ARGS
+    --enable-tuning=true
+    --linear-solver-reduction=1e-7
+)
 
-add_test_compareECLFiles(CASENAME bo_diffusion
-                         FILENAME BO_DIFFUSE_CASE1
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR diffusion )
+add_test_compareECLFiles(
+  CASENAME
+    bo_diffusion
+  FILENAME
+    BO_DIFFUSE_CASE1
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gasoildiffuse
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    diffusion
+)
 
-add_test_compareECLFiles(CASENAME fpr_nonhc
-                         FILENAME WATER2F
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR water-1ph)
+add_test_compareECLFiles(
+  CASENAME
+    fpr_nonhc
+  FILENAME
+    WATER2F
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_onephase
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    water-1ph
+)
 
-add_test_compareECLFiles(CASENAME actionx_wpimult
-                         FILENAME ACTIONX_WPIMULT
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR actionx
-                         TEST_ARGS --enable-tuning=true)
+add_test_compareECLFiles(
+  CASENAME
+    actionx_wpimult
+  FILENAME
+    ACTIONX_WPIMULT
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    actionx
+  TEST_ARGS
+    --enable-tuning=true
+)
 
-add_test_compareECLFiles(CASENAME wvfpexp_02
-                         FILENAME WVFPEXP-02
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR wvfpexp)
+add_test_compareECLFiles(
+  CASENAME
+    wvfpexp_02
+  FILENAME
+    WVFPEXP-02
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    wvfpexp
+)
 
 set(_krnum_tests
   KRNUM-02X
@@ -1061,10 +2432,16 @@ set(_krnum_tests
 add_multiple_tests(
   _krnum_tests
   ""
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR krnum
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    krnum
 )
 
 set(_gridunit_tests
@@ -1079,70 +2456,137 @@ set(_gridunit_tests
 add_multiple_tests(
   _gridunit_tests
   ""
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR gridunit
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    gridunit
 )
 
-add_test_compareECLFiles(CASENAME 01_wgrupcon
-                         FILENAME 01-WGRUPCON
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR wgrupcon
-                         TEST_ARGS --enable-tuning=true)
+add_test_compareECLFiles(
+  CASENAME
+    01_wgrupcon
+  FILENAME
+    01-WGRUPCON
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    wgrupcon
+  TEST_ARGS
+    --enable-tuning=true
+)
 
-add_test_compareECLFiles(CASENAME 02_wgrupcon
-                         FILENAME 02-WGRUPCON
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR wgrupcon
-                         TEST_ARGS --enable-tuning=true)
-add_test_compareECLFiles(CASENAME winjmult_stdw
-                         FILENAME WINJMULT_STDW
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR winjmult
-                         TEST_ARGS --enable-tuning=true)
-add_test_compareECLFiles(CASENAME winjmult_msw
-                         FILENAME WINJMULT_MSW
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR winjmult
-                         TEST_ARGS --enable-tuning=true)
-add_test_compareECLFiles(CASENAME winjdam_stdw
-                         FILENAME WINJDAM_STDW
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR winjdam
-                         TEST_ARGS --enable-tuning=true)
-add_test_compareECLFiles(CASENAME winjdam_msw
-                         FILENAME WINJDAM_MSW
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR winjdam
-                         TEST_ARGS --enable-tuning=true)
-add_test_compareECLFiles(CASENAME 01_vappars
-                         FILENAME VAPPARS-01
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR vappars)
+add_test_compareECLFiles(
+  CASENAME
+    02_wgrupcon
+  FILENAME
+    02-WGRUPCON
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    wgrupcon
+  TEST_ARGS
+    --enable-tuning=true
+)
 
-add_test_compareECLFiles(CASENAME 6_uda_model5_stdw
-  FILENAME 6_UDA_MODEL5_STDW
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR model5
-  RESTART_STEP 1
-  TEST_ARGS --enable-tuning=true
+set(_winjmult_cases
+  WINJMULT_MSW
+  WINJMULT_STDW
+)
+
+
+add_multiple_tests(
+  _winjmult_cases
+  ""
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    winjmult
+  TEST_ARGS
+    --enable-tuning=true
+)
+
+set(_winjdam_cases
+  WINJDAM_MSW
+  WINJDAM_STDW
+)
+
+add_multiple_tests(
+  _winjdam_cases
+  ""
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    winjdam
+  TEST_ARGS
+    --enable-tuning=true
+)
+
+add_test_compareECLFiles(
+  CASENAME
+    01_vappars
+  FILENAME
+    VAPPARS-01
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    vappars
+)
+
+add_test_compareECLFiles(
+  CASENAME
+    6_uda_model5_stdw
+  FILENAME
+    6_UDA_MODEL5_STDW
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    model5
+  RESTART_STEP
+    1
+  TEST_ARGS
+    --enable-tuning=true
 )
 
 set(_mult_cases
@@ -1160,50 +2604,101 @@ set(_mult_cases
 add_multiple_tests(
   _mult_cases
   ""
-  SIMULATOR flow
-  ABS_TOL ${abs_tol}
-  REL_TOL ${rel_tol}
-  DIR mult
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    mult
 )
 
-add_test_compareECLFiles(CASENAME gsatprod
-                         FILENAME GSATPROD2
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR satellite)
+add_test_compareECLFiles(
+  CASENAME
+    gsatprod
+  FILENAME
+    GSATPROD2
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    satellite
+)
 
-add_test_compareECLFiles(CASENAME gsatprod6
-                         FILENAME GSATPROD6
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR satellite)
+add_test_compareECLFiles(
+  CASENAME
+    gsatprod6
+  FILENAME
+    GSATPROD6
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    satellite
+)
 
 if(BUILD_FLOW_POLY_GRID)
-  add_test_compareECLFiles(CASENAME spe12_polyhedralgrid
-                           FILENAME SPE1CASE2
-                           SIMULATOR flow_blackoil_polyhedralgrid
-                           ABS_TOL ${abs_tol}
-                           REL_TOL ${coarse_rel_tol}
-                           DIR spe1)
+  add_test_compareECLFiles(
+    CASENAME
+      spe12_polyhedralgrid
+    FILENAME
+      SPE1CASE2
+    SIMULATOR
+      flow_blackoil_polyhedralgrid
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${coarse_rel_tol}
+    DIR
+      spe1
+  )
 endif()
 
 if(dune-alugrid_FOUND AND BUILD_FLOW_ALU_GRID AND MPI_FOUND)
-  add_test_compareECLFiles(CASENAME spe12_alugrid
-                           FILENAME SPE1CASE2
-                           SIMULATOR flow_blackoil_alugrid
-                           ABS_TOL ${abs_tol}
-                           REL_TOL ${coarse_rel_tol}
-                           DIR spe1)
+  add_test_compareECLFiles(
+    CASENAME
+      spe12_alugrid
+    FILENAME
+      SPE1CASE2
+    SIMULATOR
+      flow_blackoil_alugrid
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${coarse_rel_tol}
+    DIR
+      spe1
+  )
 endif()
 
 if(BUILD_FLOW_FLOAT_VARIANTS)
-  add_test_compareECLFiles(CASENAME spe1_float
-                           FILENAME SPE1CASE1
-                           SIMULATOR flow_blackoil_float
-                           ABS_TOL ${abs_tol}
-                           REL_TOL ${rel_tol}
-                           DIR spe1
-                           TEST_ARGS --tolerance-mb=1e-6)
+  add_test_compareECLFiles(
+    CASENAME
+      spe1_float
+    FILENAME
+      SPE1CASE1
+    SIMULATOR
+      flow_blackoil_float
+    ABS_TOL
+      ${abs_tol}
+    REL_TOL
+      ${rel_tol}
+    DIR
+      spe1
+    TEST_ARGS
+      --tolerance-mb=1e-6
+  )
 endif()

--- a/restartTests.cmake
+++ b/restartTests.cmake
@@ -4,114 +4,279 @@ opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-restart-regressionTest.sh ""
 set(abs_tol_restart 2e-1)
 set(rel_tol_restart 4e-4)
 
-add_test_compare_restarted_simulation(CASENAME spe1
-                                      FILENAME SPE1CASE2_ACTNUM
-                                      SIMULATOR flow
-                                      ABS_TOL ${abs_tol_restart}
-                                      REL_TOL ${rel_tol_restart}
-                                      RESTART_STEP 6
-                                      TEST_ARGS --sched-restart=false)
+# This is not a proper regression test; the test will load a norne case prepared
+# for restart and run one single timestep - of length one day. The results are not
+# verified in any way.
+if(USE_DEV_SIMULATOR_IN_TESTS)
+  set(RESTART_SIM flow_blackoil)
+else()
+  set(RESTART_SIM flow)
+endif()
 
-add_test_compare_restarted_simulation(CASENAME spe9
-                                      FILENAME SPE9_CP_SHORT
-                                      SIMULATOR flow
-                                      ABS_TOL ${abs_tol_restart}
-                                      REL_TOL ${rel_tol_restart}
-                                      RESTART_STEP 15
-                                      TEST_ARGS --sched-restart=false  --tolerance-mb=1e-7)
+add_test(
+  NAME
+    NORNE_RESTART
+  COMMAND
+    ${RESTART_SIM}
+    --output-dir=${BASE_RESULT_PATH}/norne-restart
+    ${OPM_TESTS_ROOT}/norne/NORNE_ATW2013_RESTART.DATA
+)
 
-add_test_compare_restarted_simulation(CASENAME ctaquifer_2d_oilwater
-                                      FILENAME 2D_OW_CTAQUIFER
-                                      SIMULATOR flow
-                                      ABS_TOL ${abs_tol_restart}
-                                      REL_TOL ${rel_tol_restart}
-                                      DIR aquifer-oilwater
-                                      RESTART_STEP 15
-                                      TEST_ARGS --sched-restart=true)
+add_test_compare_restarted_simulation(
+  CASENAME
+    spe1
+  FILENAME
+    SPE1CASE2_ACTNUM
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_restart}
+  REL_TOL
+    ${rel_tol_restart}
+  RESTART_STEP
+    6
+  TEST_ARGS
+    --sched-restart=false
+)
 
-add_test_compare_restarted_simulation(CASENAME fetkovich_2d
-                                      FILENAME 2D_FETKOVICHAQUIFER
-                                      SIMULATOR flow
-                                      ABS_TOL ${abs_tol_restart}
-                                      REL_TOL ${rel_tol_restart}
-                                      RESTART_STEP 30
-                                      DIR aquifer-fetkovich
-                                      TEST_ARGS --sched-restart=true)
+add_test_compare_restarted_simulation(
+  CASENAME
+    spe9
+  FILENAME
+    SPE9_CP_SHORT
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_restart}
+  REL_TOL
+    ${rel_tol_restart}
+  RESTART_STEP
+    15
+  TEST_ARGS
+    --sched-restart=false
+    --tolerance-mb=1e-7
+)
 
-add_test_compare_restarted_simulation(CASENAME numerical_aquifer_3d_1aqu
-                                      FILENAME 3D_1AQU_3CELLS
-                                      SIMULATOR flow
-                                      ABS_TOL 0.4
-                                      REL_TOL 4.0e-3
-                                      RESTART_STEP 3
-                                      DIR aquifer-num
-                                      TEST_ARGS --enable-tuning=true --relaxed-max-pv-fraction=0.0 --enable-drift-compensation=false)
+add_test_compare_restarted_simulation(
+  CASENAME
+    ctaquifer_2d_oilwater
+  FILENAME
+    2D_OW_CTAQUIFER
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater
+  ABS_TOL
+    ${abs_tol_restart}
+  REL_TOL
+    ${rel_tol_restart}
+  DIR
+    aquifer-oilwater
+  RESTART_STEP
+    15
+  TEST_ARGS
+    --sched-restart=true
+)
 
-add_test_compare_restarted_simulation(CASENAME numerical_aquifer_3d_2aqu
-                                      FILENAME 3D_2AQU_NUM
-                                      SIMULATOR flow
-                                      ABS_TOL 0.4
-                                      REL_TOL 4.0e-3
-                                      RESTART_STEP 3
-                                      DIR aquifer-num
-                                      TEST_ARGS --sched-restart=true --enable-tuning=true)
+add_test_compare_restarted_simulation(
+  CASENAME
+    fetkovich_2d
+  FILENAME
+    2D_FETKOVICHAQUIFER
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater
+  ABS_TOL
+    ${abs_tol_restart}
+  REL_TOL
+    ${rel_tol_restart}
+  RESTART_STEP
+    30
+  DIR
+    aquifer-fetkovich
+  TEST_ARGS
+    --sched-restart=true
+)
 
-add_test_compare_restarted_simulation(CASENAME aquflux_01
-                                      FILENAME AQUFLUX-01
-                                      SIMULATOR flow
-                                      ABS_TOL ${abs_tol_restart}
-                                      REL_TOL 3.0e-3
-                                      RESTART_STEP 3
-                                      DIR aquifers
-                                      TEST_ARGS --enable-tuning=true)
+add_test_compare_restarted_simulation(
+  CASENAME
+    numerical_aquifer_3d_1aqu
+  FILENAME
+    3D_1AQU_3CELLS
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    0.4
+  REL_TOL
+    4.0e-3
+  RESTART_STEP
+    3
+  DIR
+    aquifer-num
+  TEST_ARGS
+    --enable-tuning=true
+    --relaxed-max-pv-fraction=0.0
+    --enable-drift-compensation=false
+)
 
-add_test_compare_restarted_simulation(CASENAME aquflux_02
-                                      FILENAME AQUFLUX-02
-                                      SIMULATOR flow
-                                      ABS_TOL ${abs_tol_restart}
-                                      REL_TOL ${rel_tol_restart}
-                                      RESTART_STEP 50
-                                      DIR aquifers
-                                      TEST_ARGS --enable-tuning=true)
+add_test_compare_restarted_simulation(
+  CASENAME
+    numerical_aquifer_3d_2aqu
+  FILENAME
+    3D_2AQU_NUM
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    0.4
+  REL_TOL
+    4.0e-3
+  RESTART_STEP
+    3
+  DIR
+    aquifer-num
+  TEST_ARGS
+    --sched-restart=true
+    --enable-tuning=true
+)
 
-add_test_compare_restarted_simulation(CASENAME network_01_restart
-                                      FILENAME NETWORK-01-RESTART
-                                      SIMULATOR flow
-                                      ABS_TOL ${abs_tol_restart}
-                                      REL_TOL ${rel_tol_restart}
-                                      RESTART_STEP 5
-                                      DIR network
-                                      TEST_ARGS --enable-tuning=true --local-well-solve-control-switching=true)
+add_test_compare_restarted_simulation(
+  CASENAME
+    aquflux_01
+  FILENAME
+    AQUFLUX-01
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_restart}
+  REL_TOL
+    3.0e-3
+  RESTART_STEP
+    3
+  DIR
+    aquifers
+  TEST_ARGS
+    --enable-tuning=true
+)
 
-add_test_compare_restarted_simulation(CASENAME network_01_reroute_restart
-                                      FILENAME NETWORK-01-REROUTE-RESTART
-                                      SIMULATOR flow
-                                      ABS_TOL ${abs_tol_restart}
-                                      REL_TOL ${rel_tol_restart}
-                                      RESTART_STEP 5
-                                      DIR network
-                                      TEST_ARGS --enable-tuning=true --local-well-solve-control-switching=true)
+add_test_compare_restarted_simulation(
+  CASENAME
+    aquflux_02
+  FILENAME
+    AQUFLUX-02
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater
+  ABS_TOL
+    ${abs_tol_restart}
+  REL_TOL
+    ${rel_tol_restart}
+  RESTART_STEP
+    50
+  DIR
+    aquifers
+  TEST_ARGS
+    --enable-tuning=true
+)
 
-add_test_compare_restarted_simulation(CASENAME spe1_temp
-                                      FILENAME SPE1CASE2_TEMP
-                                      SIMULATOR flow
-                                      ABS_TOL ${abs_tol_restart}
-                                      REL_TOL 5.0e-2
-                                      RESTART_STEP 3
-                                      DIR spe1
-                                      TEST_ARGS --solver-max-time-step-in-days=1)
+add_test_compare_restarted_simulation(
+  CASENAME
+    network_01_restart
+  FILENAME
+    NETWORK-01-RESTART
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_restart}
+  REL_TOL
+    ${rel_tol_restart}
+  RESTART_STEP
+    5
+  DIR
+    network
+  TEST_ARGS
+    --enable-tuning=true
+    --local-well-solve-control-switching=true
+)
+
+add_test_compare_restarted_simulation(
+  CASENAME
+    network_01_reroute_restart
+  FILENAME
+    NETWORK-01-REROUTE-RESTART
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_restart}
+  REL_TOL
+    ${rel_tol_restart}
+  RESTART_STEP
+    5
+  DIR
+    network
+  TEST_ARGS
+    --enable-tuning=true
+    --local-well-solve-control-switching=true
+)
+
+add_test_compare_restarted_simulation(
+  CASENAME
+    spe1_temp
+  FILENAME
+    SPE1CASE2_TEMP
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil_temp
+  ABS_TOL
+    ${abs_tol_restart}
+  REL_TOL
+    5.0e-2
+  RESTART_STEP
+    3
+  DIR
+    spe1
+  TEST_ARGS
+    --solver-max-time-step-in-days=1
+)
 
 # Restart run in which a UDQ defining expression has exactly 128
 # characters.  Verifies that we don't overflow the ZUDL character
 # limit in restart files.
-add_test_compare_restarted_simulation(CASENAME udq_reg_02
-  FILENAME UDQ_REG-02
-  SIMULATOR flow
-  ABS_TOL ${abs_tol_restart}
-  REL_TOL ${rel_tol_restart}
-  RESTART_STEP 2
-  DIR udq_actionx
-  TEST_ARGS --enable-tuning=true
+add_test_compare_restarted_simulation(
+  CASENAME
+    udq_reg_02
+  FILENAME
+    UDQ_REG-02
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_restart}
+  REL_TOL
+    ${rel_tol_restart}
+  RESTART_STEP
+    2
+  DIR
+    udq_actionx
+  TEST_ARGS
+    --enable-tuning=true
 )
 
 # The dynamic MSW data is not written to /read from the restart file
@@ -121,39 +286,78 @@ add_test_compare_restarted_simulation(CASENAME udq_reg_02
 set(abs_tol_restart_msw 2e2)
 set(rel_tol_restart_msw 1e-3)
 
-add_test_compare_restarted_simulation(CASENAME msw_3d_hfa
-                                      FILENAME 3D_MSW
-                                      SIMULATOR flow
-                                      ABS_TOL ${abs_tol_restart_msw}
-                                      REL_TOL ${rel_tol_restart_msw}
-                                      RESTART_STEP 10
-                                      TEST_ARGS --enable-adaptive-time-stepping=false --sched-restart=true --tolerance-wells=1e-7)
+add_test_compare_restarted_simulation(
+  CASENAME
+    msw_3d_hfa
+  FILENAME
+    3D_MSW
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol_restart_msw}
+  REL_TOL
+    ${rel_tol_restart_msw}
+  RESTART_STEP
+    10
+  TEST_ARGS
+    --enable-adaptive-time-stepping=false
+    --sched-restart=true
+    --tolerance-wells=1e-7
+)
 
 
 # Basic restart tests which only compare the summary output, this test driver should
 # only be used in situations where it is challenging to get agreement in the restart file.
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-summary-restart-regressionTest.sh "")
 
-add_test_compare_restarted_simulation(CASENAME spe1_actnum
-                                      FILENAME SPE1CASE2_ACTNUM
-                                      SIMULATOR flow
-                                      TEST_NAME restart_spe1_summary
-                                      ABS_TOL ${abs_tol_restart}
-                                      REL_TOL ${rel_tol_restart}
-                                      RESTART_STEP 6
-                                      TEST_ARGS --sched-restart=false
-                                      DIR spe1)
+add_test_compare_restarted_simulation(
+  CASENAME
+    spe1_actnum
+  FILENAME
+    SPE1CASE2_ACTNUM
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  TEST_NAME
+    restart_spe1_summary
+  ABS_TOL
+    ${abs_tol_restart}
+  REL_TOL
+    ${rel_tol_restart}
+  RESTART_STEP
+    6
+  DIR
+    spe1
+  TEST_ARGS
+    --sched-restart=false
+)
 
 # Serialized restart tests
 if(HDF5_FOUND)
   opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-serialization-regressionTest.sh "")
-  add_test_compare_restarted_simulation(CASENAME spe1_serialized
-                                        DIR spe1
-                                        FILENAME SPE1CASE1
-                                        SIMULATOR flow
-                                        TEST_NAME compareSerializedSim_flow+spe1
-                                        ABS_TOL 2e-2
-                                        REL_TOL 1e-5
-                                        RESTART_STEP 94
-                                        TEST_ARGS --tolerance-mb=1e-7)
+  add_test_compare_restarted_simulation(
+    CASENAME
+      spe1_serialized
+    DIR
+      spe1
+    FILENAME
+      SPE1CASE1
+    SIMULATOR
+      flow
+    DEV_SIMULATOR
+      flow_blackoil
+    TEST_NAME
+      compareSerializedSim_${RESTART_SIM}+spe1
+    ABS_TOL
+      2e-2
+    REL_TOL
+      1e-5
+    RESTART_STEP
+      94
+    TEST_ARGS
+      --tolerance-mb=1e-7
+  )
 endif()

--- a/tests/run-damaris-regressionTest.sh
+++ b/tests/run-damaris-regressionTest.sh
@@ -17,12 +17,13 @@ then
   echo -e "\t\t -e <filename> Simulator binary to use"
   echo -e "\tOptional options:"
   echo -e "\t\t -n <procs>    Number of MPI processes to use"
+  echo -e "\t\t -u <filename> Simulator binary for reference data"
   exit 1
 fi
 
 MPI_PROCS=4
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:e:n:" OPT
+while getopts "i:r:b:f:a:t:c:e:n:u:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
@@ -34,10 +35,13 @@ do
     c) H5DIFF_COMMAND=${OPTARG} ;;
     e) EXE_NAME=${OPTARG} ;;
     n) MPI_PROCS=${OPTARG} ;;
+    u) REF_EXE_NAME=${OPTARG} ;;
   esac
 done
 shift $(($OPTIND-1))
 TEST_ARGS="$@"
+
+REF_EXE_NAME=${REF_EXE_NAME:-${EXE_NAME}}
 
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
@@ -49,10 +53,10 @@ echo "=== Executing comparison for files if these exists in reference folder ===
 for fname in `ls ${RESULT_PATH}/${FILENAME}*.h5`
 do
   fname=`basename $fname`
-  if test -f ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${fname}
+  if test -f ${INPUT_DATA_PATH}/opm-simulation-reference/${REF_EXE_NAME}/${fname}
   then
     echo -e "\t - ${fname}"
-    h5diffout=$(${H5DIFF_COMMAND} --relative=${REL_TOL} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${fname} ${RESULT_PATH}/${fname})
+    h5diffout=$(${H5DIFF_COMMAND} --relative=${REL_TOL} ${INPUT_DATA_PATH}/opm-simulation-reference/${REF_EXE_NAME}/${fname} ${RESULT_PATH}/${fname})
     if [ -n "${h5diffout}" ]; then
         exit 1
     fi

--- a/tests/run-init-regressionTest.sh
+++ b/tests/run-init-regressionTest.sh
@@ -18,11 +18,13 @@ then
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
   echo -e "\t\t -c <path>     Path to comparison tool"
   echo -e "\t\t -e <filename> Simulator binary to use"
+  echo -e "\tOptional options:"
+  echo -e "\t\t -u <filename> Simulator binary for reference data"
   exit 1
 fi
 
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:e:d:h:" OPT
+while getopts "i:r:b:f:a:t:c:e:d:h:u:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
@@ -35,10 +37,13 @@ do
     e) EXE_NAME=${OPTARG} ;;
     d) ;; # Ignored
     h) ;; # Ignored#
+    u) REF_EXE_NAME=${OPTARG} ;;
   esac
 done
 shift $(($OPTIND-1))
 TEST_ARGS="$@"
+
+REF_EXE_NAME=${REF_EXE_NAME:-${EXE_NAME}}
 
 rm -Rf  ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
@@ -47,11 +52,11 @@ ${BINPATH}/${EXE_NAME} ${TEST_ARGS} --enable-dry-run=true --output-dir=${RESULT_
 cd ..
 
 ecode=0
-${COMPARE_ECL_COMMAND} -t INIT ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
+${COMPARE_ECL_COMMAND} -t INIT ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-simulation-reference/${REF_EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
 if [ $? -ne 0 ]
 then
   ecode=1
-  ${COMPARE_ECL_COMMAND} -a -t INIT ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  ${COMPARE_ECL_COMMAND} -a -t INIT ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-simulation-reference/${REF_EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
 fi
 
 exit $ecode

--- a/tests/run-porv-acceptanceTest.sh
+++ b/tests/run-porv-acceptanceTest.sh
@@ -18,11 +18,13 @@ then
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
   echo -e "\t\t -c <path>     Path to comparison tool"
   echo -e "\t\t -e <filename> Simulator binary to use"
+  echo -e "\tOptional options:"
+  echo -e "\t\t -u <filename> Simulator binary for reference data"
   exit 1
 fi
 
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:e:d:h:" OPT
+while getopts "i:r:b:f:a:t:c:e:d:h:u:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
@@ -35,10 +37,13 @@ do
     e) EXE_NAME=${OPTARG} ;;
     d) ;; # Ignored
     h) ;; # Ignored
+    u) REF_EXE_NAME=${OPTARG} ;;
   esac
 done
 shift $(($OPTIND-1))
 TEST_ARGS="$@"
+
+REF_EXE_NAME=${REF_EXE_NAME:-${EXE_NAME}}
 
 rm -Rf  ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
@@ -47,11 +52,11 @@ ${BINPATH}/${EXE_NAME} ${TEST_ARGS} --enable-dry-run=true --output-dir=${RESULT_
 cd ..
 
 ecode=0
-${COMPARE_ECL_COMMAND} -t INIT -k PORV ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-porevolume-reference/${EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
+${COMPARE_ECL_COMMAND} -t INIT -k PORV ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-porevolume-reference/${REF_EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
 if [ $? -ne 0 ]
 then
   ecode=1
-  ${COMPARE_ECL_COMMAND} -a -t INIT -k PORV ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-porevolume-reference/${EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  ${COMPARE_ECL_COMMAND} -a -t INIT -k PORV ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-porevolume-reference/${REF_EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
 fi
 
 exit $ecode

--- a/tests/run-regressionTest.sh
+++ b/tests/run-regressionTest.sh
@@ -19,12 +19,13 @@ then
   echo -e "\tOptional options:"
   echo -e "\t\t -s <step>     Step to do restart testing from"
   echo -e "\t\t -h value      sched_restart value to use in restart test"
+  echo -e "\t\t -u <filename> Simulator binary for reference data"
   exit 1
 fi
 
 RESTART_STEP=""
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:d:s:e:h:" OPT
+while getopts "i:r:b:f:a:t:c:d:s:e:h:u:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
@@ -38,10 +39,13 @@ do
     s) RESTART_STEP=${OPTARG} ;;
     e) EXE_NAME=${OPTARG} ;;
     h) RESTART_SCHED=${OPTARG} ;;
+    u) REF_EXE_NAME=${OPTARG} ;;
   esac
 done
 shift $(($OPTIND-1))
 TEST_ARGS="$@"
+
+REF_EXE_NAME=${REF_EXE_NAME:-${EXE_NAME}}
 
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
@@ -81,11 +85,11 @@ else
   echo "=== Executing comparison for EGRID, INIT, UNRST, UNSMRY and RFT files if these exists in reference folder ==="
 fi
 
-${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${type} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${RESULT_PATH}/${FILENAME} ${ABS_TOL} ${REL_TOL}
+${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${type} ${INPUT_DATA_PATH}/opm-simulation-reference/${REF_EXE_NAME}/${FILENAME} ${RESULT_PATH}/${FILENAME} ${ABS_TOL} ${REL_TOL}
 if [ $? -ne 0 ]
 then
   ecode=1
-  ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${type} -a  ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${RESULT_PATH}/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${type} -a  ${INPUT_DATA_PATH}/opm-simulation-reference/${REF_EXE_NAME}/${FILENAME} ${RESULT_PATH}/${FILENAME} ${ABS_TOL} ${REL_TOL}
 fi
 
 RSTEPS=(${RESTART_STEP//,/ })
@@ -110,11 +114,11 @@ do
   else
     echo "=== Executing comparison for EGRID, INIT, UNRST, UNSMRY and RFT files for restarted run ==="
   fi
-  ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${type} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/restart/${FILENAME}_RESTART_${STEP} ${RESULT_PATH}/restart/${FILENAME}_RESTART_${STEP} ${ABS_TOL} ${REL_TOL}
+  ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${type} ${INPUT_DATA_PATH}/opm-simulation-reference/${REF_EXE_NAME}/restart/${FILENAME}_RESTART_${STEP} ${RESULT_PATH}/restart/${FILENAME}_RESTART_${STEP} ${ABS_TOL} ${REL_TOL}
   if [ $? -ne 0 ]
   then
     ecode=1
-    ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${type} -a ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/restart/${FILENAME}_RESTART_${STEP} ${RESULT_PATH}/restart/${FILENAME}_RESTART_${STEP} ${ABS_TOL} ${REL_TOL}
+    ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${type} -a ${INPUT_DATA_PATH}/opm-simulation-reference/${REF_EXE_NAME}/restart/${FILENAME}_RESTART_${STEP} ${RESULT_PATH}/restart/${FILENAME}_RESTART_${STEP} ${ABS_TOL} ${REL_TOL}
   fi
 done
 


### PR DESCRIPTION
In particular this can be useful if you are only working on e.g. the blackoil simulator. You don't have to rebuild the full flow just to run those regression tests. 

This is a de-slopped alternative to https://github.com/OPM/opm-simulators/pull/7047