### PR TITLE
examples/: address clang-tidy warnings

### DIFF
--- a/examples/lens_immiscible_ecfv_ad_23.cpp
+++ b/examples/lens_immiscible_ecfv_ad_23.cpp
@@ -54,7 +54,7 @@ struct Grid <TypeTag, TTag::LensProblemEcfvAd>
     using RangeVector = typename Base :: RangeVector ;
 
     template< typename... Args >
-    IdentityCoordFct( Args&... )
+    explicit IdentityCoordFct( Args&... )
     {}
 
     RangeVector operator()(const DomainVector& x) const

--- a/examples/opmrst_inspect.cpp
+++ b/examples/opmrst_inspect.cpp
@@ -29,11 +29,12 @@
 #include <fmt/format.h>
 
 #include <array>
+#include <exception>
 #include <iostream>
 #include <string>
 
 int main(int argc, char** argv)
-{
+try {
     if (argc < 2) {
         std::cerr << "Need one parameter, the .OPMRST file to inspect\n";
         return 1;
@@ -83,4 +84,12 @@ int main(int argc, char** argv)
               << strings[4];
 
     return 0;
+}
+catch (const std::exception& e) {
+    std::cerr << "Exception thrown " << e.what() << std::endl;
+    return 2;
+}
+catch (...) {
+  std::cerr << "Unknown exception thrown" << std::endl;
+  return 2;
 }


### PR DESCRIPTION
This addresses the clang-tidy warnings in example/, except art2dgf which is addressed in https://github.com/OPM/opm-simulators/pull/7094