### PR TITLE
remove ADDZCORN from unsupported and add regression test

### DIFF
--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -36,7 +36,6 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"ACTIONW", {true, std::nullopt}},
         {"ACTPARAM", {true, std::nullopt}},
         {"ADSALNOD", {true, std::nullopt}},
-        {"ADDZCORN", {true, std::nullopt}},
         {"ADSORP", {true, std::nullopt}},
         {"AITS", {false, std::nullopt}},
         {"AITSOFF", {false, std::nullopt}},

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -809,6 +809,23 @@ add_test_compareECLFiles(
 
 add_test_compareECLFiles(
   CASENAME
+    base_model_1_addzcorn
+  FILENAME
+    BASE_MODEL_1_ADDZCORN
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    model1
+)
+
+add_test_compareECLFiles(
+  CASENAME
     base_model2_welpi
   FILENAME
     0B_WELPI_MODEL2


### PR DESCRIPTION
Support for ADDZCORN was added some time ago. See https://github.com/OPM/opm-common/pull/5045. Time to add it to the simulator. 