### PR TITLE
revert shebang change

### DIFF
--- a/tests/update_test_reference.sh
+++ b/tests/update_test_reference.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -norc
+#!/bin/bash -norc
 
 # Location of this script.
 dir=$(dirname $0)


### PR DESCRIPTION
cannot pass options using env.

not sure if this differ on mac or whatnot, but this breaks on linux. also the update_reference_data.sh already use this shebang, i don't see why it needs to differ.

will self-merge.