### PR TITLE
Use Exact Test Name Matching When Extracting Test Properties

### DIFF
--- a/tests/getprop.awk
+++ b/tests/getprop.awk
@@ -3,33 +3,72 @@
 # User must initialise two awk variables, typically through the "-v" option,
 # when invoking this script
 #
-#   search: Search pattern.  Typically a string such as
-#      set_tests_properties($test_name
+#   test: Test name.
 #
 #   prop: Property name, for instance DIRNAME or SIMULATOR.
 #
 # Property value will be printed to the standard output stream.
 #
-# The script assumes that $1 on candidate lines is suitable for matching
-# against 'search', and that $2 of the matching lines is the word
-# 'PROPERTIES'.
-#
 # Example:
 #   # Get value of SIMULATOR property in test named by shell variable
 #   # $failed_test and assign this to shell variable 'binary'.
 #
-#   binary=$(awk -v search="set_tests_properties\\\($failed_test" \
+#   binary=$(awk -v test="${failed_test}" \
 #            -v prop="SIMULATOR" \
 #            -f getprop.awk \
 #            CTestTestfile.cmake)
 
-$1 ~ search {
-    for (i = 3; i <= NF; ++i) {
-        if ($i == prop) {
-            val = $(i + 1)
-            gsub(/"/, "", val)
-            print val
+BEGIN {
+    # Validate that the user provided the required variables
+    if (!test || !prop) {
+        print "Error: Please provide both 'test' and 'prop' variables." > "/dev/stderr"
+        print "Usage: awk -v test=\"NAME\" -v prop=\"PROP\" -f getprop.awk <file>" > "/dev/stderr"
+        exit 1
+    }
+
+    # Construct exact anchor patterns for the test name
+    bracket_target = "[=[" test "]=]"
+    quoted_target  = "\"" test "\""
+
+    # Unquoted test names must be followed by at least one blank/space
+    unquoted_target = test " "
+}
+
+{
+    # 1. Detect block start using strict literal string matches
+    if (index($0, "set_tests_properties(") &&
+        (index($0, bracket_target) ||
+         index($0, quoted_target)  ||
+         index($0, unquoted_target)))
+    {
+        in_target_block = 1
+    }
+
+    # 2. Extract target property value while inside the target block
+    if (in_target_block && index($0, prop)) {
+        # Match standard quoted string: PROPERTY "value" (e.g., SIMULATOR "flow")
+        if (match($0, prop "[[:space:]]+\"[^\"]+\"")) {
+            split(substr($0, RSTART, RLENGTH), parts, "\"")
+            print parts[2]
             exit
         }
+        # Match CMake bracket argument: PROPERTY [=[value]=] (e.g., SIMULATOR [=[flow]=])
+        else if (match($0, prop "[[:space:]]+\\[=\\[[^\\]]+\\]=\\]")) {
+            split(substr($0, RSTART, RLENGTH), parts, /\[=\[|\]=\]/)
+            print parts[2]
+            exit
+        }
+        # Match unquoted argument: PROPERTY value (e.g., SIMULATOR flow)
+        else if (match($0, prop "[[:space:]]+[^[:space:]]+")) {
+            # Split on FS--i.e., whitespace.
+            split(substr($0, RSTART, RLENGTH), parts)
+            print parts[2]
+            exit
+        }
+    }
+
+    # 3. Reset flag at the end of the command block
+    if (in_target_block && index($0, ")")) {
+        in_target_block = 0
     }
 }

--- a/tests/make_failure_report.sh
+++ b/tests/make_failure_report.sh
@@ -19,22 +19,22 @@ for failed_test in $FAILED_TESTS
 do
   if grep -q -E "compareECLFiles" <<< $failed_test
   then
-    failed_test=`echo $failed_test | sed -e 's/.*://g' -e 's/\+/./g'`
+    failed_test=$(echo "${failed_test}" | sed -e 's/.*://')
     # Extract test properties
-    binary=$(awk -v search="set_tests_properties\\\(.*${failed_test}.*\$" -v prop="SIMULATOR" -f ${SOURCE_DIR}/getprop.awk $RESULT_DIR/CTestTestfile.cmake)
-    dir_name=$(awk -v search="set_tests_properties\\\(.*${failed_test}.*\$" -v prop="DIRNAME" -f ${SOURCE_DIR}/getprop.awk $RESULT_DIR/CTestTestfile.cmake)
-    file_name=$(awk -v search="set_tests_properties\\\(.*${failed_test}.*\$" -v prop="FILENAME" -f ${SOURCE_DIR}/getprop.awk $RESULT_DIR/CTestTestfile.cmake)
-    test_name=$(awk -v search="set_tests_properties\\\(.*${failed_test}.*\$" -v prop="TESTNAME" -f ${SOURCE_DIR}/getprop.awk $RESULT_DIR/CTestTestfile.cmake)
+    binary=$(awk -v test="${failed_test}" -v prop="SIMULATOR" -f ${SOURCE_DIR}/getprop.awk $RESULT_DIR/CTestTestfile.cmake)
+    dir_name=$(awk -v test="${failed_test}" -v prop="DIRNAME" -f ${SOURCE_DIR}/getprop.awk $RESULT_DIR/CTestTestfile.cmake)
+    file_name=$(awk -v test="${failed_test}" -v prop="FILENAME" -f ${SOURCE_DIR}/getprop.awk $RESULT_DIR/CTestTestfile.cmake)
+    test_name=$(awk -v test="${failed_test}" -v prop="TESTNAME" -f ${SOURCE_DIR}/getprop.awk $RESULT_DIR/CTestTestfile.cmake)
     JOBLIST+="-r $OPM_TESTS_ROOT/${dir_name}/opm-simulation-reference/${binary}/${file_name} -s $RESULT_DIR/tests/results/$binary+$test_name/$file_name -c $test_name -o plot\\n"
   elif grep -q -E "compareSeparateECLFiles" <<< $failed_test
   then
-    failed_test=`echo $failed_test | sed -e 's/.*://g' -e 's/\+/./g'`
+    failed_test=$(echo "${failed_test}" | sed -e 's/.*://')
     # Extract test properties
-    binary=$(awk -v search="set_tests_properties\\\(.*${failed_test}.*\$" -v prop="SIMULATOR" -f ${SOURCE_DIR}/getprop.awk $RESULT_DIR/CTestTestfile.cmake)
-    dir_name=$(awk -v search="set_tests_properties\\\(.*${failed_test}.*\$" -v prop="DIRNAME" -f ${SOURCE_DIR}/getprop.awk $RESULT_DIR/CTestTestfile.cmake)
-    file_name1=$(awk -v search="set_tests_properties\\\(.*${failed_test}.*\$" -v prop="FILENAME1" -f ${SOURCE_DIR}/getprop.awk $RESULT_DIR/CTestTestfile.cmake)
-    file_name2=$(awk -v search="set_tests_properties\\\(.*${failed_test}.*\$" -v prop="FILENAME2" -f ${SOURCE_DIR}/getprop.awk $RESULT_DIR/CTestTestfile.cmake)
-    test_name=$(awk -v search="set_tests_properties\\\(.*${failed_test}.*\$" -v prop="TESTNAME" -f ${SOURCE_DIR}/getprop.awk $RESULT_DIR/CTestTestfile.cmake)
+    binary=$(awk -v test="${failed_test}" -v prop="SIMULATOR" -f ${SOURCE_DIR}/getprop.awk $RESULT_DIR/CTestTestfile.cmake)
+    dir_name=$(awk -v test="${failed_test}" -v prop="DIRNAME" -f ${SOURCE_DIR}/getprop.awk $RESULT_DIR/CTestTestfile.cmake)
+    file_name1=$(awk -v test="${failed_test}" -v prop="FILENAME1" -f ${SOURCE_DIR}/getprop.awk $RESULT_DIR/CTestTestfile.cmake)
+    file_name2=$(awk -v test="${failed_test}" -v prop="FILENAME2" -f ${SOURCE_DIR}/getprop.awk $RESULT_DIR/CTestTestfile.cmake)
+    test_name=$(awk -v test="${failed_test}" -v prop="TESTNAME" -f ${SOURCE_DIR}/getprop.awk $RESULT_DIR/CTestTestfile.cmake)
     JOBLIST+="-r $RESULT_DIR/tests/results/$binary+$test_name/$file_name1 -s $RESULT_DIR/tests/results/$binary+$test_name/$file_name2 -c $test_name -o plot -t $file_name1 -u $file_name2\\n"
   fi
 done

--- a/tests/update_test_reference.sh
+++ b/tests/update_test_reference.sh
@@ -86,23 +86,23 @@ compareResultFileContents () {
 extractTestProperties () {
     local failed_test
 
-    failed_test=$(echo "$1" | sed -e 's/.*://' -e 's/\+/./g')
+    failed_test=$(echo "$1" | sed -e 's/.*://')
 
-    testProperty["binary"]=$(awk -v search="set_tests_properties\\\(.*${failed_test}.*\$" \
-                             -v prop="SIMULATOR" -f "${dir}/getprop.awk" \
-                             "${BUILD_DIR}/CTestTestfile.cmake")
+    testProperty["binary"]=$(awk -v test="${failed_test}" \
+                                 -v prop="SIMULATOR" -f "${dir}/getprop.awk" \
+                                 "${BUILD_DIR}/CTestTestfile.cmake")
 
-    testProperty["dir_name"]=$(awk -v search="set_tests_properties\\\(.*${failed_test}.*\$" \
-                               -v prop="DIRNAME" -f "${dir}/getprop.awk" \
-                               "${BUILD_DIR}/CTestTestfile.cmake")
+    testProperty["dir_name"]=$(awk -v test="${failed_test}" \
+                                   -v prop="DIRNAME" -f "${dir}/getprop.awk" \
+                                   "${BUILD_DIR}/CTestTestfile.cmake")
 
-    testProperty["file_name"]=$(awk -v search="set_tests_properties\\\(.*${failed_test}.*\$" \
-                                -v prop="FILENAME" -f "${dir}/getprop.awk" \
-                                "${BUILD_DIR}/CTestTestfile.cmake")
+    testProperty["file_name"]=$(awk -v test="${failed_test}" \
+                                    -v prop="FILENAME" -f "${dir}/getprop.awk" \
+                                    "${BUILD_DIR}/CTestTestfile.cmake")
 
-    testProperty["test_name"]=$(awk -v search="set_tests_properties\\\(.*${failed_test}.*\$" \
-                                -v prop="TESTNAME" -f "${dir}/getprop.awk" \
-                                "${BUILD_DIR}/CTestTestfile.cmake")
+    testProperty["test_name"]=$(awk -v test="${failed_test}" \
+                                    -v prop="TESTNAME" -f "${dir}/getprop.awk" \
+                                    "${BUILD_DIR}/CTestTestfile.cmake")
 }
 
 # Copy results from a test run to reference dir


### PR DESCRIPTION
This PR switches away from matching specific test names in `CTestTestfile.cmake` using regular expressions to using exact name match instead.  The regular expressions are a little too brittle in the face of partially overlapping test names like

 * compareECLFiles_flow+UDT-1D-01
 * compareECLFiles_flow+UDT-1D-01B

for which the greedy matching `.*$` could yield false positives. Instead we use the `index` function to pinpoint the exact line, and position within the line, that matches exactly that test and specific property.  While here, switch the injected variable name away from `search` and over to `test` to better reflect the nature of the variable and update call sites accordingly.