### PR TITLE
Report non-supported options of the WECON keyword

### DIFF
--- a/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
@@ -262,6 +262,16 @@ partiallySupported()
             },
          },
          {
+            "WECON",
+            {
+               {7,{true, allow_values<std::string> {"NONE", "CON", "WELL"}, "WECON(ACTION): Only NONE, CON and WELL options are supported"}}, // ACTION
+               {8,{true, allow_values<std::string> {"NO"}, "WECON(ENDRUN): only the NO option is supported"}}, // END_RUN
+               // Item 9 (follow-on well) is supported (but not validated here because it is a string with no specific allowed values).
+               {10,{true, allow_values<std::string> {"POTN", "RATE"}, "WECON(ELTOPT): Valid options are POTN and RATE"}}, // ELTOPT
+               {12,{true, allow_values<std::string> {}, "WECON(ACTION2): Feature not supported and should be defaulted"}}, // ACTION2
+            },
+         },
+         {
             "WELSPECS",
             {
                {8,{true, allow_values<std::string> {"STD", "NO"}, "WELSPECS(WELNETWK): only the STD and NO options are supported"}}, // INFLOW_EQ
@@ -641,6 +651,16 @@ partiallySupported()
             "WAGHYSTR",
             {
                {8,{false, allow_values<double> {}, "WAGHYSTR(RES_OIL_MOD_FRACTION): Residual oil modification for STONE1 not supported - value ignored"}}, // RES_OIL_MOD_FRACTION
+            },
+         },
+         {
+            "WECON",
+            {
+               {11,{true, allow_values<double> {}, "WECON(WCUT2): Feature not supported and should be defaulted"}}, // WELOPEN
+               {13,{true, allow_values<double> {}, "WECON(GLR): Feature not supported and should be defaulted"}}, // GLR
+               {14,{true, allow_values<double> {}, "WECON(LRAT): Feature not supported and should be defaulted"}}, // LRAT
+               {15,{true, allow_values<double> {}, "WECON(TEMP): Feature not supported and should be defaulted"}}, // TEMP
+               {16,{true, allow_values<double> {}, "WECON(RESV): Feature not supported and should be defaulted"}}, // RESV
             },
          },
          {


### PR DESCRIPTION
In particular, ensures that the '+CON' workover is not silently ignored.