### PR TITLE
art2dgf: address clang-tidy warnings

### DIFF
--- a/examples/art2dgf.cpp
+++ b/examples/art2dgf.cpp
@@ -272,13 +272,13 @@ try {
         return 1;
     }
 
-    std::string filename( argv[ 1 ] );
-    std::string dgfname( filename );
+    std::string filename(argv[1]);
+    std::string dgfname(filename);
     dgfname += ".dgf";
 
     std::cout << "Converting ART file \"" << filename << "\" to DGF file \"" << dgfname << "\"\n";
-    std::ofstream dgfFile( dgfname );
-    Ewoms::Art2DGF::convert( filename, dgfFile );
+    std::ofstream dgfFile(dgfname);
+    Ewoms::Art2DGF::convert(filename, dgfFile);
 
     return 0;
 }

--- a/examples/art2dgf.cpp
+++ b/examples/art2dgf.cpp
@@ -103,13 +103,7 @@ private:
                 continue;
 
             if (curParseMode == ParseMode::Vertex) {
-                GlobalPosition coord;
-                std::istringstream iss(curLine);
-                // parse only the first two numbers as the vertex
-                // coordinate. the last number is the Z coordinate
-                // which we ignore (so far)
-                iss >> coord[0] >> coord[1];
-                vertexPos.push_back( std::make_pair( coord, 0 ) );
+                vertexPos.emplace_back(parseVertex(curLine), 0);
             }
             else if (curParseMode == ParseMode::Edge) {
                 // read an edge and update the fracture mapper
@@ -215,6 +209,20 @@ private:
         }
 
         write(dgfFile, precision);
+    }
+
+    //! \brief Parses a vertex from a string.
+    //! \param curLine String to parse
+    static GlobalPosition parseVertex(const std::string& curLine)
+    {
+        GlobalPosition coord;
+        std::istringstream iss(curLine);
+        // parse only the first two numbers as the vertex
+        // coordinate. the last number is the Z coordinate
+        // which we ignore (so far)
+        iss >> coord[0] >> coord[1];
+
+        return coord;
     }
 
     //! \brief Writes out the data to the output stream.

--- a/examples/art2dgf.cpp
+++ b/examples/art2dgf.cpp
@@ -202,6 +202,22 @@ namespace Ewoms {
             }
         }
 
+        write(dgfFile, fractureEdges, vertexPos, elements, precision);
+    }
+
+private:
+    //! \brief Writes out the data to the output stream.
+    //! \param dgfFile Stream to write to
+    //! \param fractureEdges List of fracture edges
+    //! \param vertexPos List of vertices
+    //! \param elements List of element connectivities
+    //! \param precision Precision to write at
+    static void write(std::ostream& dgfFile,
+                      const std::vector<std::pair<unsigned, unsigned>>& fractureEdges,
+                      const std::vector<std::pair<Dune::FieldVector<double, 2>, unsigned>>& vertexPos,
+                      const std::vector<std::vector<unsigned>>& elements,
+                      const unsigned precision)
+    {
         dgfFile << "DGF" << std::endl << std::endl;
 
         dgfFile << "GridParameter" << std::endl
@@ -211,19 +227,15 @@ namespace Ewoms {
 
         dgfFile << "Vertex" << std::endl;
         const bool hasFractures = fractureEdges.size() > 0;
-        if( hasFractures )
-        {
+        if (hasFractures) {
             dgfFile << "parameters 1" << std::endl;
         }
         dgfFile << std::scientific;
         dgfFile.precision( precision );
-        const size_t vxSize = vertexPos.size();
-        for( size_t i=0; i<vxSize; ++i)
-        {
-            dgfFile << vertexPos[ i ].first;
-            if( hasFractures )
-            {
-                dgfFile << " " << vertexPos[ i ].second;
+        for (const auto& vtx : vertexPos) {
+            dgfFile << vtx.first;
+            if (hasFractures) {
+                dgfFile << " " << vtx.second;
             }
             dgfFile << std::endl;
         }
@@ -231,12 +243,10 @@ namespace Ewoms {
         dgfFile << "#" << std::endl << std::endl;
 
         dgfFile << "Simplex" << std::endl;
-        const size_t elSize = elements.size();
-        for( size_t i=0; i<elSize; ++i )
-        {
-            const size_t elVx = elements[ i ].size();
-            for( size_t j=0; j<elVx; ++j )
-                dgfFile << elements[ i ][ j ] << " ";
+        for (const auto& element : elements) {
+            for (const auto idx : element) {
+                dgfFile << idx << " ";
+            }
             dgfFile << std::endl;
         }
 

--- a/examples/art2dgf.cpp
+++ b/examples/art2dgf.cpp
@@ -95,8 +95,9 @@ private:
             }
 
             // skip empty lines
-            if (curLine.empty())
+            if (curLine.empty()) {
                 continue;
+            }
 
             if (curParseMode == ParseMode::Vertex) {
                 vertexPos.emplace_back(parseVertex(curLine), 0);
@@ -114,67 +115,16 @@ private:
                 }
             }
             else if (curParseMode == ParseMode::Element) {
-                // skip the data attached to an element
-                std::istringstream iss(curLine);
-                int dataVal;
-                std::string tmp;
-                iss >> dataVal;
-                iss >> tmp;
-                assert(tmp == ":");
-
-                // read the edge indices of an element
-                std::vector<unsigned> edgeIndices;
-                while (iss) {
-                    unsigned tmp2;
-                    iss >> tmp2;
-                    if (!iss)
-                        break;
-                    edgeIndices.push_back(tmp2);
-                    assert(tmp2 < edges.size());
-                }
-
-                // so far, we only support triangles
-                assert(edgeIndices.size() == 3);
-
-                // extract the vertex indices of the element
-                std::vector<unsigned> vertIndices;
-                for (unsigned i = 0; i < 3; ++i) {
-                    bool haveFirstVertex = false;
-                    for (unsigned j = 0; j < vertIndices.size(); ++j) {
-                        assert(edgeIndices[i] < edges.size());
-                        if (vertIndices[j] == edges[edgeIndices[i]].first) {
-                            haveFirstVertex = true;
-                            break;
-                        }
-                    }
-                    if (!haveFirstVertex)
-                        vertIndices.push_back(edges[edgeIndices[i]].first);
-
-                    bool haveSecondVertex = false;
-                    for (unsigned j = 0; j < vertIndices.size(); ++j) {
-                        assert(edgeIndices[i] < edges.size());
-                        if (vertIndices[j] == edges[edgeIndices[i]].second) {
-                            haveSecondVertex = true;
-                            break;
-                        }
-                    }
-                    if (!haveSecondVertex)
-                        vertIndices.push_back(edges[edgeIndices[i]].second);
-                }
+                auto vertIndices = parseElement(curLine);
 
                 // check whether the element's vertices are given in
                 // mathematically positive direction. if not, swap the
-                // first two.
-                Dune::FieldMatrix<Scalar, 2, 2> mat;
-                mat[0] = vertexPos[vertIndices[1]].first;
-                mat[0] -= vertexPos[vertIndices[0]].first;
-                mat[1] = vertexPos[vertIndices[2]].first;
-                mat[1] -= vertexPos[vertIndices[0]].first;
-                assert(std::abs(mat.determinant()) > 1e-50);
-                if (mat.determinant() < 0)
+                // last two indices.
+                if (!isPositive(vertIndices)) {
                     std::swap(vertIndices[2], vertIndices[1]);
+                }
 
-                elements.push_back( vertIndices );
+                elements.push_back(std::move(vertIndices));
             }
             else if (curParseMode == ParseMode::Finished) {
                 assert(curLine.size() == 0);
@@ -243,6 +193,87 @@ private:
         return std::make_pair(Edge{vertIndices[0], vertIndices[1]}, dataVal < 0);
     }
 
+    //! \brief Parses an element from a string.
+    //! \param curLine String to parse
+    std::vector<unsigned>
+    parseElement(const std::string& curLine)
+    {
+        // skip the data attached to an element
+        std::istringstream iss(curLine);
+        int dataVal;
+        std::string tmp;
+        iss >> dataVal;
+        iss >> tmp;
+        assert(tmp == ":");
+
+        // read the edge indices of an element
+        std::vector<unsigned> edgeIndices;
+        while (iss) {
+            unsigned tmp2;
+            iss >> tmp2;
+            if (!iss) {
+                break;
+            }
+            edgeIndices.push_back(tmp2);
+            assert(tmp2 < edges.size());
+        }
+
+        // so far, we only support triangles
+        assert(edgeIndices.size() == 3);
+
+        // extract the vertex indices of the element
+        return extractVertexIndices(edgeIndices);
+    }
+
+    //! \brief Extracts vertex indices from edge indices.
+    //! \param edgeIndices Indices for the edges
+    std::vector<unsigned>
+    extractVertexIndices(const std::vector<unsigned>& edgeIndices)
+    {
+        // extract the vertex indices of the element
+        std::vector<unsigned> vertIndices;
+        for (unsigned i = 0; i < 3; ++i) {
+            bool haveFirstVertex = false;
+            for (unsigned j = 0; j < vertIndices.size(); ++j) {
+                assert(edgeIndices[i] < edges.size());
+                if (vertIndices[j] == edges[edgeIndices[i]].first) {
+                    haveFirstVertex = true;
+                    break;
+                }
+            }
+            if (!haveFirstVertex) {
+                vertIndices.push_back(edges[edgeIndices[i]].first);
+            }
+
+            bool haveSecondVertex = false;
+            for (unsigned j = 0; j < vertIndices.size(); ++j) {
+                assert(edgeIndices[i] < edges.size());
+                if (vertIndices[j] == edges[edgeIndices[i]].second) {
+                    haveSecondVertex = true;
+                    break;
+                }
+            }
+            if (!haveSecondVertex) {
+                vertIndices.push_back(edges[edgeIndices[i]].second);
+            }
+        }
+
+        return vertIndices;
+    }
+
+    //! \brief Check whether vertices are given in mathematically positive direction.
+    //! \param vertIndices Indices to check
+    bool isPositive(const std::vector<unsigned>& vertIndices)
+    {
+        Dune::FieldMatrix<Scalar, 2, 2> mat;
+        mat[0] = vertexPos[vertIndices[1]].first;
+        mat[0] -= vertexPos[vertIndices[0]].first;
+        mat[1] = vertexPos[vertIndices[2]].first;
+        mat[1] -= vertexPos[vertIndices[0]].first;
+        assert(std::abs(mat.determinant()) > 1e-50);
+        return mat.determinant() >= 0.0;
+    }
+
     //! \brief Writes out the data to the output stream.
     //! \param dgfFile Stream to write to
     //! \param precision Precision to write at
@@ -288,10 +319,11 @@ private:
         dgfFile << "#" << std::endl;
     }
 
+    //! List of vertices and whether they are part of a fracture (1) or not (0)
     std::vector<std::pair<GlobalPosition, unsigned>> vertexPos;
-    std::vector<Edge> edges;
-    std::vector<Edge> fractureEdges;
-    std::vector<std::vector<unsigned>> elements;
+    std::vector<Edge> edges; //!< List of edge connectivities
+    std::vector<Edge> fractureEdges; //!< List of edges that are fractures
+    std::vector<std::vector<unsigned>> elements; //!< List of elements connectivities
  };
 
 } // namespace Ewoms

--- a/examples/art2dgf.cpp
+++ b/examples/art2dgf.cpp
@@ -25,6 +25,8 @@
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
 
+#include <opm/common/utility/String.hpp>
+
 #include <algorithm>
 #include <fstream>
 #include <stdexcept>
@@ -71,20 +73,7 @@ namespace Ewoms {
                 curLine.erase(commentPos);
             }
 
-            // remove leading whitespace
-            unsigned numLeadingSpaces = 0;
-            while (curLine.size() > numLeadingSpaces
-                   && std::isspace(curLine[numLeadingSpaces]))
-                ++numLeadingSpaces;
-            curLine = curLine.substr(numLeadingSpaces,
-                                     curLine.size() - numLeadingSpaces);
-
-            // remove trailing whitespace
-            unsigned numTrailingSpaces = 0;
-            while (curLine.size() > numTrailingSpaces
-                   && std::isspace(curLine[curLine.size() - numTrailingSpaces]))
-                ++numTrailingSpaces;
-            curLine.erase(numTrailingSpaces);
+            curLine = Opm::trim_copy(curLine);
 
             // a section of the file is finished, go to the next one
             if (curLine == "$") {

--- a/examples/art2dgf.cpp
+++ b/examples/art2dgf.cpp
@@ -43,6 +43,8 @@ namespace Ewoms {
 
  struct Art2DGF
  {
+    enum class ParseMode { Vertex, Edge, Element, Finished };
+
     /*!
      * \brief Create the Grid
      */
@@ -52,7 +54,6 @@ namespace Ewoms {
     {
         using Scalar = double;
         using GlobalPosition = Dune::FieldVector< Scalar, 2 >;
-        enum ParseMode { Vertex, Edge, Element, Finished };
         std::vector< std::pair<GlobalPosition, unsigned> > vertexPos;
         std::vector<std::pair<unsigned, unsigned> > edges;
         std::vector<std::pair<unsigned, unsigned> > fractureEdges;
@@ -63,7 +64,7 @@ namespace Ewoms {
                                      +"' does not exist or is not readable");
         }
         std::string curLine;
-        ParseMode curParseMode = Vertex;
+        ParseMode curParseMode = ParseMode::Vertex;
         while (inStream) {
             std::getline(inStream, curLine);
 
@@ -77,12 +78,12 @@ namespace Ewoms {
 
             // a section of the file is finished, go to the next one
             if (curLine == "$") {
-                if (curParseMode == Vertex)
-                    curParseMode = Edge;
-                else if (curParseMode == Edge)
-                    curParseMode = Element;
-                else if (curParseMode == Element)
-                    curParseMode = Finished;
+                if (curParseMode == ParseMode::Vertex)
+                    curParseMode = ParseMode::Edge;
+                else if (curParseMode == ParseMode::Edge)
+                    curParseMode = ParseMode::Element;
+                else if (curParseMode == ParseMode::Element)
+                    curParseMode = ParseMode::Finished;
                 continue;
             }
 
@@ -90,7 +91,7 @@ namespace Ewoms {
             if (curLine.empty())
                 continue;
 
-            if (curParseMode == Vertex) {
+            if (curParseMode == ParseMode::Vertex) {
                 GlobalPosition coord;
                 std::istringstream iss(curLine);
                 // parse only the first two numbers as the vertex
@@ -99,7 +100,7 @@ namespace Ewoms {
                 iss >> coord[0] >> coord[1];
                 vertexPos.push_back( std::make_pair( coord, 0 ) );
             }
-            else if (curParseMode == Edge) {
+            else if (curParseMode == ParseMode::Edge) {
                 // read an edge and update the fracture mapper
 
                 // read the data attached to the edge
@@ -134,7 +135,7 @@ namespace Ewoms {
                     vertexPos[ edge.second ].second = 1;
                 }
             }
-            else if (curParseMode == Element) {
+            else if (curParseMode == ParseMode::Element) {
                 // skip the data attached to an element
                 std::istringstream iss(curLine);
                 int dataVal;
@@ -197,7 +198,7 @@ namespace Ewoms {
 
                 elements.push_back( vertIndices );
             }
-            else if (curParseMode == Finished) {
+            else if (curParseMode == ParseMode::Finished) {
                 assert(curLine.size() == 0);
             }
         }

--- a/examples/art2dgf.cpp
+++ b/examples/art2dgf.cpp
@@ -45,6 +45,7 @@ namespace Ewoms {
  {
     using Scalar = double;
     using GlobalPosition = Dune::FieldVector<Scalar, 2>;
+    using Edge = std::pair<unsigned, unsigned>;
 
     enum class ParseMode { Vertex, Edge, Element, Finished };
 
@@ -107,37 +108,14 @@ private:
             }
             else if (curParseMode == ParseMode::Edge) {
                 // read an edge and update the fracture mapper
-
-                // read the data attached to the edge
-                std::istringstream iss(curLine);
-                int dataVal;
-                std::string tmp;
-                iss >> dataVal;
-                iss >> tmp;
-                assert(tmp == ":");
-
-                // read the vertex indices of an edge
-                std::vector<unsigned int> vertIndices;
-                while (iss) {
-                    unsigned int tmp2;
-                    iss >> tmp2;
-                    if (!iss)
-                        break;
-                    vertIndices.push_back(tmp2);
-                    assert(tmp2 < vertexPos.size());
-                }
-
-                // an edge always has two indices!
-                assert(vertIndices.size() == 2);
-
-                std::pair<unsigned, unsigned> edge(vertIndices[0], vertIndices[1]);
+                const auto& [edge, isFracture] = parseEdge(curLine);
                 edges.push_back(edge);
 
                 // add the edge to the fracture mapper if it is a fracture
-                if (dataVal < 0) {
+                if (isFracture) {
                     fractureEdges.push_back(edge);
-                    vertexPos[ edge.first  ].second = 1;
-                    vertexPos[ edge.second ].second = 1;
+                    vertexPos[edge.first].second = 1;
+                    vertexPos[edge.second].second = 1;
                 }
             }
             else if (curParseMode == ParseMode::Element) {
@@ -225,6 +203,38 @@ private:
         return coord;
     }
 
+    //! \brief Parses an edge from a string.
+    //! \param curLine String to parse
+    //! \return Pair of edge and whether or not edge is a fracture
+    std::pair<Edge, bool>
+    parseEdge(const std::string& curLine)
+    {
+        // read the data attached to the edge
+        std::istringstream iss(curLine);
+        int dataVal;
+        std::string tmp;
+        iss >> dataVal;
+        iss >> tmp;
+        assert(tmp == ":");
+
+        // read the vertex indices of an edge
+        std::vector<unsigned int> vertIndices;
+        while (iss) {
+            unsigned int tmp2;
+            iss >> tmp2;
+            if (!iss) {
+                break;
+            }
+            vertIndices.push_back(tmp2);
+            assert(tmp2 < vertexPos.size());
+        }
+
+        // an edge always has two indices!
+        assert(vertIndices.size() == 2);
+
+        return std::make_pair(Edge{vertIndices[0], vertIndices[1]}, dataVal < 0);
+    }
+
     //! \brief Writes out the data to the output stream.
     //! \param dgfFile Stream to write to
     //! \param precision Precision to write at
@@ -270,10 +280,10 @@ private:
         dgfFile << "#" << std::endl;
     }
 
-    std::vector< std::pair<GlobalPosition, unsigned> > vertexPos;
-    std::vector<std::pair<unsigned, unsigned> > edges;
-    std::vector<std::pair<unsigned, unsigned> > fractureEdges;
-    std::vector<std::vector<unsigned> > elements;
+    std::vector<std::pair<GlobalPosition, unsigned>> vertexPos;
+    std::vector<Edge> edges;
+    std::vector<Edge> fractureEdges;
+    std::vector<std::vector<unsigned>> elements;
  };
 
 } // namespace Ewoms

--- a/examples/art2dgf.cpp
+++ b/examples/art2dgf.cpp
@@ -90,12 +90,7 @@ private:
 
             // a section of the file is finished, go to the next one
             if (curLine == "$") {
-                if (curParseMode == ParseMode::Vertex)
-                    curParseMode = ParseMode::Edge;
-                else if (curParseMode == ParseMode::Edge)
-                    curParseMode = ParseMode::Element;
-                else if (curParseMode == ParseMode::Element)
-                    curParseMode = ParseMode::Finished;
+                curParseMode = nextParseMode(curParseMode);
                 continue;
             }
 
@@ -187,6 +182,19 @@ private:
         }
 
         write(dgfFile, precision);
+    }
+
+    //! \brief Returns the next parse mode.
+    //! \param curParseMode Current parse mode
+    static ParseMode nextParseMode(const ParseMode curParseMode)
+    {
+        switch (curParseMode) {
+            case ParseMode::Vertex: return ParseMode::Edge;
+            case ParseMode::Edge:   return ParseMode::Element;
+            default:                break;
+        }
+
+        return ParseMode::Finished;
     }
 
     //! \brief Parses a vertex from a string.

--- a/examples/art2dgf.cpp
+++ b/examples/art2dgf.cpp
@@ -43,21 +43,32 @@ namespace Ewoms {
 
  struct Art2DGF
  {
+    using Scalar = double;
+    using GlobalPosition = Dune::FieldVector<Scalar, 2>;
+
     enum class ParseMode { Vertex, Edge, Element, Finished };
 
-    /*!
-     * \brief Create the Grid
-     */
-    static void convert( const std::string& artFileName,
-                         std::ostream& dgfFile,
-                         const unsigned precision = 16 )
+    //! \brief Static entry point for conversion.
+    //! \param artFileName File name for art file
+    //! \param dgfFile Stream to output dgf file to
+    //! \param precision Precision for floating point numbers
+    static void convert(const std::string& artFileName,
+                        std::ostream& dgfFile,
+                        const unsigned precision = 16)
     {
-        using Scalar = double;
-        using GlobalPosition = Dune::FieldVector< Scalar, 2 >;
-        std::vector< std::pair<GlobalPosition, unsigned> > vertexPos;
-        std::vector<std::pair<unsigned, unsigned> > edges;
-        std::vector<std::pair<unsigned, unsigned> > fractureEdges;
-        std::vector<std::vector<unsigned> > elements;
+        Art2DGF c;
+        c.doConvert(artFileName, dgfFile, precision);
+    }
+
+private:
+    //! \brief Converts a given .art file to a .dgf file
+    //! \param artFileName File name for art file
+    //! \param dgfFile Stream to output dgf file to
+    //! \param precision Precision for floating point numbers
+    void doConvert(const std::string& artFileName,
+                   std::ostream& dgfFile,
+                   const unsigned precision)
+    {
         std::ifstream inStream(artFileName);
         if (!inStream.is_open()) {
             throw std::runtime_error("File '"+artFileName
@@ -203,21 +214,14 @@ namespace Ewoms {
             }
         }
 
-        write(dgfFile, fractureEdges, vertexPos, elements, precision);
+        write(dgfFile, precision);
     }
 
-private:
     //! \brief Writes out the data to the output stream.
     //! \param dgfFile Stream to write to
-    //! \param fractureEdges List of fracture edges
-    //! \param vertexPos List of vertices
-    //! \param elements List of element connectivities
     //! \param precision Precision to write at
-    static void write(std::ostream& dgfFile,
-                      const std::vector<std::pair<unsigned, unsigned>>& fractureEdges,
-                      const std::vector<std::pair<Dune::FieldVector<double, 2>, unsigned>>& vertexPos,
-                      const std::vector<std::vector<unsigned>>& elements,
-                      const unsigned precision)
+    void write(std::ostream& dgfFile,
+                const unsigned precision)
     {
         dgfFile << "DGF" << std::endl << std::endl;
 
@@ -257,6 +261,11 @@ private:
         dgfFile << "#" << std::endl << std::endl;
         dgfFile << "#" << std::endl;
     }
+
+    std::vector< std::pair<GlobalPosition, unsigned> > vertexPos;
+    std::vector<std::pair<unsigned, unsigned> > edges;
+    std::vector<std::pair<unsigned, unsigned> > fractureEdges;
+    std::vector<std::vector<unsigned> > elements;
  };
 
 } // namespace Ewoms

--- a/examples/art2dgf.cpp
+++ b/examples/art2dgf.cpp
@@ -262,7 +262,7 @@ namespace Ewoms {
 } // namespace Ewoms
 
 int main( int argc, char** argv )
-{
+try {
     if (argc != 2) {
         std::cout << "Converts a grid file from the ART file format to DGF (Dune grid format)\n"
                   << "\n"
@@ -281,4 +281,12 @@ int main( int argc, char** argv )
     Ewoms::Art2DGF::convert( filename, dgfFile );
 
     return 0;
+}
+catch (const std::exception& e) {
+    std::cerr << "Exception thrown " << e.what() << std::endl;
+    return 2;
+}
+catch (...) {
+    std::cerr << "Unknown exception thrown" << std::endl;
+    return 2;
 }


### PR DESCRIPTION
Ref https://ci.opm-project.org/job/opm-simulators-static-analysis/474/clang-tidy/folder.1937579081/fileName.-311651421/

- avoid exceptions escaping main()
- avoid int to bool conversions (by using trim_copy)
- refactor long method to reduce cognitive load