### PR TITLE
extending the allowing component number to be 10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -913,8 +913,8 @@ endmacro()
 if(OPM_COMPILE_COMPONENTS STREQUAL "")
   message(FATAL_ERROR "OPM_COMPILE_COMPONENTS must contain at least one component.")
 endif()
-# Check that OPM_COMPILE_COMPONENTS is a subset of 2,3,4,5,6,7
-set(valid_components "2;3;4;5;6;7")
+# Check that OPM_COMPILE_COMPONENTS is a subset of 2,3,4,5,6,7,8,9,10
+set(valid_components "2;3;4;5;6;7;8;9;10")
 foreach(component IN LISTS OPM_COMPILE_COMPONENTS)
   list(FIND valid_components ${component} index)
   if(index EQUAL -1)

--- a/flowexperimental/comp/flowexp_comp10.cpp
+++ b/flowexperimental/comp/flowexp_comp10.cpp
@@ -1,0 +1,36 @@
+/*
+  Copyright 2024, SINTEF Digital
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <opm/models/utils/start.hh>
+
+#include <opm/simulators/flow/FlowGenericProblem_impl.hpp>
+
+#include "flowexp_comp.hpp"
+
+namespace Opm {
+
+template<>
+int dispatchFlowExpComp<10, true>(int argc, char** argv)
+{
+    return start<Properties::TTag::FlowExpCompProblem<10, true>>(argc, argv, false);
+}
+
+}

--- a/flowexperimental/comp/flowexp_comp10_2p.cpp
+++ b/flowexperimental/comp/flowexp_comp10_2p.cpp
@@ -1,0 +1,36 @@
+/*
+  Copyright 2024, SINTEF Digital
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <opm/models/utils/start.hh>
+
+#include <opm/simulators/flow/FlowGenericProblem_impl.hpp>
+
+#include "flowexp_comp.hpp"
+
+namespace Opm {
+
+template<>
+int dispatchFlowExpComp<10, false>(int argc, char** argv)
+{
+    return start<Properties::TTag::FlowExpCompProblem<10, false>>(argc, argv, false);
+}
+
+}

--- a/flowexperimental/comp/flowexp_comp8.cpp
+++ b/flowexperimental/comp/flowexp_comp8.cpp
@@ -1,0 +1,36 @@
+/*
+  Copyright 2024, SINTEF Digital
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <opm/models/utils/start.hh>
+
+#include <opm/simulators/flow/FlowGenericProblem_impl.hpp>
+
+#include "flowexp_comp.hpp"
+
+namespace Opm {
+
+template<>
+int dispatchFlowExpComp<8, true>(int argc, char** argv)
+{
+    return start<Properties::TTag::FlowExpCompProblem<8, true>>(argc, argv, false);
+}
+
+}

--- a/flowexperimental/comp/flowexp_comp8_2p.cpp
+++ b/flowexperimental/comp/flowexp_comp8_2p.cpp
@@ -1,0 +1,36 @@
+/*
+  Copyright 2024, SINTEF Digital
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <opm/models/utils/start.hh>
+
+#include <opm/simulators/flow/FlowGenericProblem_impl.hpp>
+
+#include "flowexp_comp.hpp"
+
+namespace Opm {
+
+template<>
+int dispatchFlowExpComp<8, false>(int argc, char** argv)
+{
+    return start<Properties::TTag::FlowExpCompProblem<8, false>>(argc, argv, false);
+}
+
+}

--- a/flowexperimental/comp/flowexp_comp9.cpp
+++ b/flowexperimental/comp/flowexp_comp9.cpp
@@ -1,0 +1,36 @@
+/*
+  Copyright 2024, SINTEF Digital
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <opm/models/utils/start.hh>
+
+#include <opm/simulators/flow/FlowGenericProblem_impl.hpp>
+
+#include "flowexp_comp.hpp"
+
+namespace Opm {
+
+template<>
+int dispatchFlowExpComp<9, true>(int argc, char** argv)
+{
+    return start<Properties::TTag::FlowExpCompProblem<9, true>>(argc, argv, false);
+}
+
+}

--- a/flowexperimental/comp/flowexp_comp9_2p.cpp
+++ b/flowexperimental/comp/flowexp_comp9_2p.cpp
@@ -1,0 +1,36 @@
+/*
+  Copyright 2024, SINTEF Digital
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <opm/models/utils/start.hh>
+
+#include <opm/simulators/flow/FlowGenericProblem_impl.hpp>
+
+#include "flowexp_comp.hpp"
+
+namespace Opm {
+
+template<>
+int dispatchFlowExpComp<9, false>(int argc, char** argv)
+{
+    return start<Properties::TTag::FlowExpCompProblem<9, false>>(argc, argv, false);
+}
+
+}


### PR DESCRIPTION
previously we set the allowed component number to be 7. Now due to the requirement with new test cases,  we are extending it to be 10.

although the new case only has 8 components, but extending 10 to avoid adding one by one. 

If requested, I can also change the PR to be only adding 8. 