### PR TITLE
Pass model parameters into BlackoilWellModelGeneric

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -228,6 +228,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/wells/BlackoilWellModelConstraints.cpp
   opm/simulators/wells/BlackoilWellModelGasLift.cpp
   opm/simulators/wells/BlackoilWellModelGeneric.cpp
+  opm/simulators/wells/BlackoilWellModelGenericParameters.cpp
   opm/simulators/wells/BlackoilWellModelGuideRates.cpp
   opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
   opm/simulators/wells/BlackoilWellModelNldd.cpp
@@ -1169,6 +1170,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/wells/BlackoilWellModelGasLift.hpp
   opm/simulators/wells/BlackoilWellModelGasLift_impl.hpp
   opm/simulators/wells/BlackoilWellModelGeneric.hpp
+  opm/simulators/wells/BlackoilWellModelGenericParameters.hpp
   opm/simulators/wells/BlackoilWellModelGuideRates.hpp
   opm/simulators/wells/BlackoilWellModelNetwork.hpp
   opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -192,7 +192,6 @@ template<class Scalar> class WellContributions;
                 initFromRestartFile(restartValues,
                                     this->simulator_.vanguard().transferWTestState(),
                                     grid().size(0),
-                                    param_.use_multisegment_well_,
                                     this->simulator_.vanguard().enableDistributedWells());
             }
 
@@ -200,7 +199,6 @@ template<class Scalar> class WellContributions;
             void prepareDeserialize(const int report_step)
             {
                 prepareDeserialize(report_step, grid().size(0),
-                                   param_.use_multisegment_well_,
                                    this->simulator_.vanguard().enableDistributedWells());
             }
 

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -225,7 +225,7 @@ initFromRestartFile(const RestartValue& restartValues,
     this->initializeWellProdIndCalculators();
     initializeWellPerfData();
 
-    bool handle_ms_well = param_.use_multisegment_well_ && anyMSWellOpenLocal();
+    const bool handle_ms_well = param_.use_multisegment_well_ && anyMSWellOpenLocal();
     // Resize for restart step
     this->wellState().resize(this->wells_ecl_, this->local_parallel_well_info_,
                              this->schedule(), handle_ms_well, numCells,

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -54,7 +54,6 @@
 
 #include <opm/material/fluidsystems/BlackOilDefaultFluidSystemIndices.hpp>
 
-#include <opm/simulators/flow/BlackoilModelParameters.hpp>
 #include <opm/simulators/utils/DeferredLogger.hpp>
 #include <opm/simulators/wells/BlackoilWellModelConstraints.hpp>
 #include <opm/simulators/wells/BlackoilWellModelGasLift.hpp>
@@ -99,7 +98,7 @@ BlackoilWellModelGeneric(Schedule& schedule,
                          const EclipseState& eclState,
                          const PhaseUsageInfo<IndexTraits>& pu,
                          const Parallel::Communication& comm,
-                         const BlackoilModelParameters<Scalar>& param)
+                         const BlackoilWellModelGenericParameters<Scalar>& param)
     : schedule_(schedule)
     , summaryState_(summaryState)
     , eclState_(eclState)

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -54,6 +54,7 @@
 
 #include <opm/material/fluidsystems/BlackOilDefaultFluidSystemIndices.hpp>
 
+#include <opm/simulators/flow/BlackoilModelParameters.hpp>
 #include <opm/simulators/utils/DeferredLogger.hpp>
 #include <opm/simulators/wells/BlackoilWellModelConstraints.hpp>
 #include <opm/simulators/wells/BlackoilWellModelGasLift.hpp>
@@ -97,11 +98,13 @@ BlackoilWellModelGeneric(Schedule& schedule,
                          const SummaryState& summaryState,
                          const EclipseState& eclState,
                          const PhaseUsageInfo<IndexTraits>& pu,
-                         const Parallel::Communication& comm)
+                         const Parallel::Communication& comm,
+                         const BlackoilModelParameters<Scalar>& param)
     : schedule_(schedule)
     , summaryState_(summaryState)
     , eclState_(eclState)
     , comm_(comm)
+    , param_(param)
     , gen_gaslift_(gaslift)
     , wbp_(*this)
     , phase_usage_info_(pu)
@@ -208,7 +211,6 @@ void BlackoilWellModelGeneric<Scalar, IndexTraits>::
 initFromRestartFile(const RestartValue& restartValues,
                     std::unique_ptr<WellTestState> wtestState,
                     const std::size_t numCells,
-                    bool handle_ms_well,
                     bool enable_distributed_wells)
 {
     // The restart step value is used to identify wells present at the given
@@ -226,7 +228,7 @@ initFromRestartFile(const RestartValue& restartValues,
     this->initializeWellProdIndCalculators();
     initializeWellPerfData();
 
-    handle_ms_well &= anyMSWellOpenLocal();
+    bool handle_ms_well = param_.use_multisegment_well_ && anyMSWellOpenLocal();
     // Resize for restart step
     this->wellState().resize(this->wells_ecl_, this->local_parallel_well_info_,
                              this->schedule(), handle_ms_well, numCells,
@@ -262,7 +264,7 @@ initFromRestartFile(const RestartValue& restartValues,
 
 template<typename Scalar, typename IndexTraits>
 void BlackoilWellModelGeneric<Scalar, IndexTraits>::
-prepareDeserialize(int report_step, const std::size_t numCells, bool handle_ms_well, bool enable_distributed_wells)
+prepareDeserialize(int report_step, const std::size_t numCells, bool enable_distributed_wells)
 {
     // wells_ecl_ should only contain wells on this processor.
     wells_ecl_ = getLocalWells(report_step);
@@ -272,7 +274,7 @@ prepareDeserialize(int report_step, const std::size_t numCells, bool handle_ms_w
     initializeWellPerfData();
 
     if (! this->wells_ecl_.empty()) {
-        handle_ms_well &= anyMSWellOpenLocal();
+        const bool handle_ms_well = param_.use_multisegment_well_ && anyMSWellOpenLocal();
         this->wellState().resize(this->wells_ecl_, this->local_parallel_well_info_,
                                  this->schedule(), handle_ms_well, numCells,
                                  this->well_perf_data_, this->summaryState_, enable_distributed_wells);
@@ -630,10 +632,10 @@ bool BlackoilWellModelGeneric<Scalar, IndexTraits>::
 checkGroupHigherConstraints(const Group& group,
                             DeferredLogger& deferred_logger,
                             const int reportStepIdx,
-                            const int max_number_of_group_switch,
                             const bool update_group_switching_log)
 {
 
+    const int max_number_of_group_switch = param_.max_number_of_group_switches_;
     bool changed = false;
     auto [fipnum, pvtreg] = this->getGroupFipnumAndPvtreg();
 
@@ -1214,7 +1216,6 @@ template<typename Scalar, typename IndexTraits>
 void BlackoilWellModelGeneric<Scalar, IndexTraits>::
 updateAndCommunicateGroupData(const int reportStepIdx,
                               const NewtonIterationContext& iterCtx,
-                              const Scalar tol_nupcol,
                               const bool update_wellgrouptarget)
 {
     OPM_TIMEFUNCTION();
@@ -1283,6 +1284,7 @@ updateAndCommunicateGroupData(const int reportStepIdx,
                         Scalar small_rate = 1e-12; // m3/s
                         Scalar denominator = (0.5*gr_rate_nupcol + 0.5*gr_rate);
                         Scalar rel_change = denominator > small_rate ? std::abs( (gr_rate_nupcol - gr_rate) / denominator) : 0.0;
+                        const Scalar tol_nupcol = param_.nupcol_group_rate_tolerance_;
                         if ( rel_change > tol_nupcol) {
                             this->updateNupcolWGState();
                             if (comm_.rank() == 0) {

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -97,13 +97,11 @@ BlackoilWellModelGeneric(Schedule& schedule,
                          const SummaryState& summaryState,
                          const EclipseState& eclState,
                          const PhaseUsageInfo<IndexTraits>& pu,
-                         const Parallel::Communication& comm,
-                         const BlackoilWellModelGenericParameters<Scalar>& param)
+                         const Parallel::Communication& comm)
     : schedule_(schedule)
     , summaryState_(summaryState)
     , eclState_(eclState)
     , comm_(comm)
-    , param_(param)
     , gen_gaslift_(gaslift)
     , wbp_(*this)
     , phase_usage_info_(pu)

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -104,8 +104,7 @@ public:
                              const SummaryState& summaryState,
                              const EclipseState& eclState,
                              const PhaseUsageInfo<IndexTraits>& phase_usage,
-                             const Parallel::Communication& comm,
-                             const BlackoilWellModelGenericParameters<Scalar>& param);
+                             const Parallel::Communication& comm);
 
     virtual ~BlackoilWellModelGeneric() = default;
     virtual int compressedIndexForInteriorLGR([[maybe_unused]] const std::string& lgr_tag,

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -58,6 +58,7 @@
 
 
 namespace Opm {
+    template<class Scalar> struct BlackoilModelParameters;
     class DeferredLogger;
     class EclipseState;
     template<typename Scalar, typename IndexTraits> class BlackoilWellModelGasLiftGeneric;
@@ -103,7 +104,8 @@ public:
                              const SummaryState& summaryState,
                              const EclipseState& eclState,
                              const PhaseUsageInfo<IndexTraits>& phase_usage,
-                             const Parallel::Communication& comm);
+                             const Parallel::Communication& comm,
+                             const BlackoilModelParameters<Scalar>& param);
 
     virtual ~BlackoilWellModelGeneric() = default;
     virtual int compressedIndexForInteriorLGR([[maybe_unused]] const std::string& lgr_tag,
@@ -194,12 +196,10 @@ public:
     void initFromRestartFile(const RestartValue& restartValues,
                              std::unique_ptr<WellTestState> wtestState,
                              const std::size_t numCells,
-                             bool handle_ms_well,
                              bool enable_distributed_wells);
 
     void prepareDeserialize(int report_step,
                             const std::size_t numCells,
-                            bool handle_ms_well,
                             bool enable_distributed_wells);
 
     /*
@@ -306,7 +306,6 @@ public:
 
     void updateAndCommunicateGroupData(const int reportStepIdx,
                                        const NewtonIterationContext& iterCtx,
-                                       const Scalar tol_nupcol,
                                        // we only want to update the wellgroup target
                                        // after the groups have found their controls
                                        const bool update_wellgrouptarget);
@@ -448,7 +447,6 @@ protected:
     bool checkGroupHigherConstraints(const Group& group,
                                      DeferredLogger& deferred_logger,
                                      const int reportStepIdx,
-                                     const int max_number_of_group_switch,
                                      const bool update_group_switching_log);
 
     void inferLocalShutWells();
@@ -514,6 +512,7 @@ protected:
     const SummaryState& summaryState_;
     const EclipseState& eclState_;
     const Parallel::Communication& comm_;
+    const BlackoilModelParameters<Scalar>& param_;
     BlackoilWellModelGasLiftGeneric<Scalar, IndexTraits>& gen_gaslift_;
     BlackoilWellModelWBP<Scalar, IndexTraits> wbp_;
 

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -33,6 +33,7 @@
 
 #include <opm/simulators/flow/NewtonIterationContext.hpp>
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
+#include <opm/simulators/wells/BlackoilWellModelGenericParameters.hpp>
 #include <opm/simulators/wells/BlackoilWellModelWBP.hpp>
 #include <opm/simulators/wells/ConnectionIndexMap.hpp>
 #include <opm/simulators/wells/ParallelPAvgDynamicSourceData.hpp>
@@ -58,7 +59,6 @@
 
 
 namespace Opm {
-    template<class Scalar> struct BlackoilModelParameters;
     class DeferredLogger;
     class EclipseState;
     template<typename Scalar, typename IndexTraits> class BlackoilWellModelGasLiftGeneric;
@@ -105,7 +105,7 @@ public:
                              const EclipseState& eclState,
                              const PhaseUsageInfo<IndexTraits>& phase_usage,
                              const Parallel::Communication& comm,
-                             const BlackoilModelParameters<Scalar>& param);
+                             const BlackoilWellModelGenericParameters<Scalar>& param);
 
     virtual ~BlackoilWellModelGeneric() = default;
     virtual int compressedIndexForInteriorLGR([[maybe_unused]] const std::string& lgr_tag,
@@ -512,7 +512,7 @@ protected:
     const SummaryState& summaryState_;
     const EclipseState& eclState_;
     const Parallel::Communication& comm_;
-    const BlackoilModelParameters<Scalar>& param_;
+    const BlackoilWellModelGenericParameters<Scalar> param_;
     BlackoilWellModelGasLiftGeneric<Scalar, IndexTraits>& gen_gaslift_;
     BlackoilWellModelWBP<Scalar, IndexTraits> wbp_;
 

--- a/opm/simulators/wells/BlackoilWellModelGenericParameters.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGenericParameters.cpp
@@ -1,0 +1,38 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+#include <opm/simulators/wells/BlackoilWellModelGenericParameters.hpp>
+
+#include <opm/simulators/flow/BlackoilModelParameters.hpp>
+
+#include <opm/models/utils/parametersystem.hpp>
+
+namespace Opm {
+
+template<class Scalar>
+BlackoilWellModelGenericParameters<Scalar>::BlackoilWellModelGenericParameters()
+    : nupcol_group_rate_tolerance_(Parameters::Get<Parameters::NupcolGroupRateTolerance<Scalar>>())
+    , max_number_of_group_switches_(Parameters::Get<Parameters::MaximumNumberOfGroupSwitches>())
+    , use_multisegment_well_(Parameters::Get<Parameters::UseMultisegmentWell>())
+{}
+
+template struct BlackoilWellModelGenericParameters<double>;
+
+} // namespace Opm

--- a/opm/simulators/wells/BlackoilWellModelGenericParameters.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGenericParameters.cpp
@@ -35,4 +35,8 @@ BlackoilWellModelGenericParameters<Scalar>::BlackoilWellModelGenericParameters()
 
 template struct BlackoilWellModelGenericParameters<double>;
 
+#if FLOW_INSTANTIATE_FLOAT
+template struct BlackoilWellModelGenericParameters<float>;
+#endif
+
 } // namespace Opm

--- a/opm/simulators/wells/BlackoilWellModelGenericParameters.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGenericParameters.hpp
@@ -1,0 +1,47 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_BLACKOILWELLMODEL_GENERIC_PARAMETERS_HEADER_INCLUDED
+#define OPM_BLACKOILWELLMODEL_GENERIC_PARAMETERS_HEADER_INCLUDED
+
+namespace Opm {
+
+/// Parameter bundle consumed by BlackoilWellModelGeneric.
+///
+/// Deliberately narrow subset of BlackoilModelParameters: holds only
+/// the fields the generic well-model base reads, so the base does not
+/// depend on parameters specific to a particular reservoir model
+/// (e.g. NLDD-solver knobs).
+///
+/// The default constructor populates fields from the global parameter
+/// system, which must already have been initialised (typically via
+/// BlackoilModelParameters::registerParameters()).
+template<class Scalar>
+struct BlackoilWellModelGenericParameters
+{
+    BlackoilWellModelGenericParameters();
+
+    Scalar nupcol_group_rate_tolerance_;
+    int max_number_of_group_switches_;
+    bool use_multisegment_well_;
+};
+
+} // namespace Opm
+
+#endif // OPM_BLACKOILWELLMODEL_GENERIC_PARAMETERS_HEADER_INCLUDED

--- a/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
@@ -145,7 +145,6 @@ update(const bool mandatory_network_balance,
             }
             well_model_.updateAndCommunicateGroupData(episodeIdx,
                                                       iterCtx,
-                                                      well_model_.param().nupcol_group_rate_tolerance_,
                                                       /*update_wellgrouptarget*/ true);
         }
         more_network_update = more_network_sub_update || well_group_thp_updated;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -85,7 +85,7 @@ namespace Opm {
                                                         simulator.vanguard().eclState(),
                                                         FluidSystem::phaseUsage(),
                                                         simulator.gridView().comm(),
-                                                        param_)
+                                                        BlackoilWellModelGenericParameters<Scalar>{})
         , simulator_(simulator)
         , guide_rate_handler_{
             *this,

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -84,7 +84,8 @@ namespace Opm {
                                                         simulator.vanguard().summaryState(),
                                                         simulator.vanguard().eclState(),
                                                         FluidSystem::phaseUsage(),
-                                                        simulator.gridView().comm())
+                                                        simulator.gridView().comm(),
+                                                        param_)
         , simulator_(simulator)
         , guide_rate_handler_{
             *this,
@@ -394,7 +395,7 @@ namespace Opm {
             // to make sure we get the correct mapping.
             this->updateAndCommunicateGroupData(reportStepIdx,
                                     iterCtx,
-                                    param_.nupcol_group_rate_tolerance_, /*update_wellgrouptarget*/ false);
+                                    /*update_wellgrouptarget*/ false);
 
             // Wells are active if they are active wells on at least one process.
             const Grid& grid = simulator_.vanguard().grid();
@@ -503,7 +504,6 @@ namespace Opm {
 
         this->updateAndCommunicateGroupData(reportStepIdx,
                                     iterCtx,
-                                    param_.nupcol_group_rate_tolerance_,
                                     /*update_wellgrouptarget*/ true);
         try {
             // Compute initial well solution for new wells and injectors that change injection type i.e. WAG.
@@ -542,7 +542,6 @@ namespace Opm {
             if (slave_needs_well_solution) {
                 this->updateAndCommunicateGroupData(reportStepIdx,
                                             iterCtx,
-                                            param_.nupcol_group_rate_tolerance_,
                                             /*update_wellgrouptarget*/ false);
                 this->sendSlaveGroupDataToMaster();
             }
@@ -1347,7 +1346,7 @@ namespace Opm {
         const auto& iterCtx = simulator_.problem().iterationContext();
         const int reportStepIdx = simulator_.episodeIndex();
         this->updateAndCommunicateGroupData(reportStepIdx, iterCtx,
-            param_.nupcol_group_rate_tolerance_, /*update_wellgrouptarget*/ true);
+            /*update_wellgrouptarget*/ true);
         // We need to call updateWellControls before we update the network as
         // network updates are only done on thp controlled wells.
         // Note that well controls are allowed to change during updateNetwork
@@ -1785,7 +1784,6 @@ namespace Opm {
         const auto& iterCtx = simulator_.problem().iterationContext();
         this->updateAndCommunicateGroupData(reportStepIdx,
                                             iterCtx,
-                                            param_.nupcol_group_rate_tolerance_,
                                             /*update_wellgrouptarget*/ true);
 
         // updateWellStateWithTarget might throw for multisegment wells hence we
@@ -1807,7 +1805,6 @@ namespace Opm {
                                    simulator_.gridView().comm())
         this->updateAndCommunicateGroupData(reportStepIdx,
                                             iterCtx,
-                                            param_.nupcol_group_rate_tolerance_,
                                             /*update_wellgrouptarget*/ true);
     }
 
@@ -1832,9 +1829,9 @@ namespace Opm {
         bool changed = false;
         // restrict the number of group switches but only after nupcol iterations.
         const int nupcol = this->schedule()[reportStepIdx].nupcol();
-        const int max_number_of_group_switches = param_.max_number_of_group_switches_;
         const bool update_group_switching_log = !iterCtx.withinNupcol(nupcol);
-        const bool changed_hc = this->checkGroupHigherConstraints(group, deferred_logger, reportStepIdx, max_number_of_group_switches, update_group_switching_log);
+        const bool changed_hc = this->checkGroupHigherConstraints(
+            group, deferred_logger, reportStepIdx, update_group_switching_log);
         if (changed_hc) {
             changed = true;
             updateAndCommunicate(reportStepIdx);
@@ -1844,7 +1841,7 @@ namespace Opm {
             BlackoilWellModelConstraints(*this).
                 updateGroupIndividualControl(group,
                                              reportStepIdx,
-                                             max_number_of_group_switches,
+                                             param_.max_number_of_group_switches_,
                                              update_group_switching_log,
                                              this->switched_inj_groups_,
                                              this->switched_prod_groups_,

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -84,8 +84,7 @@ namespace Opm {
                                                         simulator.vanguard().summaryState(),
                                                         simulator.vanguard().eclState(),
                                                         FluidSystem::phaseUsage(),
-                                                        simulator.gridView().comm(),
-                                                        BlackoilWellModelGenericParameters<Scalar>{})
+                                                        simulator.gridView().comm())
         , simulator_(simulator)
         , guide_rate_handler_{
             *this,

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -311,7 +311,7 @@ public:
                                  const Parallel::Communication& comm,
                                  bool deserialize)
         : BlackoilWellModelGeneric<double, IndexTraits>(schedule, gaslift, network_, summaryState,
-                                           eclState, phase_usage, comm, params_)
+                                           eclState, phase_usage, comm)
         , network_(*this)
     {
         if (deserialize) {
@@ -372,7 +372,6 @@ public:
 
 private:
     BlackoilWellModelNetworkGeneric<double, IndexTraits> network_;
-    BlackoilWellModelGenericParameters<double> params_;
     ParallelWellInfo<double> dummy;
 };
 

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -311,7 +311,7 @@ public:
                                  const Parallel::Communication& comm,
                                  bool deserialize)
         : BlackoilWellModelGeneric<double, IndexTraits>(schedule, gaslift, network_, summaryState,
-                                           eclState, phase_usage, comm)
+                                           eclState, phase_usage, comm, params_)
         , network_(*this)
     {
         if (deserialize) {
@@ -372,6 +372,7 @@ public:
 
 private:
     BlackoilWellModelNetworkGeneric<double, IndexTraits> network_;
+    BlackoilModelParameters<double> params_;
     ParallelWellInfo<double> dummy;
 };
 

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -372,7 +372,7 @@ public:
 
 private:
     BlackoilWellModelNetworkGeneric<double, IndexTraits> network_;
-    BlackoilModelParameters<double> params_;
+    BlackoilWellModelGenericParameters<double> params_;
     ParallelWellInfo<double> dummy;
 };
 


### PR DESCRIPTION
This refactor stores a reference to `BlackoilModelParameters` in the generic well-model base class, so the base no longer needs to receive individual parameter fields as method arguments. The reference is passed from the derived `BlackoilWellModel` constructor; its target (the derived class's `const param_` member) is fully constructed by the time any base-class method dereferences it.

**Signature simplifications.** The now-redundant arguments are dropped from three call paths:

- `tol_nupcol` from `updateAndCommunicateGroupData` (7 call sites — 6 in `BlackoilWellModel_impl.hpp`, 1 in `BlackoilWellModelNetwork_impl.hpp`)
- `max_number_of_group_switch` from `checkGroupHigherConstraints`
- `handle_ms_well` from `initFromRestartFile` and `prepareDeserialize`

The base class reads the corresponding fields (`param_.nupcol_group_rate_tolerance_`, `param_.max_number_of_group_switches_`, `param_.use_multisegment_well_`) directly from the stored `param_` reference inside the implementations.

**No behaviour change.** Pure refactor: every dropped parameter was previously plumbed in from the derived class's own `param_` member.
