### PR TITLE
flow/: address clang-tidy warnings

### DIFF
--- a/flow/flow_biofilm.cpp
+++ b/flow/flow_biofilm.cpp
@@ -28,47 +28,46 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/material/thermal/EnergyModuleType.hpp>
 
-namespace Opm {
+namespace Opm::Properties {
+
+namespace TTag {
+
 /*!
  * \brief Two-phase (gas+water) flow problem including biofilm effects (one transported
  * quantity: suspended microbes and one solid phase: biofilm).
  */
-namespace Properties {
-namespace TTag {
-struct FlowBiofilmProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+struct FlowBiofilmProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
 
 template<class TypeTag>
-struct EnableBioeffects<TypeTag, TTag::FlowBiofilmProblem> {
-    static constexpr bool value = true;
-};
+struct EnableBioeffects<TypeTag, TTag::FlowBiofilmProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct EnableDiffusion<TypeTag, TTag::FlowBiofilmProblem> {
-    static constexpr bool value = true;
-};
+struct EnableDiffusion<TypeTag, TTag::FlowBiofilmProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct EnableDispersion<TypeTag, TTag::FlowBiofilmProblem> {
-    static constexpr bool value = true;
-};
+struct EnableDispersion<TypeTag, TTag::FlowBiofilmProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct EnableDisgasInWater<TypeTag, TTag::FlowBiofilmProblem> {
-    static constexpr bool value = true;
-};
+struct EnableDisgasInWater<TypeTag, TTag::FlowBiofilmProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct EnableVapwat<TypeTag, TTag::FlowBiofilmProblem> {
-    static constexpr bool value = true;
-};
+struct EnableVapwat<TypeTag, TTag::FlowBiofilmProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct Linearizer<TypeTag, TTag::FlowBiofilmProblem> { using type = TpfaLinearizer<TypeTag>; };
+struct Linearizer<TypeTag, TTag::FlowBiofilmProblem>
+{ using type = TpfaLinearizer<TypeTag>; };
+
 template<class TypeTag>
-struct LocalResidual<TypeTag, TTag::FlowBiofilmProblem> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
+struct LocalResidual<TypeTag, TTag::FlowBiofilmProblem>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
 
 template<class TypeTag>
 struct EnergyModuleType<TypeTag, TTag::FlowBiofilmProblem>
@@ -100,10 +99,10 @@ public:
                                          /*disabledCompIdx=*/FluidSystem::oilCompIdx,
                                          2>; //Two biocomponents (suspended microbes and biofilm)
 };
-}}
+
+} // namespace Opm::Properties
 
 namespace Opm {
-
 
 // ----------------- Main program -----------------
 int flowBiofilmMain(int argc, char** argv, bool outputCout, bool outputFiles)

--- a/flow/flow_biofilm.cpp
+++ b/flow/flow_biofilm.cpp
@@ -87,7 +87,8 @@ private:
 
     // get the energy module type to determine the equation number
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
-    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal ? 1 : 0;
+
 public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),

--- a/flow/flow_blackoil.cpp
+++ b/flow/flow_blackoil.cpp
@@ -26,27 +26,28 @@
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 
+namespace Opm::Properties {
+
+template<class TypeTag>
+struct Linearizer<TypeTag, TTag::FlowProblemTPFA>
+{ using type = TpfaLinearizer<TypeTag>; };
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::FlowProblemTPFA>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
+
+template<class TypeTag>
+struct EnableDiffusion<TypeTag, TTag::FlowProblemTPFA>
+{ static constexpr bool value = false; };
+
+template<class TypeTag>
+struct AvoidElementContext<TypeTag, TTag::FlowProblemTPFA>
+{ static constexpr bool value = true; };
+
+} // namespace Opm::Properties
+
 namespace Opm {
-    namespace Properties {
 
-        template<class TypeTag>
-        struct Linearizer<TypeTag, TTag::FlowProblemTPFA> { using type = TpfaLinearizer<TypeTag>; };
-
-        template<class TypeTag>
-        struct LocalResidual<TypeTag, TTag::FlowProblemTPFA> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
-
-        template<class TypeTag>
-        struct EnableDiffusion<TypeTag, TTag::FlowProblemTPFA> { static constexpr bool value = false; };
-
-        template<class TypeTag>
-        struct AvoidElementContext<TypeTag, TTag::FlowProblemTPFA> { static constexpr bool value = true; };
-
-    }
-}
-
-
-namespace Opm
-{
 std::unique_ptr<FlowMain<Properties::TTag::FlowProblemTPFA>>
 flowBlackoilTpfaMainInit(int argc, char** argv, bool outputCout, bool outputFiles)
 {

--- a/flow/flow_blackoil_alugrid.cpp
+++ b/flow/flow_blackoil_alugrid.cpp
@@ -46,16 +46,18 @@
 #include <opm/simulators/flow/equil/InitStateEquil_impl.hpp>
 #include <opm/simulators/utils/GridDataOutput_impl.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowProblemAlugrid {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowProblemAlugrid
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
 
 template<class TypeTag>
-struct Grid<TypeTag, TTag::FlowProblemAlugrid> {
+struct Grid<TypeTag, TTag::FlowProblemAlugrid>
+{
     static const int dim = 3;
 #if HAVE_MPI
      using type = Dune::ALUGrid<dim, dim, Dune::cube, Dune::nonconforming,Dune::ALUGridMPIComm>;
@@ -66,21 +68,23 @@ struct Grid<TypeTag, TTag::FlowProblemAlugrid> {
 
 // alugrid need cp grid as equilgrid
 template<class TypeTag>
-struct EquilGrid<TypeTag, TTag::FlowProblemAlugrid> {
-    using type = Dune::CpGrid;
-};
+struct EquilGrid<TypeTag, TTag::FlowProblemAlugrid>
+{ using type = Dune::CpGrid; };
+
 template<class TypeTag>
-struct Vanguard<TypeTag, TTag::FlowProblemAlugrid> {
-    using type = Opm::AluGridVanguard<TypeTag>;
-};
-}
+struct Vanguard<TypeTag, TTag::FlowProblemAlugrid>
+{ using type = Opm::AluGridVanguard<TypeTag>; };
+
+} // namespace Opm::Properties
+
+namespace Opm {
 
 template<>
 class SupportsFaceTag<Dune::ALUGrid<3, 3, Dune::cube, Dune::nonconforming>>
     : public std::bool_constant<true>
 {};
 
-}
+} // namespace Opm
 
 int main(int argc, char** argv)
 {

--- a/flow/flow_blackoil_nohyst.cpp
+++ b/flow/flow_blackoil_nohyst.cpp
@@ -29,32 +29,42 @@
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 
 
-namespace Opm {
-namespace Properties {
-    namespace TTag {
-        struct FlowProblemNohyst {
-            using InheritsFrom = std::tuple<FlowProblem>;
-        };
-    }
-    template<class TypeTag>
-    struct Linearizer<TypeTag, TTag::FlowProblemNohyst> { using type = TpfaLinearizer<TypeTag>; };
+namespace Opm::Properties {
 
-    template<class TypeTag>
-    struct LocalResidual<TypeTag, TTag::FlowProblemNohyst> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
+namespace TTag {
 
-    template<class TypeTag>
-    struct EnableDiffusion<TypeTag, TTag::FlowProblemNohyst> { static constexpr bool value = false; };
-
-    template<class TypeTag>
-    struct EnableHysteresis<TypeTag, TTag::FlowProblemNohyst> { static constexpr bool value = false; };
-
-    template<class TypeTag>
-    struct EnableEndpointScaling<TypeTag, TTag::FlowProblemNohyst> { static constexpr bool value = true; };
-
-    template<class TypeTag>
-    struct AvoidElementContext<TypeTag, TTag::FlowProblemNohyst> { static constexpr bool value = true; };
+struct FlowProblemNohyst
+{ using InheritsFrom = std::tuple<FlowProblem>; };
 
 }
+
+template<class TypeTag>
+struct Linearizer<TypeTag, TTag::FlowProblemNohyst>
+{ using type = TpfaLinearizer<TypeTag>; };
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::FlowProblemNohyst>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
+
+template<class TypeTag>
+struct EnableDiffusion<TypeTag, TTag::FlowProblemNohyst>
+{ static constexpr bool value = false; };
+
+template<class TypeTag>
+struct EnableHysteresis<TypeTag, TTag::FlowProblemNohyst>
+{ static constexpr bool value = false; };
+
+template<class TypeTag>
+struct EnableEndpointScaling<TypeTag, TTag::FlowProblemNohyst>
+{ static constexpr bool value = true; };
+
+template<class TypeTag>
+struct AvoidElementContext<TypeTag, TTag::FlowProblemNohyst>
+{ static constexpr bool value = true; };
+
+} // namespace Opm::Properties
+
+namespace Opm {
 
 std::unique_ptr<FlowMain<Properties::TTag::FlowProblemNohyst>>
 flowBlackoilTpfaNohystMainInit(int argc, char** argv, bool outputCout, bool outputFiles)

--- a/flow/flow_blackoil_polyhedralgrid.cpp
+++ b/flow/flow_blackoil_polyhedralgrid.cpp
@@ -36,45 +36,49 @@
 #include <opm/simulators/flow/equil/InitStateEquil_impl.hpp>
 #include <opm/simulators/utils/GridDataOutput_impl.hpp>
 
-namespace Opm {
-namespace Properties {
-    namespace TTag {
-        struct FlowProblemPoly {
-            using InheritsFrom = std::tuple<FlowProblem>;
-        };
-    }
+namespace Opm::Properties {
 
-    template<class TypeTag>
-    struct Linearizer<TypeTag, TTag::FlowProblemPoly> { using type = TpfaLinearizer<TypeTag>; };
+namespace TTag {
 
-    template<class TypeTag>
-    struct LocalResidual<TypeTag, TTag::FlowProblemPoly> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
+struct FlowProblemPoly
+{ using InheritsFrom = std::tuple<FlowProblem>; };
 
-    template<class TypeTag>
-    struct EnableDiffusion<TypeTag, TTag::FlowProblemPoly> { static constexpr bool value = false; };
-
-    template<class TypeTag>
-    struct Grid<TypeTag, TTag::FlowProblemPoly> {
-        using type = Dune::PolyhedralGrid<3, 3>;
-    };
-    template<class TypeTag>
-    struct EquilGrid<TypeTag, TTag::FlowProblemPoly> {
-        //using type = Dune::CpGrid;
-        using type = GetPropType<TypeTag, Properties::Grid>;
-    };
-
-    template<class TypeTag>
-    struct Vanguard<TypeTag, TTag::FlowProblemPoly> {
-        using type = Opm::PolyhedralGridVanguard<TypeTag>;
-    };
 }
+
+template<class TypeTag>
+struct Linearizer<TypeTag, TTag::FlowProblemPoly>
+{ using type = TpfaLinearizer<TypeTag>; };
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::FlowProblemPoly>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
+
+template<class TypeTag>
+struct EnableDiffusion<TypeTag, TTag::FlowProblemPoly>
+{ static constexpr bool value = false; };
+
+template<class TypeTag>
+struct Grid<TypeTag, TTag::FlowProblemPoly>
+{ using type = Dune::PolyhedralGrid<3, 3>; };
+
+template<class TypeTag>
+struct EquilGrid<TypeTag, TTag::FlowProblemPoly>
+{ using type = GetPropType<TypeTag, Properties::Grid>; };
+
+template<class TypeTag>
+struct Vanguard<TypeTag, TTag::FlowProblemPoly>
+{ using type = Opm::PolyhedralGridVanguard<TypeTag>; };
+
+} // namespace Opm::Properties
+
+namespace Opm {
 
 template<>
 class SupportsFaceTag<Dune::PolyhedralGrid<3, 3>>
     : public std::bool_constant<true>
 {};
 
-}
+} // namespace Opm
 
 int main(int argc, char** argv)
 {

--- a/flow/flow_blackoil_temp.cpp
+++ b/flow/flow_blackoil_temp.cpp
@@ -27,12 +27,13 @@
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 #include <opm/material/thermal/EnergyModuleType.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct flowBlackoilTempProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct flowBlackoilTempProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
 
 template<class TypeTag>
@@ -40,19 +41,22 @@ struct EnergyModuleType<TypeTag, TTag::flowBlackoilTempProblem>
 { static constexpr EnergyModules value = EnergyModules::SequentialImplicitThermal; };
 
 template<class TypeTag>
-struct Linearizer<TypeTag, TTag::flowBlackoilTempProblem> { using type = TpfaLinearizer<TypeTag>; };
+struct Linearizer<TypeTag, TTag::flowBlackoilTempProblem>
+{ using type = TpfaLinearizer<TypeTag>; };
 
 template<class TypeTag>
-struct LocalResidual<TypeTag, TTag::flowBlackoilTempProblem> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
+struct LocalResidual<TypeTag, TTag::flowBlackoilTempProblem>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
 
 template<class TypeTag>
-struct EnableDiffusion<TypeTag, TTag::flowBlackoilTempProblem> { static constexpr bool value = false; };
+struct EnableDiffusion<TypeTag, TTag::flowBlackoilTempProblem>
+{ static constexpr bool value = false; };
 
 template<class TypeTag>
-struct AvoidElementContext<TypeTag, TTag::flowBlackoilTempProblem> { static constexpr bool value = true; };
+struct AvoidElementContext<TypeTag, TTag::flowBlackoilTempProblem>
+{ static constexpr bool value = true; };
 
-
-}}
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -78,4 +82,4 @@ int flowBlackoilTempMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_blackoil_tpsa.cpp
+++ b/flow/flow_blackoil_tpsa.cpp
@@ -35,9 +35,7 @@ namespace Opm::Properties {
 namespace TTag {
 
 struct FlowBlackOilProblemTPSA
-{
-    using InheritsFrom = std::tuple<FlowProblem, FlowProblemTpsa>;
-};
+{ using InheritsFrom = std::tuple<FlowProblem, FlowProblemTpsa>; };
 
 }  // namespace Opm::Properties::TTag
 

--- a/flow/flow_brine.cpp
+++ b/flow/flow_brine.cpp
@@ -26,29 +26,28 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowBrineProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowBrineProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
 
 template<class TypeTag>
-struct EnableBrine<TypeTag, TTag::FlowBrineProblem> {
-    static constexpr bool value = true;
-};
+struct EnableBrine<TypeTag, TTag::FlowBrineProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct Linearizer<TypeTag, TTag::FlowBrineProblem> {
-    using type = TpfaLinearizer<TypeTag>;
-};
+struct Linearizer<TypeTag, TTag::FlowBrineProblem>
+{ using type = TpfaLinearizer<TypeTag>; };
 
 template<class TypeTag>
-struct LocalResidual<TypeTag, TTag::FlowBrineProblem> {
-    using type = BlackOilLocalResidualTPFA<TypeTag>;
-};
-}}
+struct LocalResidual<TypeTag, TTag::FlowBrineProblem>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
+
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -74,4 +73,4 @@ int flowBrineMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_brine_energy.cpp
+++ b/flow/flow_brine_energy.cpp
@@ -21,33 +21,32 @@
 #include <opm/simulators/flow/Main.hpp>
 #include <opm/material/thermal/EnergyModuleType.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowBrineEnergyProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowBrineEnergyProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
 
 template<class TypeTag>
-struct EnableBrine<TypeTag, TTag::FlowBrineEnergyProblem> {
-    static constexpr bool value = true;
-};
+struct EnableBrine<TypeTag, TTag::FlowBrineEnergyProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct Linearizer<TypeTag, TTag::FlowBrineEnergyProblem> {
-    using type = TpfaLinearizer<TypeTag>;
-};
+struct Linearizer<TypeTag, TTag::FlowBrineEnergyProblem>
+{ using type = TpfaLinearizer<TypeTag>; };
 
 template<class TypeTag>
-struct LocalResidual<TypeTag, TTag::FlowBrineEnergyProblem> {
-    using type = BlackOilLocalResidualTPFA<TypeTag>;
-};
+struct LocalResidual<TypeTag, TTag::FlowBrineEnergyProblem>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
+
 template<class TypeTag>
 struct EnergyModuleType<TypeTag, TTag::FlowBrineEnergyProblem>
 { static constexpr EnergyModules value = EnergyModules::FullyImplicitThermal; };
-}}
 
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -74,4 +73,4 @@ int flowBrineEnergyMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_brine_precsalt_vapwat.cpp
+++ b/flow/flow_brine_precsalt_vapwat.cpp
@@ -26,38 +26,36 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowBrinePrecsaltVapwatProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowBrinePrecsaltVapwatProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
-template<class TypeTag>
-struct EnableBrine<TypeTag, TTag::FlowBrinePrecsaltVapwatProblem> {
-    static constexpr bool value = true;
-};
 
 template<class TypeTag>
-struct EnableSaltPrecipitation<TypeTag, TTag::FlowBrinePrecsaltVapwatProblem> {
-    static constexpr bool value = true;
-};
+struct EnableBrine<TypeTag, TTag::FlowBrinePrecsaltVapwatProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct EnableVapwat<TypeTag, TTag::FlowBrinePrecsaltVapwatProblem> {
-    static constexpr bool value = true;
-};
+struct EnableSaltPrecipitation<TypeTag, TTag::FlowBrinePrecsaltVapwatProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct Linearizer<TypeTag, TTag::FlowBrinePrecsaltVapwatProblem> {
-    using type = TpfaLinearizer<TypeTag>;
-};
+struct EnableVapwat<TypeTag, TTag::FlowBrinePrecsaltVapwatProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct LocalResidual<TypeTag, TTag::FlowBrinePrecsaltVapwatProblem> {
-    using type = BlackOilLocalResidualTPFA<TypeTag>;
-};
-}}
+struct Linearizer<TypeTag, TTag::FlowBrinePrecsaltVapwatProblem>
+{ using type = TpfaLinearizer<TypeTag>; };
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::FlowBrinePrecsaltVapwatProblem>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
+
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -83,4 +81,4 @@ int flowBrinePrecsaltVapwatMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_brine_saltprecipitation.cpp
+++ b/flow/flow_brine_saltprecipitation.cpp
@@ -26,34 +26,32 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowBrineSaltPrecipitationProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowBrineSaltPrecipitationProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
 
 template<class TypeTag>
-struct EnableBrine<TypeTag, TTag::FlowBrineSaltPrecipitationProblem> {
-    static constexpr bool value = true;
-};
+struct EnableBrine<TypeTag, TTag::FlowBrineSaltPrecipitationProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct EnableSaltPrecipitation<TypeTag, TTag::FlowBrineSaltPrecipitationProblem> {
-    static constexpr bool value = true;
-};
+struct EnableSaltPrecipitation<TypeTag, TTag::FlowBrineSaltPrecipitationProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct Linearizer<TypeTag, TTag::FlowBrineSaltPrecipitationProblem> {
-    using type = TpfaLinearizer<TypeTag>;
-};
+struct Linearizer<TypeTag, TTag::FlowBrineSaltPrecipitationProblem>
+{ using type = TpfaLinearizer<TypeTag>; };
 
 template<class TypeTag>
-struct LocalResidual<TypeTag, TTag::FlowBrineSaltPrecipitationProblem> {
-    using type = BlackOilLocalResidualTPFA<TypeTag>;
-};
-}}
+struct LocalResidual<TypeTag, TTag::FlowBrineSaltPrecipitationProblem>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
+
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -79,4 +77,4 @@ int flowBrineSaltPrecipitationMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_distribute_z.cpp
+++ b/flow/flow_distribute_z.cpp
@@ -47,8 +47,8 @@ std::vector<int> loadBalanceInZOnly(const Dune::CpGrid& grid)
     for( const auto &element : elements(gridView) )
     {
         const auto& id = idSet.id(element);
-        unsigned elemIdx = elemMapper.index(element);
-        const auto& cartIndex = cartMapper.cartesianIndex(elemIdx);
+        const auto elemIdx = elemMapper.index(element);
+        const auto& cartIndex = cartMapper.cartesianIndex(static_cast<int>(elemIdx));
         std::array<int,3> cartCoord;
         cartMapper.cartesianCoordinate(cartIndex, cartCoord);
         using std::min;

--- a/flow/flow_energy.cpp
+++ b/flow/flow_energy.cpp
@@ -25,26 +25,29 @@
 #include <opm/material/thermal/EnergyModuleType.hpp>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
-namespace Opm {
-namespace Properties {
+
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowEnergyProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowEnergyProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
 
 template<class TypeTag>
 struct EnergyModuleType<TypeTag, TTag::FlowEnergyProblem>
 { static constexpr EnergyModules value = EnergyModules::FullyImplicitThermal; };
 
+template<class TypeTag>
+struct Linearizer<TypeTag, TTag::FlowEnergyProblem>
+{ using type = TpfaLinearizer<TypeTag>; };
 
 template<class TypeTag>
-struct Linearizer<TypeTag, TTag::FlowEnergyProblem> { using type = TpfaLinearizer<TypeTag>; };
-template<class TypeTag>
-struct LocalResidual<TypeTag, TTag::FlowEnergyProblem> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
+struct LocalResidual<TypeTag, TTag::FlowEnergyProblem>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
 
-
-}}
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -70,4 +73,4 @@ int flowEnergyMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_extbo.cpp
+++ b/flow/flow_extbo.cpp
@@ -23,18 +23,20 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowExtboProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowExtboProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
+
 template<class TypeTag>
-struct EnableExtbo<TypeTag, TTag::FlowExtboProblem> {
-    static constexpr bool value = true;
-};
-}}
+struct EnableExtbo<TypeTag, TTag::FlowExtboProblem>
+{ static constexpr bool value = true; };
+
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -60,4 +62,4 @@ int flowExtboMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_foam.cpp
+++ b/flow/flow_foam.cpp
@@ -23,18 +23,20 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowFoamProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowFoamProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
+
 template<class TypeTag>
-struct EnableFoam<TypeTag, TTag::FlowFoamProblem> {
-    static constexpr bool value = true;
-};
-}}
+struct EnableFoam<TypeTag, TTag::FlowFoamProblem>
+{ static constexpr bool value = true; };
+
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -60,4 +62,4 @@ int flowFoamMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_gasoil.cpp
+++ b/flow/flow_gasoil.cpp
@@ -61,7 +61,8 @@ private:
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
-    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal ? 1 : 0;
+
 public:
   using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                        getPropValue<TypeTag, Properties::EnableExtbo>(),

--- a/flow/flow_gasoil.cpp
+++ b/flow/flow_gasoil.cpp
@@ -29,22 +29,26 @@
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 #include <opm/material/thermal/EnergyModuleType.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowGasOilProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowGasOilProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
 
 template<class TypeTag>
-struct Linearizer<TypeTag, TTag::FlowGasOilProblem> { using type = TpfaLinearizer<TypeTag>; };
+struct Linearizer<TypeTag, TTag::FlowGasOilProblem>
+{ using type = TpfaLinearizer<TypeTag>; };
 
 template<class TypeTag>
-struct LocalResidual<TypeTag, TTag::FlowGasOilProblem> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
+struct LocalResidual<TypeTag, TTag::FlowGasOilProblem>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
 
 template<class TypeTag>
-struct EnableDiffusion<TypeTag, TTag::FlowGasOilProblem> { static constexpr bool value = false; };
+struct EnableDiffusion<TypeTag, TTag::FlowGasOilProblem>
+{ static constexpr bool value = false; };
 
 template<class TypeTag>
 struct EnergyModuleType<TypeTag, TTag::FlowGasOilProblem>
@@ -74,7 +78,8 @@ public:
                                        /*disabledCompIdx=*/FluidSystem::waterCompIdx,
                                        getPropValue<TypeTag, Properties::EnableBioeffects>()>;
 };
-}}
+
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -100,4 +105,4 @@ int flowGasOilMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_gasoil_energy.cpp
+++ b/flow/flow_gasoil_energy.cpp
@@ -28,12 +28,13 @@
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 #include <opm/material/thermal/EnergyModuleType.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowGasOilEnergyProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowGasOilEnergyProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
 
 //! The indices required by the model
@@ -61,22 +62,28 @@ public:
                                        /*disabledCompIdx=*/FluidSystem::waterCompIdx,
                                        getPropValue<TypeTag, Properties::EnableBioeffects>()>;
 };
+
 template<class TypeTag>
 struct EnergyModuleType<TypeTag, TTag::FlowGasOilEnergyProblem>
 { static constexpr EnergyModules value = EnergyModules::FullyImplicitThermal; };
-template<class TypeTag>
-struct Linearizer<TypeTag, TTag::FlowGasOilEnergyProblem> { using type = TpfaLinearizer<TypeTag>; };
 
 template<class TypeTag>
-struct LocalResidual<TypeTag, TTag::FlowGasOilEnergyProblem> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
+struct Linearizer<TypeTag, TTag::FlowGasOilEnergyProblem>
+{ using type = TpfaLinearizer<TypeTag>; };
 
 template<class TypeTag>
-struct EnableDiffusion<TypeTag, TTag::FlowGasOilEnergyProblem> { static constexpr bool value = true; };
+struct LocalResidual<TypeTag, TTag::FlowGasOilEnergyProblem>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
 
 template<class TypeTag>
-struct EnableDispersion<TypeTag, TTag::FlowGasOilEnergyProblem> { static constexpr bool value = true; };
+struct EnableDiffusion<TypeTag, TTag::FlowGasOilEnergyProblem>
+{ static constexpr bool value = true; };
 
-}}
+template<class TypeTag>
+struct EnableDispersion<TypeTag, TTag::FlowGasOilEnergyProblem>
+{ static constexpr bool value = true; };
+
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -102,4 +109,4 @@ int flowGasOilEnergyMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_gasoil_energy.cpp
+++ b/flow/flow_gasoil_energy.cpp
@@ -48,7 +48,7 @@ private:
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
     // get the energy module type to determine the equation number
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
-    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal ? 1 : 0;
 
 public:
   using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),

--- a/flow/flow_gasoildiffuse.cpp
+++ b/flow/flow_gasoildiffuse.cpp
@@ -28,25 +28,30 @@
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 #include <opm/material/thermal/EnergyModuleType.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowGasOilDiffuseProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowGasOilDiffuseProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
 
 template<class TypeTag>
-struct Linearizer<TypeTag, TTag::FlowGasOilDiffuseProblem> { using type = TpfaLinearizer<TypeTag>; };
+struct Linearizer<TypeTag, TTag::FlowGasOilDiffuseProblem>
+{ using type = TpfaLinearizer<TypeTag>; };
 
 template<class TypeTag>
-struct LocalResidual<TypeTag, TTag::FlowGasOilDiffuseProblem> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
+struct LocalResidual<TypeTag, TTag::FlowGasOilDiffuseProblem>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
 
 template<class TypeTag>
-struct EnableDiffusion<TypeTag, TTag::FlowGasOilDiffuseProblem> { static constexpr bool value = true; };
+struct EnableDiffusion<TypeTag, TTag::FlowGasOilDiffuseProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct EnableDispersion<TypeTag, TTag::FlowGasOilDiffuseProblem> { static constexpr bool value = true; };
+struct EnableDispersion<TypeTag, TTag::FlowGasOilDiffuseProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
 struct EnergyModuleType<TypeTag, TTag::FlowGasOilDiffuseProblem>
@@ -76,7 +81,8 @@ public:
                                        /*disabledCompIdx=*/FluidSystem::waterCompIdx,
                                        getPropValue<TypeTag, Properties::EnableBioeffects>()>;
 };
-}}
+
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -102,4 +108,4 @@ int flowGasOilDiffuseMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_gasoildiffuse.cpp
+++ b/flow/flow_gasoildiffuse.cpp
@@ -63,7 +63,8 @@ private:
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
-    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal ? 1 : 0;
+
 public:
   using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                        getPropValue<TypeTag, Properties::EnableExtbo>(),

--- a/flow/flow_gaswater.cpp
+++ b/flow/flow_gaswater.cpp
@@ -28,17 +28,19 @@
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
 
 template<class TypeTag>
-struct Linearizer<TypeTag, TTag::FlowGasWaterProblem> { using type = TpfaLinearizer<TypeTag>; };
+struct Linearizer<TypeTag, TTag::FlowGasWaterProblem>
+{ using type = TpfaLinearizer<TypeTag>; };
 
 template<class TypeTag>
-struct LocalResidual<TypeTag, TTag::FlowGasWaterProblem> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
+struct LocalResidual<TypeTag, TTag::FlowGasWaterProblem>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
 
 template<class TypeTag>
-struct EnableDiffusion<TypeTag, TTag::FlowGasWaterProblem> { static constexpr bool value = false; };
+struct EnableDiffusion<TypeTag, TTag::FlowGasWaterProblem>
+{ static constexpr bool value = false; };
 
 template<class TypeTag>
 struct EnergyModuleType<TypeTag, TTag::FlowGasWaterProblem>
@@ -68,10 +70,10 @@ public:
                                          /*disabledCompIdx=*/FluidSystem::oilCompIdx,
                                          getPropValue<TypeTag, Properties::EnableBioeffects>()>;
 };
-}}
+
+} // namespace Opm::Properties
 
 namespace Opm {
-
 
 // ----------------- Main program -----------------
 int flowGasWaterMain(int argc, char** argv, bool outputCout, bool outputFiles)
@@ -106,4 +108,4 @@ flowGasWaterMainInit(int argc, char** argv, bool outputCout, bool outputFiles)
         argc, argv, outputCout, outputFiles);
 }
 
-}
+} // namespace Opm

--- a/flow/flow_gaswater.cpp
+++ b/flow/flow_gaswater.cpp
@@ -55,7 +55,8 @@ private:
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
-    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal ? 1 : 0;
+
 public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),

--- a/flow/flow_gaswater_brine.cpp
+++ b/flow/flow_gaswater_brine.cpp
@@ -76,7 +76,8 @@ private:
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
-    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal ? 1 : 0;
+
 public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),

--- a/flow/flow_gaswater_brine.cpp
+++ b/flow/flow_gaswater_brine.cpp
@@ -28,38 +28,34 @@
 #include <opm/simulators/flow/Main.hpp>
 #include <opm/material/thermal/EnergyModuleType.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowGasWaterBrineProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowGasWaterBrineProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
 
 template<class TypeTag>
-struct EnableBrine<TypeTag, TTag::FlowGasWaterBrineProblem> {
-    static constexpr bool value = true;
-};
+struct EnableBrine<TypeTag, TTag::FlowGasWaterBrineProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct EnableDisgasInWater<TypeTag, TTag::FlowGasWaterBrineProblem> {
-    static constexpr bool value = true;
-};
+struct EnableDisgasInWater<TypeTag, TTag::FlowGasWaterBrineProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct EnableVapwat<TypeTag, TTag::FlowGasWaterBrineProblem> {
-    static constexpr bool value = true;
-};
+struct EnableVapwat<TypeTag, TTag::FlowGasWaterBrineProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct Linearizer<TypeTag, TTag::FlowGasWaterBrineProblem> {
-    using type = TpfaLinearizer<TypeTag>;
-};
+struct Linearizer<TypeTag, TTag::FlowGasWaterBrineProblem>
+{ using type = TpfaLinearizer<TypeTag>; };
 
 template<class TypeTag>
-struct LocalResidual<TypeTag, TTag::FlowGasWaterBrineProblem> {
-    using type = BlackOilLocalResidualTPFA<TypeTag>;
-};
+struct LocalResidual<TypeTag, TTag::FlowGasWaterBrineProblem>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
 
 template<class TypeTag>
 struct EnergyModuleType<TypeTag, TTag::FlowGasWaterBrineProblem>
@@ -89,7 +85,8 @@ public:
                                          /*disabledCompIdx=*/FluidSystem::oilCompIdx,
                                          getPropValue<TypeTag, Properties::EnableBioeffects>()>;
 };
-}}
+
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -115,4 +112,4 @@ int flowGasWaterBrineMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_gaswater_dissolution.cpp
+++ b/flow/flow_gaswater_dissolution.cpp
@@ -71,7 +71,8 @@ private:
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
-    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal ? 1 : 0;
+
 public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),

--- a/flow/flow_gaswater_dissolution.cpp
+++ b/flow/flow_gaswater_dissolution.cpp
@@ -29,36 +29,38 @@
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 #include <opm/material/thermal/EnergyModuleType.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowGasWaterDissolutionProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowGasWaterDissolutionProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
 
 template<class TypeTag>
-struct Linearizer<TypeTag, TTag::FlowGasWaterDissolutionProblem> { using type = TpfaLinearizer<TypeTag>; };
+struct Linearizer<TypeTag, TTag::FlowGasWaterDissolutionProblem>
+{ using type = TpfaLinearizer<TypeTag>; };
 
 template<class TypeTag>
-struct LocalResidual<TypeTag, TTag::FlowGasWaterDissolutionProblem> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
+struct LocalResidual<TypeTag, TTag::FlowGasWaterDissolutionProblem>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
 
 template<class TypeTag>
-struct EnableDiffusion<TypeTag, TTag::FlowGasWaterDissolutionProblem> { static constexpr bool value = false; };
+struct EnableDiffusion<TypeTag, TTag::FlowGasWaterDissolutionProblem>
+{ static constexpr bool value = false; };
 
 template<class TypeTag>
-struct EnableDisgasInWater<TypeTag, TTag::FlowGasWaterDissolutionProblem> {
-    static constexpr bool value = true;
-};
+struct EnableDisgasInWater<TypeTag, TTag::FlowGasWaterDissolutionProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
 struct EnergyModuleType<TypeTag, TTag::FlowGasWaterDissolutionProblem>
 { static constexpr EnergyModules value = EnergyModules::ConstantTemperature; };
 
 template<class TypeTag>
-struct EnableVapwat<TypeTag, TTag::FlowGasWaterDissolutionProblem> {
-    static constexpr bool value = true;
-};
+struct EnableVapwat<TypeTag, TTag::FlowGasWaterDissolutionProblem>
+{ static constexpr bool value = true; };
 
 //! The indices required by the model
 template<class TypeTag>
@@ -84,10 +86,10 @@ public:
                                          /*disabledCompIdx=*/FluidSystem::oilCompIdx,
                                          getPropValue<TypeTag, Properties::EnableBioeffects>()>;
 };
-}}
+
+} // namespace Opm::Properties
 
 namespace Opm {
-
 
 // ----------------- Main program -----------------
 int flowGasWaterDissolutionMain(int argc, char** argv, bool outputCout, bool outputFiles)
@@ -111,4 +113,4 @@ int flowGasWaterDissolutionMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_gaswater_dissolution_diffuse.cpp
+++ b/flow/flow_gaswater_dissolution_diffuse.cpp
@@ -74,7 +74,8 @@ private:
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
-    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal ? 1 : 0;
+
 public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),

--- a/flow/flow_gaswater_dissolution_diffuse.cpp
+++ b/flow/flow_gaswater_dissolution_diffuse.cpp
@@ -29,35 +29,38 @@
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 #include <opm/material/thermal/EnergyModuleType.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowGasWaterDissolutionDiffuseProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowGasWaterDissolutionDiffuseProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
 
 template<class TypeTag>
-struct Linearizer<TypeTag, TTag::FlowGasWaterDissolutionDiffuseProblem> { using type = TpfaLinearizer<TypeTag>; };
+struct Linearizer<TypeTag, TTag::FlowGasWaterDissolutionDiffuseProblem>
+{ using type = TpfaLinearizer<TypeTag>; };
 
 template<class TypeTag>
-struct LocalResidual<TypeTag, TTag::FlowGasWaterDissolutionDiffuseProblem> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
+struct LocalResidual<TypeTag, TTag::FlowGasWaterDissolutionDiffuseProblem>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
 
 template<class TypeTag>
-struct EnableDiffusion<TypeTag, TTag::FlowGasWaterDissolutionDiffuseProblem> { static constexpr bool value = true; };
+struct EnableDiffusion<TypeTag, TTag::FlowGasWaterDissolutionDiffuseProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct EnableDispersion<TypeTag, TTag::FlowGasWaterDissolutionDiffuseProblem> { static constexpr bool value = true; };
+struct EnableDispersion<TypeTag, TTag::FlowGasWaterDissolutionDiffuseProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct EnableDisgasInWater<TypeTag, TTag::FlowGasWaterDissolutionDiffuseProblem> {
-    static constexpr bool value = true;
-};
+struct EnableDisgasInWater<TypeTag, TTag::FlowGasWaterDissolutionDiffuseProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct EnableVapwat<TypeTag, TTag::FlowGasWaterDissolutionDiffuseProblem> {
-    static constexpr bool value = true;
-};
+struct EnableVapwat<TypeTag, TTag::FlowGasWaterDissolutionDiffuseProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
 struct EnergyModuleType<TypeTag, TTag::FlowGasWaterDissolutionDiffuseProblem>
@@ -87,10 +90,10 @@ public:
                                          /*disabledCompIdx=*/FluidSystem::oilCompIdx,
                                          getPropValue<TypeTag, Properties::EnableBioeffects>()>;
 };
-}}
+
+} // namespace Opm::Properties
 
 namespace Opm {
-
 
 // ----------------- Main program -----------------
 int flowGasWaterDissolutionDiffuseMain(int argc, char** argv, bool outputCout, bool outputFiles)
@@ -114,4 +117,4 @@ int flowGasWaterDissolutionDiffuseMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_gaswater_dissolution_tpsa.cpp
+++ b/flow/flow_gaswater_dissolution_tpsa.cpp
@@ -76,7 +76,7 @@ private:
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
-    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal ? 1 : 0;
 
 public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),

--- a/flow/flow_gaswater_dissolution_tpsa.cpp
+++ b/flow/flow_gaswater_dissolution_tpsa.cpp
@@ -36,9 +36,7 @@ namespace Opm::Properties {
 namespace TTag {
 
 struct FlowGasWaterDissolutionProblemTPSA
-{
-    using InheritsFrom = std::tuple<FlowProblem, FlowProblemTpsa>;
-};
+{ using InheritsFrom = std::tuple<FlowProblem, FlowProblemTpsa>; };
 
 }  // namespace Opm::Properties::TTag
 

--- a/flow/flow_gaswater_energy.cpp
+++ b/flow/flow_gaswater_energy.cpp
@@ -28,7 +28,6 @@
 
 namespace Opm {
 
-
 // ----------------- Main program -----------------
 int flowGasWaterEnergyMain(int argc, char** argv, bool outputCout, bool outputFiles)
 {
@@ -51,4 +50,4 @@ int flowGasWaterEnergyMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_gaswater_saltprec_energy.cpp
+++ b/flow/flow_gaswater_saltprec_energy.cpp
@@ -28,42 +28,39 @@
 #include <opm/simulators/flow/Main.hpp>
 #include <opm/material/thermal/EnergyModuleType.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowGasWaterSaltprecEnergyProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowGasWaterSaltprecEnergyProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
-template<class TypeTag>
-struct EnableBrine<TypeTag, TTag::FlowGasWaterSaltprecEnergyProblem> {
-    static constexpr bool value = true;
-};
 
 template<class TypeTag>
-struct EnableSaltPrecipitation<TypeTag, TTag::FlowGasWaterSaltprecEnergyProblem> {
-    static constexpr bool value = true;
-};
+struct EnableBrine<TypeTag, TTag::FlowGasWaterSaltprecEnergyProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct EnableVapwat<TypeTag, TTag::FlowGasWaterSaltprecEnergyProblem> {
-    static constexpr bool value = true;
-};
+struct EnableSaltPrecipitation<TypeTag, TTag::FlowGasWaterSaltprecEnergyProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct EnableDisgasInWater<TypeTag, TTag::FlowGasWaterSaltprecEnergyProblem> {
-    static constexpr bool value = true;
-};
+struct EnableVapwat<TypeTag, TTag::FlowGasWaterSaltprecEnergyProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct Linearizer<TypeTag, TTag::FlowGasWaterSaltprecEnergyProblem> { 
-    using type = TpfaLinearizer<TypeTag>;
-};
+struct EnableDisgasInWater<TypeTag, TTag::FlowGasWaterSaltprecEnergyProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct LocalResidual<TypeTag, TTag::FlowGasWaterSaltprecEnergyProblem> {
-    using type = BlackOilLocalResidualTPFA<TypeTag>;
-};
+struct Linearizer<TypeTag, TTag::FlowGasWaterSaltprecEnergyProblem>
+{ using type = TpfaLinearizer<TypeTag>; };
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::FlowGasWaterSaltprecEnergyProblem>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
+
 template<class TypeTag>
 struct EnergyModuleType<TypeTag, TTag::FlowGasWaterSaltprecEnergyProblem>
 { static constexpr EnergyModules value = EnergyModules::FullyImplicitThermal; };
@@ -92,7 +89,8 @@ public:
                                          /*disabledCompIdx=*/FluidSystem::oilCompIdx,
                                          getPropValue<TypeTag, Properties::EnableBioeffects>()>;
 };
-}}
+
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -118,4 +116,4 @@ int flowGasWaterSaltprecEnergyMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_gaswater_saltprec_energy.cpp
+++ b/flow/flow_gaswater_saltprec_energy.cpp
@@ -79,7 +79,8 @@ private:
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
-    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal ? 1 : 0;
+
 public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),

--- a/flow/flow_gaswater_saltprec_vapwat.cpp
+++ b/flow/flow_gaswater_saltprec_vapwat.cpp
@@ -28,42 +28,39 @@
 #include <opm/simulators/flow/Main.hpp>
 #include <opm/material/thermal/EnergyModuleType.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowGasWaterSaltprecVapwatProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowGasWaterSaltprecVapwatProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
-template<class TypeTag>
-struct EnableBrine<TypeTag, TTag::FlowGasWaterSaltprecVapwatProblem> {
-    static constexpr bool value = true;
-};
 
 template<class TypeTag>
-struct EnableSaltPrecipitation<TypeTag, TTag::FlowGasWaterSaltprecVapwatProblem> {
-    static constexpr bool value = true;
-};
+struct EnableBrine<TypeTag, TTag::FlowGasWaterSaltprecVapwatProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct EnableVapwat<TypeTag, TTag::FlowGasWaterSaltprecVapwatProblem> {
-    static constexpr bool value = true;
-};
+struct EnableSaltPrecipitation<TypeTag, TTag::FlowGasWaterSaltprecVapwatProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct EnableDisgasInWater<TypeTag, TTag::FlowGasWaterSaltprecVapwatProblem> {
-    static constexpr bool value = true;
-};
+struct EnableVapwat<TypeTag, TTag::FlowGasWaterSaltprecVapwatProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct Linearizer<TypeTag, TTag::FlowGasWaterSaltprecVapwatProblem> {
-    using type = TpfaLinearizer<TypeTag>;
-};
+struct EnableDisgasInWater<TypeTag, TTag::FlowGasWaterSaltprecVapwatProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct LocalResidual<TypeTag, TTag::FlowGasWaterSaltprecVapwatProblem> {
-    using type = BlackOilLocalResidualTPFA<TypeTag>;
-};
+struct Linearizer<TypeTag, TTag::FlowGasWaterSaltprecVapwatProblem>
+{ using type = TpfaLinearizer<TypeTag>; };
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::FlowGasWaterSaltprecVapwatProblem>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
+
 template<class TypeTag>
 struct EnergyModuleType<TypeTag, TTag::FlowGasWaterSaltprecVapwatProblem>
 { static constexpr EnergyModules value = EnergyModules::ConstantTemperature; };
@@ -92,7 +89,8 @@ public:
                                          /*disabledCompIdx=*/FluidSystem::oilCompIdx,
                                          getPropValue<TypeTag, Properties::EnableBioeffects>()>;
 };
-}}
+
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -118,4 +116,4 @@ int flowGasWaterSaltprecVapwatMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_gaswater_saltprec_vapwat.cpp
+++ b/flow/flow_gaswater_saltprec_vapwat.cpp
@@ -79,7 +79,8 @@ private:
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
-    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal ? 1 : 0;
+
 public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),

--- a/flow/flow_gaswater_solvent.cpp
+++ b/flow/flow_gaswater_solvent.cpp
@@ -25,18 +25,18 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowGasWaterSolventProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowGasWaterSolventProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
 
 template<class TypeTag>
-struct EnableSolvent<TypeTag, TTag::FlowGasWaterSolventProblem> {
-    static constexpr bool value = true;
-};
+struct EnableSolvent<TypeTag, TTag::FlowGasWaterSolventProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
 struct EnergyModuleType<TypeTag, TTag::FlowGasWaterSolventProblem>
@@ -66,10 +66,10 @@ public:
                                          /*disabledCompIdx=*/FluidSystem::oilCompIdx,
                                          getPropValue<TypeTag, Properties::EnableBioeffects>()>;
 };
-}}
+
+} // namespace Opm::Properties
 
 namespace Opm {
-
 
 // ----------------- Main program -----------------
 int flowGasWaterSolventMain(int argc, char** argv, bool outputCout, bool outputFiles)
@@ -93,4 +93,4 @@ int flowGasWaterSolventMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_gaswater_solvent.cpp
+++ b/flow/flow_gaswater_solvent.cpp
@@ -53,7 +53,8 @@ private:
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
-    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal ? 1 : 0;
+
 public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),

--- a/flow/flow_micp.cpp
+++ b/flow/flow_micp.cpp
@@ -28,26 +28,32 @@
 #include <opm/simulators/flow/Main.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
-namespace Opm {
+namespace Opm::Properties {
+
+namespace TTag {
+
 /*!
  * \brief Single-phase (water) flow problem including microbially induced calcite precipitation (MICP)
  * effects (three transported quantities: suspended microbes, oxygen, and urea, and two solid phases:
  * biofilm and calcite).
  */
-namespace Properties {
-namespace TTag {
-struct FlowMICPProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+struct FlowMICPProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
+
 template<class TypeTag>
-struct EnableBioeffects<TypeTag, TTag::FlowMICPProblem> {
-    static constexpr bool value = true;
-};
+struct EnableBioeffects<TypeTag, TTag::FlowMICPProblem>
+{ static constexpr bool value = true; };
+
 template<class TypeTag>
-struct Linearizer<TypeTag, TTag::FlowMICPProblem> { using type = TpfaLinearizer<TypeTag>; };
+struct Linearizer<TypeTag, TTag::FlowMICPProblem>
+{ using type = TpfaLinearizer<TypeTag>; };
+
 template<class TypeTag>
-struct LocalResidual<TypeTag, TTag::FlowMICPProblem> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
+struct LocalResidual<TypeTag, TTag::FlowMICPProblem>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
+
 //! The indices required by the model
 template<class TypeTag>
 struct Indices<TypeTag, TTag::FlowMICPProblem>
@@ -74,12 +80,14 @@ public:
 };
 
 template<class TypeTag>
-struct EnableDiffusion<TypeTag, TTag::FlowMICPProblem> { static constexpr bool value = true; };
+struct EnableDiffusion<TypeTag, TTag::FlowMICPProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct EnableDispersion<TypeTag, TTag::FlowMICPProblem> { static constexpr bool value = true; };
+struct EnableDispersion<TypeTag, TTag::FlowMICPProblem>
+{ static constexpr bool value = true; };
 
-}}
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -105,4 +113,4 @@ int flowMICPMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_micp.cpp
+++ b/flow/flow_micp.cpp
@@ -59,7 +59,8 @@ private:
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
-    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal ? 1 : 0;
+
 public:
     using type = BlackOilOnePhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),

--- a/flow/flow_oilwater.cpp
+++ b/flow/flow_oilwater.cpp
@@ -28,23 +28,26 @@
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowOilWaterProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowOilWaterProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
 
 template<class TypeTag>
-struct Linearizer<TypeTag, TTag::FlowOilWaterProblem> { using type = TpfaLinearizer<TypeTag>; };
+struct Linearizer<TypeTag, TTag::FlowOilWaterProblem>
+{ using type = TpfaLinearizer<TypeTag>; };
 
 template<class TypeTag>
-struct LocalResidual<TypeTag, TTag::FlowOilWaterProblem> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
+struct LocalResidual<TypeTag, TTag::FlowOilWaterProblem>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
 
 template<class TypeTag>
-struct EnableDiffusion<TypeTag, TTag::FlowOilWaterProblem> { static constexpr bool value = false; };
-
+struct EnableDiffusion<TypeTag, TTag::FlowOilWaterProblem>
+{ static constexpr bool value = false; };
 
 //! The indices required by the model
 template<class TypeTag>
@@ -70,7 +73,8 @@ public:
                                          /*disabledCompIdx=*/FluidSystem::gasCompIdx,
                                          getPropValue<TypeTag, Properties::EnableBioeffects>()>;
 };
-}}
+
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -96,4 +100,4 @@ int flowOilWaterMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_oilwater.cpp
+++ b/flow/flow_oilwater.cpp
@@ -57,7 +57,7 @@ private:
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
-    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal ? 1 : 0;
 
 public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),

--- a/flow/flow_oilwater_brine.cpp
+++ b/flow/flow_oilwater_brine.cpp
@@ -61,7 +61,8 @@ private:
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
-    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal ? 1 : 0;
+
 public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),

--- a/flow/flow_oilwater_brine.cpp
+++ b/flow/flow_oilwater_brine.cpp
@@ -27,28 +27,26 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowOilWaterBrineProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowOilWaterBrineProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
 
 template<class TypeTag>
-struct EnableBrine<TypeTag, TTag::FlowOilWaterBrineProblem> {
-    static constexpr bool value = true;
-};
+struct EnableBrine<TypeTag, TTag::FlowOilWaterBrineProblem>
+{ static constexpr bool value = true; };
 
 template<class TypeTag>
-struct Linearizer<TypeTag, TTag::FlowOilWaterBrineProblem> {
-    using type = TpfaLinearizer<TypeTag>;
-};
+struct Linearizer<TypeTag, TTag::FlowOilWaterBrineProblem>
+{ using type = TpfaLinearizer<TypeTag>; };
 
 template<class TypeTag>
-struct LocalResidual<TypeTag, TTag::FlowOilWaterBrineProblem> {
-    using type = BlackOilLocalResidualTPFA<TypeTag>;
-};
+struct LocalResidual<TypeTag, TTag::FlowOilWaterBrineProblem>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
 
 //! The indices required by the model
 template<class TypeTag>
@@ -74,7 +72,8 @@ public:
                                          /*disabledCompIdx=*/FluidSystem::gasCompIdx,
                                          getPropValue<TypeTag, Properties::EnableBioeffects>()>;
 };
-}}
+
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -100,4 +99,4 @@ int flowOilWaterBrineMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_oilwater_polymer.cpp
+++ b/flow/flow_oilwater_polymer.cpp
@@ -25,17 +25,19 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowOilWaterPolymerProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowOilWaterPolymerProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
+
 template<class TypeTag>
-struct EnablePolymer<TypeTag, TTag::FlowOilWaterPolymerProblem> {
-    static constexpr bool value = true;
-};
+struct EnablePolymer<TypeTag, TTag::FlowOilWaterPolymerProblem>
+{ static constexpr bool value = true; };
+
 //! The indices required by the model
 template<class TypeTag>
 struct Indices<TypeTag, TTag::FlowOilWaterPolymerProblem>
@@ -60,7 +62,8 @@ public:
                                          /*disabledCompIdx=*/FluidSystem::gasCompIdx,
                                          getPropValue<TypeTag, Properties::EnableBioeffects>()>;
 };
-}}
+
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -86,4 +89,4 @@ int flowOilWaterPolymerMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_oilwater_polymer.cpp
+++ b/flow/flow_oilwater_polymer.cpp
@@ -47,7 +47,8 @@ private:
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
-    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal ? 1 : 0;
+
 public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),

--- a/flow/flow_oilwater_polymer_injectivity.cpp
+++ b/flow/flow_oilwater_polymer_injectivity.cpp
@@ -54,7 +54,8 @@ private:
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
-    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal ? 1 : 0;
+
 public:
     using type = BlackOilTwoPhaseIndices<0,
                                          0,

--- a/flow/flow_oilwater_polymer_injectivity.cpp
+++ b/flow/flow_oilwater_polymer_injectivity.cpp
@@ -25,21 +25,22 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowOilWaterPolymerInjectivityProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowOilWaterPolymerInjectivityProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
+
 template<class TypeTag>
-struct EnablePolymer<TypeTag, TTag::FlowOilWaterPolymerInjectivityProblem> {
-    static constexpr bool value = true;
-};
+struct EnablePolymer<TypeTag, TTag::FlowOilWaterPolymerInjectivityProblem>
+{ static constexpr bool value = true; };
+
 template<class TypeTag>
-struct EnablePolymerMW<TypeTag, TTag::FlowOilWaterPolymerInjectivityProblem> {
-    static constexpr bool value = true;
-};
+struct EnablePolymerMW<TypeTag, TTag::FlowOilWaterPolymerInjectivityProblem>
+{ static constexpr bool value = true; };
 
 //! The indices required by the model
 // For this case, there will be two primary variables introduced for the polymer
@@ -67,7 +68,8 @@ public:
                                          /*disabledCompIdx=*/FluidSystem::gasCompIdx,
                                          getPropValue<TypeTag, Properties::EnableBioeffects>()>;
 };
-}}
+
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -93,4 +95,4 @@ int flowOilWaterPolymerInjectivityMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_onephase.cpp
+++ b/flow/flow_onephase.cpp
@@ -54,7 +54,8 @@ private:
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
-    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal ? 1 : 0;
+
 public:
     using type = BlackOilOnePhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),

--- a/flow/flow_onephase.cpp
+++ b/flow/flow_onephase.cpp
@@ -25,23 +25,26 @@
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
 
 namespace TTag {
-struct FlowWaterOnlyProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowWaterOnlyProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
 
 template<class TypeTag>
-struct Linearizer<TypeTag, TTag::FlowWaterOnlyProblem> { using type = TpfaLinearizer<TypeTag>; };
+struct Linearizer<TypeTag, TTag::FlowWaterOnlyProblem>
+{ using type = TpfaLinearizer<TypeTag>; };
 
 template<class TypeTag>
-struct LocalResidual<TypeTag, TTag::FlowWaterOnlyProblem> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
+struct LocalResidual<TypeTag, TTag::FlowWaterOnlyProblem>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
 
 template<class TypeTag>
-struct EnableDiffusion<TypeTag, TTag::FlowWaterOnlyProblem> { static constexpr bool value = false; };
+struct EnableDiffusion<TypeTag, TTag::FlowWaterOnlyProblem>
+{ static constexpr bool value = false; };
 
 //! The indices required by the model
 template<class TypeTag>
@@ -70,6 +73,8 @@ public:
 
 } // namespace Opm::Properties
 
+namespace Opm {
+
 // ----------------- Main program -----------------
 int flowWaterOnlyMain(int argc, char** argv, bool outputCout, bool outputFiles)
 {
@@ -92,4 +97,4 @@ int flowWaterOnlyMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_onephase_energy.cpp
+++ b/flow/flow_onephase_energy.cpp
@@ -26,14 +26,15 @@
 #include <opm/models/blackoil/blackoilonephaseindices.hh>
 #include <opm/material/common/ResetLocale.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
 
 namespace TTag {
-struct FlowWaterOnlyEnergyProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowWaterOnlyEnergyProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
+
 template<class TypeTag>
 struct EnergyModuleType<TypeTag, TTag::FlowWaterOnlyEnergyProblem>
 { static constexpr EnergyModules value = EnergyModules::FullyImplicitThermal; };
@@ -65,6 +66,8 @@ public:
 
 } // namespace Opm::Properties
 
+namespace Opm {
+
 // ----------------- Main program -----------------
 int flowWaterOnlyEnergyMain(int argc, char** argv, bool outputCout, bool outputFiles)
 {
@@ -87,4 +90,4 @@ int flowWaterOnlyEnergyMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_onephase_energy.cpp
+++ b/flow/flow_onephase_energy.cpp
@@ -49,7 +49,7 @@ private:
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
-    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal ? 1 : 0;
 
 public:
     using type = Opm::BlackOilOnePhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),

--- a/flow/flow_onephase_tpsa.cpp
+++ b/flow/flow_onephase_tpsa.cpp
@@ -30,15 +30,12 @@
 
 #include <tuple>
 
-
 namespace Opm::Properties {
 
 namespace TTag {
 
 struct FlowWaterOnlyProblemTPSA
-{
-    using InheritsFrom = std::tuple<FlowProblem, FlowProblemTpsa>;
-};
+{ using InheritsFrom = std::tuple<FlowProblem, FlowProblemTpsa>; };
 
 }  // namespace Opm::Properties::TTag
 

--- a/flow/flow_onephase_tpsa.cpp
+++ b/flow/flow_onephase_tpsa.cpp
@@ -67,7 +67,7 @@ private:
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
-    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal ? 1 : 0;
 
 public:
     using type = BlackOilOnePhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),

--- a/flow/flow_polymer.cpp
+++ b/flow/flow_polymer.cpp
@@ -23,18 +23,20 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowPolymerProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowPolymerProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
+
 template<class TypeTag>
-struct EnablePolymer<TypeTag, TTag::FlowPolymerProblem> {
-    static constexpr bool value = true;
-};
-}}
+struct EnablePolymer<TypeTag, TTag::FlowPolymerProblem>
+{ static constexpr bool value = true; };
+
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -60,4 +62,4 @@ int flowPolymerMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_solvent.cpp
+++ b/flow/flow_solvent.cpp
@@ -23,18 +23,20 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowSolventProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowSolventProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
+
 template<class TypeTag>
-struct EnableSolvent<TypeTag, TTag::FlowSolventProblem> {
-    static constexpr bool value = true;
-};
-}}
+struct EnableSolvent<TypeTag, TTag::FlowSolventProblem>
+{ static constexpr bool value = true; };
+
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -60,4 +62,4 @@ int flowSolventMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm

--- a/flow/flow_solvent_foam.cpp
+++ b/flow/flow_solvent_foam.cpp
@@ -23,23 +23,24 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-namespace Opm {
-namespace Properties {
+namespace Opm::Properties {
+
 namespace TTag {
-struct FlowSolventFoamProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
+
+struct FlowSolventFoamProblem
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
 }
-template<class TypeTag>
-struct EnableSolvent<TypeTag, TTag::FlowSolventFoamProblem> {
-    static constexpr bool value = true;
-};
 
 template<class TypeTag>
-struct EnableFoam<TypeTag, TTag::FlowSolventFoamProblem> {
-    static constexpr bool value = true;
-};
-}}
+struct EnableSolvent<TypeTag, TTag::FlowSolventFoamProblem>
+{ static constexpr bool value = true; };
+
+template<class TypeTag>
+struct EnableFoam<TypeTag, TTag::FlowSolventFoamProblem>
+{ static constexpr bool value = true; };
+
+} // namespace Opm::Properties
 
 namespace Opm {
 
@@ -65,4 +66,4 @@ int flowSolventFoamMainStandalone(int argc, char** argv)
     return ret;
 }
 
-}
+} // namespace Opm


### PR DESCRIPTION
- Avoid bool to int conversion
- avoid implicit narrowing
- and drive-by nested namespace cleanup