### PR TITLE
opm_add_test: pass target

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -42,20 +42,25 @@ function(add_test_runSimulator)
   set(DRIVER_ARGS -i ${OPM_TESTS_ROOT}/${PARAM_DIR}
                   -r ${RESULT_PATH}
                   -f ${PARAM_FILENAME})
- if(PARAM_PROCS)
-   list(APPEND DRIVER_ARGS -n ${PARAM_PROCS})
- endif()
- if(PARAM_POST_COMMAND)
-   list(APPEND DRIVER_ARGS -p "${PARAM_POST_COMMAND}")
- endif()
- if(USE_DEV_SIMULATOR_IN_TESTS AND PARAM_DEV_SIMULATOR)
-   set(PARAM_SIMULATOR ${PARAM_DEV_SIMULATOR})
- endif()
- opm_add_test(runSimulator/${PARAM_CASENAME} NO_COMPILE
-              EXE_NAME ${PARAM_SIMULATOR}
-              DRIVER_ARGS ${DRIVER_ARGS}
-              TEST_ARGS ${TEST_ARGS}
-              CONFIGURATION ${PARAM_CONFIGURATION})
+  if(PARAM_PROCS)
+    list(APPEND DRIVER_ARGS -n ${PARAM_PROCS})
+  endif()
+  if(PARAM_POST_COMMAND)
+    list(APPEND DRIVER_ARGS -p "${PARAM_POST_COMMAND}")
+  endif()
+  if(USE_DEV_SIMULATOR_IN_TESTS AND PARAM_DEV_SIMULATOR)
+    set(PARAM_SIMULATOR ${PARAM_DEV_SIMULATOR})
+  endif()
+  opm_add_test(runSimulator/${PARAM_CASENAME} NO_COMPILE
+    EXE_TARGET
+      ${PARAM_SIMULATOR}
+    DRIVER_ARGS
+      ${DRIVER_ARGS}
+    TEST_ARGS
+      ${TEST_ARGS}
+    CONFIGURATION
+      ${PARAM_CONFIGURATION}
+  )
  if(PARAM_PROCS)
     set_tests_properties(runSimulator/${PARAM_CASENAME} PROPERTIES PROCESSORS ${PARAM_PROCS})
   endif()
@@ -112,9 +117,13 @@ function(add_test_compareECLFiles)
     set(PARAM_SIMULATOR ${PARAM_DEV_SIMULATOR})
   endif()
   opm_add_test(${PARAM_PREFIX}_${PARAM_SIMULATOR}+${PARAM_FILENAME} NO_COMPILE
-               EXE_NAME ${PARAM_SIMULATOR}
-               DRIVER_ARGS ${DRIVER_ARGS}
-               TEST_ARGS ${TEST_ARGS})
+    EXE_TARGET
+      ${PARAM_SIMULATOR}
+    DRIVER_ARGS
+      ${DRIVER_ARGS}
+    TEST_ARGS
+      ${TEST_ARGS}
+  )
   set_tests_properties(${PARAM_PREFIX}_${PARAM_SIMULATOR}+${PARAM_FILENAME} PROPERTIES
                         DIRNAME ${PARAM_DIR}
                         FILENAME ${PARAM_FILENAME}
@@ -179,9 +188,13 @@ function(add_test_compareSeparateECLFiles)
     list(APPEND DRIVER_ARGS -y ${PARAM_IGNORE_EXTRA_KW})
   endif()
   opm_add_test(${PARAM_PREFIX}_${PARAM_SIMULATOR}+${PARAM_CASENAME} NO_COMPILE
-               EXE_NAME ${PARAM_SIMULATOR}
-               DRIVER_ARGS ${DRIVER_ARGS}
-               TEST_ARGS ${TEST_ARGS})
+    EXE_TARGET
+      ${PARAM_SIMULATOR}
+    DRIVER_ARGS
+      ${DRIVER_ARGS}
+    TEST_ARGS
+      ${TEST_ARGS}
+  )
   set_tests_properties(${PARAM_PREFIX}_${PARAM_SIMULATOR}+${PARAM_CASENAME} PROPERTIES
                         DIRNAME ${PARAM_DIR}
                         FILENAME1 ${PARAM_FILENAME1}
@@ -233,16 +246,20 @@ function(add_test_compare_restarted_simulation)
 
   set(RESULT_PATH ${BASE_RESULT_PATH}/restart/${PARAM_SIMULATOR}+${PARAM_CASENAME})
   opm_add_test(${TEST_NAME} NO_COMPILE
-               EXE_NAME ${PARAM_SIMULATOR}
-               DRIVER_ARGS -i ${OPM_TESTS_ROOT}/${PARAM_DIR}
-                           -r ${RESULT_PATH}
-                           -f ${PARAM_FILENAME}
-                           -a ${PARAM_ABS_TOL}
-                           -t ${PARAM_REL_TOL}
-                           -c $<TARGET_FILE:compareECL>
-                           -d $<TARGET_FILE:rst_deck>
-                           -s ${PARAM_RESTART_STEP}
-               TEST_ARGS ${PARAM_TEST_ARGS})
+    EXE_TARGET
+      ${PARAM_SIMULATOR}
+    DRIVER_ARGS
+      -i ${OPM_TESTS_ROOT}/${PARAM_DIR}
+      -r ${RESULT_PATH}
+      -f ${PARAM_FILENAME}
+      -a ${PARAM_ABS_TOL}
+      -t ${PARAM_REL_TOL}
+      -c $<TARGET_FILE:compareECL>
+      -d $<TARGET_FILE:rst_deck>
+      -s ${PARAM_RESTART_STEP}
+    TEST_ARGS
+      ${PARAM_TEST_ARGS}
+  )
 endfunction()
 
 ###########################################################################
@@ -305,9 +322,13 @@ function(add_test_compare_parallel_simulation)
 
     # Add test that runs flow_mpi and outputs the results to file
     opm_add_test(compareParallelSim_${PARAM_SIMULATOR}+${PARAM_FILENAME}${PARAM_POSTFIX} NO_COMPILE
-                 EXE_NAME ${PARAM_SIMULATOR}
-                 DRIVER_ARGS ${DRIVER_ARGS}
-                 TEST_ARGS ${TEST_ARGS})
+      EXE_TARGET
+        ${PARAM_SIMULATOR}
+      DRIVER_ARGS
+        ${DRIVER_ARGS}
+      TEST_ARGS
+        ${TEST_ARGS}
+    )
     set_tests_properties(compareParallelSim_${PARAM_SIMULATOR}+${PARAM_FILENAME}${PARAM_POSTFIX}
                          PROPERTIES PROCESSORS ${MPI_PROCS})
   endif()
@@ -374,9 +395,13 @@ function(add_test_compare_parallel_restarted_simulation)
                     -n ${MPI_PROCS})
 
     opm_add_test(${TEST_NAME} NO_COMPILE
-                 EXE_NAME ${PARAM_SIMULATOR}
-                 DRIVER_ARGS ${DRIVER_ARGS}
-                 TEST_ARGS ${PARAM_TEST_ARGS})
+      EXE_TARGET
+        ${PARAM_SIMULATOR}
+      DRIVER_ARGS
+        ${DRIVER_ARGS}
+      TEST_ARGS
+        ${PARAM_TEST_ARGS}
+    )
     set_tests_properties(${TEST_NAME} PROPERTIES PROCESSORS ${MPI_PROCS})
   endif()
 endfunction()
@@ -429,9 +454,13 @@ function(add_test_split_comm)
                   -c $<TARGET_FILE:compareECL>)
 
   opm_add_test(compareParallelSplitComm_${PARAM_SIMULATOR}+${PARAM_FILENAME} NO_COMPILE
-               EXE_NAME ${PARAM_SIMULATOR}
-               DRIVER_ARGS ${DRIVER_ARGS}
-               TEST_ARGS ${PARAM_TEST_ARGS})
+    EXE_TARGET
+      ${PARAM_SIMULATOR}
+    DRIVER_ARGS
+      ${DRIVER_ARGS}
+    TEST_ARGS
+      ${PARAM_TEST_ARGS}
+  )
   set_tests_properties(compareParallelSplitComm_${PARAM_SIMULATOR}+${PARAM_FILENAME}
                        PROPERTIES PROCESSORS ${MPI_PROCS})
 endfunction()
@@ -488,9 +517,13 @@ function(add_test_compareDamarisFiles)
                   -n ${MPI_PROCS})
   set(TEST_NAME ${PARAM_PREFIX}_${PARAM_SIMULATOR}+${PARAM_FILENAME})
   opm_add_test(${TEST_NAME} NO_COMPILE
-               EXE_NAME ${PARAM_SIMULATOR}
-               DRIVER_ARGS ${DRIVER_ARGS}
-               TEST_ARGS ${TEST_ARGS})
+    EXE_TARGET
+      ${PARAM_SIMULATOR}
+    DRIVER_ARGS
+      ${DRIVER_ARGS}
+    TEST_ARGS
+      ${TEST_ARGS}
+  )
   set_tests_properties(${TEST_NAME} PROPERTIES PROCESSORS ${MPI_PROCS}
                                     DIRNAME ${PARAM_DIR}
                                     FILENAME ${PARAM_FILENAME}

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -41,7 +41,6 @@ function(add_test_runSimulator)
   set(TEST_ARGS ${PARAM_TEST_ARGS})
   set(DRIVER_ARGS -i ${OPM_TESTS_ROOT}/${PARAM_DIR}
                   -r ${RESULT_PATH}
-                  -b ${PROJECT_BINARY_DIR}/bin
                   -f ${PARAM_FILENAME})
  if(PARAM_PROCS)
    list(APPEND DRIVER_ARGS -n ${PARAM_PROCS})
@@ -97,7 +96,6 @@ function(add_test_compareECLFiles)
   set(TEST_ARGS ${PARAM_TEST_ARGS})
   set(DRIVER_ARGS -i ${OPM_TESTS_ROOT}/${PARAM_DIR}
                   -r ${RESULT_PATH}
-                  -b ${PROJECT_BINARY_DIR}/bin
                   -f ${PARAM_FILENAME}
                   -a ${PARAM_ABS_TOL}
                   -t ${PARAM_REL_TOL}
@@ -173,7 +171,6 @@ function(add_test_compareSeparateECLFiles)
                   -f ${PARAM_FILENAME1}
                   -g ${PARAM_FILENAME2}
                   -r ${RESULT_PATH}
-                  -b ${PROJECT_BINARY_DIR}/bin
                   -a ${PARAM_ABS_TOL}
                   -t ${PARAM_REL_TOL}
                   -c $<TARGET_FILE:compareECL>
@@ -239,7 +236,6 @@ function(add_test_compare_restarted_simulation)
                EXE_NAME ${PARAM_SIMULATOR}
                DRIVER_ARGS -i ${OPM_TESTS_ROOT}/${PARAM_DIR}
                            -r ${RESULT_PATH}
-                           -b ${PROJECT_BINARY_DIR}/bin
                            -f ${PARAM_FILENAME}
                            -a ${PARAM_ABS_TOL}
                            -t ${PARAM_REL_TOL}
@@ -301,7 +297,6 @@ function(add_test_compare_parallel_simulation)
 
     set(DRIVER_ARGS -i ${OPM_TESTS_ROOT}/${PARAM_DIR}
                     -r ${RESULT_PATH}
-                    -b ${PROJECT_BINARY_DIR}/bin
                     -f ${PARAM_FILENAME}
                     -a ${PARAM_ABS_TOL}
                     -t ${PARAM_REL_TOL}
@@ -370,7 +365,6 @@ function(add_test_compare_parallel_restarted_simulation)
     set(RESULT_PATH ${BASE_RESULT_PATH}/parallelRestart/${PARAM_SIMULATOR}+${PARAM_CASENAME})
     set(DRIVER_ARGS -i ${OPM_TESTS_ROOT}/${PARAM_DIR}
                     -r ${RESULT_PATH}
-                    -b ${PROJECT_BINARY_DIR}/bin
                     -f ${PARAM_FILENAME}
                     -a ${PARAM_ABS_TOL}
                     -t ${PARAM_REL_TOL}
@@ -429,12 +423,10 @@ function(add_test_split_comm)
   set(RESULT_PATH ${BASE_RESULT_PATH}/parallelSplitComm/${PARAM_SIMULATOR}+${PARAM_CASENAME})
   set(DRIVER_ARGS -i ${OPM_TESTS_ROOT}/${PARAM_DIR}
                   -r ${RESULT_PATH}
-                  -b ${PROJECT_BINARY_DIR}/bin
                   -f ${PARAM_FILENAME}
                   -a ${PARAM_ABS_TOL}
                   -t ${PARAM_REL_TOL}
-                  -c $<TARGET_FILE:compareECL>
-                  -n ${MPI_PROCS})
+                  -c $<TARGET_FILE:compareECL>)
 
   opm_add_test(compareParallelSplitComm_${PARAM_SIMULATOR}+${PARAM_FILENAME} NO_COMPILE
                EXE_NAME ${PARAM_SIMULATOR}
@@ -489,7 +481,6 @@ function(add_test_compareDamarisFiles)
   set(TEST_ARGS ${PARAM_TEST_ARGS})
   set(DRIVER_ARGS -i ${OPM_TESTS_ROOT}/${PARAM_DIR}
                   -r ${RESULT_PATH}
-                  -b ${PROJECT_BINARY_DIR}/bin
                   -f ${PARAM_FILENAME}
                   -a ${PARAM_ABS_TOL}
                   -t ${PARAM_REL_TOL}

--- a/modelTests.cmake
+++ b/modelTests.cmake
@@ -3,7 +3,7 @@ opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-vtu-test.sh "--simulation")
 opm_add_test(art2dgf
   NO_COMPILE
   EXE_NAME
-    $<TARGET_FILE:art2dgf>
+    art2dgf
   DRIVER_ARGS
     --plain
   TEST_ARGS
@@ -20,7 +20,7 @@ foreach(tgt lens_immiscible_ecfv_ad
   opm_add_test(${tgt}
     NO_COMPILE
     EXE_NAME
-      $<TARGET_FILE:${tgt}>
+      ${tgt}
     TEST_ARGS
       --end-time=3000
     WORKING_DIRECTORY
@@ -31,7 +31,7 @@ endforeach()
 opm_add_test(waterair_pvs_ni
   NO_COMPILE
   EXE_NAME
-    $<TARGET_FILE:waterair_pvs_ni>
+    waterair_pvs_ni
   TEST_ARGS
     --grid-global-refinements=1
   WORKING_DIRECTORY
@@ -86,7 +86,7 @@ foreach(tgt ${PLAIN_TGT})
   opm_add_test(${tgt}
     NO_COMPILE
     EXE_NAME
-      $<TARGET_FILE:${tgt}>
+      ${tgt}
     WORKING_DIRECTORY
       ${PROJECT_BINARY_DIR}/tests
   )
@@ -99,7 +99,7 @@ foreach(tgt reservoir_blackoil_ecfv
   opm_add_test(${tgt}
     NO_COMPILE
     EXE_NAME
-      $<TARGET_FILE:${tgt}>
+      ${tgt}
     TEST_ARGS
       --end-time=8750000
     WORKING_DIRECTORY
@@ -111,7 +111,7 @@ if(dune-alugrid_FOUND)
   opm_add_test(fracture_discretefracture
     NO_COMPILE
     EXE_NAME
-      $<TARGET_FILE:fracture_discretefracture>
+      fracture_discretefracture
     TEST_ARGS
       --end-time=400
     WORKING_DIRECTORY
@@ -123,7 +123,7 @@ if(dune-alugrid_FOUND AND dune-fem_FOUND)
   opm_add_test(finger_immiscible_ecfv_adaptive
     NO_COMPILE
     EXE_NAME
-      $<TARGET_FILE:finger_immiscible_ecfv>
+      finger_immiscible_ecfv
     TEST_ARGS
       --enable-grid-adaptation=true
       --end-time=25e3
@@ -136,7 +136,7 @@ endif()
 opm_add_test(obstacle_immiscible_parameters
   NO_COMPILE
   EXE_NAME
-    $<TARGET_FILE:obstacle_immiscible>
+    obstacle_immiscible
   DRIVER_ARGS
     --parameters
   WORKING_DIRECTORY
@@ -146,7 +146,7 @@ opm_add_test(obstacle_immiscible_parameters
 opm_add_test(obstacle_pvs_restart
   NO_COMPILE
   EXE_NAME
-    $<TARGET_FILE:obstacle_pvs>
+    obstacle_pvs
   TEST_ARGS
     --pvs-verbosity=2
     --end-time=30000

--- a/modelTests.cmake
+++ b/modelTests.cmake
@@ -2,7 +2,7 @@ opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-vtu-test.sh "--simulation")
 
 opm_add_test(art2dgf
   NO_COMPILE
-  EXE_NAME
+  EXE_TARGET
     art2dgf
   DRIVER_ARGS
     --plain
@@ -19,7 +19,7 @@ foreach(tgt lens_immiscible_ecfv_ad
             lens_immiscible_vcfv_fd)
   opm_add_test(${tgt}
     NO_COMPILE
-    EXE_NAME
+    EXE_TARGET
       ${tgt}
     TEST_ARGS
       --end-time=3000
@@ -30,7 +30,7 @@ endforeach()
 
 opm_add_test(waterair_pvs_ni
   NO_COMPILE
-  EXE_NAME
+  EXE_TARGET
     waterair_pvs_ni
   TEST_ARGS
     --grid-global-refinements=1
@@ -85,7 +85,7 @@ endif()
 foreach(tgt ${PLAIN_TGT})
   opm_add_test(${tgt}
     NO_COMPILE
-    EXE_NAME
+    EXE_TARGET
       ${tgt}
     WORKING_DIRECTORY
       ${PROJECT_BINARY_DIR}/tests
@@ -98,7 +98,7 @@ foreach(tgt reservoir_blackoil_ecfv
             reservoir_ncp_vcfv)
   opm_add_test(${tgt}
     NO_COMPILE
-    EXE_NAME
+    EXE_TARGET
       ${tgt}
     TEST_ARGS
       --end-time=8750000
@@ -110,7 +110,7 @@ endforeach()
 if(dune-alugrid_FOUND)
   opm_add_test(fracture_discretefracture
     NO_COMPILE
-    EXE_NAME
+    EXE_TARGET
       fracture_discretefracture
     TEST_ARGS
       --end-time=400
@@ -122,7 +122,7 @@ endif()
 if(dune-alugrid_FOUND AND dune-fem_FOUND)
   opm_add_test(finger_immiscible_ecfv_adaptive
     NO_COMPILE
-    EXE_NAME
+    EXE_TARGET
       finger_immiscible_ecfv
     TEST_ARGS
       --enable-grid-adaptation=true
@@ -135,7 +135,7 @@ endif()
 
 opm_add_test(obstacle_immiscible_parameters
   NO_COMPILE
-  EXE_NAME
+  EXE_TARGET
     obstacle_immiscible
   DRIVER_ARGS
     --parameters
@@ -145,7 +145,7 @@ opm_add_test(obstacle_immiscible_parameters
 
 opm_add_test(obstacle_pvs_restart
   NO_COMPILE
-  EXE_NAME
+  EXE_TARGET
     obstacle_pvs
   TEST_ARGS
     --pvs-verbosity=2

--- a/parallelUnitTests.cmake
+++ b/parallelUnitTests.cmake
@@ -14,7 +14,6 @@ opm_add_test(test_gatherconvergencereport
     tests/test_gatherconvergencereport.cpp
   DRIVER_ARGS
     -n 4
-    -b ${PROJECT_BINARY_DIR}
   PROCESSORS
     4
 )
@@ -29,7 +28,6 @@ opm_add_test(test_gatherdeferredlogger
     tests/test_gatherdeferredlogger.cpp
   DRIVER_ARGS
     -n 4
-    -b ${PROJECT_BINARY_DIR}
   PROCESSORS
     4
 )
@@ -39,7 +37,6 @@ opm_add_test(test_parallelwellinfo_mpi
     test_parallelwellinfo
   DRIVER_ARGS
     -n 4
-    -b ${PROJECT_BINARY_DIR}
   NO_COMPILE
   PROCESSORS
     4
@@ -51,7 +48,6 @@ foreach(NPROC 2 3 4)
       test_parallel_wbp_sourcevalues
     DRIVER_ARGS
       -n ${NPROC}
-      -b ${PROJECT_BINARY_DIR}
     NO_COMPILE
     PROCESSORS
       ${NPROC}
@@ -74,7 +70,6 @@ opm_add_test(test_parallel_wbp_calculation_create
     test_parallel_wbp_calculation
   DRIVER_ARGS
     -n 2
-    -b ${PROJECT_BINARY_DIR}
   TEST_ARGS
     --run_test=Create
   NO_COMPILE
@@ -87,7 +82,6 @@ opm_add_test(test_parallel_wbp_calculation_well_openconns
     test_parallel_wbp_calculation
   DRIVER_ARGS
     -n 2
-    -b ${PROJECT_BINARY_DIR}
   TEST_ARGS
     --run_test=TopOfFormation_Well_OpenConns
   NO_COMPILE
@@ -101,7 +95,6 @@ foreach(NPROC 2 3 4)
       test_rftcontainer
     DRIVER_ARGS
       -n ${NPROC}
-      -b ${PROJECT_BINARY_DIR}
     NO_COMPILE
     PROCESSORS
       ${NPROC}
@@ -114,7 +107,6 @@ foreach(NPROC 2 3 4)
       test_region_phase_pvaverage
     DRIVER_ARGS
       -n ${NPROC}
-      -b ${PROJECT_BINARY_DIR}
     TEST_ARGS
       --run_test=Parallel/*
     NO_COMPILE
@@ -129,7 +121,6 @@ foreach(NPROC 2 3 4)
       test_SatfuncConsistencyChecks_parallel
     DRIVER_ARGS
       -n ${NPROC}
-      -b ${PROJECT_BINARY_DIR}
     NO_COMPILE
     PROCESSORS
       ${NPROC}
@@ -146,7 +137,6 @@ opm_add_test(test_broadcast
     tests/test_broadcast.cpp
   DRIVER_ARGS
     -n 4
-    -b ${PROJECT_BINARY_DIR}
   PROCESSORS
     4
 )
@@ -163,7 +153,6 @@ opm_add_test(test_HDF5File_Parallel
     HDF5_FOUND
   DRIVER_ARGS
     -n 4
-    -b ${PROJECT_BINARY_DIR}
   PROCESSORS
     4
 )
@@ -181,7 +170,6 @@ opm_add_test(test_HDF5Serializer_Parallel
     HDF5_FOUND
   DRIVER_ARGS
     -n 4
-    -b ${PROJECT_BINARY_DIR}
   PROCESSORS
     4
 )
@@ -191,7 +179,6 @@ opm_add_test(test_rstconv_parallel
     test_rstconv
   DRIVER_ARGS
     -n 4
-    -b ${PROJECT_BINARY_DIR}
   NO_COMPILE
   PROCESSORS
     4

--- a/parallelUnitTests.cmake
+++ b/parallelUnitTests.cmake
@@ -33,7 +33,7 @@ opm_add_test(test_gatherdeferredlogger
 )
 
 opm_add_test(test_parallelwellinfo_mpi
-  EXE_NAME
+  EXE_TARGET
     test_parallelwellinfo
   DRIVER_ARGS
     -n 4
@@ -44,7 +44,7 @@ opm_add_test(test_parallelwellinfo_mpi
 
 foreach(NPROC 2 3 4)
   opm_add_test(test_parallel_wbp_sourcevalues_np${NPROC}
-    EXE_NAME
+    EXE_TARGET
       test_parallel_wbp_sourcevalues
     DRIVER_ARGS
       -n ${NPROC}
@@ -66,7 +66,7 @@ opm_add_executable(
 )
 
 opm_add_test(test_parallel_wbp_calculation_create
-  EXE_NAME
+  EXE_TARGET
     test_parallel_wbp_calculation
   DRIVER_ARGS
     -n 2
@@ -78,7 +78,7 @@ opm_add_test(test_parallel_wbp_calculation_create
 )
 
 opm_add_test(test_parallel_wbp_calculation_well_openconns
-  EXE_NAME
+  EXE_TARGET
     test_parallel_wbp_calculation
   DRIVER_ARGS
     -n 2
@@ -91,7 +91,7 @@ opm_add_test(test_parallel_wbp_calculation_well_openconns
 
 foreach(NPROC 2 3 4)
   opm_add_test(test_rftcontainer_np${NPROC}
-    EXE_NAME
+    EXE_TARGET
       test_rftcontainer
     DRIVER_ARGS
       -n ${NPROC}
@@ -103,7 +103,7 @@ endforeach()
 
 foreach(NPROC 2 3 4)
   opm_add_test(test_parallel_region_phase_pvaverage_np${NPROC}
-    EXE_NAME
+    EXE_TARGET
       test_region_phase_pvaverage
     DRIVER_ARGS
       -n ${NPROC}
@@ -117,7 +117,7 @@ endforeach()
 
 foreach(NPROC 2 3 4)
   opm_add_test(test_parallel_satfunc_consistency_checks_np${NPROC}
-    EXE_NAME
+    EXE_TARGET
       test_SatfuncConsistencyChecks_parallel
     DRIVER_ARGS
       -n ${NPROC}
@@ -175,7 +175,7 @@ opm_add_test(test_HDF5Serializer_Parallel
 )
 
 opm_add_test(test_rstconv_parallel
-  EXE_NAME
+  EXE_TARGET
     test_rstconv
   DRIVER_ARGS
     -n 4

--- a/tests/run-comparison.sh
+++ b/tests/run-comparison.sh
@@ -12,7 +12,6 @@ then
   echo -e "\t\t -g value      Second deck file name"
   echo -e "\t\t -y value      Ignore extra keywords in the run. For -y 'BOTH', extra keywords in both runs will be ignored. For -y 'SECOND', extra keywords in the second deck will be ignored."
   echo -e "\t\t -r <path>     Path to store results in"
-  echo -e "\t\t -b <path>     Path to simulator binary"
   echo -e "\t\t -a <tol>      Absolute tolerance in comparison"
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
   echo -e "\t\t -c <path>     Path to comparison tool"
@@ -24,7 +23,7 @@ fi
 RESTART_STEP=""
 MPI_PROCS=1
 OPTIND=1
-while getopts "i:j:f:g:r:b:a:t:c:e:y:n:" OPT
+while getopts "i:j:f:g:r:a:t:c:e:y:n:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH1=${OPTARG} ;;
@@ -32,7 +31,6 @@ do
     f) FILENAME1=${OPTARG} ;;
     g) FILENAME2=${OPTARG} ;;
     r) RESULT_PATH=${OPTARG} ;;
-    b) BINPATH=${OPTARG} ;;
     a) ABS_TOL=${OPTARG} ;;
     t) REL_TOL=${OPTARG} ;;
     c) COMPARE_ECL_COMMAND=${OPTARG} ;;
@@ -46,12 +44,11 @@ TEST_ARGS="$@"
 
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-mpirun -np ${MPI_PROCS} ${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH1}/${FILENAME1} ${TEST_ARGS} --output-dir=${RESULT_PATH}
+mpirun -np ${MPI_PROCS} "${EXE_NAME}" ${INPUT_DATA_PATH1}/${FILENAME1} ${TEST_ARGS} --output-dir=${RESULT_PATH}
 test $? -eq 0 || exit 1
-mpirun -np ${MPI_PROCS} ${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH2}/${FILENAME2} ${TEST_ARGS} --output-dir=${RESULT_PATH}
+mpirun -np ${MPI_PROCS} "${EXE_NAME}" ${INPUT_DATA_PATH2}/${FILENAME2} ${TEST_ARGS} --output-dir=${RESULT_PATH}
 test $? -eq 0 || exit 1
 cd ..
-
 
 ecode=0
 

--- a/tests/run-damaris-regressionTest.sh
+++ b/tests/run-damaris-regressionTest.sh
@@ -9,7 +9,6 @@ then
   echo -e "\tMandatory options:"
   echo -e "\t\t -i <path>     Path to read deck from"
   echo -e "\t\t -r <path>     Path to store results in"
-  echo -e "\t\t -b <path>     Path to simulator binary"
   echo -e "\t\t -f <filename> Deck file name"
   echo -e "\t\t -a <tol>      Absolute tolerance in comparison"
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
@@ -23,12 +22,11 @@ fi
 
 MPI_PROCS=4
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:e:n:u:" OPT
+while getopts "i:r:f:a:t:c:e:n:u:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
     r) RESULT_PATH=${OPTARG} ;;
-    b) BINPATH=${OPTARG} ;;
     f) FILENAME=${OPTARG} ;;
     a) ABS_TOL=${OPTARG} ;;
     t) REL_TOL=${OPTARG} ;;
@@ -41,18 +39,19 @@ done
 shift $(($OPTIND-1))
 TEST_ARGS="$@"
 
-REF_EXE_NAME=${REF_EXE_NAME:-${EXE_NAME}}
+BASE_EXE_NAME=$(basename -- "${EXE_NAME}")
+REF_EXE_NAME=${REF_EXE_NAME:-${BASE_EXE_NAME}}
 
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-mpirun -np ${MPI_PROCS} ${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH}/${FILENAME} ${TEST_ARGS} --output-dir=${RESULT_PATH} --damaris-dedicated-cores=1 --damaris-save-mesh-to-hdf=true --enable-damaris-output=true --enable-ecl-output=false --damaris-output-hdf-collective=1 --damaris-save-to-hdf=1 --damaris-sim-name="${FILENAME}"
+mpirun -np ${MPI_PROCS} "${EXE_NAME}" ${INPUT_DATA_PATH}/${FILENAME} ${TEST_ARGS} --output-dir=${RESULT_PATH} --damaris-dedicated-cores=1 --damaris-save-mesh-to-hdf=true --enable-damaris-output=true --enable-ecl-output=false --damaris-output-hdf-collective=1 --damaris-save-to-hdf=1 --damaris-sim-name="${FILENAME}"
 test $? -eq 0 || exit 1
 cd ..
 
 echo "=== Executing comparison for files if these exists in reference folder ==="
-for fname in `ls ${RESULT_PATH}/${FILENAME}*.h5`
+for fname in $(ls ${RESULT_PATH}/${FILENAME}*.h5)
 do
-  fname=`basename $fname`
+  fname=$(basename -- "$fname")
   if test -f ${INPUT_DATA_PATH}/opm-simulation-reference/${REF_EXE_NAME}/${fname}
   then
     echo -e "\t - ${fname}"

--- a/tests/run-init-regressionTest.sh
+++ b/tests/run-init-regressionTest.sh
@@ -12,7 +12,6 @@ then
   echo -e "\tMandatory options:"
   echo -e "\t\t -i <path>     Path to read deck from"
   echo -e "\t\t -r <path>     Path to store results in"
-  echo -e "\t\t -b <path>     Path to simulator binary"
   echo -e "\t\t -f <filename> Deck file name"
   echo -e "\t\t -a <tol>      Absolute tolerance in comparison"
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
@@ -24,12 +23,11 @@ then
 fi
 
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:e:d:h:u:" OPT
+while getopts "i:r:f:a:t:c:e:d:h:u:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
     r) RESULT_PATH=${OPTARG} ;;
-    b) BINPATH=${OPTARG} ;;
     f) FILENAME=${OPTARG} ;;
     a) ABS_TOL=${OPTARG} ;;
     t) REL_TOL=${OPTARG} ;;
@@ -43,12 +41,13 @@ done
 shift $(($OPTIND-1))
 TEST_ARGS="$@"
 
-REF_EXE_NAME=${REF_EXE_NAME:-${EXE_NAME}}
+BASE_EXE_NAME=$(basename -- "${EXE_NAME}")
+REF_EXE_NAME=${REF_EXE_NAME:-${BASE_EXE_NAME}}
 
 rm -Rf  ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-${BINPATH}/${EXE_NAME} ${TEST_ARGS} --enable-dry-run=true --output-dir=${RESULT_PATH} ${INPUT_DATA_PATH}/${FILENAME}
+"${EXE_NAME}" ${TEST_ARGS} --enable-dry-run=true --output-dir=${RESULT_PATH} ${INPUT_DATA_PATH}/${FILENAME}
 cd ..
 
 ecode=0

--- a/tests/run-parallel-regressionTest.sh
+++ b/tests/run-parallel-regressionTest.sh
@@ -10,7 +10,6 @@ then
   echo -e "\tMandatory options:"
   echo -e "\t\t -i <path>     Path to read deck from"
   echo -e "\t\t -r <path>     Path to store results in"
-  echo -e "\t\t -b <path>     Path to simulator binary"
   echo -e "\t\t -f <filename> Deck file name"
   echo -e "\t\t -a <tol>      Absolute tolerance in comparison"
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
@@ -24,12 +23,11 @@ fi
 MPI_PROCS=4
 OPTIND=1
 
-while getopts "i:r:b:f:a:t:c:e:n:" OPT
+while getopts "i:r:f:a:t:c:e:n:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
     r) RESULT_PATH=${OPTARG} ;;
-    b) BINPATH=${OPTARG} ;;
     f) FILENAME=${OPTARG} ;;
     a) ABS_TOL=${OPTARG} ;;
     t) REL_TOL=${OPTARG} ;;
@@ -44,12 +42,12 @@ TEST_ARGS="$@"
 rm -Rf ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-${BINPATH}/${EXE_NAME} ${TEST_ARGS} --enable-opm-rst-file=true --output-dir=${RESULT_PATH}
+"${EXE_NAME}" ${TEST_ARGS} --enable-opm-rst-file=true --output-dir=${RESULT_PATH}
 
 test $? -eq 0 || exit 1
 mkdir mpi
 cd mpi
-mpirun -np ${MPI_PROCS} ${BINPATH}/${EXE_NAME} ${TEST_ARGS} --enable-opm-rst-file=true --output-dir=${RESULT_PATH}/mpi
+mpirun -np ${MPI_PROCS} "${EXE_NAME}" ${TEST_ARGS} --enable-opm-rst-file=true --output-dir=${RESULT_PATH}/mpi
 test $? -eq 0 || exit 1
 cd ..
 

--- a/tests/run-parallel-restart-regressionTest.sh
+++ b/tests/run-parallel-restart-regressionTest.sh
@@ -10,7 +10,6 @@ then
   echo -e "\tMandatory options:"
   echo -e "\t\t -i <path>     Path to read deck from"
   echo -e "\t\t -r <path>     Path to store results in"
-  echo -e "\t\t -b <path>     Path to simulator binary"
   echo -e "\t\t -f <filename> Deck file name"
   echo -e "\t\t -a <tol>      Absolute tolerance in comparison"
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
@@ -25,12 +24,11 @@ fi
 
 MPI_PROCS=4
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:e:n:d:s:" OPT
+while getopts "i:r:f:a:t:c:e:n:d:s:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
     r) RESULT_PATH=${OPTARG} ;;
-    b) BINPATH=${OPTARG} ;;
     f) FILENAME=${OPTARG} ;;
     a) ABS_TOL=${OPTARG} ;;
     t) REL_TOL=${OPTARG} ;;
@@ -49,13 +47,13 @@ BASE_NAME=${FILENAME}_RESTART
 rm -Rf ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-mpirun -np ${MPI_PROCS} ${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH}/${FILENAME} --output-dir=${RESULT_PATH} ${TEST_ARGS}
+mpirun -np ${MPI_PROCS} "${EXE_NAME}" ${INPUT_DATA_PATH}/${FILENAME} --output-dir=${RESULT_PATH} ${TEST_ARGS}
 
 test $? -eq 0 || exit 1
 
 ${RST_DECK_COMMAND} -m inline -s ${INPUT_DATA_PATH}/${FILENAME}.DATA ${FILENAME}.UNRST:${RESTART_STEP} ${BASE_NAME}.DATA
 
-mpirun -np ${MPI_PROCS} ${BINPATH}/${EXE_NAME} ${BASE_NAME} --output-dir=${RESULT_PATH} ${TEST_ARGS}
+mpirun -np ${MPI_PROCS} "${EXE_NAME}" ${BASE_NAME} --output-dir=${RESULT_PATH} ${TEST_ARGS}
 test $? -eq 0 || exit 1
 
 ecode=0

--- a/tests/run-parallel-unitTest.sh
+++ b/tests/run-parallel-unitTest.sh
@@ -6,16 +6,14 @@ then
   echo -e "Usage:\t$0 <options> -- [additional simulator options]"
   echo -e "\tMandatory options:"
   echo -e "\t\t -n <procs>    Number of MPI Processes to use"
-  echo -e "\t\t -b <path>     Path to simulator binary"
   echo -e "\t\t -e <filename> Simulator binary to use"
   exit 1
 fi
 
 OPTIND=1
-while getopts "n:b:e:" OPT
+while getopts "n:e:" OPT
 do
   case "${OPT}" in
-    b) BDIR=${OPTARG} ;;
     e) EXE_NAME=${OPTARG} ;;
     n) NP=${OPTARG} ;;
   esac
@@ -23,4 +21,4 @@ done
 shift $(($OPTIND-1))
 TEST_ARGS="$@"
 
-mpirun -np $NP $BDIR/bin/${EXE_NAME} ${TEST_ARGS}
+mpirun -np $NP "${EXE_NAME}" ${TEST_ARGS}

--- a/tests/run-porv-acceptanceTest.sh
+++ b/tests/run-porv-acceptanceTest.sh
@@ -12,7 +12,6 @@ then
   echo -e "\tMandatory options:"
   echo -e "\t\t -i <path>     Path to read deck from"
   echo -e "\t\t -r <path>     Path to store results in"
-  echo -e "\t\t -b <path>     Path to simulator binary"
   echo -e "\t\t -f <filename> Deck file name"
   echo -e "\t\t -a <tol>      Absolute tolerance in comparison"
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
@@ -24,12 +23,11 @@ then
 fi
 
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:e:d:h:u:" OPT
+while getopts "i:r:f:a:t:c:e:d:h:u:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
     r) RESULT_PATH=${OPTARG} ;;
-    b) BINPATH=${OPTARG} ;;
     f) FILENAME=${OPTARG} ;;
     a) ABS_TOL=${OPTARG} ;;
     t) REL_TOL=${OPTARG} ;;
@@ -43,12 +41,13 @@ done
 shift $(($OPTIND-1))
 TEST_ARGS="$@"
 
-REF_EXE_NAME=${REF_EXE_NAME:-${EXE_NAME}}
+BASE_EXE_NAME=$(basename -- "${EXE_NAME}")
+REF_EXE_NAME=${REF_EXE_NAME:-${BASE_EXE_NAME}}
 
 rm -Rf  ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-${BINPATH}/${EXE_NAME} ${TEST_ARGS} --enable-dry-run=true --output-dir=${RESULT_PATH} ${INPUT_DATA_PATH}/${FILENAME}
+"${EXE_NAME}" ${TEST_ARGS} --enable-dry-run=true --output-dir=${RESULT_PATH} ${INPUT_DATA_PATH}/${FILENAME}
 cd ..
 
 ecode=0

--- a/tests/run-regressionTest.sh
+++ b/tests/run-regressionTest.sh
@@ -9,7 +9,6 @@ then
   echo -e "\tMandatory options:"
   echo -e "\t\t -i <path>     Path to read deck from"
   echo -e "\t\t -r <path>     Path to store results in"
-  echo -e "\t\t -b <path>     Path to simulator binary"
   echo -e "\t\t -f <filename> Deck file name"
   echo -e "\t\t -a <tol>      Absolute tolerance in comparison"
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
@@ -25,12 +24,11 @@ fi
 
 RESTART_STEP=""
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:d:s:e:h:u:" OPT
+while getopts "i:r:f:a:t:c:d:s:e:h:u:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
     r) RESULT_PATH=${OPTARG} ;;
-    b) BINPATH=${OPTARG} ;;
     f) FILENAME=${OPTARG} ;;
     a) ABS_TOL=${OPTARG} ;;
     t) REL_TOL=${OPTARG} ;;
@@ -45,28 +43,28 @@ done
 shift $(($OPTIND-1))
 TEST_ARGS="$@"
 
-REF_EXE_NAME=${REF_EXE_NAME:-${EXE_NAME}}
+BASE_EXE_NAME=$(basename -- "${EXE_NAME}")
+REF_EXE_NAME=${REF_EXE_NAME:-${BASE_EXE_NAME}}
 
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
 
 # Check if simulator binary exists
-if [ ! -x "${BINPATH}/${EXE_NAME}" ]; then
-    echo "ERROR: Simulator binary not found: ${BINPATH}/${EXE_NAME}"
+if [ ! -x "${EXE_NAME}" ]; then
+    echo "ERROR: Simulator binary not found: ${EXE_NAME}"
     echo ""
     echo "To build this binary, run one of:"
-    echo "  ninja ${EXE_NAME}"
-    echo "  make ${EXE_NAME}"
-    echo "  cmake --build . --target ${EXE_NAME}"
+    echo "  ninja ${BASE_EXE_NAME}"
+    echo "  make ${BASE_EXE_NAME}"
+    echo "  cmake --build . --target ${BASE_EXE_NAME}"
     echo ""
     echo "Or build all targets with: ninja / make"
     exit 1
 fi
 
-${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH}/${FILENAME} ${TEST_ARGS} --output-dir=${RESULT_PATH}
+"${EXE_NAME}" ${INPUT_DATA_PATH}/${FILENAME} ${TEST_ARGS} --output-dir=${RESULT_PATH}
 test $? -eq 0 || exit 1
 cd ..
-
 
 ecode=0
 
@@ -105,7 +103,7 @@ do
   then
     sched_rst="--sched-restart=${RESTART_SCHED}"
   fi
-  ${BINPATH}/${EXE_NAME} ${TEST_ARGS} ${sched_rst} --output-dir=${RESULT_PATH}/restart ${FILENAME}_RESTART_${STEP}
+  "${EXE_NAME}" ${TEST_ARGS} ${sched_rst} --output-dir=${RESULT_PATH}/restart ${FILENAME}_RESTART_${STEP}
   test $? -eq 0 || exit 1
 
   if test -n "$type"

--- a/tests/run-restart-regressionTest.sh
+++ b/tests/run-restart-regressionTest.sh
@@ -10,7 +10,6 @@ then
   echo -e "\tMandatory options:"
   echo -e "\t\t -i <path>     Path to read deck from"
   echo -e "\t\t -r <path>     Path to store results in"
-  echo -e "\t\t -b <path>     Path to simulator binary"
   echo -e "\t\t -f <filename> Deck file name"
   echo -e "\t\t -a <tol>      Absolute tolerance in comparison"
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
@@ -22,12 +21,11 @@ then
 fi
 
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:e:d:s:" OPT
+while getopts "i:r:f:a:t:c:e:d:s:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
     r) RESULT_PATH=${OPTARG} ;;
-    b) BINPATH=${OPTARG} ;;
     f) FILENAME=${OPTARG} ;;
     a) ABS_TOL=${OPTARG} ;;
     t) REL_TOL=${OPTARG} ;;
@@ -45,13 +43,13 @@ BASE_NAME=${FILENAME}_RESTART
 rm -Rf ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH}/${FILENAME} --output-dir=${RESULT_PATH} ${TEST_ARGS}
+"${EXE_NAME}" ${INPUT_DATA_PATH}/${FILENAME} --output-dir=${RESULT_PATH} ${TEST_ARGS}
 
 test $? -eq 0 || exit 1
 
 ${RST_DECK_COMMAND} -m inline -s ${INPUT_DATA_PATH}/${FILENAME}.DATA ${FILENAME}.UNRST:${RESTART_STEP} ${BASE_NAME}.DATA
 
-${BINPATH}/${EXE_NAME} ${BASE_NAME} --output-dir=${RESULT_PATH} ${TEST_ARGS}
+"${EXE_NAME}" ${BASE_NAME} --output-dir=${RESULT_PATH} ${TEST_ARGS}
 test $? -eq 0 || exit 1
 
 ecode=0

--- a/tests/run-serialization-regressionTest.sh
+++ b/tests/run-serialization-regressionTest.sh
@@ -10,7 +10,6 @@ then
   echo -e "\tMandatory options:"
   echo -e "\t\t -i <path>     Path to read deck from"
   echo -e "\t\t -r <path>     Path to store results in"
-  echo -e "\t\t -b <path>     Path to simulator binary"
   echo -e "\t\t -f <filename> Deck file name"
   echo -e "\t\t -a <tol>      Absolute tolerance in comparison"
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
@@ -22,12 +21,11 @@ fi
 
 OPTIND=1
 MPI_PROCS=1
-while getopts "i:r:b:f:a:t:c:e:n:d:s:" OPT
+while getopts "i:r:f:a:t:c:e:n:d:s:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
     r) RESULT_PATH=${OPTARG} ;;
-    b) BINPATH=${OPTARG} ;;
     f) FILENAME=${OPTARG} ;;
     a) ABS_TOL=${OPTARG} ;;
     t) REL_TOL=${OPTARG} ;;
@@ -44,18 +42,18 @@ TEST_ARGS="$@"
 BASE_NAME=${FILENAME}
 if test $MPI_PROCS -gt 1
 then
-  CMD_PREFIX="mpirun -np $MPI_PROCS "
+  CMD_PREFIX="mpirun -np $MPI_PROCS"
 fi
 
 rm -Rf ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-${CMD_PREFIX}${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH}/${FILENAME} --output-dir=${RESULT_PATH} ${TEST_ARGS} --save-step=${RESTART_STEP}
+${CMD_PREFIX} "${EXE_NAME}" ${INPUT_DATA_PATH}/${FILENAME} --output-dir=${RESULT_PATH} ${TEST_ARGS} --save-step=${RESTART_STEP}
 
 test $? -eq 0 || exit 1
 
 mkdir -p ${RESULT_PATH}/restart
-${CMD_PREFIX}${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH}/${FILENAME} --output-dir=${RESULT_PATH}/restart ${TEST_ARGS} --load-step=${RESTART_STEP} --save-file=${RESULT_PATH}/${FILENAME}.OPMRST
+${CMD_PREFIX} "${EXE_NAME}" ${INPUT_DATA_PATH}/${FILENAME} --output-dir=${RESULT_PATH}/restart ${TEST_ARGS} --load-step=${RESTART_STEP} --save-file=${RESULT_PATH}/${FILENAME}.OPMRST
 test $? -eq 0 || exit 1
 
 echo "=== Executing comparison for restart file ==="

--- a/tests/run-split-comm-test.sh
+++ b/tests/run-split-comm-test.sh
@@ -11,7 +11,6 @@ then
   echo -e "\tMandatory options:"
   echo -e "\t\t -i <path>     Path to read deck from"
   echo -e "\t\t -r <path>     Path to store results in"
-  echo -e "\t\t -b <path>     Path to simulator binary"
   echo -e "\t\t -f <filename> Deck file name"
   echo -e "\t\t -a <tol>      Absolute tolerance in comparison"
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
@@ -23,12 +22,11 @@ fi
 BASE_MPI_PROCS=3
 TEST_MPI_PROCS=4 # should be 1 more than the base
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:e:n:" OPT
+while getopts "i:r:f:a:t:c:e:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
     r) RESULT_PATH=${OPTARG} ;;
-    b) BINPATH=${OPTARG} ;;
     f) FILENAME=${OPTARG} ;;
     a) ABS_TOL=${OPTARG} ;;
     t) REL_TOL=${OPTARG} ;;
@@ -42,12 +40,10 @@ TEST_ARGS="$@"
 rm -Rf ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 
-echo mpirun -np ${BASE_MPI_PROCS} ${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH}/${FILENAME}.DATA ${TEST_ARGS} --output-dir=${RESULT_PATH}/base
-mpirun -np ${BASE_MPI_PROCS} ${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH}/${FILENAME}.DATA ${TEST_ARGS} --output-dir=${RESULT_PATH}/base
+mpirun -np ${BASE_MPI_PROCS} "${EXE_NAME}" ${INPUT_DATA_PATH}/${FILENAME}.DATA ${TEST_ARGS} --output-dir=${RESULT_PATH}/base
 test $? -eq 0 || exit 1
 
-echo mpirun -np ${TEST_MPI_PROCS} ${BINPATH}/${EXE_NAME} --test-split-communicator=true ${INPUT_DATA_PATH}/${FILENAME}.DATA ${TEST_ARGS} --output-dir=${RESULT_PATH}/test
-mpirun -np ${TEST_MPI_PROCS} ${BINPATH}/${EXE_NAME} --test-split-communicator=true ${INPUT_DATA_PATH}/${FILENAME}.DATA ${TEST_ARGS} --output-dir=${RESULT_PATH}/test
+mpirun -np ${TEST_MPI_PROCS} "${EXE_NAME}" --test-split-communicator=true ${INPUT_DATA_PATH}/${FILENAME}.DATA ${TEST_ARGS} --output-dir=${RESULT_PATH}/test
 test $? -eq 0 || exit 1
 
 ecode=0

--- a/tests/run-summary-restart-regressionTest.sh
+++ b/tests/run-summary-restart-regressionTest.sh
@@ -12,7 +12,6 @@ then
   echo -e "\tMandatory options:"
   echo -e "\t\t -i <path>     Path to read deck from"
   echo -e "\t\t -r <path>     Path to store results in"
-  echo -e "\t\t -b <path>     Path to simulator binary"
   echo -e "\t\t -f <filename> Deck file name"
   echo -e "\t\t -a <tol>      Absolute tolerance in comparison"
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
@@ -24,12 +23,11 @@ then
 fi
 
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:e:d:s:" OPT
+while getopts "i:r:f:a:t:c:e:d:s:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
     r) RESULT_PATH=${OPTARG} ;;
-    b) BINPATH=${OPTARG} ;;
     f) FILENAME=${OPTARG} ;;
     a) ABS_TOL=${OPTARG} ;;
     t) REL_TOL=${OPTARG} ;;
@@ -47,13 +45,13 @@ BASE_NAME=${FILENAME}_RESTART
 rm -Rf ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH}/${FILENAME} --output-dir=${RESULT_PATH} ${TEST_ARGS}
+"${EXE_NAME}" ${INPUT_DATA_PATH}/${FILENAME} --output-dir=${RESULT_PATH} ${TEST_ARGS}
 
 test $? -eq 0 || exit 1
 
 ${RST_DECK_COMMAND} -m inline -s ${INPUT_DATA_PATH}/${FILENAME}.DATA ${FILENAME}.UNRST:${RESTART_STEP} ${BASE_NAME}.DATA
 
-${BINPATH}/${EXE_NAME} ${BASE_NAME} --output-dir=${RESULT_PATH} ${TEST_ARGS}
+"${EXE_NAME}" ${BASE_NAME} --output-dir=${RESULT_PATH} ${TEST_ARGS}
 test $? -eq 0 || exit 1
 
 ecode=0

--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -8,7 +8,6 @@ then
   echo -e "\tMandatory options:"
   echo -e "\t\t -i <path>     Path to read deck from"
   echo -e "\t\t -r <path>     Path to store results in"
-  echo -e "\t\t -b <path>     Path to simulator binary"
   echo -e "\t\t -f <filename> Deck file name"
   echo -e "\t\t -e <filename> Simulator binary to use"
   echo -e "\tOptional options:"
@@ -19,12 +18,11 @@ fi
 
 OPTIND=1
 MPI_PROCS=1
-while getopts "i:r:b:f:e:n:p:" OPT
+while getopts "i:r:f:e:n:p:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
     r) RESULT_PATH=${OPTARG} ;;
-    b) BINPATH=${OPTARG} ;;
     f) FILENAME=${OPTARG} ;;
     e) EXE_NAME=${OPTARG} ;;
     n) MPI_PROCS=${OPTARG} ;;
@@ -37,9 +35,9 @@ TEST_ARGS="$@"
 mkdir -p ${RESULT_PATH}
 if (( ${MPI_PROCS} > 1))
 then
-  mpirun -np ${MPI_PROCS} ${BINPATH}/${EXE_NAME} ${TEST_ARGS} --output-dir=${RESULT_PATH} "${INPUT_DATA_PATH}/${FILENAME}.DATA"
+  mpirun -np ${MPI_PROCS} "${EXE_NAME}" ${TEST_ARGS} --output-dir=${RESULT_PATH} "${INPUT_DATA_PATH}/${FILENAME}.DATA"
 else
-  ${BINPATH}/${EXE_NAME} ${TEST_ARGS} --output-dir=${RESULT_PATH} "${INPUT_DATA_PATH}/${FILENAME}.DATA"
+  "${EXE_NAME}" ${TEST_ARGS} --output-dir=${RESULT_PATH} "${INPUT_DATA_PATH}/${FILENAME}.DATA"
 fi
 test $? -eq 0 || exit 1
 


### PR DESCRIPTION
The EXE_NAME is now a target and parameter is renamed accordingly.
Downstream of https://github.com/OPM/opm-common/pull/5180