### PR TITLE
PyBaseSimulator: reset parameter system on destruction

### DIFF
--- a/opm/simulators/flow/python/PyBaseSimulator.hpp
+++ b/opm/simulators/flow/python/PyBaseSimulator.hpp
@@ -56,6 +56,11 @@ public:
                     std::shared_ptr<SummaryConfig> summary_config,
                     const std::vector<std::string>& args);
 
+    virtual ~PyBaseSimulator()
+    {
+        Parameters::reset();
+    }
+
     void advance(int report_step);
 
     bool checkSimulationFinished();


### PR DESCRIPTION
when the python modules are linked against a shared opm-simulators library, the unit tests fails (first test is fine, second would break) because old parameters are used for the second instance. This because Parameters::IsRegistrationOpen() returns false.