### PR TITLE
opm/models/blackoil: address clang-tidy warnings

### DIFF
--- a/opm/models/blackoil/blackoilbioeffectsparams.cpp
+++ b/opm/models/blackoil/blackoilbioeffectsparams.cpp
@@ -34,12 +34,10 @@
 
 #include <stdexcept>
 
-namespace Opm {
+namespace {
 
-template<class Scalar>
-template<bool enableBioeffects , bool enableMICP>
-void BlackOilBioeffectsParams<Scalar>::
-initFromState(const EclipseState& eclState)
+template<bool enableBioeffects, bool enableMICP>
+void verifyState(const Opm::EclipseState& eclState)
 {
     // some sanity checks:
     // if biofilm is enabled, the BIOFILM keyword must be present,
@@ -70,6 +68,18 @@ initFromState(const EclipseState& eclState)
                                      "contains the MICP keyword");
         }
     }
+}
+
+}
+
+namespace Opm {
+
+template<class Scalar>
+template<bool enableBioeffects, bool enableMICP>
+void BlackOilBioeffectsParams<Scalar>::
+initFromState(const EclipseState& eclState)
+{
+    verifyState<enableBioeffects, enableMICP>(eclState);
 
     if (!eclState.runspec().micp() && !eclState.runspec().biof())
         return; // bioeffects are supposed to be disabled

--- a/opm/models/blackoil/blackoilbrineparams.cpp
+++ b/opm/models/blackoil/blackoilbrineparams.cpp
@@ -36,6 +36,29 @@
 #include <cstddef>
 #include <stdexcept>
 
+namespace {
+
+template<bool enableBrine, bool enableSaltPrecipitation>
+void verifyState(const Opm::EclipseState& eclState)
+{
+    // some sanity checks: if brine are enabled, the BRINE keyword must be
+    // present, if brine are disabled the keyword must not be present.
+    if constexpr (enableBrine) {
+        if (!eclState.runspec().phases().active(Opm::Phase::BRINE)) {
+            throw std::runtime_error("Non-trivial brine treatment requested at compile time, but "
+                                     "the deck does not contain the BRINE keyword");
+        }
+    }
+    else {
+        if (eclState.runspec().phases().active(Opm::Phase::BRINE)) {
+            throw std::runtime_error("Brine treatment disabled at compile time, but the deck "
+                                     "contains the BRINE keyword");
+        }
+    }
+}
+
+}
+
 namespace Opm {
 
 template<class Scalar>
@@ -43,20 +66,7 @@ template<bool enableBrine, bool enableSaltPrecipitation>
 void BlackOilBrineParams<Scalar>::
 initFromState(const EclipseState& eclState)
 {
-    // some sanity checks: if brine are enabled, the BRINE keyword must be
-    // present, if brine are disabled the keyword must not be present.
-    if constexpr (enableBrine) {
-        if (!eclState.runspec().phases().active(Phase::BRINE)) {
-            throw std::runtime_error("Non-trivial brine treatment requested at compile time, but "
-                                     "the deck does not contain the BRINE keyword");
-        }
-    }
-    else {
-        if (eclState.runspec().phases().active(Phase::BRINE)) {
-            throw std::runtime_error("Brine treatment disabled at compile time, but the deck "
-                                     "contains the BRINE keyword");
-        }
-    }
+    verifyState<enableBrine, enableSaltPrecipitation>(eclState);
 
     if (!eclState.runspec().phases().active(Phase::BRINE)) {
         return; // brine treatment is supposed to be disabled

--- a/opm/models/blackoil/blackoilextboparams.cpp
+++ b/opm/models/blackoil/blackoilextboparams.cpp
@@ -58,6 +58,25 @@ void verifyState(const Opm::EclipseState& eclState)
     }
 }
 
+template<class Scalar>
+std::vector<Scalar>
+parseSdensity(const Opm::EclipseState& eclState,
+              const std::size_t numPvtRegions)
+{
+    const auto& sdensityTables = eclState.getTableManager().getSolventDensityTables();
+    if (sdensityTables.size() == numPvtRegions) {
+        std::vector<Scalar> zReferenceDensity(numPvtRegions);
+        for (std::size_t regionIdx = 0; regionIdx < numPvtRegions; ++regionIdx) {
+            const Scalar rhoRefS = sdensityTables[regionIdx].getSolventDensityColumn().front();
+            zReferenceDensity[regionIdx] = rhoRefS;
+        }
+        return zReferenceDensity;
+    }
+    else {
+        throw std::runtime_error("Extbo: kw SDENSITY is missing or not aligned with NTPVT\n");
+    }
+}
+
 }
 
 namespace Opm {
@@ -73,11 +92,10 @@ initFromState(const EclipseState& eclState)
     }
 
     // pvt properties from kw PVTSOL:
-
     const auto& tableManager = eclState.getTableManager();
     const auto& pvtsolTables = tableManager.getPvtsolTables();
 
-    std::size_t numPvtRegions = pvtsolTables.size();
+    const std::size_t numPvtRegions = pvtsolTables.size();
 
     BO_.resize(numPvtRegions, Tabulated2DFunction{Tabulated2DFunction::InterpolationPolicy::LeftExtreme});
     BG_.resize(numPvtRegions, Tabulated2DFunction{Tabulated2DFunction::InterpolationPolicy::LeftExtreme});
@@ -129,7 +147,7 @@ initFromState(const EclipseState& eclState)
             PBUB_RV_[regionIdx].appendXPos(ZCO2);
 
             const auto& underSaturatedTable = pvtsolTable.getUnderSaturatedTable(outerIdx);
-            std::size_t numRows = underSaturatedTable.numRows();
+            const std::size_t numRows = underSaturatedTable.numRows();
 
             Scalar bo0 = 0.0;
             Scalar po0 = 0.0;
@@ -147,7 +165,7 @@ initFromState(const EclipseState& eclState)
                 if (bo0 > bo) { // This is undersaturated oil-phase for ZCO2 <= zLim ...
                     // Here we assume tabulated bo to decay beyond boiling point
                     if (extractCmpFromPvt) {
-                        Scalar cmpFactor = (bo - bo0) / (po - po0);
+                        const Scalar cmpFactor = (bo - bo0) / (po - po0);
                         oilCmp[outerIdx] = cmpFactor;
                         zLim_[regionIdx] = ZCO2;
                         //std::cout << "### cmpFactorOil: " << cmpFactor << "  zLim: " << zLim_[regionIdx] << std::endl;
@@ -156,9 +174,9 @@ initFromState(const EclipseState& eclState)
                 } else if (bo0 == bo) { // This is undersaturated gas-phase for ZCO2 > zLim ...
                     // Here we assume tabulated bo to be constant extrapolated beyond dew point
                     if (innerIdx+1 < numRows && ZCO2<1.0 && extractCmpFromPvt) {
-                        Scalar rvNxt = underSaturatedTable.get("RV", innerIdx + 1) + innerIdx * 1.0e-10;
-                        Scalar bgNxt = underSaturatedTable.get("B_G", innerIdx + 1);
-                        Scalar cmpFactor = (bgNxt - bg) / (rvNxt - rv);
+                        const Scalar rvNxt = underSaturatedTable.get("RV", innerIdx + 1) + innerIdx * 1.0e-10;
+                        const Scalar bgNxt = underSaturatedTable.get("B_G", innerIdx + 1);
+                        const Scalar cmpFactor = (bgNxt - bg) / (rvNxt - rv);
                         gasCmp[outerIdx] = cmpFactor;
                         //std::cout << "### cmpFactorGas: " << cmpFactor << "  zLim: " << zLim_[regionIdx] << std::endl;
                     }
@@ -198,17 +216,8 @@ initFromState(const EclipseState& eclState)
         gasCmp_[regionIdx].setXYContainers(zArg, gasCmp, /*sortInput=*/false);
     }
 
-           // Reference density for pure z-component taken from kw SDENSITY
-    const auto& sdensityTables = eclState.getTableManager().getSolventDensityTables();
-    if (sdensityTables.size() == numPvtRegions) {
-        zReferenceDensity_.resize(numPvtRegions);
-        for (unsigned regionIdx = 0; regionIdx < numPvtRegions; ++regionIdx) {
-            Scalar rhoRefS = sdensityTables[regionIdx].getSolventDensityColumn().front();
-            zReferenceDensity_[regionIdx] = rhoRefS;
-        }
-    }
-    else
-        throw std::runtime_error("Extbo:  kw SDENSITY is missing or not aligned with NTPVT\n");
+    // Reference density for pure z-component taken from kw SDENSITY
+    zReferenceDensity_ = parseSdensity<Scalar>(eclState, numPvtRegions);
 }
 
 #define INSTANTIATE_TYPE(T)                                                          \

--- a/opm/models/blackoil/blackoilextboparams.cpp
+++ b/opm/models/blackoil/blackoilextboparams.cpp
@@ -37,6 +37,29 @@
 #include <cstddef>
 #include <stdexcept>
 
+namespace {
+
+template<bool enableExtbo>
+void verifyState(const Opm::EclipseState& eclState)
+{
+    // some sanity checks: if extended BO is enabled, the PVTSOL keyword must be
+    // present, if extended BO is disabled the keyword must not be present.
+    if constexpr (enableExtbo) {
+        if (!eclState.runspec().phases().active(Opm::Phase::ZFRACTION)) {
+            throw std::runtime_error("Extended black oil treatment requested at compile "
+                                     "time, but the deck does not contain the PVTSOL keyword");
+        }
+    }
+    else {
+        if (eclState.runspec().phases().active(Opm::Phase::ZFRACTION)) {
+            throw std::runtime_error("Extended black oil treatment disabled at compile time, but the deck "
+                                     "contains the PVTSOL keyword");
+        }
+    }
+}
+
+}
+
 namespace Opm {
 
 template<class Scalar>
@@ -44,21 +67,7 @@ template<bool enableExtbo>
 void BlackOilExtboParams<Scalar>::
 initFromState(const EclipseState& eclState)
 {
-    // some sanity checks: if extended BO is enabled, the PVTSOL keyword must be
-    // present, if extended BO is disabled the keyword must not be present.
-    if constexpr (enableExtbo) {
-        if (!eclState.runspec().phases().active(Phase::ZFRACTION)) {
-            throw std::runtime_error("Extended black oil treatment requested at compile "
-                                     "time, but the deck does not contain the PVTSOL keyword");
-        }
-    }
-    else {
-        if (!enableExtbo && eclState.runspec().phases().active(Phase::ZFRACTION)) {
-            throw std::runtime_error("Extended black oil treatment disabled at compile time, but the deck "
-                                     "contains the PVTSOL keyword");
-        }
-    }
-
+    verifyState<enableExtbo>(eclState);
     if (!eclState.runspec().phases().active(Phase::ZFRACTION)) {
         return; // solvent treatment is supposed to be disabled
     }

--- a/opm/models/blackoil/blackoilpolymerparams.cpp
+++ b/opm/models/blackoil/blackoilpolymerparams.cpp
@@ -31,6 +31,7 @@ copyright holders.
 #include <opm/input/eclipse/EclipseState/Tables/PlyshlogTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PlyviscTable.hpp>
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <stdexcept>
@@ -124,50 +125,15 @@ initFromState(const EclipseState& eclState)
 
     processPlmixpar<enablePolymerMolarWeight>(eclState);
 
-    hasPlyshlog_ = eclState.getTableManager().hasTables("PLYSHLOG");
-    hasShrate_ = eclState.getTableManager().useShrate();
+    hasPlyshlog_ = tableManager.hasTables("PLYSHLOG");
+    hasShrate_ = tableManager.useShrate();
 
     if ((hasPlyshlog_ || hasShrate_) && enablePolymerMolarWeight) {
         OpmLog::warning("PLYSHLOG and SHRATE should not be used in POLYMW runs, they will have no effect.\n");
     }
 
     if (hasPlyshlog_ && !enablePolymerMolarWeight) {
-        const auto& plyshlogTables = tableManager.getPlyshlogTables();
-        assert(numPvtRegions == plyshlogTables.size());
-        plyshlogShearEffectRefMultiplier_.resize(numPvtRegions);
-        plyshlogShearEffectRefLogVelocity_.resize(numPvtRegions);
-        for (unsigned pvtRegionIdx = 0; pvtRegionIdx < numPvtRegions; ++pvtRegionIdx) {
-            const auto& plyshlogTable = plyshlogTables.template getTable<PlyshlogTable>(pvtRegionIdx);
-
-            Scalar plyshlogRefPolymerConcentration = plyshlogTable.getRefPolymerConcentration();
-            auto waterVelocity = plyshlogTable.getWaterVelocityColumn().vectorCopy();
-            auto shearMultiplier = plyshlogTable.getShearMultiplierColumn().vectorCopy();
-
-                   // do the unit version here for the waterVelocity
-            UnitSystem unitSystem = eclState.getDeckUnitSystem();
-            double siFactor = hasShrate_? unitSystem.parse("1/Time").getSIScaling() : unitSystem.parse("Length/Time").getSIScaling();
-            for (std::size_t i = 0; i < waterVelocity.size(); ++i) {
-                waterVelocity[i] *= siFactor;
-                // for plyshlog the input must be stored as logarithms
-                // the interpolation is then done the log-space.
-                waterVelocity[i] = std::log(waterVelocity[i]);
-            }
-
-            Scalar refViscMult = plyviscViscosityMultiplierTable_[pvtRegionIdx].eval(plyshlogRefPolymerConcentration, /*extrapolate=*/true);
-            // convert the table using referece conditions
-            for (std::size_t i = 0; i < waterVelocity.size(); ++i) {
-                shearMultiplier[i] *= refViscMult;
-                shearMultiplier[i] -= 1;
-                shearMultiplier[i] /= (refViscMult - 1);
-            }
-            plyshlogShearEffectRefMultiplier_[pvtRegionIdx].resize(waterVelocity.size());
-            plyshlogShearEffectRefLogVelocity_[pvtRegionIdx].resize(waterVelocity.size());
-
-            for (std::size_t i = 0; i < waterVelocity.size(); ++i) {
-                plyshlogShearEffectRefMultiplier_[pvtRegionIdx][i] = shearMultiplier[i];
-                plyshlogShearEffectRefLogVelocity_[pvtRegionIdx][i] = waterVelocity[i];
-            }
-        }
+        processPlyshlog(eclState);
     }
 
     if (hasShrate_ && !enablePolymerMolarWeight) {
@@ -420,6 +386,52 @@ processPlmixpar(const EclipseState& eclState)
     else {
         if constexpr (!enablePolymerMolarWeight) {
             throw std::runtime_error("PLMIXPAR must be specified in POLYMER runs\n");
+        }
+    }
+}
+
+template<class Scalar>
+void BlackOilPolymerParams<Scalar>::
+processPlyshlog(const EclipseState& eclState)
+{
+    const auto& tableManager = eclState.getTableManager();
+    const auto& plyshlogTables = tableManager.getPlyshlogTables();
+    const unsigned numPvtRegions = tableManager.getTabdims().getNumPVTTables();
+    assert(numPvtRegions == plyshlogTables.size());
+    plyshlogShearEffectRefMultiplier_.resize(numPvtRegions);
+    plyshlogShearEffectRefLogVelocity_.resize(numPvtRegions);
+    for (unsigned pvtRegionIdx = 0; pvtRegionIdx < numPvtRegions; ++pvtRegionIdx) {
+        const auto& plyshlogTable = plyshlogTables.template getTable<PlyshlogTable>(pvtRegionIdx);
+
+        const Scalar plyshlogRefPolymerConcentration = plyshlogTable.getRefPolymerConcentration();
+        auto waterVelocity = plyshlogTable.getWaterVelocityColumn().vectorCopy();
+        auto shearMultiplier = plyshlogTable.getShearMultiplierColumn().vectorCopy();
+
+        // do the unit version here for the waterVelocity
+        UnitSystem unitSystem = eclState.getDeckUnitSystem();
+        const double siFactor = hasShrate_? unitSystem.parse("1/Time").getSIScaling()
+                                          : unitSystem.parse("Length/Time").getSIScaling();
+
+        // for plyshlog the input must be stored as logarithms
+        // the interpolation is then done in log-space.
+        std::ranges::transform(waterVelocity, waterVelocity.begin(),
+                               [siFactor](const double input)
+                               { return std::log(input * siFactor); });
+
+        const Scalar refViscMult = plyviscViscosityMultiplierTable_[pvtRegionIdx].
+                                      eval(plyshlogRefPolymerConcentration, /*extrapolate=*/true);
+
+        // convert the table using reference conditions
+        std::ranges::transform(shearMultiplier, shearMultiplier.begin(),
+                               [refViscMult](const double input)
+                               { return (input * refViscMult - 1.0) / (refViscMult - 1.0); });
+
+        plyshlogShearEffectRefMultiplier_[pvtRegionIdx].resize(waterVelocity.size());
+        plyshlogShearEffectRefLogVelocity_[pvtRegionIdx].resize(waterVelocity.size());
+
+        for (std::size_t i = 0; i < waterVelocity.size(); ++i) {
+            plyshlogShearEffectRefMultiplier_[pvtRegionIdx][i] = shearMultiplier[i];
+            plyshlogShearEffectRefLogVelocity_[pvtRegionIdx][i] = waterVelocity[i];
         }
     }
 }

--- a/opm/models/blackoil/blackoilpolymerparams.cpp
+++ b/opm/models/blackoil/blackoilpolymerparams.cpp
@@ -147,33 +147,7 @@ initFromState(const EclipseState& eclState)
         processPlyvmh(eclState);
         processPlymwinj(eclState);
         processSkprwat(eclState);
-
-        // handling SKPRPOLY keyword
-        const auto& skprpolyTables = tableManager.getSkprpolyTables();
-        for (const auto& table : skprpolyTables) {
-            const int tableNumber = table.first;
-            const auto& skprpolytable = table.second;
-            const std::vector<double>& throughput = skprpolytable.getThroughputs();
-            const std::vector<double>& watervelocity = skprpolytable.getVelocities();
-            const std::vector<std::vector<double>>& skinpressure = skprpolytable.getSkinPressures();
-            const double refPolymerConcentration = skprpolytable.referenceConcentration();
-            if constexpr (std::is_same_v<Scalar, float>) {
-                const std::vector<Scalar> tp(throughput.begin(), throughput.end());
-                const std::vector<Scalar> wv(watervelocity.begin(), watervelocity.end());
-                const auto sp = convertVecToVec<float>(skinpressure);
-                SkprpolyTable tablefunc {
-                    refPolymerConcentration,
-                    TabulatedTwoDFunction(tp, wv, sp, true, false)
-                };
-                skprpolyTables_[tableNumber] = std::move(tablefunc);
-            } else {
-                SkprpolyTable tablefunc {
-                    refPolymerConcentration,
-                    TabulatedTwoDFunction(throughput, watervelocity, skinpressure, true, false)
-                };
-                skprpolyTables_[tableNumber] = std::move(tablefunc);
-            }
-        }
+        processSkprpoly(eclState);
     }
 }
 
@@ -461,6 +435,38 @@ processSkprwat(const EclipseState& eclState)
         } else {
             TabulatedTwoDFunction tablefunc(throughput, watervelocity, skinpressure, true, false);
             skprwatTables_[tableNumber] = std::move(tablefunc);
+        }
+    }
+}
+
+template<class Scalar>
+void BlackOilPolymerParams<Scalar>::
+processSkprpoly(const EclipseState& eclState)
+{
+    const auto& tableManager = eclState.getTableManager();
+    const auto& skprpolyTables = tableManager.getSkprpolyTables();
+    for (const auto& table : skprpolyTables) {
+        const int tableNumber = table.first;
+        const auto& skprpolytable = table.second;
+        const std::vector<double>& throughput = skprpolytable.getThroughputs();
+        const std::vector<double>& watervelocity = skprpolytable.getVelocities();
+        const std::vector<std::vector<double>>& skinpressure = skprpolytable.getSkinPressures();
+        const double refPolymerConcentration = skprpolytable.referenceConcentration();
+        if constexpr (std::is_same_v<Scalar, float>) {
+            const std::vector<Scalar> tp(throughput.begin(), throughput.end());
+            const std::vector<Scalar> wv(watervelocity.begin(), watervelocity.end());
+            const auto sp = convertVecToVec<float>(skinpressure);
+            SkprpolyTable tablefunc {
+                refPolymerConcentration,
+                TabulatedTwoDFunction(tp, wv, sp, true, false)
+            };
+            skprpolyTables_[tableNumber] = std::move(tablefunc);
+        } else {
+            SkprpolyTable tablefunc {
+                refPolymerConcentration,
+                TabulatedTwoDFunction(throughput, watervelocity, skinpressure, true, false)
+            };
+            skprpolyTables_[tableNumber] = std::move(tablefunc);
         }
     }
 }

--- a/opm/models/blackoil/blackoilpolymerparams.cpp
+++ b/opm/models/blackoil/blackoilpolymerparams.cpp
@@ -51,38 +51,32 @@ convertVecToVec(const std::vector<std::vector<From>>& input)
     return output;
 }
 
-}
-
-namespace Opm {
-
-template<class Scalar>
 template<bool enablePolymer, bool enablePolymerMolarWeight>
-void BlackOilPolymerParams<Scalar>::
-initFromState(const EclipseState& eclState)
+void verifyState(const Opm::EclipseState& eclState)
 {
     // some sanity checks: if polymers are enabled, the POLYMER keyword must be
     // present, if polymers are disabled the keyword must not be present.
     if constexpr (enablePolymer) {
-        if (!eclState.runspec().phases().active(Phase::POLYMER)) {
+        if (!eclState.runspec().phases().active(Opm::Phase::POLYMER)) {
             throw std::runtime_error("Non-trivial polymer treatment requested at compile time, but "
                                      "the deck does not contain the POLYMER keyword");
         }
     }
     else {
-        if (eclState.runspec().phases().active(Phase::POLYMER)) {
+        if (eclState.runspec().phases().active(Opm::Phase::POLYMER)) {
             throw std::runtime_error("Polymer treatment disabled at compile time, but the deck "
                                      "contains the POLYMER keyword");
         }
     }
 
     if constexpr (enablePolymerMolarWeight) {
-        if (!eclState.runspec().phases().active(Phase::POLYMW)) {
+        if (!eclState.runspec().phases().active(Opm::Phase::POLYMW)) {
             throw std::runtime_error("Polymer molecular weight tracking is enabled at compile time, but "
                                      "the deck does not contain the POLYMW keyword");
         }
     }
     else {
-        if (eclState.runspec().phases().active(Phase::POLYMW)) {
+        if (eclState.runspec().phases().active(Opm::Phase::POLYMW)) {
             throw std::runtime_error("Polymer molecular weight tracking is disabled at compile time, but the deck "
                                      "contains the POLYMW keyword");
         }
@@ -92,7 +86,18 @@ initFromState(const EclipseState& eclState)
         throw std::runtime_error("Polymer molecular weight tracking is enabled while polymer treatment "
                                  "is disabled at compile time");
     }
+}
 
+}
+
+namespace Opm {
+
+template<class Scalar>
+template<bool enablePolymer, bool enablePolymerMolarWeight>
+void BlackOilPolymerParams<Scalar>::
+initFromState(const EclipseState& eclState)
+{
+    verifyState<enablePolymer, enablePolymerMolarWeight>(eclState);
     if (!eclState.runspec().phases().active(Phase::POLYMER)) {
         return; // polymer treatment is supposed to be disabled
     }

--- a/opm/models/blackoil/blackoilpolymerparams.cpp
+++ b/opm/models/blackoil/blackoilpolymerparams.cpp
@@ -117,27 +117,7 @@ initFromState(const EclipseState& eclState)
     plyviscViscosityMultiplierTable_.resize(numPvtRegions);
 
     // initialize the objects which deal with the PLYVISC keyword
-    const auto& plyviscTables = tableManager.getPlyviscTables();
-    if (!plyviscTables.empty()) {
-        // different viscosity model is used for POLYMW
-        if constexpr (enablePolymerMolarWeight) {
-            OpmLog::warning("PLYVISC should not be used in POLYMW runs, "
-                            "it will have no effect. A viscosity model based on PLYVMH is used instead.\n");
-        }
-        else {
-            assert(numPvtRegions == plyviscTables.size());
-            for (unsigned pvtRegionIdx = 0; pvtRegionIdx < numPvtRegions; ++pvtRegionIdx) {
-                const auto& plyadsTable = plyviscTables.template getTable<PlyviscTable>(pvtRegionIdx);
-                // Copy data
-                const auto& c = plyadsTable.getPolymerConcentrationColumn();
-                const auto& visc = plyadsTable.getViscosityMultiplierColumn();
-                plyviscViscosityMultiplierTable_[pvtRegionIdx].setXYContainers(c, visc);
-            }
-        }
-    }
-    else if constexpr (!enablePolymerMolarWeight) {
-        throw std::runtime_error("PLYVISC must be specified in POLYMER runs\n");
-    }
+    processPlyvisc<enablePolymerMolarWeight>(eclState);
 
     // initialize the objects which deal with the PLYMAX keyword
     const auto& plymaxTables = tableManager.getPlymaxTables();
@@ -385,6 +365,38 @@ processPlyads(const EclipseState& eclState)
     }
     else {
         throw std::runtime_error("PLYADS must be specified in POLYMER runs\n");
+    }
+}
+
+template<class Scalar>
+template<bool enablePolymerMolarWeight>
+void BlackOilPolymerParams<Scalar>::
+processPlyvisc(const EclipseState& eclState)
+{
+    const auto& tableManager = eclState.getTableManager();
+    const auto& plyviscTables = tableManager.getPlyviscTables();
+    const unsigned numPvtRegions = tableManager.getTabdims().getNumPVTTables();
+    if (!plyviscTables.empty()) {
+        // different viscosity model is used for POLYMW
+        if constexpr (enablePolymerMolarWeight) {
+            OpmLog::warning("PLYVISC should not be used in POLYMW runs, "
+                            "it will have no effect. A viscosity model based on PLYVMH is used instead.\n");
+        }
+        else {
+            assert(numPvtRegions == plyviscTables.size());
+            for (unsigned pvtRegionIdx = 0; pvtRegionIdx < numPvtRegions; ++pvtRegionIdx) {
+                const auto& plyadsTable = plyviscTables.template getTable<PlyviscTable>(pvtRegionIdx);
+                // Copy data
+                const auto& c = plyadsTable.getPolymerConcentrationColumn();
+                const auto& visc = plyadsTable.getViscosityMultiplierColumn();
+                plyviscViscosityMultiplierTable_[pvtRegionIdx].setXYContainers(c, visc);
+            }
+        }
+    }
+    else {
+        if constexpr (!enablePolymerMolarWeight) {
+            throw std::runtime_error("PLYVISC must be specified in POLYMER runs\n");
+        }
     }
 }
 

--- a/opm/models/blackoil/blackoilpolymerparams.cpp
+++ b/opm/models/blackoil/blackoilpolymerparams.cpp
@@ -144,21 +144,7 @@ initFromState(const EclipseState& eclState)
     }
 
     if constexpr (enablePolymerMolarWeight) {
-        const auto& plyvmhTable = eclState.getTableManager().getPlyvmhTable();
-        const auto& plymaxTables = tableManager.getPlymaxTables();
-        const unsigned numMixRegions = plymaxTables.size();
-        if (!plyvmhTable.empty()) {
-            assert(plyvmhTable.size() == numMixRegions);
-            for (std::size_t regionIdx = 0; regionIdx < numMixRegions; ++regionIdx) {
-                plyvmhCoefficients_[regionIdx].k_mh = plyvmhTable[regionIdx].k_mh;
-                plyvmhCoefficients_[regionIdx].a_mh = plyvmhTable[regionIdx].a_mh;
-                plyvmhCoefficients_[regionIdx].gamma = plyvmhTable[regionIdx].gamma;
-                plyvmhCoefficients_[regionIdx].kappa = plyvmhTable[regionIdx].kappa;
-            }
-        }
-        else {
-            throw std::runtime_error("PLYVMH keyword must be specified in POLYMW rus \n");
-        }
+        processPlyvmh(eclState);
 
         // handling PLYMWINJ keyword
         const auto& plymwinjTables = tableManager.getPlymwinjTables();
@@ -442,6 +428,28 @@ processShrate(const EclipseState& eclState)
         else {
             throw std::runtime_error("SHRATE must either have 0 or number of NUMPVT entries\n");
         }
+    }
+}
+
+template<class Scalar>
+void BlackOilPolymerParams<Scalar>::
+processPlyvmh(const EclipseState& eclState)
+{
+    const auto& tableManager = eclState.getTableManager();
+    const auto& plyvmhTable = tableManager.getPlyvmhTable();
+    const auto& plymaxTables = tableManager.getPlymaxTables();
+    const unsigned numMixRegions = plymaxTables.size();
+    if (!plyvmhTable.empty()) {
+        assert(plyvmhTable.size() == numMixRegions);
+        for (std::size_t regionIdx = 0; regionIdx < numMixRegions; ++regionIdx) {
+            plyvmhCoefficients_[regionIdx].k_mh = plyvmhTable[regionIdx].k_mh;
+            plyvmhCoefficients_[regionIdx].a_mh = plyvmhTable[regionIdx].a_mh;
+            plyvmhCoefficients_[regionIdx].gamma = plyvmhTable[regionIdx].gamma;
+            plyvmhCoefficients_[regionIdx].kappa = plyvmhTable[regionIdx].kappa;
+        }
+    }
+    else {
+        throw std::runtime_error("PLYVMH keyword must be specified in POLYMW runs\n");
     }
 }
 

--- a/opm/models/blackoil/blackoilpolymerparams.cpp
+++ b/opm/models/blackoil/blackoilpolymerparams.cpp
@@ -140,19 +140,7 @@ initFromState(const EclipseState& eclState)
         if (!hasPlyshlog_) {
             throw std::runtime_error("PLYSHLOG must be specified if SHRATE is used in POLYMER runs\n");
         }
-        const auto& shrateTable = eclState.getTableManager().getShrateTable();
-        shrate_.resize(numPvtRegions);
-        for (unsigned pvtRegionIdx = 0; pvtRegionIdx < numPvtRegions; ++pvtRegionIdx) {
-            if (shrateTable.empty()) {
-                shrate_[pvtRegionIdx] = 4.8; //default;
-            }
-            else if (shrateTable.size() == numPvtRegions) {
-                shrate_[pvtRegionIdx] = shrateTable[pvtRegionIdx].rate;
-            }
-            else {
-                throw std::runtime_error("SHRATE must either have 0 or number of NUMPVT entries\n");
-            }
-        }
+        processShrate(eclState);
     }
 
     if constexpr (enablePolymerMolarWeight) {
@@ -432,6 +420,27 @@ processPlyshlog(const EclipseState& eclState)
         for (std::size_t i = 0; i < waterVelocity.size(); ++i) {
             plyshlogShearEffectRefMultiplier_[pvtRegionIdx][i] = shearMultiplier[i];
             plyshlogShearEffectRefLogVelocity_[pvtRegionIdx][i] = waterVelocity[i];
+        }
+    }
+}
+
+template<class Scalar>
+void BlackOilPolymerParams<Scalar>::
+processShrate(const EclipseState& eclState)
+{
+    const auto& tableManager = eclState.getTableManager();
+    const auto& shrateTable = tableManager.getShrateTable();
+    const unsigned numPvtRegions = tableManager.getTabdims().getNumPVTTables();
+    shrate_.resize(numPvtRegions);
+    for (unsigned pvtRegionIdx = 0; pvtRegionIdx < numPvtRegions; ++pvtRegionIdx) {
+        if (shrateTable.empty()) {
+            shrate_[pvtRegionIdx] = 4.8; //default;
+        }
+        else if (shrateTable.size() == numPvtRegions) {
+            shrate_[pvtRegionIdx] = shrateTable[pvtRegionIdx].rate;
+        }
+        else {
+            throw std::runtime_error("SHRATE must either have 0 or number of NUMPVT entries\n");
         }
     }
 }

--- a/opm/models/blackoil/blackoilpolymerparams.cpp
+++ b/opm/models/blackoil/blackoilpolymerparams.cpp
@@ -107,25 +107,10 @@ initFromState(const EclipseState& eclState)
     unsigned numSatRegions = tableManager.getTabdims().getNumSatTables();
     setNumSatRegions(numSatRegions);
 
-           // initialize the objects which deal with the PLYROCK keyword
-    const auto& plyrockTables = tableManager.getPlyrockTables();
-    if (!plyrockTables.empty()) {
-        assert(numSatRegions == plyrockTables.size());
-        for (unsigned satRegionIdx = 0; satRegionIdx < numSatRegions; ++satRegionIdx) {
-            const auto& plyrockTable = plyrockTables.template getTable<PlyrockTable>(satRegionIdx);
-            setPlyrock(satRegionIdx,
-                       plyrockTable.getDeadPoreVolumeColumn()[0],
-                       plyrockTable.getResidualResistanceFactorColumn()[0],
-                       plyrockTable.getRockDensityFactorColumn()[0],
-                       static_cast<AdsorptionBehaviour>(plyrockTable.getAdsorbtionIndexColumn()[0]),
-                       plyrockTable.getMaxAdsorbtionColumn()[0]);
-        }
-    }
-    else {
-        throw std::runtime_error("PLYROCK must be specified in POLYMER runs\n");
-    }
+    // initialize the objects which deal with the PLYROCK keyword
+    processPlyrock(eclState);
 
-           // initialize the objects which deal with the PLYADS keyword
+    // initialize the objects which deal with the PLYADS keyword
     const auto& plyadsTables = tableManager.getPlyadsTables();
     if (!plyadsTables.empty()) {
         assert(numSatRegions == plyadsTables.size());
@@ -145,7 +130,7 @@ initFromState(const EclipseState& eclState)
     unsigned numPvtRegions = tableManager.getTabdims().getNumPVTTables();
     plyviscViscosityMultiplierTable_.resize(numPvtRegions);
 
-           // initialize the objects which deal with the PLYVISC keyword
+    // initialize the objects which deal with the PLYVISC keyword
     const auto& plyviscTables = tableManager.getPlyviscTables();
     if (!plyviscTables.empty()) {
         // different viscosity model is used for POLYMW
@@ -168,7 +153,7 @@ initFromState(const EclipseState& eclState)
         throw std::runtime_error("PLYVISC must be specified in POLYMER runs\n");
     }
 
-           // initialize the objects which deal with the PLYMAX keyword
+    // initialize the objects which deal with the PLYMAX keyword
     const auto& plymaxTables = tableManager.getPlymaxTables();
     const unsigned numMixRegions = plymaxTables.size();
     setNumMixRegions(numMixRegions, enablePolymerMolarWeight);
@@ -278,7 +263,7 @@ initFromState(const EclipseState& eclState)
             throw std::runtime_error("PLYVMH keyword must be specified in POLYMW rus \n");
         }
 
-               // handling PLYMWINJ keyword
+        // handling PLYMWINJ keyword
         const auto& plymwinjTables = tableManager.getPlymwinjTables();
         for (const auto& table : plymwinjTables) {
             const int tableNumber = table.first;
@@ -298,7 +283,7 @@ initFromState(const EclipseState& eclState)
             }
         }
 
-               // handling SKPRWAT keyword
+        // handling SKPRWAT keyword
         const auto& skprwatTables = tableManager.getSkprwatTables();
         for (const auto& table : skprwatTables) {
             const int tableNumber = table.first;
@@ -318,7 +303,7 @@ initFromState(const EclipseState& eclState)
             }
         }
 
-               // handling SKPRPOLY keyword
+        // handling SKPRPOLY keyword
         const auto& skprpolyTables = tableManager.getSkprpolyTables();
         for (const auto& table : skprpolyTables) {
             const int tableNumber = table.first;
@@ -368,6 +353,30 @@ setNumMixRegions(unsigned numRegions, bool enablePolymerMolarWeight)
 
     if (enablePolymerMolarWeight) {
         plyvmhCoefficients_.resize(numRegions);
+    }
+}
+
+template<class Scalar>
+void BlackOilPolymerParams<Scalar>::
+processPlyrock(const EclipseState& eclState)
+{
+    const auto& tableManager = eclState.getTableManager();
+    const unsigned numSatRegions = tableManager.getTabdims().getNumSatTables();
+    const auto& plyrockTables = tableManager.getPlyrockTables();
+    if (!plyrockTables.empty()) {
+        assert(numSatRegions == plyrockTables.size());
+        for (unsigned satRegionIdx = 0; satRegionIdx < numSatRegions; ++satRegionIdx) {
+            const auto& plyrockTable = plyrockTables.template getTable<PlyrockTable>(satRegionIdx);
+            setPlyrock(satRegionIdx,
+                       plyrockTable.getDeadPoreVolumeColumn()[0],
+                       plyrockTable.getResidualResistanceFactorColumn()[0],
+                       plyrockTable.getRockDensityFactorColumn()[0],
+                       static_cast<AdsorptionBehaviour>(plyrockTable.getAdsorbtionIndexColumn()[0]),
+                       plyrockTable.getMaxAdsorbtionColumn()[0]);
+        }
+    }
+    else {
+        throw std::runtime_error("PLYROCK must be specified in POLYMER runs\n");
     }
 }
 

--- a/opm/models/blackoil/blackoilpolymerparams.cpp
+++ b/opm/models/blackoil/blackoilpolymerparams.cpp
@@ -145,26 +145,7 @@ initFromState(const EclipseState& eclState)
 
     if constexpr (enablePolymerMolarWeight) {
         processPlyvmh(eclState);
-
-        // handling PLYMWINJ keyword
-        const auto& plymwinjTables = tableManager.getPlymwinjTables();
-        for (const auto& table : plymwinjTables) {
-            const int tableNumber = table.first;
-            const auto& plymwinjtable = table.second;
-            const std::vector<double>& throughput = plymwinjtable.getThroughputs();
-            const std::vector<double>& watervelocity = plymwinjtable.getVelocities();
-            const std::vector<std::vector<double>>& molecularweight = plymwinjtable.getMoleWeights();
-            if constexpr (std::is_same_v<Scalar, float>) {
-                const std::vector<Scalar> tp(throughput.begin(), throughput.end());
-                const std::vector<Scalar> wv(watervelocity.begin(), watervelocity.end());
-                const auto mw = convertVecToVec<float>(molecularweight);
-                TabulatedTwoDFunction tablefunc(tp, wv, mw, true, false);
-                plymwinjTables_[tableNumber] = std::move(tablefunc);
-            } else {
-                TabulatedTwoDFunction tablefunc(throughput, watervelocity, molecularweight, true, false);
-                plymwinjTables_[tableNumber] = std::move(tablefunc);
-            }
-        }
+        processPlymwinj(eclState);
 
         // handling SKPRWAT keyword
         const auto& skprwatTables = tableManager.getSkprwatTables();
@@ -450,6 +431,31 @@ processPlyvmh(const EclipseState& eclState)
     }
     else {
         throw std::runtime_error("PLYVMH keyword must be specified in POLYMW runs\n");
+    }
+}
+
+template<class Scalar>
+void BlackOilPolymerParams<Scalar>::
+processPlymwinj(const EclipseState& eclState)
+{
+    const auto& tableManager = eclState.getTableManager();
+    const auto& plymwinjTables = tableManager.getPlymwinjTables();
+    for (const auto& table : plymwinjTables) {
+        const int tableNumber = table.first;
+        const auto& plymwinjtable = table.second;
+        const std::vector<double>& throughput = plymwinjtable.getThroughputs();
+        const std::vector<double>& watervelocity = plymwinjtable.getVelocities();
+        const std::vector<std::vector<double>>& molecularweight = plymwinjtable.getMoleWeights();
+        if constexpr (std::is_same_v<Scalar, float>) {
+            const std::vector<Scalar> tp(throughput.begin(), throughput.end());
+            const std::vector<Scalar> wv(watervelocity.begin(), watervelocity.end());
+            const auto mw = convertVecToVec<float>(molecularweight);
+            TabulatedTwoDFunction tablefunc(tp, wv, mw, true, false);
+            plymwinjTables_[tableNumber] = std::move(tablefunc);
+        } else {
+            TabulatedTwoDFunction tablefunc(throughput, watervelocity, molecularweight, true, false);
+            plymwinjTables_[tableNumber] = std::move(tablefunc);
+        }
     }
 }
 

--- a/opm/models/blackoil/blackoilpolymerparams.cpp
+++ b/opm/models/blackoil/blackoilpolymerparams.cpp
@@ -120,18 +120,7 @@ initFromState(const EclipseState& eclState)
     processPlyvisc<enablePolymerMolarWeight>(eclState);
 
     // initialize the objects which deal with the PLYMAX keyword
-    const auto& plymaxTables = tableManager.getPlymaxTables();
-    const unsigned numMixRegions = plymaxTables.size();
-    setNumMixRegions(numMixRegions, enablePolymerMolarWeight);
-    if (!plymaxTables.empty()) {
-        for (unsigned mixRegionIdx = 0; mixRegionIdx < numMixRegions; ++mixRegionIdx) {
-            const auto& plymaxTable = plymaxTables.template getTable<PlymaxTable>(mixRegionIdx);
-            plymaxMaxConcentration_[mixRegionIdx] = plymaxTable.getPolymerConcentrationColumn()[0];
-        }
-    }
-    else {
-        throw std::runtime_error("PLYMAX must be specified in POLYMER runs\n");
-    }
+    processPlymax<enablePolymerMolarWeight>(eclState);
 
     if (!eclState.getTableManager().getPlmixparTable().empty()) {
         if constexpr (enablePolymerMolarWeight) {
@@ -397,6 +386,26 @@ processPlyvisc(const EclipseState& eclState)
         if constexpr (!enablePolymerMolarWeight) {
             throw std::runtime_error("PLYVISC must be specified in POLYMER runs\n");
         }
+    }
+}
+
+template<class Scalar>
+template<bool enablePolymerMolarWeight>
+void BlackOilPolymerParams<Scalar>::
+processPlymax(const EclipseState& eclState)
+{
+    const auto& tableManager = eclState.getTableManager();
+    const auto& plymaxTables = tableManager.getPlymaxTables();
+    const unsigned numMixRegions = plymaxTables.size();
+    setNumMixRegions(numMixRegions, enablePolymerMolarWeight);
+    if (!plymaxTables.empty()) {
+        for (unsigned mixRegionIdx = 0; mixRegionIdx < numMixRegions; ++mixRegionIdx) {
+            const auto& plymaxTable = plymaxTables.template getTable<PlymaxTable>(mixRegionIdx);
+            plymaxMaxConcentration_[mixRegionIdx] = plymaxTable.getPolymerConcentrationColumn()[0];
+        }
+    }
+    else {
+        throw std::runtime_error("PLYMAX must be specified in POLYMER runs\n");
     }
 }
 

--- a/opm/models/blackoil/blackoilpolymerparams.cpp
+++ b/opm/models/blackoil/blackoilpolymerparams.cpp
@@ -146,26 +146,7 @@ initFromState(const EclipseState& eclState)
     if constexpr (enablePolymerMolarWeight) {
         processPlyvmh(eclState);
         processPlymwinj(eclState);
-
-        // handling SKPRWAT keyword
-        const auto& skprwatTables = tableManager.getSkprwatTables();
-        for (const auto& table : skprwatTables) {
-            const int tableNumber = table.first;
-            const auto& skprwattable = table.second;
-            const std::vector<double>& throughput = skprwattable.getThroughputs();
-            const std::vector<double>& watervelocity = skprwattable.getVelocities();
-            const std::vector<std::vector<double>>& skinpressure = skprwattable.getSkinPressures();
-            if constexpr (std::is_same_v<Scalar, float>) {
-                const std::vector<Scalar> tp(throughput.begin(), throughput.end());
-                const std::vector<Scalar> wv(watervelocity.begin(), watervelocity.end());
-                const auto sp = convertVecToVec<float>(skinpressure);
-                TabulatedTwoDFunction tablefunc(tp, wv, sp, true, false);
-                skprwatTables_[tableNumber] = std::move(tablefunc);
-            } else {
-                TabulatedTwoDFunction tablefunc(throughput, watervelocity, skinpressure, true, false);
-                skprwatTables_[tableNumber] = std::move(tablefunc);
-            }
-        }
+        processSkprwat(eclState);
 
         // handling SKPRPOLY keyword
         const auto& skprpolyTables = tableManager.getSkprpolyTables();
@@ -455,6 +436,31 @@ processPlymwinj(const EclipseState& eclState)
         } else {
             TabulatedTwoDFunction tablefunc(throughput, watervelocity, molecularweight, true, false);
             plymwinjTables_[tableNumber] = std::move(tablefunc);
+        }
+    }
+}
+
+template<class Scalar>
+void BlackOilPolymerParams<Scalar>::
+processSkprwat(const EclipseState& eclState)
+{
+    const auto& tableManager = eclState.getTableManager();
+    const auto& skprwatTables = tableManager.getSkprwatTables();
+    for (const auto& table : skprwatTables) {
+        const int tableNumber = table.first;
+        const auto& skprwattable = table.second;
+        const std::vector<double>& throughput = skprwattable.getThroughputs();
+        const std::vector<double>& watervelocity = skprwattable.getVelocities();
+        const std::vector<std::vector<double>>& skinpressure = skprwattable.getSkinPressures();
+        if constexpr (std::is_same_v<Scalar, float>) {
+            const std::vector<Scalar> tp(throughput.begin(), throughput.end());
+            const std::vector<Scalar> wv(watervelocity.begin(), watervelocity.end());
+            const auto sp = convertVecToVec<float>(skinpressure);
+            TabulatedTwoDFunction tablefunc(tp, wv, sp, true, false);
+            skprwatTables_[tableNumber] = std::move(tablefunc);
+        } else {
+            TabulatedTwoDFunction tablefunc(throughput, watervelocity, skinpressure, true, false);
+            skprwatTables_[tableNumber] = std::move(tablefunc);
         }
     }
 }

--- a/opm/models/blackoil/blackoilpolymerparams.cpp
+++ b/opm/models/blackoil/blackoilpolymerparams.cpp
@@ -111,23 +111,9 @@ initFromState(const EclipseState& eclState)
     processPlyrock(eclState);
 
     // initialize the objects which deal with the PLYADS keyword
-    const auto& plyadsTables = tableManager.getPlyadsTables();
-    if (!plyadsTables.empty()) {
-        assert(numSatRegions == plyadsTables.size());
-        for (unsigned satRegionIdx = 0; satRegionIdx < numSatRegions; ++satRegionIdx) {
-            const auto& plyadsTable = plyadsTables.template getTable<PlyadsTable>(satRegionIdx);
-            // Copy data
-            const auto& c = plyadsTable.getPolymerConcentrationColumn();
-            const auto& ads = plyadsTable.getAdsorbedPolymerColumn();
-            plyadsAdsorbedPolymer_[satRegionIdx].setXYContainers(c, ads);
-        }
-    }
-    else {
-        throw std::runtime_error("PLYADS must be specified in POLYMER runs\n");
-    }
+    processPlyads(eclState);
 
-
-    unsigned numPvtRegions = tableManager.getTabdims().getNumPVTTables();
+    const unsigned numPvtRegions = tableManager.getTabdims().getNumPVTTables();
     plyviscViscosityMultiplierTable_.resize(numPvtRegions);
 
     // initialize the objects which deal with the PLYVISC keyword
@@ -382,6 +368,28 @@ processPlyrock(const EclipseState& eclState)
 
 template<class Scalar>
 void BlackOilPolymerParams<Scalar>::
+processPlyads(const EclipseState& eclState)
+{
+    const auto& tableManager = eclState.getTableManager();
+    const unsigned numSatRegions = tableManager.getTabdims().getNumSatTables();
+    const auto& plyadsTables = tableManager.getPlyadsTables();
+    if (!plyadsTables.empty()) {
+        assert(numSatRegions == plyadsTables.size());
+        for (unsigned satRegionIdx = 0; satRegionIdx < numSatRegions; ++satRegionIdx) {
+            const auto& plyadsTable = plyadsTables.template getTable<PlyadsTable>(satRegionIdx);
+            // Copy data
+            const auto& c = plyadsTable.getPolymerConcentrationColumn();
+            const auto& ads = plyadsTable.getAdsorbedPolymerColumn();
+            plyadsAdsorbedPolymer_[satRegionIdx].setXYContainers(c, ads);
+        }
+    }
+    else {
+        throw std::runtime_error("PLYADS must be specified in POLYMER runs\n");
+    }
+}
+
+template<class Scalar>
+void BlackOilPolymerParams<Scalar>::
 setPlyrock(unsigned satRegionIdx,
            const Scalar& plyrockDeadPoreVolume,
            const Scalar& plyrockResidualResistanceFactor,
@@ -395,6 +403,7 @@ setPlyrock(unsigned satRegionIdx,
     plyrockAdsorbtionIndex_[satRegionIdx] = plyrockAdsorbtionIndex;
     plyrockMaxAdsorbtion_[satRegionIdx] = plyrockMaxAdsorbtion;
 }
+
 
 #define INSTANTIATE_TYPE(T)                                                                  \
     template struct BlackOilPolymerParams<T>;                                                \

--- a/opm/models/blackoil/blackoilpolymerparams.cpp
+++ b/opm/models/blackoil/blackoilpolymerparams.cpp
@@ -122,21 +122,7 @@ initFromState(const EclipseState& eclState)
     // initialize the objects which deal with the PLYMAX keyword
     processPlymax<enablePolymerMolarWeight>(eclState);
 
-    if (!eclState.getTableManager().getPlmixparTable().empty()) {
-        if constexpr (enablePolymerMolarWeight) {
-            OpmLog::warning("PLMIXPAR should not be used in POLYMW runs, it will have no effect.\n");
-        }
-        else {
-            const auto& plmixparTable = eclState.getTableManager().getPlmixparTable();
-            // initialize the objects which deal with the PLMIXPAR keyword
-            for (unsigned mixRegionIdx = 0; mixRegionIdx < numMixRegions; ++mixRegionIdx) {
-                plymixparToddLongstaff_[mixRegionIdx] = plmixparTable[mixRegionIdx].todd_langstaff;
-            }
-        }
-    }
-    else if constexpr (!enablePolymerMolarWeight) {
-        throw std::runtime_error("PLMIXPAR must be specified in POLYMER runs\n");
-    }
+    processPlmixpar<enablePolymerMolarWeight>(eclState);
 
     hasPlyshlog_ = eclState.getTableManager().hasTables("PLYSHLOG");
     hasShrate_ = eclState.getTableManager().useShrate();
@@ -205,6 +191,8 @@ initFromState(const EclipseState& eclState)
 
     if constexpr (enablePolymerMolarWeight) {
         const auto& plyvmhTable = eclState.getTableManager().getPlyvmhTable();
+        const auto& plymaxTables = tableManager.getPlymaxTables();
+        const unsigned numMixRegions = plymaxTables.size();
         if (!plyvmhTable.empty()) {
             assert(plyvmhTable.size() == numMixRegions);
             for (std::size_t regionIdx = 0; regionIdx < numMixRegions; ++regionIdx) {
@@ -406,6 +394,33 @@ processPlymax(const EclipseState& eclState)
     }
     else {
         throw std::runtime_error("PLYMAX must be specified in POLYMER runs\n");
+    }
+}
+
+template<class Scalar>
+template<bool enablePolymerMolarWeight>
+void BlackOilPolymerParams<Scalar>::
+processPlmixpar(const EclipseState& eclState)
+{
+    const auto& tableManager = eclState.getTableManager();
+    const auto& plmixparTable = tableManager.getPlmixparTable();
+    const auto& plymaxTables = tableManager.getPlymaxTables();
+    const unsigned numMixRegions = plymaxTables.size();
+    if (!plmixparTable.empty()) {
+        if constexpr (enablePolymerMolarWeight) {
+            OpmLog::warning("PLMIXPAR should not be used in POLYMW runs, it will have no effect.\n");
+        }
+        else {
+            // initialize the objects which deal with the PLMIXPAR keyword
+            for (unsigned mixRegionIdx = 0; mixRegionIdx < numMixRegions; ++mixRegionIdx) {
+                plymixparToddLongstaff_[mixRegionIdx] = plmixparTable[mixRegionIdx].todd_langstaff;
+            }
+        }
+    }
+    else {
+        if constexpr (!enablePolymerMolarWeight) {
+            throw std::runtime_error("PLMIXPAR must be specified in POLYMER runs\n");
+        }
     }
 }
 

--- a/opm/models/blackoil/blackoilpolymerparams.hpp
+++ b/opm/models/blackoil/blackoilpolymerparams.hpp
@@ -116,6 +116,11 @@ private:
      * \brief Process the Plyrock data.
      */
     void processPlyrock(const EclipseState& eclState);
+
+    /*!
+     * \brief Process the Plyads data.
+     */
+    void processPlyads(const EclipseState& eclState);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilpolymerparams.hpp
+++ b/opm/models/blackoil/blackoilpolymerparams.hpp
@@ -164,6 +164,11 @@ private:
      * \brief Process the Skprwat data.
      */
     void processSkprwat(const EclipseState& eclState);
+
+    /*!
+     * \brief Process the Skprpoly data.
+     */
+    void processSkprpoly(const EclipseState& eclState);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilpolymerparams.hpp
+++ b/opm/models/blackoil/blackoilpolymerparams.hpp
@@ -133,6 +133,12 @@ private:
      */
     template<bool enablePolymerMolarWeight>
     void processPlymax(const EclipseState& eclState);
+
+    /*!
+     * \brief Process the Plmixpar data.
+     */
+    template<bool enablePolymerMolarWeight>
+    void processPlmixpar(const EclipseState& eclState);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilpolymerparams.hpp
+++ b/opm/models/blackoil/blackoilpolymerparams.hpp
@@ -111,6 +111,11 @@ private:
                     const Scalar& plyrockRockDensityFactor,
                     const Scalar& plyrockAdsorbtionIndex,
                     const Scalar& plyrockMaxAdsorbtion);
+
+    /*!
+     * \brief Process the Plyrock data.
+     */
+    void processPlyrock(const EclipseState& eclState);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilpolymerparams.hpp
+++ b/opm/models/blackoil/blackoilpolymerparams.hpp
@@ -49,32 +49,6 @@ struct BlackOilPolymerParams {
     template<bool enablePolymer, bool enablePolymerMolarWeight>
     void initFromState(const EclipseState& eclState);
 
-    /*!
-     * \brief Specify the number of satuation regions.
-     *
-     * This must be called before setting the PLYROCK and PLYADS of any region.
-     */
-    void setNumSatRegions(unsigned numRegions);
-
-    /*!
-     * \brief Specify the number of mix regions.
-     *
-     * This must be called before setting the PLYMAC and PLMIXPAR of any region.
-     */
-    void setNumMixRegions(unsigned numRegions, bool enablePolymerMolarWeight);
-
-    /*!
-     * \brief Specify the polymer rock properties a single region.
-     *
-     * The index of specified here must be in range [0, numSatRegions)
-     */
-    void setPlyrock(unsigned satRegionIdx,
-                    const Scalar& plyrockDeadPoreVolume,
-                    const Scalar& plyrockResidualResistanceFactor,
-                    const Scalar& plyrockRockDensityFactor,
-                    const Scalar& plyrockAdsorbtionIndex,
-                    const Scalar& plyrockMaxAdsorbtion);
-
     // a struct containing the constants to calculate polymer viscosity
     // based on Mark-Houwink equation and Huggins equation, the constants are provided
     // by the keyword PLYVMH
@@ -110,6 +84,33 @@ struct BlackOilPolymerParams {
     std::map<int, TabulatedTwoDFunction> skprwatTables_{};
 
     std::map<int, SkprpolyTable> skprpolyTables_{};
+
+private:
+    /*!
+     * \brief Specify the number of saturation regions.
+     *
+     * This must be called before setting the PLYROCK and PLYADS of any region.
+     */
+    void setNumSatRegions(unsigned numRegions);
+
+    /*!
+     * \brief Specify the number of mix regions.
+     *
+     * This must be called before setting the PLYMAX and PLMIXPAR of any region.
+     */
+    void setNumMixRegions(unsigned numRegions, bool enablePolymerMolarWeight);
+
+    /*!
+     * \brief Specify the polymer rock properties a single region.
+     *
+     * The index of specified here must be in range [0, numSatRegions)
+     */
+    void setPlyrock(unsigned satRegionIdx,
+                    const Scalar& plyrockDeadPoreVolume,
+                    const Scalar& plyrockResidualResistanceFactor,
+                    const Scalar& plyrockRockDensityFactor,
+                    const Scalar& plyrockAdsorbtionIndex,
+                    const Scalar& plyrockMaxAdsorbtion);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilpolymerparams.hpp
+++ b/opm/models/blackoil/blackoilpolymerparams.hpp
@@ -159,6 +159,11 @@ private:
      * \brief Process the Plymwinj data.
      */
     void processPlymwinj(const EclipseState& eclState);
+
+    /*!
+     * \brief Process the Skprwat data.
+     */
+    void processSkprwat(const EclipseState& eclState);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilpolymerparams.hpp
+++ b/opm/models/blackoil/blackoilpolymerparams.hpp
@@ -123,11 +123,16 @@ private:
     void processPlyads(const EclipseState& eclState);
 
     /*!
-     *
      * \brief Process the Plyvisc data.
      */
     template<bool enablePolymerMolarWeight>
     void processPlyvisc(const EclipseState& eclState);
+
+    /*!
+     * \brief Process the Plymax data.
+     */
+    template<bool enablePolymerMolarWeight>
+    void processPlymax(const EclipseState& eclState);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilpolymerparams.hpp
+++ b/opm/models/blackoil/blackoilpolymerparams.hpp
@@ -149,6 +149,11 @@ private:
      * \brief Process the Shrate data.
      */
     void processShrate(const EclipseState& eclState);
+
+    /*!
+     * \brief Process the Plyvmh data.
+     */
+    void processPlyvmh(const EclipseState& eclState);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilpolymerparams.hpp
+++ b/opm/models/blackoil/blackoilpolymerparams.hpp
@@ -121,6 +121,13 @@ private:
      * \brief Process the Plyads data.
      */
     void processPlyads(const EclipseState& eclState);
+
+    /*!
+     *
+     * \brief Process the Plyvisc data.
+     */
+    template<bool enablePolymerMolarWeight>
+    void processPlyvisc(const EclipseState& eclState);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilpolymerparams.hpp
+++ b/opm/models/blackoil/blackoilpolymerparams.hpp
@@ -154,6 +154,11 @@ private:
      * \brief Process the Plyvmh data.
      */
     void processPlyvmh(const EclipseState& eclState);
+
+    /*!
+     * \brief Process the Plymwinj data.
+     */
+    void processPlymwinj(const EclipseState& eclState);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilpolymerparams.hpp
+++ b/opm/models/blackoil/blackoilpolymerparams.hpp
@@ -139,6 +139,11 @@ private:
      */
     template<bool enablePolymerMolarWeight>
     void processPlmixpar(const EclipseState& eclState);
+
+    /*!
+     * \brief Process the Plyshlog data.
+     */
+    void processPlyshlog(const EclipseState& eclState);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilpolymerparams.hpp
+++ b/opm/models/blackoil/blackoilpolymerparams.hpp
@@ -144,6 +144,11 @@ private:
      * \brief Process the Plyshlog data.
      */
     void processPlyshlog(const EclipseState& eclState);
+
+    /*!
+     * \brief Process the Shrate data.
+     */
+    void processShrate(const EclipseState& eclState);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilsolventparams.cpp
+++ b/opm/models/blackoil/blackoilsolventparams.cpp
@@ -72,7 +72,6 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
     processSsfn(eclState);
 
     const auto& tableManager = eclState.getTableManager();
-    unsigned numSatRegions = tableManager.getTabdims().getNumSatTables();
 
     // initialize the objects needed for miscible solvent and oil simulations
     isMiscible_ = false;
@@ -82,37 +81,8 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
         processSof2(eclState);
         processMisc(eclState);
         processPmisc(eclState);
+        processMsfn(eclState);
 
-        // miscible relative permeability multipleiers
-        msfnKrsg_.resize(numSatRegions);
-        msfnKro_.resize(numSatRegions);
-        const auto& msfnTables = tableManager.getMsfnTables();
-        if (!msfnTables.empty()) {
-            assert(numSatRegions == msfnTables.size());
-
-            for (unsigned regionIdx = 0; regionIdx < numSatRegions; ++regionIdx) {
-                const MsfnTable& msfnTable = msfnTables.template getTable<MsfnTable>(regionIdx);
-
-                // Copy data
-                // Ssg = Ss + Sg;
-                const auto& Ssg = msfnTable.getGasPhaseFractionColumn();
-                const auto& krsg = msfnTable.getGasSolventRelpermMultiplierColumn();
-                const auto& kro = msfnTable.getOilRelpermMultiplierColumn();
-
-                msfnKrsg_[regionIdx].setXYContainers(Ssg, krsg);
-                msfnKro_[regionIdx].setXYContainers(Ssg, kro);
-            }
-        }
-        else {
-            std::vector<double> x = {0.0,1.0};
-            std::vector<double> y = {1.0,0.0};
-            TabulatedFunction unit = TabulatedFunction(2, x, x);
-            TabulatedFunction invUnit = TabulatedFunction(2, x, y);
-
-            for (unsigned regionIdx = 0; regionIdx < numSatRegions; ++regionIdx) {
-                setMsfn(regionIdx, unit, invUnit);
-            }
-        }
         // resize the attributes of the object
         sorwmis_.resize(numMiscRegions);
         const auto& sorwmisTables = tableManager.getSorwmisTables();
@@ -365,6 +335,45 @@ processPmisc(const EclipseState& eclState)
         const TabulatedFunction constant = TabulatedFunction(2, x, y);
         for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx) {
             pmisc_[regionIdx] = constant;
+        }
+    }
+}
+
+template<class Scalar>
+void BlackOilSolventParams<Scalar>::
+processMsfn(const EclipseState& eclState)
+{
+    const auto& tableManager = eclState.getTableManager();
+    const unsigned numSatRegions = tableManager.getTabdims().getNumSatTables();
+
+    // miscible relative permeability multipleiers
+    msfnKrsg_.resize(numSatRegions);
+    msfnKro_.resize(numSatRegions);
+    const auto& msfnTables = tableManager.getMsfnTables();
+    if (!msfnTables.empty()) {
+        assert(numSatRegions == msfnTables.size());
+
+        for (unsigned regionIdx = 0; regionIdx < numSatRegions; ++regionIdx) {
+            const MsfnTable& msfnTable = msfnTables.template getTable<MsfnTable>(regionIdx);
+
+            // Copy data
+            // Ssg = Ss + Sg;
+            const auto& Ssg = msfnTable.getGasPhaseFractionColumn();
+            const auto& krsg = msfnTable.getGasSolventRelpermMultiplierColumn();
+            const auto& kro = msfnTable.getOilRelpermMultiplierColumn();
+
+            msfnKrsg_[regionIdx].setXYContainers(Ssg, krsg);
+            msfnKro_[regionIdx].setXYContainers(Ssg, kro);
+        }
+    }
+    else {
+        const std::vector<double> x = {0.0,1.0};
+        const std::vector<double> y = {1.0,0.0};
+        const TabulatedFunction unit = TabulatedFunction(2, x, x);
+        const TabulatedFunction invUnit = TabulatedFunction(2, x, y);
+
+        for (unsigned regionIdx = 0; regionIdx < numSatRegions; ++regionIdx) {
+            setMsfn(regionIdx, unit, invUnit);
         }
     }
 }

--- a/opm/models/blackoil/blackoilsolventparams.cpp
+++ b/opm/models/blackoil/blackoilsolventparams.cpp
@@ -76,29 +76,11 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
 
     // initialize the objects needed for miscible solvent and oil simulations
     isMiscible_ = false;
-    if (!eclState.getTableManager().getMiscTables().empty()) {
+    if (!tableManager.getMiscTables().empty()) {
         isMiscible_ = true;
-        unsigned numMiscRegions = 1;
+        const unsigned numMiscRegions = 1;
         processSof2(eclState);
-
-        const auto& miscTables = tableManager.getMiscTables();
-        if (!miscTables.empty()) {
-            assert(numMiscRegions == miscTables.size());
-
-            // resize the attributes of the object
-            misc_.resize(numMiscRegions);
-            for (unsigned miscRegionIdx = 0; miscRegionIdx < numMiscRegions; ++miscRegionIdx) {
-                const auto& miscTable = miscTables.template getTable<MiscTable>(miscRegionIdx);
-
-                // solventFraction = Ss / (Ss + Sg);
-                const auto& solventFraction = miscTable.getSolventFractionColumn();
-                const auto& misc = miscTable.getMiscibilityColumn();
-                misc_[miscRegionIdx].setXYContainers(solventFraction, misc);
-            }
-        }
-        else {
-            throw std::runtime_error("MISC must be specified in MISCIBLE (SOLVENT) runs\n");
-        }
+        processMisc(eclState);
 
         // resize the attributes of the object
         pmisc_.resize(numMiscRegions);
@@ -349,6 +331,32 @@ processSof2(const EclipseState& eclState)
     }
     else if (eclState.runspec().phases().active(Phase::OIL)) {
         throw std::runtime_error("SOF2 must be specified in MISCIBLE (SOLVENT and OIL) runs\n");
+    }
+}
+
+template<class Scalar>
+void BlackOilSolventParams<Scalar>::
+processMisc(const EclipseState& eclState)
+{
+    const auto& tableManager = eclState.getTableManager();
+    const auto& miscTables = tableManager.getMiscTables();
+    const unsigned numMiscRegions = 1;
+    if (!miscTables.empty()) {
+        assert(numMiscRegions == miscTables.size());
+
+        // resize the attributes of the object
+        misc_.resize(numMiscRegions);
+        for (unsigned miscRegionIdx = 0; miscRegionIdx < numMiscRegions; ++miscRegionIdx) {
+            const auto& miscTable = miscTables.template getTable<MiscTable>(miscRegionIdx);
+
+            // solventFraction = Ss / (Ss + Sg);
+            const auto& solventFraction = miscTable.getSolventFractionColumn();
+            const auto& misc = miscTable.getMiscibilityColumn();
+            misc_[miscRegionIdx].setXYContainers(solventFraction, misc);
+        }
+    }
+    else {
+        throw std::runtime_error("MISC must be specified in MISCIBLE (SOLVENT) runs\n");
     }
 }
 

--- a/opm/models/blackoil/blackoilsolventparams.cpp
+++ b/opm/models/blackoil/blackoilsolventparams.cpp
@@ -34,6 +34,28 @@
 #include <opm/input/eclipse/EclipseState/Tables/SgcwmisTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TlpmixpaTable.hpp>
 
+namespace {
+
+template<bool enableSolvent>
+void verifyState(const Opm::EclipseState& eclState)
+{
+    // some sanity checks: if solvents are enabled, the SOLVENT keyword must be
+    // present, if solvents are disabled the keyword must not be present.
+    if constexpr (enableSolvent) {
+        if (!eclState.runspec().phases().active(Opm::Phase::SOLVENT)) {
+            throw std::runtime_error("Non-trivial solvent treatment requested at compile "
+                                     "time, but the deck does not contain the SOLVENT keyword");
+        }
+    } else {
+        if (eclState.runspec().phases().active(Opm::Phase::SOLVENT)) {
+            throw std::runtime_error("Solvent treatment disabled at compile time, but the deck "
+                                     "contains the SOLVENT keyword");
+        }
+    }
+}
+
+}
+
 namespace Opm {
 
 template<class Scalar>
@@ -41,20 +63,7 @@ template<bool enableSolvent>
 void BlackOilSolventParams<Scalar>::
 initFromState(const EclipseState& eclState, const Schedule& schedule)
 {
-    // some sanity checks: if solvents are enabled, the SOLVENT keyword must be
-    // present, if solvents are disabled the keyword must not be present.
-    if constexpr (enableSolvent) {
-        if (!eclState.runspec().phases().active(Phase::SOLVENT)) {
-            throw std::runtime_error("Non-trivial solvent treatment requested at compile "
-                                     "time, but the deck does not contain the SOLVENT keyword");
-        }
-    } else {
-        if (eclState.runspec().phases().active(Phase::SOLVENT)) {
-            throw std::runtime_error("Solvent treatment disabled at compile time, but the deck "
-                                     "contains the SOLVENT keyword");
-        }
-    }
-
+    verifyState<enableSolvent>(eclState);
     if (!eclState.runspec().phases().active(Phase::SOLVENT)) {
         return; // solvent treatment is supposed to be disabled
     }

--- a/opm/models/blackoil/blackoilsolventparams.cpp
+++ b/opm/models/blackoil/blackoilsolventparams.cpp
@@ -84,22 +84,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
         processMsfn(eclState);
         processSorwmis(eclState);
         processSgcwmis(eclState);
-
-        const auto& tlmixpar = eclState.getTableManager().getTLMixpar();
-        if (!tlmixpar.empty()) {
-            // resize the attributes of the object
-            tlMixParamViscosity_.resize(numMiscRegions);
-            tlMixParamDensity_.resize(numMiscRegions);
-
-            assert(numMiscRegions == tlmixpar.size());
-            for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx) {
-                const auto& tlp = tlmixpar[regionIdx];
-                tlMixParamViscosity_[regionIdx] = tlp.viscosity_parameter;
-                tlMixParamDensity_[regionIdx] = tlp.density_parameter;
-            }
-        }
-        else
-            throw std::runtime_error("TLMIXPAR must be specified in MISCIBLE (SOLVENT) runs\n");
+        processTlmixpar(eclState);
 
         // resize the attributes of the object
         tlPMixTable_.resize(numMiscRegions);
@@ -392,6 +377,30 @@ processSgcwmis(const EclipseState& eclState)
         for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx) {
             sgcwmis_[regionIdx] = zero;
         }
+    }
+}
+
+template<class Scalar>
+void BlackOilSolventParams<Scalar>::
+processTlmixpar(const EclipseState& eclState)
+{
+    const auto& tableManager = eclState.getTableManager();
+    const unsigned numMiscRegions = 1;
+    const auto& tlmixpar = tableManager.getTLMixpar();
+    if (!tlmixpar.empty()) {
+        // resize the attributes of the object
+        tlMixParamViscosity_.resize(numMiscRegions);
+        tlMixParamDensity_.resize(numMiscRegions);
+
+        assert(numMiscRegions == tlmixpar.size());
+        for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx) {
+            const auto& tlp = tlmixpar[regionIdx];
+            tlMixParamViscosity_[regionIdx] = tlp.viscosity_parameter;
+            tlMixParamDensity_[regionIdx] = tlp.density_parameter;
+        }
+    }
+    else {
+        throw std::runtime_error("TLMIXPAR must be specified in MISCIBLE (SOLVENT) runs\n");
     }
 }
 

--- a/opm/models/blackoil/blackoilsolventparams.cpp
+++ b/opm/models/blackoil/blackoilsolventparams.cpp
@@ -77,7 +77,6 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
     isMiscible_ = false;
     if (!tableManager.getMiscTables().empty()) {
         isMiscible_ = true;
-        const unsigned numMiscRegions = 1;
         processSof2(eclState);
         processMisc(eclState);
         processPmisc(eclState);
@@ -85,43 +84,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
         processSorwmis(eclState);
         processSgcwmis(eclState);
         processTlmixpar(eclState);
-
-        // resize the attributes of the object
-        tlPMixTable_.resize(numMiscRegions);
-        if (!eclState.getTableManager().getTlpmixpaTables().empty()) {
-            const auto& tlpmixparTables = tableManager.getTlpmixpaTables();
-            if (!tlpmixparTables.empty()) {
-                assert(numMiscRegions == tlpmixparTables.size());
-                for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx) {
-                    const auto& tlpmixparTable = tlpmixparTables.template getTable<TlpmixpaTable>(regionIdx);
-
-                    // Copy data
-                    const auto& po = tlpmixparTable.getOilPhasePressureColumn();
-                    const auto& tlpmixpa = tlpmixparTable.getMiscibilityColumn();
-
-                    tlPMixTable_[regionIdx].setXYContainers(po, tlpmixpa);
-                }
-            }
-            else {
-                // if empty keyword. Try to use the pmisc table as default.
-                if (!pmisc_.empty()) {
-                    tlPMixTable_ = pmisc_;
-                }
-                else {
-                    throw std::invalid_argument("If the pressure dependent TL values in "
-                                                "TLPMIXPA is defaulted (no entries), then "
-                                                "the PMISC tables must be specified.");
-                }
-            }
-        }
-        else {
-            // default
-            std::vector<double> x = {0.0,1.0e20};
-            std::vector<double> y = {1.0,1.0};
-            TabulatedFunction ones = TabulatedFunction(2, x, y);
-            for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx)
-                tlPMixTable_[regionIdx] = ones;
-        }
+        processTlpmixpa(eclState);
     }
 }
 
@@ -401,6 +364,43 @@ processTlmixpar(const EclipseState& eclState)
     }
     else {
         throw std::runtime_error("TLMIXPAR must be specified in MISCIBLE (SOLVENT) runs\n");
+    }
+}
+
+template<class Scalar>
+void BlackOilSolventParams<Scalar>::
+processTlpmixpa(const EclipseState& eclState)
+{
+    const auto& tableManager = eclState.getTableManager();
+    const unsigned numMiscRegions = 1;
+    const auto& tlpmixparTables = tableManager.getTlpmixpaTables();
+
+    // resize the attributes of the object
+    tlPMixTable_.resize(numMiscRegions);
+    if (!tableManager.getTlpmixpaTables().empty()) {
+        assert(numMiscRegions == tlpmixparTables.size());
+        for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx) {
+            const auto& tlpmixparTable = tlpmixparTables.template getTable<TlpmixpaTable>(regionIdx);
+
+            // Copy data
+            const auto& po = tlpmixparTable.getOilPhasePressureColumn();
+            const auto& tlpmixpa = tlpmixparTable.getMiscibilityColumn();
+
+            tlPMixTable_[regionIdx].setXYContainers(po, tlpmixpa);
+        }
+    }
+    else {
+        OpmLog::warning("The pressure dependent TL values in "
+                        "TLPMIXPA is missing or defaulted,"
+                        "using dummy values");
+
+        // default
+        const std::vector<double> x = {0.0,1.0e20};
+        const std::vector<double> y = {1.0,1.0};
+        const TabulatedFunction ones = TabulatedFunction(2, x, y);
+        for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx) {
+            tlPMixTable_[regionIdx] = ones;
+        }
     }
 }
 

--- a/opm/models/blackoil/blackoilsolventparams.cpp
+++ b/opm/models/blackoil/blackoilsolventparams.cpp
@@ -78,24 +78,8 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
     isMiscible_ = false;
     if (!eclState.getTableManager().getMiscTables().empty()) {
         isMiscible_ = true;
-
         unsigned numMiscRegions = 1;
-
-        // misicible hydrocabon relative permeability wrt water
-        const auto& sof2Tables = tableManager.getSof2Tables();
-        if (!sof2Tables.empty()) {
-            // resize the attributes of the object
-            sof2Krn_.resize(numSatRegions);
-            for (unsigned satRegionIdx = 0; satRegionIdx < numSatRegions; ++satRegionIdx) {
-                const auto& sof2Table = sof2Tables.template getTable<Sof2Table>(satRegionIdx);
-                sof2Krn_[satRegionIdx].setXYContainers(sof2Table.getSoColumn(),
-                                                       sof2Table.getKroColumn(),
-                                                       /*sortInput=*/true);
-            }
-        }
-        else if (eclState.runspec().phases().active(Phase::OIL)) {
-            throw std::runtime_error("SOF2 must be specified in MISCIBLE (SOLVENT and OIL) runs\n");
-        }
+        processSof2(eclState);
 
         const auto& miscTables = tableManager.getMiscTables();
         if (!miscTables.empty()) {
@@ -342,6 +326,29 @@ processSsfn(const EclipseState& eclState)
         ssfnKrs_[satRegionIdx].setXYContainers(ssfnTable.getSolventFractionColumn(),
                                                ssfnTable.getSolventRelPermMultiplierColumn(),
                                                /*sortInput=*/true);
+    }
+}
+
+template<class Scalar>
+void BlackOilSolventParams<Scalar>::
+processSof2(const EclipseState& eclState)
+{
+    // miscible hydrocarbon relative permeability wrt water
+    const auto& tableManager = eclState.getTableManager();
+    const auto& sof2Tables = tableManager.getSof2Tables();
+    const unsigned numSatRegions = tableManager.getTabdims().getNumSatTables();
+    if (!sof2Tables.empty()) {
+        // resize the attributes of the object
+        sof2Krn_.resize(numSatRegions);
+        for (unsigned satRegionIdx = 0; satRegionIdx < numSatRegions; ++satRegionIdx) {
+            const auto& sof2Table = sof2Tables.template getTable<Sof2Table>(satRegionIdx);
+            sof2Krn_[satRegionIdx].setXYContainers(sof2Table.getSoColumn(),
+                                                   sof2Table.getKroColumn(),
+                                                   /*sortInput=*/true);
+        }
+    }
+    else if (eclState.runspec().phases().active(Phase::OIL)) {
+        throw std::runtime_error("SOF2 must be specified in MISCIBLE (SOLVENT and OIL) runs\n");
     }
 }
 

--- a/opm/models/blackoil/blackoilsolventparams.cpp
+++ b/opm/models/blackoil/blackoilsolventparams.cpp
@@ -69,21 +69,10 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
     }
 
     setupPvts(eclState, schedule);
+    processSsfn(eclState);
 
     const auto& tableManager = eclState.getTableManager();
-    // initialize the objects which deal with the SSFN keyword
-    const auto& ssfnTables = tableManager.getSsfnTables();
     unsigned numSatRegions = tableManager.getTabdims().getNumSatTables();
-    setNumSatRegions(numSatRegions);
-    for (unsigned satRegionIdx = 0; satRegionIdx < numSatRegions; ++satRegionIdx) {
-        const auto& ssfnTable = ssfnTables.template getTable<SsfnTable>(satRegionIdx);
-        ssfnKrg_[satRegionIdx].setXYContainers(ssfnTable.getSolventFractionColumn(),
-                                               ssfnTable.getGasRelPermMultiplierColumn(),
-                                               /*sortInput=*/true);
-        ssfnKrs_[satRegionIdx].setXYContainers(ssfnTable.getSolventFractionColumn(),
-                                               ssfnTable.getSolventRelPermMultiplierColumn(),
-                                               /*sortInput=*/true);
-    }
 
     // initialize the objects needed for miscible solvent and oil simulations
     isMiscible_ = false;
@@ -333,6 +322,26 @@ setupPvts(const EclipseState& eclState,
     }
     else {
         solventPvt_.initFromState(eclState, schedule);
+    }
+}
+
+template<class Scalar>
+void BlackOilSolventParams<Scalar>::
+processSsfn(const EclipseState& eclState)
+{
+    const auto& tableManager = eclState.getTableManager();
+    // initialize the objects which deal with the SSFN keyword
+    const auto& ssfnTables = tableManager.getSsfnTables();
+    const unsigned numSatRegions = tableManager.getTabdims().getNumSatTables();
+    setNumSatRegions(numSatRegions);
+    for (unsigned satRegionIdx = 0; satRegionIdx < numSatRegions; ++satRegionIdx) {
+        const auto& ssfnTable = ssfnTables.template getTable<SsfnTable>(satRegionIdx);
+        ssfnKrg_[satRegionIdx].setXYContainers(ssfnTable.getSolventFractionColumn(),
+                                               ssfnTable.getGasRelPermMultiplierColumn(),
+                                               /*sortInput=*/true);
+        ssfnKrs_[satRegionIdx].setXYContainers(ssfnTable.getSolventFractionColumn(),
+                                               ssfnTable.getSolventRelPermMultiplierColumn(),
+                                               /*sortInput=*/true);
     }
 }
 

--- a/opm/models/blackoil/blackoilsolventparams.cpp
+++ b/opm/models/blackoil/blackoilsolventparams.cpp
@@ -82,32 +82,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
         processMisc(eclState);
         processPmisc(eclState);
         processMsfn(eclState);
-
-        // resize the attributes of the object
-        sorwmis_.resize(numMiscRegions);
-        const auto& sorwmisTables = tableManager.getSorwmisTables();
-        if (!sorwmisTables.empty()) {
-            assert(numMiscRegions == sorwmisTables.size());
-
-            for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx) {
-                const auto& sorwmisTable = sorwmisTables.template getTable<SorwmisTable>(regionIdx);
-
-                // Copy data
-                const auto& sw = sorwmisTable.getWaterSaturationColumn();
-                const auto& sorwmis = sorwmisTable.getMiscibleResidualOilColumn();
-
-                sorwmis_[regionIdx].setXYContainers(sw, sorwmis);
-            }
-        }
-        else {
-            // default
-            std::vector<double> x = {0.0,1.0};
-            std::vector<double> y = {0.0,0.0};
-            TabulatedFunction zero = TabulatedFunction(2, x, y);
-            for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx) {
-                sorwmis_[regionIdx] = zero;
-            }
-        }
+        processSorwmis(eclState);
 
         // resize the attributes of the object
         sgcwmis_.resize(numMiscRegions);
@@ -374,6 +349,38 @@ processMsfn(const EclipseState& eclState)
 
         for (unsigned regionIdx = 0; regionIdx < numSatRegions; ++regionIdx) {
             setMsfn(regionIdx, unit, invUnit);
+        }
+    }
+}
+
+template<class Scalar>
+void BlackOilSolventParams<Scalar>::
+processSorwmis(const EclipseState& eclState)
+{
+    const auto& tableManager = eclState.getTableManager();
+    const unsigned numMiscRegions = 1;
+    sorwmis_.resize(numMiscRegions);
+    const auto& sorwmisTables = tableManager.getSorwmisTables();
+    if (!sorwmisTables.empty()) {
+        assert(numMiscRegions == sorwmisTables.size());
+
+        for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx) {
+            const auto& sorwmisTable = sorwmisTables.template getTable<SorwmisTable>(regionIdx);
+
+            // Copy data
+            const auto& sw = sorwmisTable.getWaterSaturationColumn();
+            const auto& sorwmis = sorwmisTable.getMiscibleResidualOilColumn();
+
+            sorwmis_[regionIdx].setXYContainers(sw, sorwmis);
+        }
+    }
+    else {
+        // default
+        const std::vector<double> x = {0.0,1.0};
+        const std::vector<double> y = {0.0,0.0};
+        const TabulatedFunction zero = TabulatedFunction(2, x, y);
+        for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx) {
+            sorwmis_[regionIdx] = zero;
         }
     }
 }

--- a/opm/models/blackoil/blackoilsolventparams.cpp
+++ b/opm/models/blackoil/blackoilsolventparams.cpp
@@ -83,31 +83,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
         processPmisc(eclState);
         processMsfn(eclState);
         processSorwmis(eclState);
-
-        // resize the attributes of the object
-        sgcwmis_.resize(numMiscRegions);
-        const auto& sgcwmisTables = tableManager.getSgcwmisTables();
-        if (!sgcwmisTables.empty()) {
-            assert(numMiscRegions == sgcwmisTables.size());
-
-            for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx) {
-                const auto& sgcwmisTable = sgcwmisTables.template getTable<SgcwmisTable>(regionIdx);
-
-                // Copy data
-                const auto& sw = sgcwmisTable.getWaterSaturationColumn();
-                const auto& sgcwmis = sgcwmisTable.getMiscibleResidualGasColumn();
-
-                sgcwmis_[regionIdx].setXYContainers(sw, sgcwmis);
-            }
-        }
-        else {
-            // default
-            std::vector<double> x = {0.0,1.0};
-            std::vector<double> y = {0.0,0.0};
-            TabulatedFunction zero = TabulatedFunction(2, x, y);
-            for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx)
-                sgcwmis_[regionIdx] = zero;
-        }
+        processSgcwmis(eclState);
 
         const auto& tlmixpar = eclState.getTableManager().getTLMixpar();
         if (!tlmixpar.empty()) {
@@ -381,6 +357,40 @@ processSorwmis(const EclipseState& eclState)
         const TabulatedFunction zero = TabulatedFunction(2, x, y);
         for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx) {
             sorwmis_[regionIdx] = zero;
+        }
+    }
+}
+
+template<class Scalar>
+void BlackOilSolventParams<Scalar>::
+processSgcwmis(const EclipseState& eclState)
+{
+    const auto& tableManager = eclState.getTableManager();
+    const unsigned numMiscRegions = 1;
+
+    // resize the attributes of the object
+    sgcwmis_.resize(numMiscRegions);
+    const auto& sgcwmisTables = tableManager.getSgcwmisTables();
+    if (!sgcwmisTables.empty()) {
+        assert(numMiscRegions == sgcwmisTables.size());
+
+        for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx) {
+            const auto& sgcwmisTable = sgcwmisTables.template getTable<SgcwmisTable>(regionIdx);
+
+            // Copy data
+            const auto& sw = sgcwmisTable.getWaterSaturationColumn();
+            const auto& sgcwmis = sgcwmisTable.getMiscibleResidualGasColumn();
+
+            sgcwmis_[regionIdx].setXYContainers(sw, sgcwmis);
+        }
+    }
+    else {
+        // default
+        const std::vector<double> x = {0.0,1.0};
+        const std::vector<double> y = {0.0,0.0};
+        const TabulatedFunction zero = TabulatedFunction(2, x, y);
+        for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx) {
+            sgcwmis_[regionIdx] = zero;
         }
     }
 }

--- a/opm/models/blackoil/blackoilsolventparams.cpp
+++ b/opm/models/blackoil/blackoilsolventparams.cpp
@@ -68,26 +68,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
         return; // solvent treatment is supposed to be disabled
     }
 
-    co2sol_ = eclState.runspec().co2Sol();
-    h2sol_ = eclState.runspec().h2Sol();
-
-    if (co2sol_ && h2sol_) {
-        throw std::runtime_error("CO2SOL and H2SOL can not be used together");
-    }
-
-    if (co2sol_ || h2sol_) {
-        if (co2sol_) {
-            co2GasPvt_.initFromState(eclState, schedule);
-            brineCo2Pvt_.initFromState(eclState, schedule);
-        } else {
-            h2GasPvt_.initFromState(eclState, schedule);
-            brineH2Pvt_.initFromState(eclState, schedule);
-        }
-        if (eclState.getSimulationConfig().hasDISGASW()) {
-            rsSolw_active_ = true;
-        }
-    } else
-        solventPvt_.initFromState(eclState, schedule);
+    setupPvts(eclState, schedule);
 
     const auto& tableManager = eclState.getTableManager();
     // initialize the objects which deal with the SSFN keyword
@@ -323,6 +304,36 @@ setMsfn(unsigned satRegionIdx,
 {
     msfnKrsg_[satRegionIdx] = msfnKrsg;
     msfnKro_[satRegionIdx] = msfnKro;
+}
+
+template<class Scalar>
+void BlackOilSolventParams<Scalar>::
+setupPvts(const EclipseState& eclState,
+          const Schedule& schedule)
+{
+    co2sol_ = eclState.runspec().co2Sol();
+    h2sol_ = eclState.runspec().h2Sol();
+
+    if (co2sol_ && h2sol_) {
+        throw std::runtime_error("CO2SOL and H2SOL can not be used together");
+    }
+
+    if (co2sol_ || h2sol_) {
+        if (co2sol_) {
+            co2GasPvt_.initFromState(eclState, schedule);
+            brineCo2Pvt_.initFromState(eclState, schedule);
+        }
+        else {
+            h2GasPvt_.initFromState(eclState, schedule);
+            brineH2Pvt_.initFromState(eclState, schedule);
+        }
+        if (eclState.getSimulationConfig().hasDISGASW()) {
+            rsSolw_active_ = true;
+        }
+    }
+    else {
+        solventPvt_.initFromState(eclState, schedule);
+    }
 }
 
 #define INSTANTIATE_TYPE(T)                                                                             \

--- a/opm/models/blackoil/blackoilsolventparams.cpp
+++ b/opm/models/blackoil/blackoilsolventparams.cpp
@@ -81,31 +81,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
         const unsigned numMiscRegions = 1;
         processSof2(eclState);
         processMisc(eclState);
-
-        // resize the attributes of the object
-        pmisc_.resize(numMiscRegions);
-        const auto& pmiscTables = tableManager.getPmiscTables();
-        if (!pmiscTables.empty()) {
-            assert(numMiscRegions == pmiscTables.size());
-
-            for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx) {
-                const auto& pmiscTable = pmiscTables.template getTable<PmiscTable>(regionIdx);
-
-                // Copy data
-                const auto& po = pmiscTable.getOilPhasePressureColumn();
-                const auto& pmisc = pmiscTable.getMiscibilityColumn();
-
-                pmisc_[regionIdx].setXYContainers(po, pmisc);
-            }
-        }
-        else {
-            std::vector<double> x = {0.0,1.0e20};
-            std::vector<double> y = {1.0,1.0};
-            TabulatedFunction constant = TabulatedFunction(2, x, y);
-            for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx) {
-                pmisc_[regionIdx] = constant;
-            }
-        }
+        processPmisc(eclState);
 
         // miscible relative permeability multipleiers
         msfnKrsg_.resize(numSatRegions);
@@ -357,6 +333,39 @@ processMisc(const EclipseState& eclState)
     }
     else {
         throw std::runtime_error("MISC must be specified in MISCIBLE (SOLVENT) runs\n");
+    }
+}
+
+template<class Scalar>
+void BlackOilSolventParams<Scalar>::
+processPmisc(const EclipseState& eclState)
+{
+    const auto& tableManager = eclState.getTableManager();
+    const unsigned numMiscRegions = 1;
+
+    // resize the attributes of the object
+    pmisc_.resize(numMiscRegions);
+    const auto& pmiscTables = tableManager.getPmiscTables();
+    if (!pmiscTables.empty()) {
+        assert(numMiscRegions == pmiscTables.size());
+
+        for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx) {
+            const auto& pmiscTable = pmiscTables.template getTable<PmiscTable>(regionIdx);
+
+            // Copy data
+            const auto& po = pmiscTable.getOilPhasePressureColumn();
+            const auto& pmisc = pmiscTable.getMiscibilityColumn();
+
+            pmisc_[regionIdx].setXYContainers(po, pmisc);
+        }
+    }
+    else {
+        const std::vector<double> x = {0.0,1.0e20};
+        const std::vector<double> y = {1.0,1.0};
+        const TabulatedFunction constant = TabulatedFunction(2, x, y);
+        for (unsigned regionIdx = 0; regionIdx < numMiscRegions; ++regionIdx) {
+            pmisc_[regionIdx] = constant;
+        }
     }
 }
 

--- a/opm/models/blackoil/blackoilsolventparams.hpp
+++ b/opm/models/blackoil/blackoilsolventparams.hpp
@@ -96,6 +96,12 @@ private:
     void setMsfn(unsigned satRegionIdx,
                  const TabulatedFunction& msfnKrsg,
                  const TabulatedFunction& msfnKro);
+
+    /*!
+     * \brief Setup active pvt members.
+     */
+    void setupPvts(const EclipseState& eclState,
+                   const Schedule& schedule);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilsolventparams.hpp
+++ b/opm/models/blackoil/blackoilsolventparams.hpp
@@ -139,9 +139,14 @@ private:
     void processSgcwmis(const EclipseState& eclState);
 
     /*!
-     * \brief Process the Tlmixpar data.
+     * \brief Process the TLMIXPAR data.
      */
     void processTlmixpar(const EclipseState& eclState);
+
+    /*!
+     * \brief Process the TLPMIXPA data.
+     */
+    void processTlpmixpa(const EclipseState& eclState);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilsolventparams.hpp
+++ b/opm/models/blackoil/blackoilsolventparams.hpp
@@ -117,6 +117,11 @@ private:
      * \brief Process the MISC data.
      */
     void processMisc(const EclipseState& eclState);
+
+    /*!
+     * \brief Process the PMISC data.
+     */
+    void processPmisc(const EclipseState& eclState);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilsolventparams.hpp
+++ b/opm/models/blackoil/blackoilsolventparams.hpp
@@ -122,6 +122,11 @@ private:
      * \brief Process the PMISC data.
      */
     void processPmisc(const EclipseState& eclState);
+
+    /*!
+     * \brief Process the MSFN data.
+     */
+    void processMsfn(const EclipseState& eclState);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilsolventparams.hpp
+++ b/opm/models/blackoil/blackoilsolventparams.hpp
@@ -132,6 +132,11 @@ private:
      * \brief Process the SORWMIS data.
      */
     void processSorwmis(const EclipseState& eclState);
+
+    /*!
+     * \brief Process the SGCWMIS data.
+     */
+    void processSgcwmis(const EclipseState& eclState);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilsolventparams.hpp
+++ b/opm/models/blackoil/blackoilsolventparams.hpp
@@ -127,6 +127,11 @@ private:
      * \brief Process the MSFN data.
      */
     void processMsfn(const EclipseState& eclState);
+
+    /*!
+     * \brief Process the SORWMIS data.
+     */
+    void processSorwmis(const EclipseState& eclState);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilsolventparams.hpp
+++ b/opm/models/blackoil/blackoilsolventparams.hpp
@@ -80,8 +80,9 @@ struct BlackOilSolventParams
     bool co2sol_ = false;
     bool h2sol_ = false;
 
+private:
     /*!
-     * \brief Specify the number of satuation regions.
+     * \brief Specify the number of saturation regions.
      *
      * This must be called before setting the SSFN of any region.
      */

--- a/opm/models/blackoil/blackoilsolventparams.hpp
+++ b/opm/models/blackoil/blackoilsolventparams.hpp
@@ -112,6 +112,11 @@ private:
      * \brief Process the SOF2 data.
      */
     void processSof2(const EclipseState& eclState);
+
+    /*!
+     * \brief Process the MISC data.
+     */
+    void processMisc(const EclipseState& eclState);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilsolventparams.hpp
+++ b/opm/models/blackoil/blackoilsolventparams.hpp
@@ -102,6 +102,11 @@ private:
      */
     void setupPvts(const EclipseState& eclState,
                    const Schedule& schedule);
+
+    /*!
+     * \brief Process the SSFN data.
+     */
+    void processSsfn(const EclipseState& eclState);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilsolventparams.hpp
+++ b/opm/models/blackoil/blackoilsolventparams.hpp
@@ -137,6 +137,11 @@ private:
      * \brief Process the SGCWMIS data.
      */
     void processSgcwmis(const EclipseState& eclState);
+
+    /*!
+     * \brief Process the Tlmixpar data.
+     */
+    void processTlmixpar(const EclipseState& eclState);
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilsolventparams.hpp
+++ b/opm/models/blackoil/blackoilsolventparams.hpp
@@ -107,6 +107,11 @@ private:
      * \brief Process the SSFN data.
      */
     void processSsfn(const EclipseState& eclState);
+
+    /*!
+     * \brief Process the SOF2 data.
+     */
+    void processSof2(const EclipseState& eclState);
 };
 
 } // namespace Opm


### PR DESCRIPTION
These are all about long methods / "high cognitive complexity".

The last commit needs special attention. I found a bug/issue, and have to tried to resolve as good as I can.
The original code used deck keyword existence and empty keyword state. We no longer have the tools to distinguish these at this point. I've tried to join the two elses.