### PR TITLE
Reservoir coupling: Add network iteration

### DIFF
--- a/opm/simulators/flow/rescoup/ReservoirCoupling.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCoupling.hpp
@@ -132,10 +132,13 @@ private:
 };
 
 enum class MessageTag : int {
+    CoupledNetworkActiveStatus,
     InjectionGroupTargets,
     MasterGroupNames,
     MasterGroupNamesSize,
+    MasterGroupNodePressures,
     MasterStartOfReportStep,
+    NumMasterGroupNodePressures,
     NumSlaveGroupConstraints,
     ProductionGroupConstraints,
     SlaveActivationDate,
@@ -266,6 +269,20 @@ struct MasterProductionLimits {
     Scalar gas_limit{-1};
     Scalar liquid_limit{-1};
     Scalar resv_limit{-1};
+};
+
+/// @brief Master-computed network-leaf node pressure for a single master group.
+///
+/// The slave applies the pressure as a dynamic THP limit to every producer
+/// in the corresponding master group.
+///
+/// Only emitted for master groups that are leaf nodes in the master's extended network.
+template <class Scalar>
+struct MasterGroupNodePressure {
+    // To save memory and avoid varying size of the struct when serializing
+    // and deserializing the group name, we use an index instead of the full name.
+    std::size_t group_name_idx;   // Index of group name in the master group names vector
+    Scalar pressure;              // Network-leaf node pressure (SI units, Pa)
 };
 
 // Helper functions

--- a/opm/simulators/flow/rescoup/ReservoirCouplingMaster.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingMaster.cpp
@@ -437,12 +437,43 @@ sendInjectionTargetsToSlave(std::size_t slave_idx,
 template <class Scalar>
 void
 ReservoirCouplingMaster<Scalar>::
+sendMasterGroupNodePressuresToSlave(std::size_t slave_idx,
+                                    const std::vector<MasterGroupNodePressure>& pressures) const
+{
+    assert(this->report_step_data_);
+    this->report_step_data_->sendMasterGroupNodePressuresToSlave(slave_idx, pressures);
+}
+
+template <class Scalar>
+void
+ReservoirCouplingMaster<Scalar>::
+sendCoupledNetworkActiveStatusToSlave(std::size_t slave_idx, bool active) const
+{
+    assert(this->report_step_data_);
+    this->report_step_data_->sendCoupledNetworkActiveStatusToSlave(slave_idx, active);
+}
+
+template <class Scalar>
+void
+ReservoirCouplingMaster<Scalar>::
 sendNumGroupConstraintsToSlave(std::size_t slave_idx,
                            std::size_t num_injection_targets,
                            std::size_t num_production_constraints) const
 {
     assert(this->report_step_data_);
     this->report_step_data_->sendNumGroupConstraintsToSlave(slave_idx, num_injection_targets, num_production_constraints);
+}
+
+template <class Scalar>
+void
+ReservoirCouplingMaster<Scalar>::
+sendNumMasterGroupNodePressuresToSlave(std::size_t slave_idx,
+                                       std::size_t num_pressures,
+                                       bool is_final) const
+{
+    assert(this->report_step_data_);
+    this->report_step_data_->sendNumMasterGroupNodePressuresToSlave(
+        slave_idx, num_pressures, is_final);
 }
 
 template <class Scalar>

--- a/opm/simulators/flow/rescoup/ReservoirCouplingMaster.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingMaster.hpp
@@ -42,6 +42,7 @@ public:
     using Potentials = ReservoirCoupling::Potentials<Scalar>;
     using SlaveGroupProductionData = ReservoirCoupling::SlaveGroupProductionData<Scalar>;
     using InjectionGroupTarget = ReservoirCoupling::InjectionGroupTarget<Scalar>;
+    using MasterGroupNodePressure = ReservoirCoupling::MasterGroupNodePressure<Scalar>;
     using ProductionGroupConstraints = ReservoirCoupling::ProductionGroupConstraints<Scalar>;
 
     ReservoirCouplingMaster(
@@ -137,14 +138,32 @@ public:
     void sendNextTimeStepToSlaves(double next_time_step) {
         this->time_stepper_->sendNextTimeStepToSlaves(next_time_step);
     }
+    /// @brief Send a single boolean to a slave telling it whether the master
+    ///   will iterate the cross-rescoup network exchange this sync timestep.
+    void sendCoupledNetworkActiveStatusToSlave(
+        std::size_t slave_idx,
+        bool active
+    ) const;
     void sendInjectionTargetsToSlave(
         std::size_t slave_idx,
         const std::vector<InjectionGroupTarget>& injection_targets
+    ) const;
+    /// @brief Send master-computed network-leaf node pressures to a slave.
+    void sendMasterGroupNodePressuresToSlave(
+        std::size_t slave_idx,
+        const std::vector<MasterGroupNodePressure>& pressures
     ) const;
     void sendNumGroupConstraintsToSlave(
         std::size_t slave_idx,
         std::size_t num_injection_targets,
         std::size_t num_production_constraints
+    ) const;
+    /// @brief Send the count of master-computed network-leaf node pressures
+    ///   plus the master's `is_final` flag for this sync-step iteration.
+    void sendNumMasterGroupNodePressuresToSlave(
+        std::size_t slave_idx,
+        std::size_t num_pressures,
+        bool is_final
     ) const;
     void sendProductionConstraintsToSlave(
         std::size_t slave_idx,

--- a/opm/simulators/flow/rescoup/ReservoirCouplingMasterReportStep.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingMasterReportStep.cpp
@@ -227,6 +227,36 @@ receiveProductionDataFromSlaves()
     }
 }
 
+// Send a single boolean telling the slave whether the master will iterate the
+// cross-rescoup network exchange this sync timestep.  Encoded as a single
+// size_t (0 = inactive, 1 = active) so the slave can mirror the value into its
+// `last_received_master_group_node_pressures_is_final_` flag.
+template <class Scalar>
+void
+ReservoirCouplingMasterReportStep<Scalar>::
+sendCoupledNetworkActiveStatusToSlave(std::size_t slave_idx, bool active) const
+{
+    // Only rank 0 sends data to slaves. Other ranks in the master's MPI
+    // communicator do not participate in master-slave communication.
+    if (this->comm().rank() == 0) {
+        std::size_t payload = active ? 1u : 0u;
+        auto MPI_SIZE_T_TYPE = Dune::MPITraits<std::size_t>::getType();
+        // NOTE: See comment about error handling at the top of this file.
+        MPI_Send(
+            &payload,
+            /*count=*/1,
+            /*datatype=*/MPI_SIZE_T_TYPE,
+            /*dest_rank=*/0,
+            /*tag=*/static_cast<int>(MessageTag::CoupledNetworkActiveStatus),
+            this->getSlaveComm(slave_idx)
+        );
+        this->logger().debug(fmt::format(
+            "Sent coupled-network active status (active={}) to {}",
+            active, this->slaveName(slave_idx)
+        ));
+    }
+}
+
 template <class Scalar>
 void
 ReservoirCouplingMasterReportStep<Scalar>::
@@ -250,6 +280,34 @@ sendInjectionTargetsToSlave(std::size_t slave_idx,
         this->logger().debug(fmt::format(
             "Sent {} injection targets to {}",
             num_injection_targets, this->slaveName(slave_idx)
+        ));
+    }
+}
+
+template <class Scalar>
+void
+ReservoirCouplingMasterReportStep<Scalar>::
+sendMasterGroupNodePressuresToSlave(std::size_t slave_idx,
+                                    const std::vector<MasterGroupNodePressure>& pressures) const
+{
+    // Only rank 0 sends data to slaves. Other ranks in the master's MPI communicator
+    // do not participate in master-slave communication (no else branch needed).
+    if (this->comm().rank() == 0) {
+        auto num_pressures = pressures.size();
+        auto MPI_MASTER_GROUP_NODE_PRESSURE_TYPE =
+            Dune::MPITraits<MasterGroupNodePressure>::getType();
+        // NOTE: See comment about error handling at the top of this file.
+        MPI_Send(
+            pressures.data(),
+            /*count=*/num_pressures,
+            /*datatype=*/MPI_MASTER_GROUP_NODE_PRESSURE_TYPE,
+            /*dest_rank=*/0,
+            /*tag=*/static_cast<int>(MessageTag::MasterGroupNodePressures),
+            this->getSlaveComm(slave_idx)
+        );
+        this->logger().debug(fmt::format(
+            "Sent {} master group node pressures to {}",
+            num_pressures, this->slaveName(slave_idx)
         ));
     }
 }
@@ -281,6 +339,42 @@ sendNumGroupConstraintsToSlave(std::size_t slave_idx,
         this->logger().debug(fmt::format(
             "Sent constraint counts (inj={}, prod={}) to {}",
             num_injection_targets, num_production_constraints, this->slaveName(slave_idx)
+        ));
+    }
+}
+
+// The slave process will use this information to determine how many node
+// pressures to expect, and whether the master is sending its final pressure
+// update for the current sync timestep (is_final = 1) or expects another
+// round of slave rates back (is_final = 0).  Carries both values in a
+// 2-element size_t vector to keep the wire format symmetric with
+// sendNumGroupConstraintsToSlave.
+template <class Scalar>
+void
+ReservoirCouplingMasterReportStep<Scalar>::
+sendNumMasterGroupNodePressuresToSlave(std::size_t slave_idx,
+                                       std::size_t num_pressures,
+                                       bool is_final) const
+{
+    // Only rank 0 sends data to slaves. Other ranks in the master's MPI communicator
+    // do not participate in master-slave communication (no else branch needed).
+    if (this->comm().rank() == 0) {
+        std::vector<std::size_t> header(2);
+        header[0] = num_pressures;
+        header[1] = is_final ? 1u : 0u;
+        auto MPI_SIZE_T_TYPE = Dune::MPITraits<std::size_t>::getType();
+        // NOTE: See comment about error handling at the top of this file.
+        MPI_Send(
+            header.data(),
+            /*count=*/2,
+            /*datatype=*/MPI_SIZE_T_TYPE,
+            /*dest_rank=*/0,
+            /*tag=*/static_cast<int>(MessageTag::NumMasterGroupNodePressures),
+            this->getSlaveComm(slave_idx)
+        );
+        this->logger().debug(fmt::format(
+            "Sent master-group-node-pressure header (count={}, is_final={}) to {}",
+            num_pressures, is_final, this->slaveName(slave_idx)
         ));
     }
 }

--- a/opm/simulators/flow/rescoup/ReservoirCouplingMasterReportStep.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingMasterReportStep.hpp
@@ -64,6 +64,7 @@ public:
     using SlaveGroupProductionData = ReservoirCoupling::SlaveGroupProductionData<Scalar>;
     using SlaveGroupInjectionData = ReservoirCoupling::SlaveGroupInjectionData<Scalar>;
     using InjectionGroupTarget = ReservoirCoupling::InjectionGroupTarget<Scalar>;
+    using MasterGroupNodePressure = ReservoirCoupling::MasterGroupNodePressure<Scalar>;
     using ProductionGroupConstraints = ReservoirCoupling::ProductionGroupConstraints<Scalar>;
 
     /// @brief Construct a report step manager for the master process
@@ -201,12 +202,45 @@ public:
     /// @return Reference to the Schedule object containing well and group definitions
     const Schedule &schedule() const { return this->master_.schedule(); }
 
+    /// @brief Send a single boolean to a slave telling it whether the master
+    ///   will iterate the cross-rescoup network exchange this sync timestep.
+    ///   Rank-0-only on the master comm.
+    /// @param slave_idx Zero-based slave index.
+    /// @param active True if the master will iterate (the slave should
+    ///   participate in per-iteration node-pressure receives in
+    ///   updateWellControlsAndNetworkIteration); false if the master will not
+    ///   iterate cross-rescoup this sync timestep.
+    void sendCoupledNetworkActiveStatusToSlave(
+        std::size_t slave_idx, bool active
+    ) const;
+
     void sendInjectionTargetsToSlave(
         std::size_t slave_idx, const std::vector<InjectionGroupTarget>& injection_targets
     ) const;
+
+    /// @brief Send master-computed network-leaf node pressures to a slave.
+    /// @details Only emits entries for master groups that are leaf nodes in
+    ///   the master's extended network.  Rank-0-only on the master comm.
+    void sendMasterGroupNodePressuresToSlave(
+        std::size_t slave_idx, const std::vector<MasterGroupNodePressure>& pressures
+    ) const;
+
     void sendNumGroupConstraintsToSlave(
         std::size_t slave_idx, std::size_t num_injection_targets, std::size_t num_production_constraints
     ) const;
+
+    /// @brief Send the count of master-computed network-leaf node pressures
+    ///   that will follow, plus an `is_final` flag telling the slave whether
+    ///   the master will iterate again.  Rank-0-only on the master comm.
+    /// @param slave_idx Zero-based slave index.
+    /// @param num_pressures Number of pressures that will follow.
+    /// @param is_final True if this is the master's final pressure send for
+    ///   the current sync timestep; false if the master is iterating and
+    ///   expects to receive updated rates from the slave.
+    void sendNumMasterGroupNodePressuresToSlave(
+        std::size_t slave_idx, std::size_t num_pressures, bool is_final
+    ) const;
+
     void sendProductionConstraintsToSlave(
         std::size_t slave_idx, const std::vector<ProductionGroupConstraints>& production_constraints
     ) const;

--- a/opm/simulators/flow/rescoup/ReservoirCouplingMpiTraits.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingMpiTraits.hpp
@@ -231,6 +231,15 @@ struct MPITraits<
         &::Opm::ReservoirCoupling::ProductionGroupConstraints<Scalar>::liquid_limit,
         &::Opm::ReservoirCoupling::ProductionGroupConstraints<Scalar>::resv_limit> { };
 
+// Trait for MasterGroupNodePressure
+template<class Scalar>
+struct MPITraits<
+        ::Opm::ReservoirCoupling::MasterGroupNodePressure<Scalar>>
+  : detail::StructMPITraits<
+        ::Opm::ReservoirCoupling::MasterGroupNodePressure<Scalar>,
+        &::Opm::ReservoirCoupling::MasterGroupNodePressure<Scalar>::group_name_idx,
+        &::Opm::ReservoirCoupling::MasterGroupNodePressure<Scalar>::pressure> { };
+
 /// @brief MPI datatype trait for SlaveGroupProductionData structure
 ///
 /// This specialization enables SlaveGroupProductionData to be sent via MPI

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlave.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlave.cpp
@@ -129,6 +129,15 @@ lastReceivedMasterGroupNodePressuresIsFinal() const
 template <class Scalar>
 bool
 ReservoirCouplingSlave<Scalar>::
+connectedToMasterCoupledNetwork() const
+{
+    assert(this->report_step_data_);
+    return this->report_step_data_->connectedToMasterCoupledNetwork();
+}
+
+template <class Scalar>
+bool
+ReservoirCouplingSlave<Scalar>::
 isLastSubstepOfSyncTimestep() const
 {
     assert(this->report_step_data_);

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlave.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlave.cpp
@@ -66,6 +66,15 @@ ReservoirCouplingSlave(
 template <class Scalar>
 bool
 ReservoirCouplingSlave<Scalar>::
+hasMasterGroupNodePressure(const std::string& gname) const
+{
+    assert(this->report_step_data_);
+    return this->report_step_data_->hasMasterGroupNodePressure(gname);
+}
+
+template <class Scalar>
+bool
+ReservoirCouplingSlave<Scalar>::
 hasMasterInjectionTarget(const std::string& gname, const Phase phase) const
 {
     assert(this->report_step_data_);
@@ -111,6 +120,15 @@ isFirstSubstepOfSyncTimestep() const
 template <class Scalar>
 bool
 ReservoirCouplingSlave<Scalar>::
+lastReceivedMasterGroupNodePressuresIsFinal() const
+{
+    assert(this->report_step_data_);
+    return this->report_step_data_->lastReceivedMasterGroupNodePressuresIsFinal();
+}
+
+template <class Scalar>
+bool
+ReservoirCouplingSlave<Scalar>::
 isLastSubstepOfSyncTimestep() const
 {
     assert(this->report_step_data_);
@@ -122,6 +140,24 @@ bool
 ReservoirCouplingSlave<Scalar>::
 isSlaveGroup(const std::string& group_name) const {
     return this->slave_to_master_group_map_.find(group_name) != this->slave_to_master_group_map_.end();
+}
+
+template <class Scalar>
+Scalar
+ReservoirCouplingSlave<Scalar>::
+masterGroupNodePressure(const std::string& gname) const
+{
+    assert(this->report_step_data_);
+    return this->report_step_data_->masterGroupNodePressure(gname);
+}
+
+template <class Scalar>
+const std::map<std::string, Scalar>&
+ReservoirCouplingSlave<Scalar>::
+masterGroupNodePressures() const
+{
+    assert(this->report_step_data_);
+    return this->report_step_data_->masterGroupNodePressures();
 }
 
 template <class Scalar>
@@ -220,6 +256,15 @@ receiveInjectionGroupTargetsFromMaster(std::size_t num_targets)
 }
 
 template <class Scalar>
+void
+ReservoirCouplingSlave<Scalar>::
+receiveMasterGroupNodePressuresFromMaster(std::size_t num_pressures)
+{
+    assert(this->report_step_data_);
+    this->report_step_data_->receiveMasterGroupNodePressuresFromMaster(num_pressures);
+}
+
+template <class Scalar>
 double
 ReservoirCouplingSlave<Scalar>::
 receiveNextTimeStepFromMaster() {
@@ -247,11 +292,29 @@ receiveNextTimeStepFromMaster() {
 }
 
 template <class Scalar>
+void
+ReservoirCouplingSlave<Scalar>::
+receiveCoupledNetworkActiveStatusFromMaster()
+{
+    assert(this->report_step_data_);
+    this->report_step_data_->receiveCoupledNetworkActiveStatusFromMaster();
+}
+
+template <class Scalar>
 std::pair<std::size_t, std::size_t>
 ReservoirCouplingSlave<Scalar>::
 receiveNumGroupConstraintsFromMaster() const {
     assert(this->report_step_data_);
     return this->report_step_data_->receiveNumGroupConstraintsFromMaster();
+}
+
+template <class Scalar>
+std::pair<std::size_t, bool>
+ReservoirCouplingSlave<Scalar>::
+receiveNumMasterGroupNodePressuresFromMaster()
+{
+    assert(this->report_step_data_);
+    return this->report_step_data_->receiveNumMasterGroupNodePressuresFromMaster();
 }
 
 template <class Scalar>

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlave.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlave.hpp
@@ -90,6 +90,11 @@ public:
     /// @details Delegates to ReservoirCouplingSlaveReportStep.
     bool lastReceivedMasterGroupNodePressuresIsFinal() const;
 
+    /// @brief Whether this slave is connected to the master's cross-rescoup
+    ///   network this sync step.
+    /// @details Delegates to ReservoirCouplingSlaveReportStep.
+    bool connectedToMasterCoupledNetwork() const;
+
     ReservoirCoupling::Logger& logger() { return this->logger_; }
     ReservoirCoupling::Logger& logger() const { return this->logger_; }
     /// @brief Get the master-computed network-leaf node pressure for a master group

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlave.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlave.hpp
@@ -44,6 +44,7 @@ public:
     using SlaveGroupInjectionData = ReservoirCoupling::SlaveGroupInjectionData<Scalar>;
     using SlaveGroupProductionData = ReservoirCoupling::SlaveGroupProductionData<Scalar>;
     using InjectionGroupTarget = ReservoirCoupling::InjectionGroupTarget<Scalar>;
+    using MasterGroupNodePressure = ReservoirCoupling::MasterGroupNodePressure<Scalar>;
     using MasterProductionLimits = typename ReservoirCoupling::MasterProductionLimits<Scalar>;
     using ProductionGroupConstraints = ReservoirCoupling::ProductionGroupConstraints<Scalar>;
 
@@ -57,6 +58,10 @@ public:
     const std::string& getSlaveName() const { return slave_name_; }
     const std::map<std::string, std::string>& getSlaveToMasterGroupNameMap() const {
         return slave_to_master_group_map_; }
+    /// @brief Check if a master-computed network-leaf node pressure exists for a master group
+    /// @details Delegates to ReservoirCouplingSlaveReportStep
+    bool hasMasterGroupNodePressure(const std::string& gname) const;
+
     /// @brief Check if a master-imposed injection target exists for a group and phase
     /// @details Delegates to ReservoirCouplingSlaveReportStep
     bool hasMasterInjectionTarget(const std::string& gname, const Phase phase) const;
@@ -79,8 +84,22 @@ public:
     /// @return true if this is the last substep of a "sync" timestep, false if not
     bool isLastSubstepOfSyncTimestep() const;
     bool isSlaveGroup(const std::string& group_name) const;
+
+    /// @brief Whether the most recent master-group-node-pressures receive
+    ///   carried the `is_final` flag.
+    /// @details Delegates to ReservoirCouplingSlaveReportStep.
+    bool lastReceivedMasterGroupNodePressuresIsFinal() const;
+
     ReservoirCoupling::Logger& logger() { return this->logger_; }
     ReservoirCoupling::Logger& logger() const { return this->logger_; }
+    /// @brief Get the master-computed network-leaf node pressure for a master group
+    /// @details Delegates to ReservoirCouplingSlaveReportStep
+    Scalar masterGroupNodePressure(const std::string& gname) const;
+
+    /// @brief Get the full map of master-computed network-leaf node pressures
+    /// @details Delegates to ReservoirCouplingSlaveReportStep
+    const std::map<std::string, Scalar>& masterGroupNodePressures() const;
+
     /// @brief Get the master-imposed injection target and control mode for a group and phase
     /// @details Delegates to ReservoirCouplingSlaveReportStep
     std::pair<Scalar, Group::InjectionCMode> masterInjectionTarget(
@@ -95,11 +114,26 @@ public:
     std::pair<Scalar, Group::ProductionCMode> masterProductionTarget(const std::string& gname) const;
     void maybeActivate(int report_step);
     std::size_t numSlaveGroups() const { return this->slave_group_order_.size(); }
+    /// @brief Receive the master's single-bool flag for the current sync
+    ///   timestep and mirror it into the slave's local is_final state.
+    /// @details Delegates to ReservoirCouplingSlaveReportStep.  Side effect:
+    ///   updates last_received_master_group_node_pressures_is_final_; query
+    ///   it via lastReceivedMasterGroupNodePressuresIsFinal().
+    void receiveCoupledNetworkActiveStatusFromMaster();
     double receiveNextTimeStepFromMaster();
     std::pair<std::size_t, std::size_t> receiveNumGroupConstraintsFromMaster() const;
     /// @brief Receive injection group targets from master and store them locally
     /// @details Delegates to ReservoirCouplingSlaveReportStep
     void receiveInjectionGroupTargetsFromMaster(std::size_t num_targets);
+
+    /// @brief Receive master-computed network-leaf node pressures from master
+    /// @details Delegates to ReservoirCouplingSlaveReportStep
+    void receiveMasterGroupNodePressuresFromMaster(std::size_t num_pressures);
+
+    /// @brief Receive the master-group-node-pressures header from master.
+    /// @details Delegates to ReservoirCouplingSlaveReportStep.  Returns
+    ///   (num_pressures, is_final).
+    std::pair<std::size_t, bool> receiveNumMasterGroupNodePressuresFromMaster();
 
     /// @brief Receive production group constraints from master and store them locally
     /// @details Delegates to ReservoirCouplingSlaveReportStep

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.cpp
@@ -141,6 +141,12 @@ receiveCoupledNetworkActiveStatusFromMaster()
     this->comm().broadcast(&payload, /*count=*/1, /*emitter_rank=*/0);
     const bool active = payload != 0u;
     this->last_received_master_group_node_pressures_is_final_ = !active;
+    // No coupled-network iteration this sync step: the per-iteration pressure
+    // receive (which clears the map) is not entered, so drop any pressures
+    // left over from a previous sync step to avoid re-applying stale THP limits.
+    if (!active) {
+        this->master_group_node_pressures_.clear();
+    }
     this->logger().debug(fmt::format(
         "Received coupled-network active status (active={}) from master process",
         active));
@@ -278,6 +284,12 @@ receiveNumMasterGroupNodePressuresFromMaster()
     const auto num_pressures = header[0];
     const bool is_final = header[1] != 0u;
     this->last_received_master_group_node_pressures_is_final_ = is_final;
+    // When the master sends count == 0 the payload receive (which clears and
+    // repopulates the map) is skipped by the caller. Clear here so stale
+    // pressures from a previous iteration are not re-applied as THP limits.
+    if (num_pressures == 0) {
+        this->master_group_node_pressures_.clear();
+    }
     this->logger().debug(fmt::format(
         "Received master-group-node-pressures header (count={}, is_final={}) from master process",
         num_pressures, is_final

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.cpp
@@ -52,6 +52,14 @@ ReservoirCouplingSlaveReportStep(
 template <class Scalar>
 bool
 ReservoirCouplingSlaveReportStep<Scalar>::
+hasMasterGroupNodePressure(const std::string& gname) const
+{
+    return this->master_group_node_pressures_.count(gname) > 0;
+}
+
+template <class Scalar>
+bool
+ReservoirCouplingSlaveReportStep<Scalar>::
 hasMasterInjectionTarget(const std::string& gname, const Phase phase) const
 {
     return this->master_injection_targets_.count({phase, gname}) > 0;
@@ -71,6 +79,14 @@ ReservoirCouplingSlaveReportStep<Scalar>::
 hasMasterProductionTarget(const std::string& gname) const
 {
     return this->master_production_targets_.count(gname) > 0;
+}
+
+template <class Scalar>
+Scalar
+ReservoirCouplingSlaveReportStep<Scalar>::
+masterGroupNodePressure(const std::string& gname) const
+{
+    return this->master_group_node_pressures_.at(gname);
 }
 
 template <class Scalar>
@@ -95,6 +111,39 @@ ReservoirCouplingSlaveReportStep<Scalar>::
 masterProductionTarget(const std::string& gname) const
 {
     return this->master_production_targets_.at(gname);
+}
+
+// Receive the master's single-bool flag telling the slave whether the master
+// will iterate the cross-rescoup network exchange this sync timestep.
+// Mirrored into `last_received_master_group_node_pressures_is_final_`:
+// is_final = !active, so when the master is active the slave's outer-loop
+// gate sees "not final" and participates in the per-iteration node-pressure
+// receive in updateWellControlsAndNetworkIteration.
+template <class Scalar>
+void
+ReservoirCouplingSlaveReportStep<Scalar>::
+receiveCoupledNetworkActiveStatusFromMaster()
+{
+    std::size_t payload = 0u;
+    if (this->comm().rank() == 0) {
+        auto MPI_SIZE_T_TYPE = Dune::MPITraits<std::size_t>::getType();
+        // NOTE: See comment about error handling at the top of this file.
+        MPI_Recv(
+            &payload,
+            /*count=*/1,
+            /*datatype=*/MPI_SIZE_T_TYPE,
+            /*source_rank=*/0,
+            /*tag=*/static_cast<int>(MessageTag::CoupledNetworkActiveStatus),
+            this->getSlaveMasterComm(),
+            MPI_STATUS_IGNORE
+        );
+    }
+    this->comm().broadcast(&payload, /*count=*/1, /*emitter_rank=*/0);
+    const bool active = payload != 0u;
+    this->last_received_master_group_node_pressures_is_final_ = !active;
+    this->logger().debug(fmt::format(
+        "Received coupled-network active status (active={}) from master process",
+        active));
 }
 
 template <class Scalar>
@@ -139,6 +188,45 @@ receiveInjectionGroupTargetsFromMaster(std::size_t num_targets)
 }
 
 template <class Scalar>
+void
+ReservoirCouplingSlaveReportStep<Scalar>::
+receiveMasterGroupNodePressuresFromMaster(std::size_t num_pressures)
+{
+    std::vector<MasterGroupNodePressure> pressures(num_pressures);
+    if (this->comm().rank() == 0) {
+        auto MPI_MASTER_GROUP_NODE_PRESSURE_TYPE =
+            Dune::MPITraits<MasterGroupNodePressure>::getType();
+        // NOTE: See comment about error handling at the top of this file.
+        MPI_Recv(
+            pressures.data(),
+            /*count=*/num_pressures,
+            /*datatype=*/MPI_MASTER_GROUP_NODE_PRESSURE_TYPE,
+            /*source_rank=*/0,
+            /*tag=*/static_cast<int>(MessageTag::MasterGroupNodePressures),
+            this->getSlaveMasterComm(),
+            MPI_STATUS_IGNORE
+        );
+        this->logger().debug(fmt::format(
+            "Received {} master group node pressures from master process rank 0",
+            num_pressures
+        ));
+    }
+    this->comm().broadcast(
+        pressures.data(), num_pressures, /*emitter_rank=*/0
+    );
+    // Clear old pressures before storing new ones from master
+    this->master_group_node_pressures_.clear();
+    for (const auto& entry : pressures) {
+        const auto& group_name = this->slave_.slaveGroupIdxToGroupName(entry.group_name_idx);
+        this->setMasterGroupNodePressure(group_name, entry.pressure);
+        this->logger().debug(fmt::format(
+            "Stored master group node pressure for group '{}': pressure={}",
+            group_name, entry.pressure
+        ));
+    }
+}
+
+template <class Scalar>
 std::pair<std::size_t, std::size_t>
 ReservoirCouplingSlaveReportStep<Scalar>::
 receiveNumGroupConstraintsFromMaster() const {
@@ -164,6 +252,37 @@ receiveNumGroupConstraintsFromMaster() const {
                              "production constraints: {} from master process",
                              num_injection_targets, num_production_constraints));
     return std::make_pair(num_injection_targets, num_production_constraints);
+}
+
+template <class Scalar>
+std::pair<std::size_t, bool>
+ReservoirCouplingSlaveReportStep<Scalar>::
+receiveNumMasterGroupNodePressuresFromMaster()
+{
+    std::vector<std::size_t> header(2);
+    if (this->comm().rank() == 0) {
+        auto MPI_SIZE_T_TYPE = Dune::MPITraits<std::size_t>::getType();
+        // NOTE: See comment about error handling at the top of this file.
+        MPI_Recv(
+            header.data(),
+            /*count=*/2,
+            /*datatype=*/MPI_SIZE_T_TYPE,
+            /*source_rank=*/0,
+            /*tag=*/static_cast<int>(MessageTag::NumMasterGroupNodePressures),
+            this->getSlaveMasterComm(),
+            MPI_STATUS_IGNORE
+        );
+        this->logger().debug("Received master-group-node-pressures header from master process rank 0");
+    }
+    this->comm().broadcast(header.data(), /*count=*/2, /*emitter_rank=*/0);
+    const auto num_pressures = header[0];
+    const bool is_final = header[1] != 0u;
+    this->last_received_master_group_node_pressures_is_final_ = is_final;
+    this->logger().debug(fmt::format(
+        "Received master-group-node-pressures header (count={}, is_final={}) from master process",
+        num_pressures, is_final
+    ));
+    return {num_pressures, is_final};
 }
 
 template <class Scalar>
@@ -231,6 +350,14 @@ sendProductionDataToMaster(
 ) const
 {
     sendDataToMaster_(production_data, MessageTag::SlaveProductionData, "production data");
+}
+
+template <class Scalar>
+void
+ReservoirCouplingSlaveReportStep<Scalar>::
+setMasterGroupNodePressure(const std::string& gname, const Scalar pressure)
+{
+    this->master_group_node_pressures_[gname] = pressure;
 }
 
 template <class Scalar>

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.cpp
@@ -139,7 +139,10 @@ receiveCoupledNetworkActiveStatusFromMaster()
         );
     }
     this->comm().broadcast(&payload, /*count=*/1, /*emitter_rank=*/0);
+    // The received flag is now per-slave: "is this slave connected to the
+    // master's cross-rescoup network this sync step?".
     const bool active = payload != 0u;
+    this->connected_to_master_coupled_network_ = active;
     this->last_received_master_group_node_pressures_is_final_ = !active;
     // No coupled-network iteration this sync step: the per-iteration pressure
     // receive (which clears the map) is not entered, so drop any pressures

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.hpp
@@ -56,6 +56,7 @@ class ReservoirCouplingSlaveReportStep {
 public:
     using InjectionGroupTarget = ReservoirCoupling::InjectionGroupTarget<Scalar>;
     using ProductionGroupConstraints = ReservoirCoupling::ProductionGroupConstraints<Scalar>;
+    using MasterGroupNodePressure = ReservoirCoupling::MasterGroupNodePressure<Scalar>;
     using MessageTag = ReservoirCoupling::MessageTag;
     using MasterProductionLimits = ReservoirCoupling::MasterProductionLimits<Scalar>;
     using SlaveGroupInjectionData = ReservoirCoupling::SlaveGroupInjectionData<Scalar>;
@@ -80,6 +81,11 @@ public:
     /// @param phase Injection phase (e.g., Phase::WATER, Phase::GAS)
     /// @return true if the master sent an injection target for this group/phase pair
     bool hasMasterInjectionTarget(const std::string& gname, const Phase phase) const;
+
+    /// @brief Check if a master-computed network-leaf node pressure exists for a master group
+    /// @param gname Slave group name
+    /// @return true if the master sent a node pressure for this group
+    bool hasMasterGroupNodePressure(const std::string& gname) const;
 
     /// @brief Check if master-imposed per-rate-type production limits exist for a group
     /// @param gname Slave group name
@@ -111,6 +117,17 @@ public:
     /// @return Reference to the logger object for this coupling session
     ReservoirCoupling::Logger& logger() const { return this->slave_.logger(); }
 
+    /// @brief Get the master-computed network-leaf node pressure for a master group
+    /// @param gname Slave group name
+    /// @return Node pressure (SI units, Pa)
+    /// @throws std::out_of_range if no pressure exists for the given group
+    Scalar masterGroupNodePressure(const std::string& gname) const;
+
+    /// @brief Get the full map of master-computed network-leaf node pressures
+    /// @return Map keyed by slave group name; values are pressures in SI units (Pa)
+    const std::map<std::string, Scalar>& masterGroupNodePressures() const
+    { return master_group_node_pressures_; }
+
     /// @brief Get the master-imposed injection target and control mode for a group and phase
     /// @param gname Slave group name
     /// @param phase Injection phase
@@ -130,6 +147,34 @@ public:
     /// @return Pair of (target rate, control mode)
     /// @throws std::out_of_range if no target exists for the given group
     std::pair<Scalar, Group::ProductionCMode> masterProductionTarget(const std::string& gname) const;
+
+    /// @brief Receive master-computed network-leaf node pressures from master
+    ///   and store them locally.  Only emitted for master groups that are
+    ///   leaf nodes in the master's extended network.
+    /// @param num_pressures Number of pressure entries to receive
+    void receiveMasterGroupNodePressuresFromMaster(std::size_t num_pressures);
+
+    /// @brief Receive the master-group-node-pressures header from master.
+    /// @return (num_pressures, is_final).  is_final tells the slave whether
+    ///   the master is done iterating for the current sync timestep.
+    std::pair<std::size_t, bool> receiveNumMasterGroupNodePressuresFromMaster();
+
+    /// @brief Receive the master's single-bool flag for the current sync
+    ///   timestep and mirror it into
+    ///   `last_received_master_group_node_pressures_is_final_`
+    ///   (is_final = !active).
+    /// @details The flag is queryable via
+    ///   lastReceivedMasterGroupNodePressuresIsFinal().
+    void receiveCoupledNetworkActiveStatusFromMaster();
+
+    /// @brief Whether the most recent master-group-node-pressures receive
+    ///   carried the `is_final` flag.  Updated by every call to
+    ///   `receiveNumMasterGroupNodePressuresFromMaster`, and by
+    ///   `receiveCoupledNetworkActiveStatusFromMaster` at the start of
+    ///   each sync step.
+    /// @details See `last_received_master_group_node_pressures_is_final_` variable for details.
+    bool lastReceivedMasterGroupNodePressuresIsFinal() const
+    { return last_received_master_group_node_pressures_is_final_; }
 
     /// @brief Receive the number of injection and production constraints from master
     /// @return Pair of (num_injection_targets, num_production_constraints)
@@ -187,6 +232,11 @@ public:
     /// @brief Get the name of this slave process
     /// @return Reference to the name string for this slave
     const std::string& slaveName() const { return this->slave_.getSlaveName(); }
+
+    /// @brief Store a master-computed network-leaf node pressure for a master group
+    /// @param gname Slave group name
+    /// @param pressure Node pressure (SI units, Pa)
+    void setMasterGroupNodePressure(const std::string& gname, const Scalar pressure);
 
     /// @brief Store a master-imposed injection target for a group and phase
     /// @param gname Slave group name
@@ -253,6 +303,27 @@ private:
     // Per-rate-type production limits from master hierarchy. Key: slave group name.
     // A limit of -1 means no limit defined in the hierarchy for that rate type.
     std::map<std::string, MasterProductionLimits> master_production_limits_;
+    // Master-computed network-leaf node pressures keyed by slave group name. Only
+    // populated for master groups that are leaf nodes in the master's extended
+    // network. Cleared and repopulated on every receive cycle.
+    std::map<std::string, Scalar> master_group_node_pressures_;
+    // This variable is initialized for each sync step through the call chain: beginTimeStep()
+    //   -> BlackoilWellModelRescoup::sendCoupledNetworkActiveStatus()
+    //   -> BlackoilWellModelRescoup::masterNetworkHasMasterGroupLeaves()
+    // Which determines the value:
+    //   1) true : the master has no master groups connected to its network,
+    //             or has no network at all.
+    //   2) false: the master has master groups connected to its network (and the master has not
+    //             sent the final node pressures in the network iteration in BlackoilWellModel::assemble()).
+    //
+    // In the case of "false" above: The value is reset to "true" in the course of the network iteration
+    // in BlackoilWellModel::assemble() -> BlackoilWellModel::updateWellControlsAndNetworkIteration()
+    // based on the "more_network_update" return value of BlackoilWellModelNetwork::update().
+    // If it returns "false" the flag below is reset to "true" and stays true for the rest of the sync timestep.
+    //
+    // So in the case of "false" above: The slaves use this variable to determine when to exit
+    // the outer network loop such that the MPI master-slave communication protocol is kept in sync.
+    bool last_received_master_group_node_pressures_is_final_{true};
 };
 } // namespace Opm
 #endif // OPM_RESERVOIR_COUPLING_SLAVE_REPORT_STEP_HPP

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.hpp
@@ -176,6 +176,16 @@ public:
     bool lastReceivedMasterGroupNodePressuresIsFinal() const
     { return last_received_master_group_node_pressures_is_final_; }
 
+    /// @brief Whether this slave is connected to the master's cross-rescoup
+    ///   network this sync step (i.e. at least one of its master groups is a
+    ///   leaf node in the master network). Set by
+    ///   `receiveCoupledNetworkActiveStatusFromMaster` from the master's
+    ///   per-slave flag. Distinct from the per-iteration `is_final` flag: an
+    ///   unconnected slave never participates in the cross-rescoup exchange
+    ///   and balances only its own (local) network.
+    bool connectedToMasterCoupledNetwork() const
+    { return connected_to_master_coupled_network_; }
+
     /// @brief Receive the number of injection and production constraints from master
     /// @return Pair of (num_injection_targets, num_production_constraints)
     std::pair<std::size_t, std::size_t> receiveNumGroupConstraintsFromMaster() const;
@@ -307,22 +317,31 @@ private:
     // populated for master groups that are leaf nodes in the master's extended
     // network. Cleared and repopulated on every receive cycle.
     std::map<std::string, Scalar> master_group_node_pressures_;
-    // This variable is initialized for each sync step through the call chain: beginTimeStep()
-    //   -> BlackoilWellModelRescoup::sendCoupledNetworkActiveStatus()
-    //   -> BlackoilWellModelRescoup::masterNetworkHasMasterGroupLeaves()
-    // Which determines the value:
-    //   1) true : the master has no master groups connected to its network,
-    //             or has no network at all.
-    //   2) false: the master has master groups connected to its network (and the master has not
-    //             sent the final node pressures in the network iteration in BlackoilWellModel::assemble()).
+    // Whether *this* slave is connected to the master's cross-rescoup network
+    // this sync step. Set once per sync step by
+    // receiveCoupledNetworkActiveStatusFromMaster() from the master's per-slave
+    // flag (BlackoilWellModelRescoup::masterNetworkHasMasterGroupLeavesForSlave_()).
+    // A slave that is not connected does not participate in the cross-rescoup
+    // exchange at all and balances only its own (local) network.
     //
-    // In the case of "false" above: The value is reset to "true" in the course of the network iteration
+    // This is deliberately separate from
+    // last_received_master_group_node_pressures_is_final_ below: connectivity is
+    // a per-sync-step property, whereas is_final is the per-iteration
+    // termination signal (only meaningful while connected).
+    bool connected_to_master_coupled_network_{false};
+    // The iteration-termination flag. Initialized for each sync step through:
+    //   beginTimeStep() -> BlackoilWellModelRescoup::sendCoupledNetworkActiveStatus()
+    // to is_final = !connected (so an unconnected slave sees is_final = true and
+    // never enters the per-iteration receive). For a connected slave it then
+    // tracks the per-iteration is_final from the node-pressure header:
+    //
+    // In that case it is set to "true" in the course of the network iteration
     // in BlackoilWellModel::assemble() -> BlackoilWellModel::updateWellControlsAndNetworkIteration()
     // based on the "more_network_update" return value of BlackoilWellModelNetwork::update().
-    // If it returns "false" the flag below is reset to "true" and stays true for the rest of the sync timestep.
+    // If it returns "false" the flag is reset to "true" and stays true for the rest of the sync timestep.
     //
-    // So in the case of "false" above: The slaves use this variable to determine when to exit
-    // the outer network loop such that the MPI master-slave communication protocol is kept in sync.
+    // Connected slaves use this variable to determine when to exit the outer
+    // network loop such that the MPI master-slave communication protocol is kept in sync.
     bool last_received_master_group_node_pressures_is_final_{true};
 };
 } // namespace Opm

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -214,10 +214,10 @@ template<class Scalar> class WellContributions;
                 BlackoilWellModelGuideRates(*this)
                     .assignWellGuideRates(wsrpt, this->reportStepIndex());
 
-                this->assignWellTracerRates(wsrpt);
+                this->assignWellTracerRates_(wsrpt);
 
                 if constexpr (has_geochem_) {
-                    this->assignWellSpeciesRates(wsrpt);
+                    this->assignWellSpeciesRates_(wsrpt);
                 }
 
                 if (const auto& rspec = eclState().runspec();
@@ -368,6 +368,14 @@ template<class Scalar> class WellContributions;
 
             const Simulator& simulator() const
             { return simulator_; }
+            Simulator& simulator()
+            { return simulator_; }
+
+            BlackoilWellModelNetwork<TypeTag>& network() { return network_; }
+            const BlackoilWellModelNetwork<TypeTag>& network() const { return network_; }
+
+            std::vector<WellInterfacePtr>& wellContainer() { return well_container_; }
+            const std::vector<WellInterfacePtr>& wellContainer() const { return well_container_; }
 
             void setNlddAdapter(BlackoilWellModelNldd<TypeTag>* mod)
             { nldd_ = mod; }
@@ -419,10 +427,16 @@ template<class Scalar> class WellContributions;
             ReservoirCouplingMaster<Scalar>& reservoirCouplingMaster() {
                 return rescoup_.master();
             }
+            const ReservoirCouplingMaster<Scalar>& reservoirCouplingMaster() const {
+                return rescoup_.master();
+            }
 
             /// @brief Get reference to reservoir coupling slave
             /// @note Caller must ensure isReservoirCouplingSlave() is true
             ReservoirCouplingSlave<Scalar>& reservoirCouplingSlave() {
+                return rescoup_.slave();
+            }
+            const ReservoirCouplingSlave<Scalar>& reservoirCouplingSlave() const {
                 return rescoup_.slave();
             }
 
@@ -610,6 +624,59 @@ template<class Scalar> class WellContributions;
             void computeWellTemperature();
 
         private:
+            // Private helper methods (alphabetical order)
+            // --------------------------------------------
+
+            void assignWellSpeciesRates_(data::Wells& wsrpt) const;
+            void assignWellTracerRates_(data::Wells& wsrpt) const;
+
+            /// @brief True when the master is in the active cross-rescoup network
+            ///   iteration: master process AND first substep of a sync step AND at
+            ///   least one master group is a network leaf AND the master has not
+            ///   yet sent is_final = true.
+            /// @details Gates both the per-iteration master->slave node-pressure
+            ///   send inside updateWellControlsAndNetworkIteration() and the
+            ///   trailing-final send at the end of updateWellControlsAndNetwork().
+            bool isRescoupMasterCoupledNetworkIteration_() const;
+
+            /// @brief True when the slave is in the active cross-rescoup network
+            ///   iteration: isRescoupSlaveOnSyncStepFirstSubstep_() AND the master
+            ///   has not yet signaled termination via is_final.
+            /// @details Gates the per-iteration master->slave node-pressure
+            ///   receive at the top of updateWellControlsAndNetworkIteration(),
+            ///   and the bump of the slave's outer-loop iteration ceiling in
+            ///   updateWellControlsAndNetwork().
+            bool isRescoupSlaveCoupledNetworkIteration_() const;
+
+            /// @brief True when the slave is on the first substep of a sync step,
+            ///   regardless of the master's is_final state.
+            /// @details Gates post-Newton handling at the end of
+            ///   updateWellControlsAndNetworkIteration(), which must run on the
+            ///   terminating iteration too so the slave can set
+            ///   more_network_update = false and exit its outer loop.
+            bool isRescoupSlaveOnSyncStepFirstSubstep_() const;
+
+            /// @brief Slave-side: if the master is still iterating, ship fresh
+            ///   slave rates back and request another outer iteration; if the
+            ///   master has signaled termination, do nothing and exit the loop.
+            /// @param reportStepIdx Current report step.
+            /// @return New value for more_network_update: true to continue the
+            ///   slave's outer loop, false to exit.
+            bool maybeSendSlaveGroupFlowToMaster_(const int reportStepIdx);
+
+            /// @brief Master-side: send the trailing-final is_final = true to
+            ///   unblock the slave when the master's outer loop exited without
+            ///   having sent is_final via the normal per-iteration path (e.g.
+            ///   max_iter exceeded with the network still unconverged).
+            void sendSlaveNetworkLoopTerminationSignal_();
+
+            /// @brief Check if the network should be rebalanced initially at the start of a timestep.
+            /// @return True if the network should be rebalanced initially
+            bool shouldDoPreStepNetworkRebalance_(const int episodeIdx) const;
+
+            /// @brief Refresh the network's cached `active_` flag.
+            void updateNetworkActiveState_();
+
             BlackoilWellModelGasLift<TypeTag> gaslift_;
             BlackoilWellModelNetwork<TypeTag> network_;
 #ifdef RESERVOIR_COUPLING_ENABLED
@@ -625,9 +692,6 @@ template<class Scalar> class WellContributions;
 
             // Store cell rates after assembling to avoid iterating all wells and connections for every element
             std::map<int, RateVector> cellRates_;
-
-            void assignWellTracerRates(data::Wells& wsrpt) const;
-            void assignWellSpeciesRates(data::Wells& wsrpt) const;
 
             [[nodiscard]] auto rsConstInfo() const
                 -> typename WellState<Scalar,IndexTraits>::RsConstInfo;

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -630,6 +630,16 @@ template<class Scalar> class WellContributions;
             void assignWellSpeciesRates_(data::Wells& wsrpt) const;
             void assignWellTracerRates_(data::Wells& wsrpt) const;
 
+            /// @brief True when this process takes part in a *shared* (cross-rescoup)
+            ///   network this sync step: a master with at least one master-group
+            ///   network leaf, or a slave connected to the master's network.
+            /// @details Used to gate operations whose inner network solve would
+            ///   run the cross-rescoup pressure/rate exchange. A non-participant
+            ///   (master with no leaves, or an unconnected slave) does no
+            ///   cross-rescoup MPI in the network solve and so is safe to treat
+            ///   like a standalone process.
+            bool isRescoupCoupledNetworkParticipant_() const;
+
             /// @brief True when the master is in the active cross-rescoup network
             ///   iteration: master process AND first substep of a sync step AND at
             ///   least one master group is a network leaf AND the master has not
@@ -655,6 +665,16 @@ template<class Scalar> class WellContributions;
             ///   terminating iteration too so the slave can set
             ///   more_network_update = false and exit its outer loop.
             bool isRescoupSlaveOnSyncStepFirstSubstep_() const;
+
+            /// @brief True when this slave participates in the master's
+            ///   cross-rescoup network this sync step (at least one of its
+            ///   master groups is a leaf in the master network).
+            /// @details Distinct from isRescoupSlaveOnSyncStepFirstSubstep_():
+            ///   a slave can be on its first sync substep yet not be connected
+            ///   to the master network, in which case it balances only its own
+            ///   (local) network and does not take part in the cross-rescoup
+            ///   exchange.
+            bool isRescoupSlaveConnectedToMasterNetwork_() const;
 
             /// @brief Slave-side: if the master is still iterating, ship fresh
             ///   slave rates back and request another outer iteration; if the

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
@@ -92,6 +92,14 @@ updateActiveState(const int report_step)
         const auto& rescoup_master = rescoup_proxy.master();
         const auto num_slaves = rescoup_master.numSlaves();
         for (std::size_t s = 0; s < num_slaves && !network_active; ++s) {
+            // Only an activated slave supplies leaf rates this step; a master
+            // group whose slave is inactive must not keep the network active
+            // (it would be solved against missing/stale slave rates). This
+            // matches the slaveIsActivated gate used in the coupled-network
+            // iteration.
+            if (!rescoup_master.slaveIsActivated(s)) {
+                continue;
+            }
             for (const auto& master_group : rescoup_master.getMasterGroupNamesForSlave(s)) {
                 if (network.has_node(master_group)) {
                     network_active = true;

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
@@ -81,6 +81,26 @@ updateActiveState(const int report_step)
             break;
         }
     }
+#ifdef RESERVOIR_COUPLING_ENABLED
+    // A reservoir coupling master may have no local wells in the network
+    // leaf groups, the leaf rates come from slave-reported
+    // network_surface_rates instead.  Without this clause the master's
+    // network solver short-circuits via active_=false and the leaf
+    // pressures are never iterated.
+    const auto& rescoup_proxy = well_model_.groupStateHelper().rescoup();
+    if (!network_active && rescoup_proxy.isMaster()) {
+        const auto& rescoup_master = rescoup_proxy.master();
+        const auto num_slaves = rescoup_master.numSlaves();
+        for (std::size_t s = 0; s < num_slaves && !network_active; ++s) {
+            for (const auto& master_group : rescoup_master.getMasterGroupNamesForSlave(s)) {
+                if (network.has_node(master_group)) {
+                    network_active = true;
+                    break;
+                }
+            }
+        }
+    }
+#endif
     this->active_ = well_model_.comm().max(network_active);
 }
 

--- a/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
@@ -62,7 +62,9 @@ doPreStepRebalance(DeferredLogger& deferred_logger)
     auto& well_state = well_model_.wellState();
 
     const bool changed_well_group =
-        well_model_.updateWellControlsAndNetwork(true, dt, deferred_logger);
+        well_model_.updateWellControlsAndNetwork(/*mandatory_network_balance=*/true,
+                                                 dt,
+                                                 deferred_logger);
     well_model_.assembleWellEqWithoutIteration(dt);
     const bool converged =
         well_model_.getWellConvergence(well_model_.B_avg(), true).converged() &&
@@ -93,7 +95,7 @@ update(const bool mandatory_network_balance,
     const int episodeIdx = well_model_.simulator().episodeIndex();
     const auto& network = well_model_.schedule()[episodeIdx].network();
     if (!well_model_.wellsActive() && !network.active()) {
-        return {false, 0.0};
+        return {/*more_network_update=*/false, /*network_imbalance=*/0.0};
     }
 
     const auto& comm = well_model_.simulator().vanguard().grid().comm();

--- a/opm/simulators/wells/BlackoilWellModelRescoup.hpp
+++ b/opm/simulators/wells/BlackoilWellModelRescoup.hpp
@@ -34,23 +34,99 @@ namespace Opm {
     class DeferredLogger;
     class Schedule;
     template<class TypeTag> class BlackoilWellModel;
+    template<class Scalar, class IndexTraits> class GroupStateHelper;
+    template<class Scalar, class IndexTraits> class WellState;
+    template<class Scalar> class ReservoirCouplingMaster;
+    template<class Scalar> class ReservoirCouplingSlave;
 }
 
 namespace Opm {
 
 /// \brief Reservoir-coupling flow helper bound to a BlackoilWellModel.
 ///
-/// Holds no state of its own; all methods reach back to the parent
-/// BlackoilWellModel via well_model_ and forward to the helpers in
-/// opm/simulators/wells/rescoup/.  Construct once per BlackoilWellModel.
+/// All methods reach back to the parent BlackoilWellModel via well_model_
+/// (and a few cached references to commonly-accessed sub-objects) and
+/// forward to the helpers in opm/simulators/wells/rescoup/.  Construct
+/// once per BlackoilWellModel.
+///
+/// The mode-query, accessor and reservoir-coupling-facade wrappers in
+/// the public section are pure forwarders -- they exist so the method
+/// bodies in BlackoilWellModelRescoup_impl.hpp read as `this->X()`
+/// rather than `this->well_model_.X()`.
 template<typename TypeTag>
 class BlackoilWellModelRescoup {
-    using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
-    using Scalar      = GetPropType<TypeTag, Properties::Scalar>;
-    using IndexTraits = typename FluidSystem::IndexTraitsType;
+    using FluidSystem     = GetPropType<TypeTag, Properties::FluidSystem>;
+    using Scalar          = GetPropType<TypeTag, Properties::Scalar>;
+    using IndexTraits     = typename FluidSystem::IndexTraitsType;
+    using Simulator       = GetPropType<TypeTag, Properties::Simulator>;
+    using ModelParameters = BlackoilModelParameters<Scalar>;
+    using WellInterfacePtr = typename BlackoilWellModel<TypeTag>::WellInterfacePtr;
 
 public:
     explicit BlackoilWellModelRescoup(BlackoilWellModel<TypeTag>& well_model);
+
+    // === Mode queries and rescoup-facade forwarders ===
+
+    bool isReservoirCouplingMaster() const { return well_model_.isReservoirCouplingMaster(); }
+    bool isReservoirCouplingSlave()  const { return well_model_.isReservoirCouplingSlave(); }
+
+    ReservoirCouplingMaster<Scalar>& reservoirCouplingMaster()
+    { return well_model_.reservoirCouplingMaster(); }
+    const ReservoirCouplingMaster<Scalar>& reservoirCouplingMaster() const
+    { return well_model_.reservoirCouplingMaster(); }
+
+    ReservoirCouplingSlave<Scalar>& reservoirCouplingSlave()
+    { return well_model_.reservoirCouplingSlave(); }
+    const ReservoirCouplingSlave<Scalar>& reservoirCouplingSlave() const
+    { return well_model_.reservoirCouplingSlave(); }
+
+    // === Common-state accessor forwarders ===
+
+    GroupStateHelper<Scalar, IndexTraits>& groupStateHelper()
+    { return well_model_.groupStateHelper(); }
+    const GroupStateHelper<Scalar, IndexTraits>& groupStateHelper() const
+    { return well_model_.groupStateHelper(); }
+
+    WellState<Scalar, IndexTraits>& wellState()
+    { return well_model_.wellState(); }
+    const WellState<Scalar, IndexTraits>& wellState() const
+    { return well_model_.wellState(); }
+
+    const Schedule& schedule() const { return well_model_.schedule(); }
+
+    std::vector<WellInterfacePtr>& wellContainer()
+    { return well_model_.wellContainer(); }
+
+    // === Rescoup flow methods ===
+
+    /// \brief True if the most recent sendMasterGroupNodePressuresToSlaves
+    ///   carried is_final = true (or if no send has happened yet).  Used
+    ///   to gate redundant sends and to decide whether a trailing-final
+    ///   send is needed when the master's outer loop exits.  Default true:
+    ///   the slave is in the "not waiting for master" state until the
+    ///   first non-final send happens.
+    bool lastSentMasterGroupNodePressuresIsFinal() const
+    { return last_sent_master_group_node_pressures_is_final_; }
+
+    /// \brief True if at least one master group is a leaf node in the
+    ///   master's extended network.  False when (a) the master is not
+    ///   in rescoup-master mode, (b) the master has no active extended
+    ///   network, or (c) the master's network has leaves but none of
+    ///   them correspond to a master group of any slave.
+    ///
+    /// Used as the gate for the cross-rescoup network exchange.
+    /// Queries the parsed Schedule topology so the answer is correct
+    /// at every call site including the very first beginTimeStep call.
+    bool masterNetworkHasMasterGroupLeaves() const;
+
+    /// \brief Slave-side counterpart of sendCoupledNetworkActiveStatus().
+    ///
+    /// Blocking receive of the master's per-sync-step "is the cross-rescoup
+    /// network exchange active?" flag.  Mirrored into the slave's
+    /// lastReceivedMasterGroupNodePressuresIsFinal() so the slave's updateWellControlsAndNetworkIteration()
+    /// gates see the master's iteration decision before updateWellControlsAndNetworkIteration() runs.
+    /// Called from the slave's beginTimeStep first-substep handshake.
+    void receiveCoupledNetworkActiveStatus();
 
     /// \brief Slave-side counterpart of sendMasterGroupConstraintsToSlaves().
     ///
@@ -59,6 +135,11 @@ public:
     /// written into the slave's group state via the receiver helper.
     /// Called from the slave's beginTimeStep first-substep handshake.
     void receiveGroupConstraintsFromMaster();
+
+    /// \brief Receive master-computed network-leaf node pressures and
+    ///   apply them as dynamic THP limits on every slave producer
+    ///   whose group has a master-supplied pressure.
+    void receiveMasterGroupNodePressuresFromMaster();
 
     /// \brief Master-side blocking receive of per-slave production data
     ///   (rates, potentials, and injection data) from every activated slave.
@@ -77,6 +158,18 @@ public:
     /// of the sync step.  Called from timeStepSucceeded.
     void rescoupSyncSummaryData();
 
+    /// \brief Master-side: send a single boolean to every activated slave
+    ///   telling it whether the master will iterate the cross-rescoup
+    ///   network exchange this sync timestep.  active = true iff at least
+    ///   one master group is a leaf in the master's extended network (see
+    ///   masterNetworkHasMasterGroupLeaves()).  Called from the master's
+    ///   beginTimeStep first-substep handshake.
+    ///
+    /// Side effect: updates last_sent_master_group_node_pressures_is_final_
+    /// (is_final = !active) so the master's own updateWellControlsAndNetworkIteration()
+    /// gates pick up the initial state.
+    void sendCoupledNetworkActiveStatus();
+
     /// \brief Master-side: compute per-master-group production targets and
     ///   injection limits, then dispatch them to each activated slave.
     ///
@@ -85,6 +178,16 @@ public:
     /// calculator helper.  Called from the master's beginTimeStep
     /// first-substep handshake.
     void sendMasterGroupConstraintsToSlaves();
+
+    /// \brief Send master-computed network-leaf node pressures to each
+    ///   activated slave so the slave can apply them as dynamic THP
+    ///   limits on its producers in the corresponding master groups.
+    /// \param is_final True if this is the master's final pressure
+    ///   send for the current sync timestep; false if the master is
+    ///   iterating and expects updated rates back from the slave.
+    ///
+    /// Side effect: updates last_sent_master_group_node_pressures_is_final_.
+    void sendMasterGroupNodePressuresToSlaves(bool is_final);
 
     /// \brief Slave-side counterpart of receiveSlaveGroupData().
     ///
@@ -100,6 +203,12 @@ public:
 
 private:
     BlackoilWellModel<TypeTag>& well_model_;
+    BlackoilWellModelNetwork<TypeTag>& network_;
+    Simulator& simulator_;
+    const ModelParameters& param_;
+
+    // See lastSentMasterGroupNodePressuresIsFinal().
+    bool last_sent_master_group_node_pressures_is_final_{true};
 };
 
 } // namespace Opm

--- a/opm/simulators/wells/BlackoilWellModelRescoup.hpp
+++ b/opm/simulators/wells/BlackoilWellModelRescoup.hpp
@@ -202,6 +202,14 @@ public:
     std::optional<ReservoirCoupling::ScopedLoggerGuard> setupScopedLogger(DeferredLogger& local_logger);
 
 private:
+    /// \brief Per-slave variant of masterNetworkHasMasterGroupLeaves():
+    ///   true iff at least one of the given slave's master groups is a
+    ///   leaf node in the master's extended network.  This is what
+    ///   determines whether *that* slave participates in the cross-rescoup
+    ///   network exchange; the (public) global version is the OR over all
+    ///   activated slaves and gates the master's own iteration.
+    bool masterNetworkHasMasterGroupLeavesForSlave_(std::size_t slave_idx) const;
+
     BlackoilWellModel<TypeTag>& well_model_;
     BlackoilWellModelNetwork<TypeTag>& network_;
     Simulator& simulator_;

--- a/opm/simulators/wells/BlackoilWellModelRescoup_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelRescoup_impl.hpp
@@ -63,17 +63,12 @@ masterNetworkHasMasterGroupLeaves() const
     // `node_pressures_` map.  The runtime map is empty on the very first beginTimeStep call
     // (network_.update has not yet run for this substep).
     if (!this->isReservoirCouplingMaster()) return false;
-    const int episodeIdx = this->simulator_.episodeIndex();
-    const auto& network = this->schedule()[episodeIdx].network();
-    if (!network.active()) return false;
     const auto& rcm = this->reservoirCouplingMaster();
     const auto num_slaves = rcm.numSlaves();
     for (std::size_t s = 0; s < num_slaves; ++s) {
         if (!rcm.slaveIsActivated(s)) continue;
-        for (const auto& mg : rcm.getMasterGroupNamesForSlave(s)) {
-            if (network.has_node(mg)) {
-                return true;
-            }
+        if (this->masterNetworkHasMasterGroupLeavesForSlave_(s)) {
+            return true;
         }
     }
     return false;
@@ -124,6 +119,21 @@ receiveMasterGroupNodePressuresFromMaster()
     // directly, because setDynamicThpLimit() alone leaves the active
     // control's THP value stale and the subsequent well-solve would
     // converge against the old THP.
+    //
+    // TODO (follow-up PR): this THP-direct path is only correct when the
+    // slave has no extended network between its slave group and the wells
+    // (the case exercised here).  When the slave uses an extended network
+    // with the slave group declared as a fixed-pressure node, the master-
+    // supplied pressure should instead be installed as that node's terminal
+    // pressure and the slave's network solver should propagate it down to
+    // the wells.  The plumbing exists -- the solver already reads
+    // Network::Node::terminal_pressure() when walking up branches -- but
+    // surfacing the master-sent value into the solver needs a runtime
+    // override path (e.g. a fixed-pressure override map on
+    // BlackoilWellModelNetwork) so we do not mutate the parsed Schedule
+    // network at runtime.  Until then, decks where the slave group is a
+    // fixed-pressure node in the slave's extended network are not handled
+    // correctly.
     const auto& pressures = rescoup_slave.masterGroupNodePressures();
     if (pressures.empty()) return;
     const auto& summary_state = this->well_model_.summaryState();
@@ -188,22 +198,30 @@ sendCoupledNetworkActiveStatus()
 {
     OPM_TIMEFUNCTION();
     assert(this->isReservoirCouplingMaster());
-    // Send to each activated slave a single bool: "will the master iterate
-    // the cross-rescoup network exchange this sync timestep?".  Sent as a
-    // dedicated one-element MPI message; the per-iteration node-pressure
-    // sends inside updateWellControlsAndNetworkIteration() carry their own
-    // is_final flag in the NumMasterGroupNodePressures header.
-    const bool active = this->masterNetworkHasMasterGroupLeaves();
+    // Send to each activated slave a single bool: "are you connected to the
+    // master's cross-rescoup network this sync timestep?", i.e. does this
+    // slave have a master group that is a leaf in the master network.  This
+    // is per-slave: a slave with no leaf in the master network does not
+    // participate even if other slaves do.  Sent as a dedicated one-element
+    // MPI message; the per-iteration node-pressure sends inside
+    // updateWellControlsAndNetworkIteration() carry their own is_final flag
+    // in the NumMasterGroupNodePressures header.
     auto& rescoup_master = this->reservoirCouplingMaster();
     const auto num_slaves = rescoup_master.numSlaves();
+    bool any_connected = false;
     for (std::size_t slave_idx = 0; slave_idx < num_slaves; ++slave_idx) {
         if (rescoup_master.slaveIsActivated(slave_idx)) {
-            rescoup_master.sendCoupledNetworkActiveStatusToSlave(slave_idx, active);
+            const bool connected =
+                this->masterNetworkHasMasterGroupLeavesForSlave_(slave_idx);
+            any_connected = any_connected || connected;
+            rescoup_master.sendCoupledNetworkActiveStatusToSlave(slave_idx, connected);
         }
     }
-    // Mirror into the master's local is_final state so the master's own
-    // updateWellControlsAndNetworkIteration() gates see the initial value before the per-iteration sends.
-    this->last_sent_master_group_node_pressures_is_final_ = !active;
+    // Mirror the *global* active state into the master's own is_final flag:
+    // the master iterates the exchange iff at least one slave is connected.
+    // (This must stay global -- a per-slave value would break the master's
+    // own updateWellControlsAndNetworkIteration() gate.)
+    this->last_sent_master_group_node_pressures_is_final_ = !any_connected;
 }
 
 template<typename TypeTag>
@@ -290,6 +308,30 @@ setupScopedLogger(DeferredLogger& local_logger)
     }
     return std::nullopt;
 }
+
+// Private methods alphabetically
+// ------------------------------
+
+template<typename TypeTag>
+bool
+BlackoilWellModelRescoup<TypeTag>::
+masterNetworkHasMasterGroupLeavesForSlave_(std::size_t slave_idx) const
+{
+    // See masterNetworkHasMasterGroupLeaves() for why the parsed Schedule
+    // topology is queried rather than the runtime node_pressures_ map.
+    if (!this->isReservoirCouplingMaster()) return false;
+    const int episodeIdx = this->simulator_.episodeIndex();
+    const auto& network = this->schedule()[episodeIdx].network();
+    if (!network.active()) return false;
+    const auto& rcm = this->reservoirCouplingMaster();
+    for (const auto& mg : rcm.getMasterGroupNamesForSlave(slave_idx)) {
+        if (network.has_node(mg)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 
 } // namespace Opm
 

--- a/opm/simulators/wells/BlackoilWellModelRescoup_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelRescoup_impl.hpp
@@ -46,10 +46,48 @@ template<typename TypeTag>
 BlackoilWellModelRescoup<TypeTag>::
 BlackoilWellModelRescoup(BlackoilWellModel<TypeTag>& well_model)
     : well_model_{well_model}
+    , network_{well_model.network()}
+    , simulator_{well_model.simulator()}
+    , param_{well_model.param()}
 {}
 
 // Public methods alphabetically
 // ------------------------------
+
+template<typename TypeTag>
+bool
+BlackoilWellModelRescoup<TypeTag>::
+masterNetworkHasMasterGroupLeaves() const
+{
+    // Query the parsed Schedule topology (`network.has_node(...)`) rather than the runtime
+    // `node_pressures_` map.  The runtime map is empty on the very first beginTimeStep call
+    // (network_.update has not yet run for this substep).
+    if (!this->isReservoirCouplingMaster()) return false;
+    const int episodeIdx = this->simulator_.episodeIndex();
+    const auto& network = this->schedule()[episodeIdx].network();
+    if (!network.active()) return false;
+    const auto& rcm = this->reservoirCouplingMaster();
+    const auto num_slaves = rcm.numSlaves();
+    for (std::size_t s = 0; s < num_slaves; ++s) {
+        if (!rcm.slaveIsActivated(s)) continue;
+        for (const auto& mg : rcm.getMasterGroupNamesForSlave(s)) {
+            if (network.has_node(mg)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+template<typename TypeTag>
+void
+BlackoilWellModelRescoup<TypeTag>::
+receiveCoupledNetworkActiveStatus()
+{
+    OPM_TIMEFUNCTION();
+    assert(this->isReservoirCouplingSlave());
+    this->reservoirCouplingSlave().receiveCoupledNetworkActiveStatusFromMaster();
+}
 
 template<typename TypeTag>
 void
@@ -59,9 +97,47 @@ receiveGroupConstraintsFromMaster()
     OPM_TIMEFUNCTION();
     RescoupReceiveGroupConstraints<Scalar, IndexTraits> constraint_receiver{
         this->well_model_.guideRateHandler(),
-        this->well_model_.groupStateHelper()
+        this->groupStateHelper()
     };
     constraint_receiver.receiveGroupConstraintsFromMaster();
+}
+
+template<typename TypeTag>
+void
+BlackoilWellModelRescoup<TypeTag>::
+receiveMasterGroupNodePressuresFromMaster()
+{
+    OPM_TIMEFUNCTION();
+    assert(this->isReservoirCouplingSlave());
+    auto& rescoup_slave = this->reservoirCouplingSlave();
+    const auto [num_pressures, _is_final] =
+        rescoup_slave.receiveNumMasterGroupNodePressuresFromMaster();
+    if (num_pressures > 0) {
+        rescoup_slave.receiveMasterGroupNodePressuresFromMaster(num_pressures);
+    }
+    // Apply pressures as dynamic THP limits on every producer whose
+    // group has a master-supplied pressure.  Wells in master groups that
+    // are not network leaves are not touched (no entry in the map).
+    // Mirrors the standard local-network apply pattern in
+    // BlackoilWellModelNetworkGeneric::updatePressures(): when the well is
+    // currently THP-controlled, also write the new THP into the WellState
+    // directly, because setDynamicThpLimit() alone leaves the active
+    // control's THP value stale and the subsequent well-solve would
+    // converge against the old THP.
+    const auto& pressures = rescoup_slave.masterGroupNodePressures();
+    if (pressures.empty()) return;
+    const auto& summary_state = this->well_model_.summaryState();
+    auto& well_state = this->wellState();
+    for (auto& well : this->wellContainer()) {
+        if (!well->isProducer() || !well->wellEcl().predictionMode()) continue;
+        const auto it = pressures.find(well->wellEcl().groupName());
+        if (it == pressures.end()) continue;
+        well->setDynamicThpLimit(it->second);
+        auto& ws = well_state[well->indexOfWell()];
+        if (ws.production_cmode == Well::ProducerCMode::THP) {
+            ws.thp = well->getTHPConstraint(summary_state);
+        }
+    }
 }
 
 template<typename TypeTag>
@@ -70,9 +146,9 @@ BlackoilWellModelRescoup<TypeTag>::
 receiveSlaveGroupData()
 {
     OPM_TIMEFUNCTION();
-    assert(this->well_model_.isReservoirCouplingMaster());
+    assert(this->isReservoirCouplingMaster());
     RescoupReceiveSlaveGroupData<Scalar, IndexTraits> slave_group_data_receiver{
-        this->well_model_.groupStateHelper(),
+        this->groupStateHelper(),
     };
     slave_group_data_receiver.receiveSlaveGroupData();
 }
@@ -92,14 +168,14 @@ rescoupSyncSummaryData()
     // Slave side: on the last substep of the sync step, the slave sends its
     // production data to the master.  The master is already waiting at this
     // point (blocked on MPI_Recv from its first substep's timeStepSucceeded).
-    if (this->well_model_.isReservoirCouplingMaster()) {
-        if (this->well_model_.reservoirCouplingMaster().needsSlaveDataReceive()) {
+    if (this->isReservoirCouplingMaster()) {
+        if (this->reservoirCouplingMaster().needsSlaveDataReceive()) {
             this->receiveSlaveGroupData();
-            this->well_model_.reservoirCouplingMaster().setNeedsSlaveDataReceive(false);
+            this->reservoirCouplingMaster().setNeedsSlaveDataReceive(false);
         }
     }
-    if (this->well_model_.isReservoirCouplingSlave()) {
-        if (this->well_model_.reservoirCouplingSlave().isLastSubstepOfSyncTimestep()) {
+    if (this->isReservoirCouplingSlave()) {
+        if (this->reservoirCouplingSlave().isLastSubstepOfSyncTimestep()) {
             this->sendSlaveGroupDataToMaster();
         }
     }
@@ -108,13 +184,26 @@ rescoupSyncSummaryData()
 template<typename TypeTag>
 void
 BlackoilWellModelRescoup<TypeTag>::
-sendSlaveGroupDataToMaster()
+sendCoupledNetworkActiveStatus()
 {
     OPM_TIMEFUNCTION();
-    assert(this->well_model_.isReservoirCouplingSlave());
-    RescoupSendSlaveGroupData<Scalar, IndexTraits> slave_group_data_sender{
-        this->well_model_.groupStateHelper()};
-    slave_group_data_sender.sendSlaveGroupDataToMaster();
+    assert(this->isReservoirCouplingMaster());
+    // Send to each activated slave a single bool: "will the master iterate
+    // the cross-rescoup network exchange this sync timestep?".  Sent as a
+    // dedicated one-element MPI message; the per-iteration node-pressure
+    // sends inside updateWellControlsAndNetworkIteration() carry their own
+    // is_final flag in the NumMasterGroupNodePressures header.
+    const bool active = this->masterNetworkHasMasterGroupLeaves();
+    auto& rescoup_master = this->reservoirCouplingMaster();
+    const auto num_slaves = rescoup_master.numSlaves();
+    for (std::size_t slave_idx = 0; slave_idx < num_slaves; ++slave_idx) {
+        if (rescoup_master.slaveIsActivated(slave_idx)) {
+            rescoup_master.sendCoupledNetworkActiveStatusToSlave(slave_idx, active);
+        }
+    }
+    // Mirror into the master's local is_final state so the master's own
+    // updateWellControlsAndNetworkIteration() gates see the initial value before the per-iteration sends.
+    this->last_sent_master_group_node_pressures_is_final_ = !active;
 }
 
 template<typename TypeTag>
@@ -123,12 +212,55 @@ BlackoilWellModelRescoup<TypeTag>::
 sendMasterGroupConstraintsToSlaves()
 {
     OPM_TIMEFUNCTION();
-    // This function is called by the master process to send the group constraints to the slaves.
+    // This function is called by the master process to send the group
+    // constraints to the slaves.  The "will the master iterate cross-rescoup?"
+    // flag is shipped separately by sendCoupledNetworkActiveStatus().
     RescoupConstraintsCalculator<Scalar, IndexTraits> constraints_calculator{
         this->well_model_.guideRateHandler(),
-        this->well_model_.groupStateHelper()
+        this->groupStateHelper()
     };
     constraints_calculator.calculateMasterGroupConstraintsAndSendToSlaves();
+}
+
+template<typename TypeTag>
+void
+BlackoilWellModelRescoup<TypeTag>::
+sendMasterGroupNodePressuresToSlaves(bool is_final)
+{
+    OPM_TIMEFUNCTION();
+    assert(this->isReservoirCouplingMaster());
+    auto& rescoup_master = this->reservoirCouplingMaster();
+    const auto& node_pressures = this->network_.nodePressures();
+    const auto num_slaves = rescoup_master.numSlaves();
+    for (std::size_t slave_idx = 0; slave_idx < num_slaves; ++slave_idx) {
+        if (!rescoup_master.slaveIsActivated(slave_idx)) continue;
+        std::vector<typename ReservoirCoupling::MasterGroupNodePressure<Scalar>> pressures;
+        const auto& master_groups = rescoup_master.getMasterGroupNamesForSlave(slave_idx);
+        for (std::size_t i = 0; i < master_groups.size(); ++i) {
+            const auto it = node_pressures.find(master_groups[i]);
+            if (it != node_pressures.end()) {
+                pressures.push_back({i, it->second});
+            }
+        }
+        rescoup_master.sendNumMasterGroupNodePressuresToSlave(
+            slave_idx, pressures.size(), is_final);
+        if (!pressures.empty()) {
+            rescoup_master.sendMasterGroupNodePressuresToSlave(slave_idx, pressures);
+        }
+    }
+    this->last_sent_master_group_node_pressures_is_final_ = is_final;
+}
+
+template<typename TypeTag>
+void
+BlackoilWellModelRescoup<TypeTag>::
+sendSlaveGroupDataToMaster()
+{
+    OPM_TIMEFUNCTION();
+    assert(this->isReservoirCouplingSlave());
+    RescoupSendSlaveGroupData<Scalar, IndexTraits> slave_group_data_sender{
+        this->groupStateHelper()};
+    slave_group_data_sender.sendSlaveGroupDataToMaster();
 }
 
 // Automatically manages the lifecycle of the DeferredLogger pointer
@@ -145,14 +277,14 @@ std::optional<ReservoirCoupling::ScopedLoggerGuard>
 BlackoilWellModelRescoup<TypeTag>::
 setupScopedLogger(DeferredLogger& local_logger)
 {
-    if (this->well_model_.isReservoirCouplingMaster()) {
+    if (this->isReservoirCouplingMaster()) {
         return ReservoirCoupling::ScopedLoggerGuard{
-            this->well_model_.reservoirCouplingMaster().logger(),
+            this->reservoirCouplingMaster().logger(),
             &local_logger
         };
-    } else if (this->well_model_.isReservoirCouplingSlave()) {
+    } else if (this->isReservoirCouplingSlave()) {
         return ReservoirCoupling::ScopedLoggerGuard{
-            this->well_model_.reservoirCouplingSlave().logger(),
+            this->reservoirCouplingSlave().logger(),
             &local_logger
         };
     }

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -471,6 +471,7 @@ namespace Opm {
             if (this->reservoirCouplingSlave().isFirstSubstepOfSyncTimestep()) {
                 this->rescoupHelper_.sendSlaveGroupDataToMaster();
                 this->rescoupHelper_.receiveGroupConstraintsFromMaster();
+                this->rescoupHelper_.receiveCoupledNetworkActiveStatus();
                 this->groupStateHelper().updateSlaveGroupCmodesFromMaster();
                 this->reservoirCouplingSlave().markSlaveGroupsInSchedule(
                     this->schedule_, reportStepIdx);
@@ -537,6 +538,7 @@ namespace Opm {
         else if (this->isReservoirCouplingMaster()) {
             if (this->reservoirCouplingMaster().isFirstSubstepOfSyncTimestep()) {
                 this->rescoupHelper_.sendMasterGroupConstraintsToSlaves();
+                this->rescoupHelper_.sendCoupledNetworkActiveStatus();
                 this->rescoupHelper_.receiveSlaveGroupData();
             }
         }
@@ -1105,6 +1107,9 @@ namespace Opm {
         this->closed_offending_wells_.clear();
 
         {
+            if (iterCtx.needsTimestepInit()) {
+                this->updateNetworkActiveState_();
+            }
             const int episodeIdx = simulator_.episodeIndex();
             const auto& network = this->schedule()[episodeIdx].network();
             if (!this->wellsActive() && !network.active()) {
@@ -1129,7 +1134,10 @@ namespace Opm {
                                            this->terminal_output_, grid().comm());
         }
 
-        const bool well_group_control_changed = updateWellControlsAndNetwork(false, dt, local_deferredLogger);
+        const bool well_group_control_changed = updateWellControlsAndNetwork(
+                            /*mandatory_network_balance=*/false,
+                            dt,
+                            local_deferredLogger);
 
         // even when there is no wells active, the network nodal pressure still need to be updated through updateWellControlsAndNetwork()
         // but there is no need to assemble the well equations
@@ -1169,7 +1177,8 @@ namespace Opm {
         std::size_t network_update_iteration = 0;
         network_needs_more_balancing_force_another_newton_iteration_ = false;
         while (do_network_update) {
-            if (network_update_iteration >= max_iteration ) {
+            if (!this->isRescoupSlaveCoupledNetworkIteration_()
+                && network_update_iteration >= max_iteration ) {
                 // only output to terminal if we at the last newton iterations where we try to balance the network.
                 const int episodeIdx = simulator_.episodeIndex();
                 if (this->network_.willBalanceOnNextIteration(episodeIdx)) {
@@ -1202,6 +1211,9 @@ namespace Opm {
                     updateWellControlsAndNetworkIteration(mandatory_network_balance, relax_network_balance, optimize_gas_lift, dt,local_deferredLogger);
             ++network_update_iteration;
         }
+        if (this->isRescoupMasterCoupledNetworkIteration_()) {
+            this->sendSlaveNetworkLoopTerminationSignal_();
+        }
         return well_group_control_changed;
     }
 
@@ -1219,6 +1231,12 @@ namespace Opm {
     {
         OPM_TIMEFUNCTION();
         const int reportStepIdx = simulator_.episodeIndex();
+
+#ifdef RESERVOIR_COUPLING_ENABLED
+        if (this->isRescoupSlaveCoupledNetworkIteration_()) {
+            this->rescoupHelper_.receiveMasterGroupNodePressuresFromMaster();
+        }
+#endif
         this->updateAndCommunicateGroupData(reportStepIdx, /*update_wellgrouptarget*/ true);
         // We need to call updateWellControls before we update the network as
         // network updates are only done on thp controlled wells.
@@ -1229,6 +1247,17 @@ namespace Opm {
                 this->network_.update(mandatory_network_balance,
                                       local_deferredLogger,
                                       relax_network_tolerance);
+#ifdef RESERVOIR_COUPLING_ENABLED
+        if (this->isRescoupMasterCoupledNetworkIteration_()) {
+            const bool is_final = !more_inner_network_update;
+            // send the pressures freshly computed by network_.update() to all activated slaves
+            this->rescoupHelper_.sendMasterGroupNodePressuresToSlaves(is_final);
+            if (!is_final) {
+                // receive slaves' updated network_surface_rates for the next outer iteration.
+                this->rescoupHelper_.receiveSlaveGroupData();
+            }
+        }
+#endif
 
         bool alq_updated = false;
         OPM_BEGIN_PARALLEL_TRY_CATCH();
@@ -1265,8 +1294,13 @@ namespace Opm {
         }
         // we need to re-iterate the network when the well group controls changed or gaslift/alq is changed or
         // the inner iterations are did not converge
-        const bool more_network_update = this->network_.shouldBalance(reportStepIdx) &&
+        bool more_network_update = this->network_.shouldBalance(reportStepIdx) &&
                     (more_inner_network_update || alq_updated);
+
+        if (this->isRescoupSlaveOnSyncStepFirstSubstep_()) {
+            more_network_update = this->maybeSendSlaveGroupFlowToMaster_(reportStepIdx);
+        }
+
         return {well_group_control_changed, more_network_update, network_imbalance};
     }
 
@@ -1899,14 +1933,10 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     prepareTimeStep(DeferredLogger& deferred_logger)
     {
-        // Check if there is a network with active prediction wells at this time step.
         const auto episodeIdx = simulator_.episodeIndex();
-        this->network_.updateActiveState(episodeIdx);
 
-        // Rebalance the network initially if any wells in the network have status changes
-        // (Need to check this before clearing events)
-        const bool do_prestep_network_rebalance =
-            param_.pre_solve_network_ && this->network_.needPreStepRebalance(episodeIdx);
+        // Need to check this before clearing events
+        const bool do_prestep_network_rebalance = this->shouldDoPreStepNetworkRebalance_(episodeIdx);
 
         for (const auto& well : well_container_) {
             auto& events = this->wellState().well(well->indexOfWell()).events;
@@ -2134,32 +2164,6 @@ namespace Opm {
 
 
     template <typename TypeTag>
-    void BlackoilWellModel<TypeTag>::
-    assignWellTracerRates(data::Wells& wsrpt) const
-    {
-        const auto reportStepIdx = static_cast<unsigned int>(this->reportStepIndex());
-        const auto& trMod = this->simulator_.problem().tracerModel();
-
-        BlackoilWellModelGeneric<Scalar, IndexTraits>::assignWellTracerRates(wsrpt, trMod.getWellTracerRates(), reportStepIdx);
-        BlackoilWellModelGeneric<Scalar, IndexTraits>::assignWellTracerRates(wsrpt, trMod.getWellFreeTracerRates(), reportStepIdx);
-        BlackoilWellModelGeneric<Scalar, IndexTraits>::assignWellTracerRates(wsrpt, trMod.getWellSolTracerRates(), reportStepIdx);
-
-        this->assignMswTracerRates(wsrpt, trMod.getMswTracerRates(), reportStepIdx);
-    }
-
-    template <typename TypeTag>
-    void BlackoilWellModel<TypeTag>::
-    assignWellSpeciesRates(data::Wells& wsrpt) const
-    {
-        const auto reportStepIdx = static_cast<unsigned int>(this->reportStepIndex());
-        const auto& geochemMod = this->simulator_.problem().geochemistryModel();
-
-        BlackoilWellModelGeneric<Scalar, IndexTraits>::assignWellTracerRates(wsrpt, geochemMod.getWellSpeciesRates(), reportStepIdx);
-
-        this->assignMswTracerRates(wsrpt, geochemMod.getMswSpeciesRates(), reportStepIdx);
-    }
-
-    template <typename TypeTag>
     [[nodiscard]] auto BlackoilWellModel<TypeTag>::rsConstInfo() const
         -> typename WellState<Scalar,IndexTraits>::RsConstInfo
     {
@@ -2181,6 +2185,160 @@ namespace Opm {
         const auto rsConst = rsConstTables[0].getColumn(0).front();
 
         return { true, static_cast<Scalar>(rsConst) };
+    }
+
+    // Private helper methods (alphabetical order)
+    // --------------------------------------------
+
+    template <typename TypeTag>
+    void BlackoilWellModel<TypeTag>::
+    assignWellTracerRates_(data::Wells& wsrpt) const
+    {
+        const auto reportStepIdx = static_cast<unsigned int>(this->reportStepIndex());
+        const auto& trMod = this->simulator_.problem().tracerModel();
+
+        BlackoilWellModelGeneric<Scalar, IndexTraits>::assignWellTracerRates(wsrpt, trMod.getWellTracerRates(), reportStepIdx);
+        BlackoilWellModelGeneric<Scalar, IndexTraits>::assignWellTracerRates(wsrpt, trMod.getWellFreeTracerRates(), reportStepIdx);
+        BlackoilWellModelGeneric<Scalar, IndexTraits>::assignWellTracerRates(wsrpt, trMod.getWellSolTracerRates(), reportStepIdx);
+
+        this->assignMswTracerRates(wsrpt, trMod.getMswTracerRates(), reportStepIdx);
+    }
+
+    template <typename TypeTag>
+    void BlackoilWellModel<TypeTag>::
+    assignWellSpeciesRates_(data::Wells& wsrpt) const
+    {
+        const auto reportStepIdx = static_cast<unsigned int>(this->reportStepIndex());
+        const auto& geochemMod = this->simulator_.problem().geochemistryModel();
+
+        BlackoilWellModelGeneric<Scalar, IndexTraits>::assignWellTracerRates(wsrpt, geochemMod.getWellSpeciesRates(), reportStepIdx);
+
+        this->assignMswTracerRates(wsrpt, geochemMod.getMswSpeciesRates(), reportStepIdx);
+    }
+
+    template <typename TypeTag>
+    bool BlackoilWellModel<TypeTag>::isRescoupMasterCoupledNetworkIteration_() const
+    {
+#ifdef RESERVOIR_COUPLING_ENABLED
+        return this->isReservoirCouplingMaster()
+            && this->reservoirCouplingMaster().isFirstSubstepOfSyncTimestep()
+            && this->rescoupHelper_.masterNetworkHasMasterGroupLeaves()
+            && !this->rescoupHelper_.lastSentMasterGroupNodePressuresIsFinal();
+#else
+        return false;
+#endif
+    }
+
+    template <typename TypeTag>
+    bool BlackoilWellModel<TypeTag>::isRescoupSlaveCoupledNetworkIteration_() const
+    {
+        // True when the slave is on the first substep of a sync step AND the
+        // master has not yet signaled termination.  Gates the per-iteration
+        // master->slave node-pressure receive at the top of
+        // updateWellControlsAndNetworkIteration().  The outer loop exit on
+        // the slave is driven by the master's is_final flag (propagated to
+        // local variable "more_network_update" at the end of updateWellControlsAndNetworkIteration(),
+        // not by the slave's local network convergence.  The master's own max_iter
+        // bounds the iteration count from above, so the slave skips the local max_iter check entirely
+        // and lets the master signal termination.
+#ifdef RESERVOIR_COUPLING_ENABLED
+        return this->isRescoupSlaveOnSyncStepFirstSubstep_()
+            && !this->reservoirCouplingSlave().lastReceivedMasterGroupNodePressuresIsFinal();
+#else
+        return false;
+#endif
+    }
+
+    template <typename TypeTag>
+    bool BlackoilWellModel<TypeTag>::isRescoupSlaveOnSyncStepFirstSubstep_() const
+    {
+        // True when the slave is on the first substep of a sync step,
+        // regardless of is_final state.  Gates post-Newton handling at the
+        // end of updateWellControlsAndNetworkIteration(), which must run on
+        // the terminating iteration too (so the slave can set
+        // more_network_update = false and exit its outer loop).
+#ifdef RESERVOIR_COUPLING_ENABLED
+        return this->isReservoirCouplingSlave()
+            && this->reservoirCouplingSlave().isFirstSubstepOfSyncTimestep();
+#else
+        return false;
+#endif
+    }
+
+    template <typename TypeTag>
+    bool BlackoilWellModel<TypeTag>::
+    maybeSendSlaveGroupFlowToMaster_([[maybe_unused]] const int reportStepIdx)
+    {
+#ifdef RESERVOIR_COUPLING_ENABLED
+        // For a rescoup slave: after the well-solve in
+        // prepareWellsBeforeAssembling() has produced fresh rates under the
+        // new THP, ship them back to the master and force one more outer
+        // iteration so we re-enter updateWellControlsAndNetworkIteration() to receive the next pressures.
+        // When the just-received message had is_final = true, we skip the
+        // send and let the slave's outer loop exit naturally.
+        assert(this->isReservoirCouplingSlave());
+        const bool is_final =
+            this->reservoirCouplingSlave().lastReceivedMasterGroupNodePressuresIsFinal();
+        if (!is_final) {
+            this->updateAndCommunicateGroupData(reportStepIdx, /*update_wellgrouptarget=*/false);
+            this->rescoupHelper_.sendSlaveGroupDataToMaster();
+            return /*more_network_update=*/true;
+        }
+        return /*more_network_update=*/false;
+#else
+        return /*more_network_update=*/false;
+#endif
+    }
+
+    template <typename TypeTag>
+    void BlackoilWellModel<TypeTag>::
+    sendSlaveNetworkLoopTerminationSignal_()
+    {
+#ifdef RESERVOIR_COUPLING_ENABLED
+        // When the master's outer loop exits without having sent is_final = true (e.g. max_iter
+        // exceeded with the network still unconverged), the slave is stuck
+        // waiting on its next receive.  Fire one final pressure send to
+        // unblock it.
+        assert(this->isReservoirCouplingMaster());
+        this->rescoupHelper_.sendMasterGroupNodePressuresToSlaves(/*is_final=*/true);
+#endif
+    }
+
+    template <typename TypeTag>
+    bool BlackoilWellModel<TypeTag>::
+    shouldDoPreStepNetworkRebalance_(const int episodeIdx) const
+    {
+        // Rebalance the network initially if any wells in the network have status changes
+        //
+        // In reservoir-coupling mode this rebalance is skipped: its inner
+        // updateWellControlsAndNetwork call would run the cross-rescoup
+        // pressure/rate exchange, but needPreStepRebalance is collectivised
+        // only over the local OPM communicator -- not across the rescoup
+        // boundary -- so master and slave may disagree on whether to enter the
+        // rebalance, deadlocking the exchange.  Re-enabling the rebalance
+        // under rescoup is left to a follow-up PR that collectivises the
+        // decision across the rescoup boundary.
+        return param_.pre_solve_network_
+            && this->network_.needPreStepRebalance(episodeIdx)
+            && !this->isReservoirCouplingMaster()
+            && !this->isReservoirCouplingSlave();
+    }
+
+    template <typename TypeTag>
+    void BlackoilWellModel<TypeTag>::
+    updateNetworkActiveState_()
+    {
+        // Refresh the network's cached `active_` flag once per timestep
+        // init.  updateActiveState's inputs (Schedule network, well list,
+        // per-well groupName/predictionMode, and rescoup master groups)
+        // are constant within a substep; ACTIONX-driven well structure
+        // changes propagate via wellStructureChangedDynamically_ at the
+        // top of beginTimeStep, before the first assemble() of the new
+        // substep.  Doing this in assemble() rather than only in
+        // prepareTimeStep() covers the case of a rescoup master with no
+        // local wells, where prepareTimeStep() is skipped (gated on wellsActive()).
+        const int episodeIdx = this->simulator_.episodeIndex();
+        this->network_.updateActiveState(episodeIdx);
     }
 
 } // namespace Opm

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1297,8 +1297,17 @@ namespace Opm {
         bool more_network_update = this->network_.shouldBalance(reportStepIdx) &&
                     (more_inner_network_update || alq_updated);
 
-        if (this->isRescoupSlaveOnSyncStepFirstSubstep_()) {
-            more_network_update = this->maybeSendSlaveGroupFlowToMaster_(reportStepIdx);
+        if (this->isRescoupSlaveOnSyncStepFirstSubstep_()
+            && this->isRescoupSlaveConnectedToMasterNetwork_()) {
+            // Connected slave: the call ships this slave's flow to the master
+            // and reports whether the cross-rescoup exchange continues.  OR
+            // with the local decision so a connected slave that also has its
+            // own network keeps iterating it.  A slave not connected to the
+            // master network skips this branch entirely and runs purely on its
+            // local more_network_update.
+            const bool more_cross_rescoup_update =
+                this->maybeSendSlaveGroupFlowToMaster_(reportStepIdx);
+            more_network_update = more_network_update || more_cross_rescoup_update;
         }
 
         return {well_group_control_changed, more_network_update, network_imbalance};
@@ -2243,6 +2252,7 @@ namespace Opm {
         // and lets the master signal termination.
 #ifdef RESERVOIR_COUPLING_ENABLED
         return this->isRescoupSlaveOnSyncStepFirstSubstep_()
+            && this->reservoirCouplingSlave().connectedToMasterCoupledNetwork()
             && !this->reservoirCouplingSlave().lastReceivedMasterGroupNodePressuresIsFinal();
 #else
         return false;
@@ -2260,6 +2270,17 @@ namespace Opm {
 #ifdef RESERVOIR_COUPLING_ENABLED
         return this->isReservoirCouplingSlave()
             && this->reservoirCouplingSlave().isFirstSubstepOfSyncTimestep();
+#else
+        return false;
+#endif
+    }
+
+    template <typename TypeTag>
+    bool BlackoilWellModel<TypeTag>::isRescoupSlaveConnectedToMasterNetwork_() const
+    {
+#ifdef RESERVOIR_COUPLING_ENABLED
+        return this->isReservoirCouplingSlave()
+            && this->reservoirCouplingSlave().connectedToMasterCoupledNetwork();
 #else
         return false;
 #endif
@@ -2310,18 +2331,34 @@ namespace Opm {
     {
         // Rebalance the network initially if any wells in the network have status changes
         //
-        // In reservoir-coupling mode this rebalance is skipped: its inner
-        // updateWellControlsAndNetwork call would run the cross-rescoup
-        // pressure/rate exchange, but needPreStepRebalance is collectivised
-        // only over the local OPM communicator -- not across the rescoup
-        // boundary -- so master and slave may disagree on whether to enter the
-        // rebalance, deadlocking the exchange.  Re-enabling the rebalance
-        // under rescoup is left to a follow-up PR that collectivises the
-        // decision across the rescoup boundary.
+        // The rebalance is skipped only for *coupled-network participants*: its
+        // inner updateWellControlsAndNetwork call would run the cross-rescoup
+        // pressure/rate exchange, but needPreStepRebalance is collectivised only
+        // over the local OPM communicator -- not across the rescoup boundary --
+        // so a coupled master and slave may disagree on whether to enter the
+        // rebalance, deadlocking the exchange.  A non-participant (a master with
+        // no master-group network leaves, or a slave not connected to the master
+        // network) does no cross-rescoup MPI in the network solve, so it is safe
+        // to rebalance like a standalone process and we no longer skip it.
         return param_.pre_solve_network_
             && this->network_.needPreStepRebalance(episodeIdx)
-            && !this->isReservoirCouplingMaster()
-            && !this->isReservoirCouplingSlave();
+            && !this->isRescoupCoupledNetworkParticipant_();
+    }
+
+    template <typename TypeTag>
+    bool BlackoilWellModel<TypeTag>::isRescoupCoupledNetworkParticipant_() const
+    {
+#ifdef RESERVOIR_COUPLING_ENABLED
+        if (this->isReservoirCouplingMaster()) {
+            return this->rescoupHelper_.masterNetworkHasMasterGroupLeaves();
+        }
+        if (this->isReservoirCouplingSlave()) {
+            return this->reservoirCouplingSlave().connectedToMasterCoupledNetwork();
+        }
+        return false;
+#else
+        return false;
+#endif
     }
 
     template <typename TypeTag>


### PR DESCRIPTION
Builds on #7066.

The reservoir-coupling feature ships slave-side group production rates to the master once per sync step. Before this PR, the master's extended network model (`BRANPROP`/`NODEPROP`) treated master groups as static leaf nodes whose pressures were not iterated against the slaves' actual rates. The cross-boundary network was solved with stale leaf pressures, causing material divergence from reference simulator output on decks with non-trivial network topology.

This PR folds the cross-rescoup pressure/rate exchange into the master's outer Newton loop, so the network model converges across the rescoup boundary.

#### Protocol

On each outer iteration of `updateWellControlsAndNetworkIteration`:

- The **master** ships freshly computed network-leaf node pressures (`network_.update()` output) to each activated slave.
- The **slave** applies the pressures as dynamic THP limits on producers in the corresponding master groups, re-solves its producers, and ships updated surface rates back to the master.
- The master's next `network_.update()` consumes the new slave rates.

Termination is driven by an `is_final` flag the master sets when its local network sub-iteration converges, or in a trailing-final send when the master's outer loop exits unconverged. On the slave the outer-loop exit is driven by the master's `is_final` flag rather than by local convergence, so the two sides stay in step on the protocol.

#### Other changes carried by this PR

- **`updateActiveState()` extended** so a rescoup master with no local wells (where leaf rates come from slave-reported `network_surface_rates`) still reports its network as active. Without this the master's network solver short-circuits via `active_=false` and the leaf pressures are never iterated.
- **Slave pressure-receive sets `ws.thp` directly** when the well is in THP control mode, mirroring the standard local-network apply pattern in `BlackoilWellModelNetworkGeneric::updatePressures()`. `setDynamicThpLimit()` alone leaves the active control's THP value stale and the subsequent well-solve would converge against the old THP.
- **`doPreStepRebalance` gated off in rescoup mode** to avoid a deadlock when `needPreStepRebalance` disagrees across the rescoup boundary (it is collectivised only over the local OPM communicator). Restoring this optimisation under rescoup needs a collectivised rebalance decision and is left to a follow-up PR.

#### Wire format

Three new `MessageTag` values carry the protocol:

- `CoupledNetworkActiveStatus`: single bool sent once per sync step, telling the slave whether the master will iterate cross-rescoup this step.
- `NumMasterGroupNodePressures`: per-iteration header carrying `(count, is_final)`.
- `MasterGroupNodePressures`: per-iteration pressure payload (only emitted when `count > 0`).

#### Known limitations (follow-up PRs)

- **Injection-side coupling** (`REIN`, `VREP`) is not yet cascaded from master to slave; the cap-and-redistribute pass currently handles only production master groups.
- **Standard network model** (`GRUPNET`) coupling is not in scope here; only the extended network (`BRANPROP`/`NODEPROP`) is handled.
- **`doPreStepRebalance` under rescoup**: re-enable after collectivising the rebalance decision across the rescoup boundary.

