### PR TITLE
[LGR Summary] readDeck: supply an LGR-aware GridDims call-back to SummaryConfig

### DIFF
--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -44,7 +44,9 @@
 #include <opm/input/eclipse/Deck/Deck.hpp>
 
 #include <opm/input/eclipse/EclipseState/checkDeck.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldData.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/GridDims.hpp>
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 #include <opm/input/eclipse/Parser/ErrorGuard.hpp>
@@ -398,9 +400,32 @@ namespace {
         }
 
         if (summaryConfig == nullptr) {
+            // Supply an LGR-aware GridDims call-back so LGR block/connection
+            // summary vectors (LB*/LC*) resolve their NUMS.  SummaryConfig stays
+            // decoupled from EclipseGrid: the grid is captured here, in the client.
+            const auto& inputGrid = eclipseState->getInputGrid();
+            auto lgrGridDims =
+                [&inputGrid](const std::string& gridID) -> Opm::GridDims
+            {
+                if (gridID.empty()) {
+                    return Opm::GridDims {
+                        inputGrid.getNX(), inputGrid.getNY(), inputGrid.getNZ()
+                    };
+                }
+
+                const auto labels = inputGrid.get_all_lgr_labels();
+                if (std::ranges::find(labels, gridID) == labels.end()) {
+                    return Opm::GridDims{};
+                }
+
+                const auto& lgr = inputGrid.getLGRCell(gridID);
+                return Opm::GridDims { lgr.getNX(), lgr.getNY(), lgr.getNZ() };
+            };
+
             summaryConfig = std::make_shared<Opm::SummaryConfig>
                 (deck, *schedule, eclipseState->fieldProps(),
-                 eclipseState->aquifer(), *parseContext, errorGuard);
+                 eclipseState->aquifer(), *parseContext, errorGuard,
+                 std::move(lgrGridDims));
         }
 
         Opm::checkConsistentArrayDimensions(*eclipseState, *schedule,


### PR DESCRIPTION
# [LGR Summary] readDeck: supply an LGR-aware GridDims call-back to SummaryConfig

## Summary

LGR block/connection summary vectors (`LB*`/`LC*`) carry their cell identity as a `NUMS`
value that `SummaryConfig` populates only when its `CellIndexMapper` call-back returns the
LGR's own dimensions. The production parse path in `readDeck` constructed `SummaryConfig`
without such a call-back, so for any LGR the mapper returned a default `GridDims` (`NX == 0`)
and those nodes were left at `SummaryNode::default_number` — the runtime evaluators then
emitted nothing.

This builds an LGR-aware `GridDims` call-back at the construction site (which already owns
the `EclipseState` and its grid) and passes it through the existing
`std::function<GridDims(const std::string&)>` constructor, keeping `SummaryConfig` decoupled
from `EclipseGrid`.

## Change

`opm/simulators/utils/readDeck.cpp` — when building the production `SummaryConfig`, build a
call-back that returns the global grid dimensions for the empty grid id, and each LGR's own
dimensions for a known label (via `EclipseGrid::getLGRCell`, guarded by `get_all_lgr_labels()`);
unknown labels return a default `GridDims`. Pass it to the call-back constructor.

## Effect

Real `flow` runs on a deck with LGR summary requests now populate `NUMS` for `LB*`/`LC*`
nodes, so the connection-summary evaluators emit values. The connection cell identity on
`data::Connection` is already populated in production runs (opm-simulators#7056), and the
connection-summary evaluators are already in opm-common master.

Non-LGR decks are unaffected — the call-back returns the global grid dimensions exactly as
before.