### PR TITLE
[LGR Wells] Populate `data::Connection::lgr_grid` from schedule

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -395,6 +395,11 @@ initializeWellPerfData()
                     pd.connection_transmissibility_factor = connection.CF();
                     pd.satnum_id = connection.satTableId();
                     pd.ecl_index = connection_index;
+                    // Connection::get_lgr_level() is the Connection's grid identity
+                    pd.grid_id = connection.get_lgr_level();
+
+                    // Connection::global_index() is the linearised Cartesian cell index relative to the grid
+                    pd.global_index = connection.global_index();
 
                     parallelWellInfo.pushBackEclIndex(connection_index_above,
                                                       connection_index);

--- a/opm/simulators/wells/PerfData.cpp
+++ b/opm/simulators/wells/PerfData.cpp
@@ -49,6 +49,8 @@ PerfData<Scalar>::PerfData(const std::size_t num_perf,
     , connection_compaction_tmult(num_perf)
     , satnum_id(num_perf)
     , ecl_index(num_perf)
+    , grid_id(num_perf)
+    , global_index(num_perf)
     , gas_mass_rates(num_perf)
     , wat_mass_rates(num_perf)
 {
@@ -89,6 +91,8 @@ PerfData<Scalar> PerfData<Scalar>::serializationTestObject()
     result.connection_compaction_tmult.assign(1, 21.75);
     result.satnum_id = {22, 23};
     result.ecl_index = {24};
+    result.grid_id = {1, 0, 2};
+    result.global_index = {17, 0, 42};
     result.water_throughput = {25.0, 26.0};
     result.skin_pressure = {27.0, 28.0};
     result.water_velocity = {29.0, 30.0};
@@ -166,6 +170,8 @@ bool PerfData<Scalar>::operator==(const PerfData& rhs) const
         && (this->connection_compaction_tmult == rhs.connection_compaction_tmult)
         && (this->satnum_id == rhs.satnum_id)
         && (this->ecl_index == rhs.ecl_index)
+        && (this->grid_id == rhs.grid_id)
+        && (this->global_index == rhs.global_index)
         && (this->water_throughput == rhs.water_throughput)
         && (this->skin_pressure == rhs.skin_pressure)
         && (this->water_velocity == rhs.water_velocity)

--- a/opm/simulators/wells/PerfData.hpp
+++ b/opm/simulators/wells/PerfData.hpp
@@ -73,6 +73,8 @@ public:
         serializer(connection_compaction_tmult);
         serializer(satnum_id);
         serializer(ecl_index);
+        serializer(grid_id);
+        serializer(global_index);
         serializer(water_throughput);
         serializer(skin_pressure);
         serializer(water_velocity);
@@ -107,6 +109,8 @@ public:
     std::vector<Scalar> connection_compaction_tmult{};
     std::vector<int> satnum_id{};
     std::vector<std::size_t> ecl_index{};
+    std::vector<int> grid_id{};
+    std::vector<std::size_t> global_index{};
     std::vector<Scalar> gas_mass_rates{};
     std::vector<Scalar> wat_mass_rates{};
 

--- a/opm/simulators/wells/PerforationData.hpp
+++ b/opm/simulators/wells/PerforationData.hpp
@@ -34,6 +34,21 @@ struct PerforationData
     int satnum_id{};
     /// \brief The original index of the perforation in ECL Schedule
     std::size_t ecl_index{};
+    /// \brief Grid identity for this perforation: 0 = global grid,
+    ///        > 0 = numeric LGR level (refined grid in CARFIN
+    ///        declaration order).
+    int grid_id{};
+    /// \brief Linearised Cartesian cell index relative to the cell's
+    ///        own grid origin.  For grid_id == 0 this is the global-grid
+    ///        Cartesian index; for grid_id > 0 this is the LGR-local
+    ///        Cartesian index.
+    ///
+    /// Together with grid_id, the pair (grid_id, global_index) uniquely
+    /// identifies any cell in the deck -- including refined siblings
+    /// under a common coarse parent, which would otherwise alias if
+    /// identified via globalCellIdxMap[active_idx] alone (which returns
+    /// the level-0 ancestor's Cartesian, shared by all siblings).
+    std::size_t global_index{};
 };
 
 template<class Scalar>

--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -62,6 +62,8 @@ SingleWellState(const std::string& name_,
         this->perf_data.connection_d_factor[perf] = perf_input[perf].connection_d_factor;
         this->perf_data.satnum_id[perf] = perf_input[perf].satnum_id;
         this->perf_data.ecl_index[perf] = perf_input[perf].ecl_index;
+        this->perf_data.grid_id[perf] = perf_input[perf].grid_id;
+        this->perf_data.global_index[perf] = perf_input[perf].global_index;
     }
 }
 

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -686,7 +686,15 @@ reportConnections(std::vector<data::Connection>& connections,
     connections.resize(num_perf_well);
 
     for (auto i = 0*num_perf_well; i < num_perf_well; ++i) {
-        connections[i].index = globalCellIdxMap[perf_data.cell_index[i]];
+        // For LGR perforations, write the LGR-local Cartesian identity so
+        // that (lgr_grid, index) uniquely identifies the cell.  Going
+        // through globalCellIdxMap (= CpGrid::globalCell()) would yield
+        // the level-0 ancestor's Cartesian -- shared by all refined
+        // siblings under one coarse parent -- which aliases the cell.
+        connections[i].index = (perf_data.grid_id[i] > 0)
+            ? perf_data.global_index[i]
+            : globalCellIdxMap[perf_data.cell_index[i]];
+        connections[i].lgr_grid = perf_data.grid_id[i];
     }
 
     this->reportConnectionFactors(well_index, connections);

--- a/tests/test_wellstate.cpp
+++ b/tests/test_wellstate.cpp
@@ -502,6 +502,49 @@ BOOST_AUTO_TEST_CASE(RSCONST_InjectionWellDoesNotSynthesizeGas)
 
 // ---------------------------------------------------------------------
 
+BOOST_AUTO_TEST_CASE(ReportConnections_LgrGridField_NonLgrWells)
+{
+    // data::Connection::lgr_grid is the numeric LGR level (0 == global
+    // grid, > 0 == refined grid in declaration order).  Wells declared
+    // via WELSPECS (i.e., not WELSPECL) live in the global grid, so
+    // every reported connection must have lgr_grid == 0.
+    //
+    // The companion case where WELSPECL connections receive a non-zero
+    // lgr_grid is covered end-to-end by the spe1case1_carfin test
+    // (see compareECLFiles.cmake) -- its restart-file diff catches
+    // regressions in the populated path.
+    const auto setup  = Setup { makeOilWaterRsconstWellDeck() };
+    auto       pinfos = std::vector<Opm::ParallelWellInfo<double>>{};
+
+    const auto wstate = [&setup, &pinfos]()
+    {
+        const auto tstep = std::size_t{0};
+        return buildWellState(setup, tstep, pinfos);
+    }();
+
+    const auto rpt = wstate
+        .report(setup.grid.c_grid()->global_cell,
+                [](const int) { return false; });
+
+    BOOST_REQUIRE(!rpt.empty());
+
+    for (const auto& [name, well] : rpt) {
+        BOOST_TEST_CONTEXT("well " << name) {
+            for (const auto& c : well.connections) {
+                // Non-LGR well: lgr_grid must be 0.  When lgr_grid == 0
+                // WellState::reportConnections selects c.index from the
+                // globalCellIdxMap path (rather than from
+                // perf_data.global_index, which is the LGR-local
+                // Cartesian path); the spe1case1_carfin regression
+                // exercises the lgr_grid != 0 branch end-to-end.
+                BOOST_CHECK_EQUAL(c.lgr_grid, 0);
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+
 //BOOST_AUTO_TEST_CASE(GlobalWellInfo_TEST) {
 //    const Setup setup{ "msw.data" };
 //    std::vector<Opm::Well> local_wells = { setup.sched.getWell("PROD01", 1) };


### PR DESCRIPTION
# [LGR Wells] Populate `data::Connection::lgr_grid` from schedule

## Summary

`opm::data::Connection` carries two cell-identity fields:

- `lgr_grid` (`int`, `0` = global grid, `> 0` = numeric LGR level matching
  the `WELSPECL` declaration order in `Schedule::Connection::get_lgr_level()`)
- `index` (`size_t`, linearised Cartesian — global for `lgr_grid == 0`,
  LGR-local for `lgr_grid > 0`)

Downstream code in opm-common already consumes the pair — most notably
`RestartValue::filter_wells_for_lgr`, which uses `lgr_grid` to partition
reported wells/connections per LGR for restart output:

https://github.com/OPM/opm-common/blob/master/opm/output/eclipse/RestartValue.cpp#L84

However, **no production code path in opm-simulators populated either
field correctly**:

- `lgr_grid` was always `0`, regardless of whether the connection actually
  belonged to an LGR — so `filter_wells_for_lgr` was effectively a no-op
  for LGR decks.
- `index` for LGR perforations went through `globalCellIdxMap` =
  `CpGrid::globalCell()`, which for refined leaf cells returns the
  **level-0 ancestor's** Cartesian. Every refined sibling under one
  coarse parent therefore aliased to the same `index`.

This PR closes both gaps.

## Approach

Mirror the existing `ecl_index` pipeline end-to-end — same idiom, same
ownership boundaries, no new infrastructure. Sourced from the
`Schedule::Connection` already in scope at the perf-data construction site:

```
opm::Connection::get_lgr_level()        opm::Connection::global_index()
  (Schedule, opm-common)                  (Schedule, opm-common)
  → 0 = global, >0 = LGR id               → global cart (grid_id==0)
                                            or LGR-local cart (grid_id>0)
        │                                       │
        ▼                                       ▼
PerforationData::grid_id                PerforationData::global_index      (NEW)
        │                                       │   both set by
        │                                       │   BlackoilWellModelGeneric
        ▼                                       ▼
PerfData::grid_id                       PerfData::global_index             (NEW)
        │                                       │   serialized via serializeOp
        │                                       │   copied in SingleWellState ctor
        ▼                                       ▼
data::Connection::lgr_grid              data::Connection::index            (conditional)
                                          = global_index     if grid_id > 0
                                          = globalCellIdxMap[cell_index] else
        │
        ▼
RestartValue::filter_wells_for_lgr      (already consumes lgr_grid)
```

The `grid_id == 0` arm in `WellState::reportConnections` is
**byte-identical** to pre-PR behaviour, so global-grid wells see no change.

`Schedule::Connection::global_index()` is documented at
`CompletedCells::Cell` as the "linearised Cartesian cell index relative
to grid origin — e.g., in an LGR or in the main grid." That is exactly
the Cartesian-in-its-own-grid value needed for unique cell identity
when paired with `lgr_grid`.

All new struct fields are appended at the end of their respective
structs to avoid disrupting aggregate brace-initialisation at call sites.

## Files touched

| File | Change |
|---|---|
| `opm/simulators/wells/PerforationData.hpp` | new fields `int grid_id{}`, `std::size_t global_index{}` |
| `opm/simulators/wells/PerfData.hpp` | new vectors + `serializeOp` entries |
| `opm/simulators/wells/PerfData.cpp` | ctor resize, `serializationTestObject`, `operator==` |
| `opm/simulators/wells/SingleWellState.cpp` | copy from `PerforationData` to `PerfData` |
| `opm/simulators/wells/BlackoilWellModelGeneric.cpp` | `pd.grid_id = connection.get_lgr_level()` + `pd.global_index = connection.global_index()` |
| `opm/simulators/wells/WellState.cpp` | conditional write in `reportConnections` |
| `tests/test_wellstate.cpp` | regression test on non-LGR path |

Total: +84 / -1 LOC across 7 files. Single commit.
