### PR TITLE
Move reservoir coupling methods to a separate class

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -1178,6 +1178,8 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/wells/BlackoilWellModelNetworkPressureComputation.hpp
   opm/simulators/wells/BlackoilWellModelNldd.hpp
   opm/simulators/wells/BlackoilWellModelNldd_impl.hpp
+  opm/simulators/wells/BlackoilWellModelRescoup.hpp
+  opm/simulators/wells/BlackoilWellModelRescoup_impl.hpp
   opm/simulators/wells/BlackoilWellModelRestart.hpp
   opm/simulators/wells/BlackoilWellModelWBP.hpp
   opm/simulators/wells/ConnectionIndexMap.hpp

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -51,6 +51,7 @@
 #include <opm/simulators/wells/BlackoilWellModelGeneric.hpp>
 #include <opm/simulators/wells/BlackoilWellModelGuideRates.hpp>
 #include <opm/simulators/wells/BlackoilWellModelNetwork.hpp>
+#include <opm/simulators/wells/BlackoilWellModelRescoup.hpp>
 #include <opm/simulators/wells/GasLiftGroupInfo.hpp>
 #include <opm/simulators/wells/GasLiftSingleWell.hpp>
 #include <opm/simulators/wells/GasLiftSingleWellGeneric.hpp>
@@ -371,6 +372,12 @@ template<class Scalar> class WellContributions;
             void setNlddAdapter(BlackoilWellModelNldd<TypeTag>* mod)
             { nldd_ = mod; }
 
+            GuideRateHandler<Scalar, IndexTraits>& guideRateHandler()
+            { return guide_rate_handler_; }
+
+            const GuideRateHandler<Scalar, IndexTraits>& guideRateHandler() const
+            { return guide_rate_handler_; }
+
             // === Reservoir Coupling ===
 
             /// @brief Get the reservoir coupling proxy
@@ -432,27 +439,6 @@ template<class Scalar> class WellContributions;
                 this->guide_rate_handler_.setReservoirCouplingSlave(slave);
                 this->groupStateHelper().setReservoirCouplingSlave(slave);
             }
-
-            /// \brief Send comprehensive slave group data to master
-            void sendSlaveGroupDataToMaster();
-
-            /// \brief Receive comprehensive slave group data from slaves
-            void receiveSlaveGroupData();
-
-            void receiveGroupConstraintsFromMaster();
-            void sendMasterGroupConstraintsToSlaves();
-            void rescoupSyncSummaryData();
-
-            /// \brief Setup RAII guard for reservoir coupling logger
-            ///
-            /// Creates a scoped logger guard that automatically clears the logger
-            /// when it goes out of scope. This eliminates the need for manual cleanup.
-            ///
-            /// @param local_logger The local DeferredLogger to bind to the reservoir coupling logger
-            /// @return An optional containing the ScopedLoggerGuard if reservoir coupling is active,
-            ///         or std::nullopt if not active
-            std::optional<ReservoirCoupling::ScopedLoggerGuard>
-                setupRescoupScopedLogger(DeferredLogger& local_logger);
 #endif
 
             bool updateWellControlsAndNetwork(const bool mandatory_network_balance,
@@ -626,6 +612,9 @@ template<class Scalar> class WellContributions;
         private:
             BlackoilWellModelGasLift<TypeTag> gaslift_;
             BlackoilWellModelNetwork<TypeTag> network_;
+#ifdef RESERVOIR_COUPLING_ENABLED
+            BlackoilWellModelRescoup<TypeTag> rescoupHelper_;
+#endif
             BlackoilWellModelNldd<TypeTag>* nldd_ = nullptr; //!< NLDD well model adapter (not owned)
 
             // These members are used to avoid reallocation in specific functions

--- a/opm/simulators/wells/BlackoilWellModelRescoup.hpp
+++ b/opm/simulators/wells/BlackoilWellModelRescoup.hpp
@@ -1,0 +1,110 @@
+/*
+  Copyright 2025 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_BLACKOILWELLMODEL_RESCOUP_HEADER_INCLUDED
+#define OPM_BLACKOILWELLMODEL_RESCOUP_HEADER_INCLUDED
+
+#include <opm/simulators/flow/rescoup/ReservoirCouplingEnabled.hpp>
+
+#ifdef RESERVOIR_COUPLING_ENABLED
+
+#include <opm/models/utils/basicproperties.hh>
+
+#include <opm/simulators/flow/rescoup/ReservoirCoupling.hpp>
+
+#include <optional>
+
+namespace Opm {
+    class DeferredLogger;
+    class Schedule;
+    template<class TypeTag> class BlackoilWellModel;
+}
+
+namespace Opm {
+
+/// \brief Reservoir-coupling flow helper bound to a BlackoilWellModel.
+///
+/// Holds no state of its own; all methods reach back to the parent
+/// BlackoilWellModel via well_model_ and forward to the helpers in
+/// opm/simulators/wells/rescoup/.  Construct once per BlackoilWellModel.
+template<typename TypeTag>
+class BlackoilWellModelRescoup {
+    using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
+    using Scalar      = GetPropType<TypeTag, Properties::Scalar>;
+    using IndexTraits = typename FluidSystem::IndexTraitsType;
+
+public:
+    explicit BlackoilWellModelRescoup(BlackoilWellModel<TypeTag>& well_model);
+
+    /// \brief Slave-side counterpart of sendMasterGroupConstraintsToSlaves().
+    ///
+    /// Blocking receive of the per-master-group production targets and
+    /// injection limits computed by the master.  The received values are
+    /// written into the slave's group state via the receiver helper.
+    /// Called from the slave's beginTimeStep first-substep handshake.
+    void receiveGroupConstraintsFromMaster();
+
+    /// \brief Master-side blocking receive of per-slave production data
+    ///   (rates, potentials, and injection data) from every activated slave.
+    ///
+    /// The data is integrated into the master's group state so it is
+    /// available to the constraint calculator and summary output.
+    /// Called from the master's beginTimeStep first-substep handshake and
+    /// from rescoupSyncSummaryData() when a slave has fresh data to deliver.
+    void receiveSlaveGroupData();
+
+    /// \brief End-of-substep summary-data synchronisation.
+    ///
+    /// On the master, blocks for any pending slave production data so that
+    /// the subsequent evalSummaryState() call sees up-to-date rates.  On
+    /// the slave, ships production data to the master on the last substep
+    /// of the sync step.  Called from timeStepSucceeded.
+    void rescoupSyncSummaryData();
+
+    /// \brief Master-side: compute per-master-group production targets and
+    ///   injection limits, then dispatch them to each activated slave.
+    ///
+    /// Runs once per sync step.  Drives the full master-side target-
+    /// distribution flow (pre-phase + Phase 1/2/3) via the constraint
+    /// calculator helper.  Called from the master's beginTimeStep
+    /// first-substep handshake.
+    void sendMasterGroupConstraintsToSlaves();
+
+    /// \brief Slave-side counterpart of receiveSlaveGroupData().
+    ///
+    /// Collects current production rates, potentials and injection data
+    /// from the slave's local groups and ships them to the master.  Called
+    /// from the slave's beginTimeStep first-substep handshake and from
+    /// rescoupSyncSummaryData() on the last substep of a sync step.
+    void sendSlaveGroupDataToMaster();
+
+    /// \brief RAII guard for the deferred-logger binding.
+    /// Replaces the previous BlackoilWellModel::setupRescoupScopedLogger().
+    std::optional<ReservoirCoupling::ScopedLoggerGuard> setupScopedLogger(DeferredLogger& local_logger);
+
+private:
+    BlackoilWellModel<TypeTag>& well_model_;
+};
+
+} // namespace Opm
+
+#include "BlackoilWellModelRescoup_impl.hpp"
+
+#endif // RESERVOIR_COUPLING_ENABLED
+#endif // OPM_BLACKOILWELLMODEL_RESCOUP_HEADER_INCLUDED

--- a/opm/simulators/wells/BlackoilWellModelRescoup_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelRescoup_impl.hpp
@@ -1,0 +1,165 @@
+/*
+  Copyright 2025 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_BLACKOILWELLMODEL_RESCOUP_IMPL_HEADER_INCLUDED
+#define OPM_BLACKOILWELLMODEL_RESCOUP_IMPL_HEADER_INCLUDED
+
+// Improve IDE experience
+#ifndef OPM_BLACKOILWELLMODEL_RESCOUP_HEADER_INCLUDED
+#include <config.h>
+#include <opm/simulators/wells/BlackoilWellModelRescoup.hpp>
+#endif
+
+#ifdef RESERVOIR_COUPLING_ENABLED
+
+#include <opm/common/TimingMacros.hpp>
+
+#include <opm/simulators/wells/BlackoilWellModel.hpp>
+#include <opm/simulators/wells/rescoup/RescoupConstraintsCalculator.hpp>
+#include <opm/simulators/wells/rescoup/RescoupReceiveGroupConstraints.hpp>
+#include <opm/simulators/wells/rescoup/RescoupReceiveSlaveGroupData.hpp>
+#include <opm/simulators/wells/rescoup/RescoupSendSlaveGroupData.hpp>
+
+#include <cassert>
+
+namespace Opm {
+
+// Constructor
+// -----------
+template<typename TypeTag>
+BlackoilWellModelRescoup<TypeTag>::
+BlackoilWellModelRescoup(BlackoilWellModel<TypeTag>& well_model)
+    : well_model_{well_model}
+{}
+
+// Public methods alphabetically
+// ------------------------------
+
+template<typename TypeTag>
+void
+BlackoilWellModelRescoup<TypeTag>::
+receiveGroupConstraintsFromMaster()
+{
+    OPM_TIMEFUNCTION();
+    RescoupReceiveGroupConstraints<Scalar, IndexTraits> constraint_receiver{
+        this->well_model_.guideRateHandler(),
+        this->well_model_.groupStateHelper()
+    };
+    constraint_receiver.receiveGroupConstraintsFromMaster();
+}
+
+template<typename TypeTag>
+void
+BlackoilWellModelRescoup<TypeTag>::
+receiveSlaveGroupData()
+{
+    OPM_TIMEFUNCTION();
+    assert(this->well_model_.isReservoirCouplingMaster());
+    RescoupReceiveSlaveGroupData<Scalar, IndexTraits> slave_group_data_receiver{
+        this->well_model_.groupStateHelper(),
+    };
+    slave_group_data_receiver.receiveSlaveGroupData();
+}
+
+template<typename TypeTag>
+void
+BlackoilWellModelRescoup<TypeTag>::
+rescoupSyncSummaryData()
+{
+    // Reservoir coupling: exchange production data between slaves and master.
+    //
+    // Master side: after its first substep, the master blocks here until all
+    // slaves have completed the sync step and sent their production data.
+    // This ensures evalSummaryState() (called next in endTimeStep) and all
+    // subsequent master substeps have correct slave production rates.
+    //
+    // Slave side: on the last substep of the sync step, the slave sends its
+    // production data to the master.  The master is already waiting at this
+    // point (blocked on MPI_Recv from its first substep's timeStepSucceeded).
+    if (this->well_model_.isReservoirCouplingMaster()) {
+        if (this->well_model_.reservoirCouplingMaster().needsSlaveDataReceive()) {
+            this->receiveSlaveGroupData();
+            this->well_model_.reservoirCouplingMaster().setNeedsSlaveDataReceive(false);
+        }
+    }
+    if (this->well_model_.isReservoirCouplingSlave()) {
+        if (this->well_model_.reservoirCouplingSlave().isLastSubstepOfSyncTimestep()) {
+            this->sendSlaveGroupDataToMaster();
+        }
+    }
+}
+
+template<typename TypeTag>
+void
+BlackoilWellModelRescoup<TypeTag>::
+sendSlaveGroupDataToMaster()
+{
+    OPM_TIMEFUNCTION();
+    assert(this->well_model_.isReservoirCouplingSlave());
+    RescoupSendSlaveGroupData<Scalar, IndexTraits> slave_group_data_sender{
+        this->well_model_.groupStateHelper()};
+    slave_group_data_sender.sendSlaveGroupDataToMaster();
+}
+
+template<typename TypeTag>
+void
+BlackoilWellModelRescoup<TypeTag>::
+sendMasterGroupConstraintsToSlaves()
+{
+    OPM_TIMEFUNCTION();
+    // This function is called by the master process to send the group constraints to the slaves.
+    RescoupConstraintsCalculator<Scalar, IndexTraits> constraints_calculator{
+        this->well_model_.guideRateHandler(),
+        this->well_model_.groupStateHelper()
+    };
+    constraints_calculator.calculateMasterGroupConstraintsAndSendToSlaves();
+}
+
+// Automatically manages the lifecycle of the DeferredLogger pointer
+// in the reservoir coupling logger.  Ensures the logger is properly
+// cleared when it goes out of scope, preventing dangling pointer issues:
+//
+// - The ScopedLoggerGuard constructor sets the logger pointer
+// - When the guard goes out of scope, the destructor clears the pointer
+// - Move semantics transfer ownership safely when returning from this function
+//   - The moved-from guard is "nullified" and its destructor does nothing
+//   - Only the final guard in the caller will clear the logger
+template<typename TypeTag>
+std::optional<ReservoirCoupling::ScopedLoggerGuard>
+BlackoilWellModelRescoup<TypeTag>::
+setupScopedLogger(DeferredLogger& local_logger)
+{
+    if (this->well_model_.isReservoirCouplingMaster()) {
+        return ReservoirCoupling::ScopedLoggerGuard{
+            this->well_model_.reservoirCouplingMaster().logger(),
+            &local_logger
+        };
+    } else if (this->well_model_.isReservoirCouplingSlave()) {
+        return ReservoirCoupling::ScopedLoggerGuard{
+            this->well_model_.reservoirCouplingSlave().logger(),
+            &local_logger
+        };
+    }
+    return std::nullopt;
+}
+
+} // namespace Opm
+
+#endif // RESERVOIR_COUPLING_ENABLED
+#endif // OPM_BLACKOILWELLMODEL_RESCOUP_IMPL_HEADER_INCLUDED

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -48,13 +48,6 @@
 #include <opm/simulators/wells/VFPProperties.hpp>
 #include <opm/simulators/wells/GroupStateHelper.hpp>
 
-#ifdef RESERVOIR_COUPLING_ENABLED
-#include <opm/simulators/wells/rescoup/RescoupReceiveGroupConstraints.hpp>
-#include <opm/simulators/wells/rescoup/RescoupReceiveSlaveGroupData.hpp>
-#include <opm/simulators/wells/rescoup/RescoupSendSlaveGroupData.hpp>
-#include <opm/simulators/wells/rescoup/RescoupConstraintsCalculator.hpp>
-#endif
-
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 #if HAVE_MPI
 #include <opm/simulators/utils/MPIPacker.hpp>
@@ -95,6 +88,9 @@ namespace Opm {
         }
         , gaslift_(this->terminal_output_)
         , network_(*this)
+#ifdef RESERVOIR_COUPLING_ENABLED
+        , rescoupHelper_(*this)
+#endif
     {
         local_num_cells_ = simulator_.gridView().size(0);
 
@@ -337,7 +333,7 @@ namespace Opm {
         auto& local_deferredLogger = this->groupStateHelper().deferredLogger();
 
 #ifdef RESERVOIR_COUPLING_ENABLED
-        auto rescoup_logger_guard = this->setupRescoupScopedLogger(local_deferredLogger);
+        auto rescoup_logger_guard = this->rescoupHelper_.setupScopedLogger(local_deferredLogger);
 #endif
 
         this->switched_prod_groups_.clear();
@@ -385,7 +381,7 @@ namespace Opm {
 #ifdef RESERVOIR_COUPLING_ENABLED
             if (this->isReservoirCouplingMaster()) {
                 if (this->reservoirCouplingMaster().isFirstSubstepOfSyncTimestep()) {
-                    this->receiveSlaveGroupData();
+                    this->rescoupHelper_.receiveSlaveGroupData();
                 }
             }
 #endif
@@ -473,8 +469,8 @@ namespace Opm {
 #ifdef RESERVOIR_COUPLING_ENABLED
         if (this->isReservoirCouplingSlave()) {
             if (this->reservoirCouplingSlave().isFirstSubstepOfSyncTimestep()) {
-                this->sendSlaveGroupDataToMaster();
-                this->receiveGroupConstraintsFromMaster();
+                this->rescoupHelper_.sendSlaveGroupDataToMaster();
+                this->rescoupHelper_.receiveGroupConstraintsFromMaster();
                 this->groupStateHelper().updateSlaveGroupCmodesFromMaster();
                 this->reservoirCouplingSlave().markSlaveGroupsInSchedule(
                     this->schedule_, reportStepIdx);
@@ -533,19 +529,15 @@ namespace Opm {
         OPM_PARALLEL_CATCH_CLAUSE(exc_type, exc_msg);
 
 #ifdef RESERVOIR_COUPLING_ENABLED
-        if (this->isReservoirCouplingSlave()) {
-            if (slave_needs_well_solution) {
-                this->updateAndCommunicateGroupData(reportStepIdx, /*update_wellgrouptarget*/ false);
-                this->sendSlaveGroupDataToMaster();
-            }
+        if (slave_needs_well_solution) {  // isReservoirCouplingSlave()
+            // Need to update group data based on new well solution.
+            this->updateAndCommunicateGroupData(reportStepIdx, /*update_wellgrouptarget*/ false);
+            this->rescoupHelper_.sendSlaveGroupDataToMaster();
         }
-#endif
-
-#ifdef RESERVOIR_COUPLING_ENABLED
-        if (this->isReservoirCouplingMaster()) {
+        else if (this->isReservoirCouplingMaster()) {
             if (this->reservoirCouplingMaster().isFirstSubstepOfSyncTimestep()) {
-                this->sendMasterGroupConstraintsToSlaves();
-                this->receiveSlaveGroupData();
+                this->rescoupHelper_.sendMasterGroupConstraintsToSlaves();
+                this->rescoupHelper_.receiveSlaveGroupData();
             }
         }
 #endif
@@ -560,115 +552,6 @@ namespace Opm {
                                          exc_type, "beginTimeStep() failed: " + exc_msg, this->terminal_output_, comm);
 
     }
-
-#ifdef RESERVOIR_COUPLING_ENABLED
-    // Automatically manages the lifecycle of the DeferredLogger pointer
-    // in the reservoir coupling logger. Ensures the logger is properly
-    // cleared when it goes out of scope, preventing dangling pointer issues:
-    //
-    // - The ScopedLoggerGuard constructor sets the logger pointer
-    // - When the guard goes out of scope, the destructor clears the pointer
-    // - Move semantics transfer ownership safely when returning from this function
-    //    - The moved-from guard is "nullified" and its destructor does nothing
-    //    - Only the final guard in the caller will clear the logger
-    template<typename TypeTag>
-    std::optional<ReservoirCoupling::ScopedLoggerGuard>
-    BlackoilWellModel<TypeTag>::
-    setupRescoupScopedLogger(DeferredLogger& local_logger) {
-        if (this->isReservoirCouplingMaster()) {
-            return ReservoirCoupling::ScopedLoggerGuard{
-                this->reservoirCouplingMaster().logger(),
-                &local_logger
-            };
-        } else if (this->isReservoirCouplingSlave()) {
-            return ReservoirCoupling::ScopedLoggerGuard{
-                this->reservoirCouplingSlave().logger(),
-                &local_logger
-            };
-        }
-        return std::nullopt;
-    }
-
-    template<typename TypeTag>
-    void
-    BlackoilWellModel<TypeTag>::
-    receiveSlaveGroupData()
-    {
-        OPM_TIMEFUNCTION();
-        assert(this->isReservoirCouplingMaster());
-        RescoupReceiveSlaveGroupData<Scalar, IndexTraits> slave_group_data_receiver{
-            this->groupStateHelper(),
-        };
-        slave_group_data_receiver.receiveSlaveGroupData();
-    }
-
-    template<typename TypeTag>
-    void
-    BlackoilWellModel<TypeTag>::
-    sendSlaveGroupDataToMaster()
-    {
-        OPM_TIMEFUNCTION();
-        assert(this->isReservoirCouplingSlave());
-        RescoupSendSlaveGroupData<Scalar, IndexTraits> slave_group_data_sender{this->groupStateHelper()};
-        slave_group_data_sender.sendSlaveGroupDataToMaster();
-    }
-
-    template<typename TypeTag>
-    void
-    BlackoilWellModel<TypeTag>::
-    sendMasterGroupConstraintsToSlaves()
-    {
-        OPM_TIMEFUNCTION();
-        // This function is called by the master process to send the group constraints to the slaves.
-        RescoupConstraintsCalculator<Scalar, IndexTraits> constraints_calculator{
-            this->guide_rate_handler_,
-            this->groupStateHelper()
-        };
-        constraints_calculator.calculateMasterGroupConstraintsAndSendToSlaves();
-    }
-
-    template<typename TypeTag>
-    void
-    BlackoilWellModel<TypeTag>::
-    receiveGroupConstraintsFromMaster()
-    {
-        OPM_TIMEFUNCTION();
-        RescoupReceiveGroupConstraints<Scalar, IndexTraits> constraint_receiver{
-            this->guide_rate_handler_,
-            this->groupStateHelper()
-        };
-        constraint_receiver.receiveGroupConstraintsFromMaster();
-    }
-
-    template<typename TypeTag>
-    void
-    BlackoilWellModel<TypeTag>::
-    rescoupSyncSummaryData()
-    {
-        // Reservoir coupling: exchange production data between slaves and master.
-        //
-        // Master side: after its first substep, the master blocks here until all
-        // slaves have completed the sync step and sent their production data.
-        // This ensures evalSummaryState() (called next in endTimeStep) and all
-        // subsequent master substeps have correct slave production rates.
-        //
-        // Slave side: on the last substep of the sync step, the slave sends its
-        // production data to the master.  The master is already waiting at this
-        // point (blocked on MPI_Recv from its first substep's timeStepSucceeded).
-        if (this->isReservoirCouplingMaster()) {
-            if (this->reservoirCouplingMaster().needsSlaveDataReceive()) {
-                this->receiveSlaveGroupData();
-                this->reservoirCouplingMaster().setNeedsSlaveDataReceive(false);
-            }
-        }
-        if (this->isReservoirCouplingSlave()) {
-            if (this->reservoirCouplingSlave().isLastSubstepOfSyncTimestep()) {
-                this->sendSlaveGroupDataToMaster();
-            }
-        }
-    }
-
-#endif // RESERVOIR_COUPLING_ENABLED
 
     template<typename TypeTag>
     void
@@ -824,7 +707,7 @@ namespace Opm {
         this->groupStateHelper().updateNONEProductionGroups();
 
 #ifdef RESERVOIR_COUPLING_ENABLED
-        this->rescoupSyncSummaryData();
+        this->rescoupHelper_.rescoupSyncSummaryData();
 #endif
         this->commitWGState();
 


### PR DESCRIPTION
Builds on https://github.com/OPM/opm-simulators/pull/7065

Extracts the reservoir-coupling flow methods from `BlackoilWellModel<TypeTag>` into a new templated helper class `BlackoilWellModelRescoup<TypeTag>`, modelled as has-a on `BlackoilWellModel`. Motivation: `BlackoilWellModel_impl.hpp` had ~160 LOC of rescoup-specific code interleaved with the rest of the file, and upcoming rescoup-network work will roughly double that footprint, this gives those additions a clean target file. No behavior change.

#### Moved to the wrapper

- `receiveGroupConstraintsFromMaster()`
- `receiveSlaveGroupData()`
- `rescoupSyncSummaryData()`
- `sendMasterGroupConstraintsToSlaves()`
- `sendSlaveGroupDataToMaster()`
- `setupRescoupScopedLogger()`: renamed to `setupScopedLogger` since the class name already carries the `Rescoup` prefix.

#### Stayed on `BlackoilWellModel`

The rescoup mode-query API stays on `BlackoilWellModel`: `isReservoirCouplingMaster/Slave`, `isReservoirCouplingMasterGroup`, `reservoirCouplingMaster/Slave`, `setReservoirCouplingMaster/Slave`, and the `rescoup()` proxy accessor. These are **read-only mode queries** used widely by call sites that should not have to bounce through the wrapper to ask "are we in master mode?".

#### Other changes

- Adds a public `guideRateHandler()` accessor on `BlackoilWellModel` so the wrapper can construct `RescoupConstraintsCalculator` and `RescoupReceiveGroupConstraints` without `friend` access.
- Adds the two new headers to `CMakeLists_files.cmake` (`PUBLIC_HEADER_FILES`, alongside the existing `BlackoilWellModelNetwork.hpp` entries).

#### Files

| File | Change |
|---|---|
| `opm/simulators/wells/BlackoilWellModelRescoup.hpp` | new (110 lines) — class declaration with doxygen for each method |
| `opm/simulators/wells/BlackoilWellModelRescoup_impl.hpp` | new (165 lines) — method definitions |
| `opm/simulators/wells/BlackoilWellModel.hpp` | +25 / −19 (include, `guideRateHandler()` accessor, `rescoupHelper_` member; removed 6 flow-method declarations) |
| `opm/simulators/wells/BlackoilWellModel_impl.hpp` | +13 / −150 (delegated inline `#ifdef` blocks and `rescoupSyncSummaryData` call to wrapper; deleted moved method bodies) |
| `CMakeLists_files.cmake` | +2 (new headers) |

### Follow-up

This refactor unblocks the planned reservoir-coupling network PR series: those additions can land directly into `BlackoilWellModelRescoup` instead of growing `BlackoilWellModel_impl.hpp` further.
