### PR TITLE
Pass iteration context into BlackoilWellModelGeneric

### DIFF
--- a/flowexperimental/comp/wells/CompWellModel.hpp
+++ b/flowexperimental/comp/wells/CompWellModel.hpp
@@ -41,6 +41,7 @@
 namespace Opm {
 
 class Schedule;
+struct NewtonIterationContext;
 
 template<typename TypeTag>
 class CompWellModel : WellConnectionAuxiliaryModule<TypeTag, CompWellModel<TypeTag>>
@@ -69,7 +70,7 @@ public:
 
     // TODO: Scalar will probably to be TypeTag later
     using CompWellPtr = std::shared_ptr<CompWell<TypeTag> >;
-    explicit CompWellModel(Simulator& /*simulator*/);
+    CompWellModel(Simulator& /*simulator*/, const NewtonIterationContext& /*iter_ctx*/);
 
     // No extra dofs are inserted for wells. (we use a Schur complement.)
     [[nodiscard]] unsigned numDofs() const override

--- a/flowexperimental/comp/wells/CompWellModel_impl.hpp
+++ b/flowexperimental/comp/wells/CompWellModel_impl.hpp
@@ -33,7 +33,7 @@
 namespace Opm {
 
 template <typename TypeTag>
-CompWellModel<TypeTag>::CompWellModel(Simulator& simulator)
+CompWellModel<TypeTag>::CompWellModel(Simulator& simulator, const NewtonIterationContext& /*iter_ctx*/)
     : WellConnectionModule(*this, simulator.gridView().comm())
     , simulator_(simulator)
     , schedule_(simulator.vanguard().schedule())

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -230,7 +230,7 @@ public:
                               (energyModuleType == EnergyModules::FullyImplicitThermal ||
                                energyModuleType == EnergyModules::SequentialImplicitThermal),                       enableDiffusion,
                               enableDispersion)
-        , wellModel_(simulator)
+        , wellModel_(simulator, this->iterationContext())
         , aquiferModel_(simulator)
         , pffDofData_(simulator.gridView(), this->elementMapper())
         , tracerModel_(simulator)

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -141,7 +141,7 @@ template<class Scalar> class WellContributions;
             using AverageRegionalPressureType = RegionAverageCalculator::
                 AverageRegionalPressure<FluidSystem, std::vector<int> >;
 
-            explicit BlackoilWellModel(Simulator& simulator);
+            BlackoilWellModel(Simulator& simulator, const NewtonIterationContext& iter_ctx);
 
             void init();
             void initWellContainer(const int reportStepIdx) override;

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -97,11 +97,13 @@ BlackoilWellModelGeneric(Schedule& schedule,
                          const SummaryState& summaryState,
                          const EclipseState& eclState,
                          const PhaseUsageInfo<IndexTraits>& pu,
-                         const Parallel::Communication& comm)
+                         const Parallel::Communication& comm,
+                         const NewtonIterationContext& iter_ctx)
     : schedule_(schedule)
     , summaryState_(summaryState)
     , eclState_(eclState)
     , comm_(comm)
+    , iter_ctx_(iter_ctx)
     , gen_gaslift_(gaslift)
     , wbp_(*this)
     , phase_usage_info_(pu)
@@ -1212,7 +1214,6 @@ groupAndNetworkData(const int reportStepIdx) const
 template<typename Scalar, typename IndexTraits>
 void BlackoilWellModelGeneric<Scalar, IndexTraits>::
 updateAndCommunicateGroupData(const int reportStepIdx,
-                              const NewtonIterationContext& iterCtx,
                               const bool update_wellgrouptarget)
 {
     OPM_TIMEFUNCTION();
@@ -1220,7 +1221,7 @@ updateAndCommunicateGroupData(const int reportStepIdx,
     const int nupcol = schedule()[reportStepIdx].nupcol();
 
     // Update accumulated group consumption/import rates for current report step
-    if (iterCtx.isFirstGlobalIteration()) {
+    if (iter_ctx_.isFirstGlobalIteration()) {
         this->groupState().update_gconsump(schedule(), reportStepIdx, this->summaryState_);
     }
 
@@ -1237,7 +1238,7 @@ updateAndCommunicateGroupData(const int reportStepIdx,
     this->wellState().updateGlobalIsGrup(comm_, well_status);
 
     GroupStateHelperType &group_state_helper = this->groupStateHelper();
-    if (iterCtx.withinNupcol(nupcol)) {
+    if (iter_ctx_.withinNupcol(nupcol)) {
         OPM_TIMEBLOCK(updateNupcol);
         this->updateNupcolWGState();
     } else {
@@ -1288,7 +1289,7 @@ updateAndCommunicateGroupData(const int reportStepIdx,
                                 const std::string control_str = is_vrep? "VREP" : "REIN";
                                 const std::string msg = fmt::format("Group prodution relative change {} larger than tolerance {} "
                                                         "at iteration {}. Update {} for Group {} even if iteration is larger than {} given by NUPCOL." ,
-                                                        rel_change, tol_nupcol, iterCtx.iteration(), control_str, gr_name, nupcol);
+                                                        rel_change, tol_nupcol, iter_ctx_.iteration(), control_str, gr_name, nupcol);
                                 group_state_helper.deferredLogger().debug(msg);
                             }
                         }
@@ -1324,7 +1325,7 @@ updateAndCommunicateGroupData(const int reportStepIdx,
     this->wellState().communicateGroupRates(comm_);
     this->groupState().communicate_rates(comm_);
 
-    if (iterCtx.isFirstGlobalIteration()) {
+    if (iter_ctx_.isFirstGlobalIteration()) {
         group_state_helper.updatePreviousGroupProductionRates(fieldGroup);
     }
 

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -104,7 +104,8 @@ public:
                              const SummaryState& summaryState,
                              const EclipseState& eclState,
                              const PhaseUsageInfo<IndexTraits>& phase_usage,
-                             const Parallel::Communication& comm);
+                             const Parallel::Communication& comm,
+                             const NewtonIterationContext& iter_ctx);
 
     virtual ~BlackoilWellModelGeneric() = default;
     virtual int compressedIndexForInteriorLGR([[maybe_unused]] const std::string& lgr_tag,
@@ -304,10 +305,12 @@ public:
     }
 
     void updateAndCommunicateGroupData(const int reportStepIdx,
-                                       const NewtonIterationContext& iterCtx,
                                        // we only want to update the wellgroup target
                                        // after the groups have found their controls
                                        const bool update_wellgrouptarget);
+
+    const NewtonIterationContext& iterationContext() const
+    { return iter_ctx_; }
 
     const EclipseState& eclState() const
     { return eclState_; }
@@ -512,6 +515,7 @@ protected:
     const EclipseState& eclState_;
     const Parallel::Communication& comm_;
     const BlackoilWellModelGenericParameters<Scalar> param_;
+    const NewtonIterationContext& iter_ctx_;
     BlackoilWellModelGasLiftGeneric<Scalar, IndexTraits>& gen_gaslift_;
     BlackoilWellModelWBP<Scalar, IndexTraits> wbp_;
 

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
@@ -105,7 +105,7 @@ needPreStepRebalance(const int report_step) const
 
 template<typename Scalar, typename IndexTraits>
 bool BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
-shouldBalance(const int reportStepIdx, const NewtonIterationContext& iterCtx) const
+shouldBalance(const int reportStepIdx) const
 {
     // if network is not active, we do not need to balance the network
     const auto& network = well_model_.schedule()[reportStepIdx].network();
@@ -114,6 +114,7 @@ shouldBalance(const int reportStepIdx, const NewtonIterationContext& iterCtx) co
     }
 
     const auto& balance = well_model_.schedule()[reportStepIdx].network_balance();
+    const auto& iterCtx = well_model_.iterationContext();
     if (balance.mode() == Network::Balance::CalcMode::TimeStepStart) {
         return iterCtx.isFirstGlobalIteration();
     } else if (balance.mode() == Network::Balance::CalcMode::NUPCOL) {
@@ -130,7 +131,7 @@ shouldBalance(const int reportStepIdx, const NewtonIterationContext& iterCtx) co
 
 template<typename Scalar, typename IndexTraits>
 bool BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
-willBalanceOnNextIteration(const int reportStepIdx, const NewtonIterationContext& iterCtx) const
+willBalanceOnNextIteration(const int reportStepIdx) const
 {
     // if network is not active, we do not need to balance the network
     const auto& schedule_state = well_model_.schedule()[reportStepIdx];
@@ -140,7 +141,7 @@ willBalanceOnNextIteration(const int reportStepIdx, const NewtonIterationContext
 
     if (schedule_state.network_balance().mode() == Network::Balance::CalcMode::NUPCOL) {
         const int nupcol = schedule_state.nupcol();
-        return iterCtx.withinNupcol(nupcol - 1); // Note the -1 here!
+        return well_model_.iterationContext().withinNupcol(nupcol - 1); // Note the -1 here!
     } else {
         // Any other rebalancing mode will only rebalance
         // at the start of the timestep.

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.hpp
@@ -82,11 +82,9 @@ public:
 
     /// Checks if we shall perform a network re-balance.
     /// This is typically controlled by the NETBALAN keyword.
-    bool shouldBalance(const int reportStepIndex,
-                       const NewtonIterationContext& iterCtx) const;
+    bool shouldBalance(const int reportStepIndex) const;
     /// Checks if we will perform a network re-balance on the next Newton iteration.
-    bool willBalanceOnNextIteration(const int reportStepIndex,
-                                    const NewtonIterationContext& iterCtx) const;
+    bool willBalanceOnNextIteration(const int reportStepIndex) const;
 
     Scalar updatePressures(const int reportStepIdx,
                            const Scalar damping_factor,

--- a/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
@@ -96,13 +96,12 @@ update(const bool mandatory_network_balance,
         return {false, 0.0};
     }
 
-    const auto& iterCtx = well_model_.simulator().problem().iterationContext();
     const auto& comm = well_model_.simulator().vanguard().grid().comm();
 
     // network related
     Scalar network_imbalance = 0.0;
     bool more_network_update = false;
-    if (this->shouldBalance(episodeIdx, iterCtx) || mandatory_network_balance) {
+    if (this->shouldBalance(episodeIdx) || mandatory_network_balance) {
         OPM_TIMEBLOCK(BalanceNetwork);
         const double dt = well_model_.simulator().timeStepSize();
         // Calculate common THP for subsea manifold well group (item 3 of NODEPROP set to YES)
@@ -143,9 +142,7 @@ update(const bool mandatory_network_balance,
                                                       well_model_.wellState());
                 }
             }
-            well_model_.updateAndCommunicateGroupData(episodeIdx,
-                                                      iterCtx,
-                                                      /*update_wellgrouptarget*/ true);
+            well_model_.updateAndCommunicateGroupData(episodeIdx, /*update_wellgrouptarget*/ true);
         }
         more_network_update = more_network_sub_update || well_group_thp_updated;
     }

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -76,7 +76,7 @@
 namespace Opm {
     template<typename TypeTag>
     BlackoilWellModel<TypeTag>::
-    BlackoilWellModel(Simulator& simulator)
+    BlackoilWellModel(Simulator& simulator, const NewtonIterationContext& iter_ctx)
         : WellConnectionModule(*this, simulator.gridView().comm())
         , BlackoilWellModelGeneric<Scalar, IndexTraits>(simulator.vanguard().schedule(),
                                                         gaslift_,
@@ -84,7 +84,8 @@ namespace Opm {
                                                         simulator.vanguard().summaryState(),
                                                         simulator.vanguard().eclState(),
                                                         FluidSystem::phaseUsage(),
-                                                        simulator.gridView().comm())
+                                                        simulator.gridView().comm(),
+                                                        iter_ctx)
         , simulator_(simulator)
         , guide_rate_handler_{
             *this,
@@ -373,7 +374,6 @@ namespace Opm {
         this->wellState().gliftTimeStepInit();
 
         const double simulationTime = simulator_.time();
-        const auto& iterCtx = simulator_.problem().iterationContext();
         OPM_BEGIN_PARALLEL_TRY_CATCH();
         {
             // test wells
@@ -392,9 +392,7 @@ namespace Opm {
 
             // we need to update the group data after the well is created
             // to make sure we get the correct mapping.
-            this->updateAndCommunicateGroupData(reportStepIdx,
-                                    iterCtx,
-                                    /*update_wellgrouptarget*/ false);
+            this->updateAndCommunicateGroupData(reportStepIdx, /*update_wellgrouptarget*/ false);
 
             // Wells are active if they are active wells on at least one process.
             const Grid& grid = simulator_.vanguard().grid();
@@ -501,9 +499,7 @@ namespace Opm {
             OPM_PARALLEL_CATCH_CLAUSE(exc_type, exc_msg);
         }
 
-        this->updateAndCommunicateGroupData(reportStepIdx,
-                                    iterCtx,
-                                    /*update_wellgrouptarget*/ true);
+        this->updateAndCommunicateGroupData(reportStepIdx, /*update_wellgrouptarget*/ true);
         try {
             // Compute initial well solution for new wells and injectors that change injection type i.e. WAG.
             for (auto& well : well_container_) {
@@ -539,9 +535,7 @@ namespace Opm {
 #ifdef RESERVOIR_COUPLING_ENABLED
         if (this->isReservoirCouplingSlave()) {
             if (slave_needs_well_solution) {
-                this->updateAndCommunicateGroupData(reportStepIdx,
-                                            iterCtx,
-                                            /*update_wellgrouptarget*/ false);
+                this->updateAndCommunicateGroupData(reportStepIdx, /*update_wellgrouptarget*/ false);
                 this->sendSlaveGroupDataToMaster();
             }
         }
@@ -1295,8 +1289,7 @@ namespace Opm {
             if (network_update_iteration >= max_iteration ) {
                 // only output to terminal if we at the last newton iterations where we try to balance the network.
                 const int episodeIdx = simulator_.episodeIndex();
-                const auto& iterCtx = simulator_.problem().iterationContext();
-                if (this->network_.willBalanceOnNextIteration(episodeIdx, iterCtx)) {
+                if (this->network_.willBalanceOnNextIteration(episodeIdx)) {
                     if (this->terminal_output_) {
                         const std::string msg = fmt::format("Maximum of {:d} network iterations has been used and we stop the update, \n"
                             "and try again after the next Newton iteration (imbalance = {:.2e} bar)",
@@ -1342,10 +1335,8 @@ namespace Opm {
                                           DeferredLogger& local_deferredLogger)
     {
         OPM_TIMEFUNCTION();
-        const auto& iterCtx = simulator_.problem().iterationContext();
         const int reportStepIdx = simulator_.episodeIndex();
-        this->updateAndCommunicateGroupData(reportStepIdx, iterCtx,
-            /*update_wellgrouptarget*/ true);
+        this->updateAndCommunicateGroupData(reportStepIdx, /*update_wellgrouptarget*/ true);
         // We need to call updateWellControls before we update the network as
         // network updates are only done on thp controlled wells.
         // Note that well controls are allowed to change during updateNetwork
@@ -1362,7 +1353,7 @@ namespace Opm {
             if (optimize_gas_lift) {
                 // we need to update the potentials if the thp limit as been modified by
                 // the network balancing
-                const bool updatePotentials = (this->network_.shouldBalance(reportStepIdx, iterCtx) ||
+                const bool updatePotentials = (this->network_.shouldBalance(reportStepIdx) ||
                                                mandatory_network_balance);
                 alq_updated = gaslift_.maybeDoGasLiftOptimize(simulator_,
                                                           well_container_,
@@ -1391,7 +1382,7 @@ namespace Opm {
         }
         // we need to re-iterate the network when the well group controls changed or gaslift/alq is changed or
         // the inner iterations are did not converge
-        const bool more_network_update = this->network_.shouldBalance(reportStepIdx, iterCtx) &&
+        const bool more_network_update = this->network_.shouldBalance(reportStepIdx) &&
                     (more_inner_network_update || alq_updated);
         return {well_group_control_changed, more_network_update, network_imbalance};
     }
@@ -1780,10 +1771,7 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     updateAndCommunicate(const int reportStepIdx)
     {
-        const auto& iterCtx = simulator_.problem().iterationContext();
-        this->updateAndCommunicateGroupData(reportStepIdx,
-                                            iterCtx,
-                                            /*update_wellgrouptarget*/ true);
+        this->updateAndCommunicateGroupData(reportStepIdx, /*update_wellgrouptarget*/ true);
 
         // updateWellStateWithTarget might throw for multisegment wells hence we
         // have a parallel try catch here to thrown on all processes.
@@ -1802,9 +1790,7 @@ namespace Opm {
         }
         OPM_END_PARALLEL_TRY_CATCH("BlackoilWellModel::updateAndCommunicate failed: ",
                                    simulator_.gridView().comm())
-        this->updateAndCommunicateGroupData(reportStepIdx,
-                                            iterCtx,
-                                            /*update_wellgrouptarget*/ true);
+        this->updateAndCommunicateGroupData(reportStepIdx, /*update_wellgrouptarget*/ true);
     }
 
     template<typename TypeTag>

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -311,7 +311,7 @@ public:
                                  const Parallel::Communication& comm,
                                  bool deserialize)
         : BlackoilWellModelGeneric<double, IndexTraits>(schedule, gaslift, network_, summaryState,
-                                           eclState, phase_usage, comm)
+                                           eclState, phase_usage, comm, iter_ctx_)
         , network_(*this)
     {
         if (deserialize) {
@@ -372,6 +372,7 @@ public:
 
 private:
     BlackoilWellModelNetworkGeneric<double, IndexTraits> network_;
+    NewtonIterationContext iter_ctx_;
     ParallelWellInfo<double> dummy;
 };
 


### PR DESCRIPTION
Builds on https://github.com/OPM/opm-simulators/pull/7064.

Follow-up to the previous refactor (storing `BlackoilModelParameters` on the generic base): store a reference to the simulator's `NewtonIterationContext` on `BlackoilWellModelGeneric` and expose it via a new `iterationContext()` accessor. The address of the iteration context is stable for the lifetime of the simulator — it lives as a member of `FvBaseProblem` — and it is mutated in place during NLDD local solves, so a stored reference correctly observes both global and local-solve state.

**Construction wiring.** `iterationContext_` is a member of `FvBaseProblem`, which is constructed before `wellModel_` in `FlowProblem`'s initializer list. So `FlowProblem` passes `this->iterationContext()` to the new `BlackoilWellModel(Simulator&, const NewtonIterationContext&)` constructor; the derived class forwards it down to the generic base. We can **not** read it via `simulator.problem().iterationContext()` from inside the `BlackoilWellModel` constructor, because at that point the simulator's `problem_` `unique_ptr` is still null.

**Signature simplifications.** The now-redundant `iterCtx` parameter is dropped from three method signatures:

- `BlackoilWellModelGeneric::updateAndCommunicateGroupData` (6 call sites in `BlackoilWellModel_impl.hpp` plus 1 in `BlackoilWellModelNetwork_impl.hpp`)
- `BlackoilWellModelNetworkGeneric::shouldBalance` (3 call sites)
- `BlackoilWellModelNetworkGeneric::willBalanceOnNextIteration` (1 call site)

The implementations read the stored reference directly: `iter_ctx_` in the well-model base, and `well_model_.iterationContext()` in the network base. On the caller side, several local `simulator_.problem().iterationContext()` lookups become unused after the parameter drops and are removed.

**No behaviour change.** Pure refactor; every dropped parameter was previously plumbed in by the caller fetching the same iteration-context reference.
