### PR TITLE
Linear solver for the full (reservoir, well) system

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -192,6 +192,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/linalg/PreconditionerFactory7.cpp
   opm/simulators/linalg/PropertyTree.cpp
   opm/simulators/linalg/setupPropertyTree.cpp
+  opm/simulators/linalg/system/SystemPreconditioner.cpp
   opm/simulators/linalg/TPSALinearSolverParameters.cpp
   opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
   opm/simulators/timestepping/AdaptiveTimeStepping.cpp
@@ -513,6 +514,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_preconditionerfactory.cpp
   tests/test_privarspacking.cpp
   tests/test_propertytree.cpp
+  tests/test_setuppropertytree.cpp
   tests/test_region_phase_pvaverage.cpp
   tests/test_relpermdiagnostics.cpp
   tests/test_RestartSerialization.cpp
@@ -530,6 +532,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_tpsa_localresidual.cpp
   tests/test_tpsa_primaryvariables.cpp
   tests/test_vfpproperties.cpp
+  tests/test_WellMatrixMerger.cpp
   tests/test_WaterSatfuncConsistencyChecks.cpp
   tests/test_wellmodel.cpp
   tests/test_wellprodindexcalculator.cpp
@@ -698,6 +701,12 @@ list (APPEND TEST_DATA_FILES
   tests/options_flexiblesolver_1x1.json
   tests/options_flexiblesolver_3x3.json
   tests/options_flexiblesolver_simple.json
+  tests/options_system_cpr_complete.json
+  tests/options_system_cpr_missing_precond_type.json
+  tests/options_system_cpr_missing_ressolver.json
+  tests/options_system_cpr_missing_smoother.json
+  tests/options_system_cpr_missing_well.json
+  tests/options_system_cpr_res_precond_not_cpr.json
   tests/GCONSUMP.DATA
   tests/GCONSUMP_COMPLEX.DATA
   tests/GROUP_HIGHER_CONSTRAINTS.DATA
@@ -1126,6 +1135,12 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/linalg/is_gpu_operator.hpp
   opm/simulators/linalg/ISTLSolver.hpp
   opm/simulators/linalg/ISTLSolverRuntimeOptionProxy.hpp
+  opm/simulators/linalg/Preconditioner2InverseOperator.hpp
+  opm/simulators/linalg/system/MultiComm.hpp
+  opm/simulators/linalg/system/SystemPreconditioner.hpp
+  opm/simulators/linalg/system/SystemPreconditionerFactory.hpp
+  opm/simulators/linalg/system/SystemTypes.hpp
+  opm/simulators/linalg/system/WellMatrixMerger.hpp
   opm/simulators/linalg/ISTLSolverTPSA.hpp
   opm/simulators/linalg/istlpreconditionerwrappers.hh
   opm/simulators/linalg/istlsolverwrappers.hh

--- a/opm/simulators/flow/BlackoilModelParameters.cpp
+++ b/opm/simulators/flow/BlackoilModelParameters.cpp
@@ -20,6 +20,8 @@
 #include <config.h>
 #include <opm/simulators/flow/BlackoilModelParameters.hpp>
 
+#include <opm/simulators/linalg/FlowLinearSolverParameters.hpp>
+
 #include <opm/models/discretization/common/fvbaseparameters.hh>
 
 #include <opm/models/nonlinear/newtonmethodparams.hpp>

--- a/opm/simulators/linalg/FlexibleSolver_impl.hpp
+++ b/opm/simulators/linalg/FlexibleSolver_impl.hpp
@@ -28,6 +28,7 @@
 #include <opm/simulators/linalg/FlexibleSolver.hpp>
 #include <opm/simulators/linalg/PreconditionerFactory.hpp>
 #include <opm/simulators/linalg/PropertyTree.hpp>
+#include <opm/simulators/linalg/Preconditioner2InverseOperator.hpp>
 #include <opm/simulators/linalg/WellOperators.hpp>
 #include <opm/simulators/linalg/PreconditionerFactoryGPUIncludeWrapper.hpp>
 #include <opm/simulators/linalg/is_gpu_operator.hpp>
@@ -38,11 +39,21 @@
 
 #include <dune/common/fmatrix.hh>
 #include <dune/istl/bcrsmatrix.hh>
+#include <dune/istl/multitypeblockvector.hh>
 #include <dune/istl/solvers.hh>
 #include <dune/istl/umfpack.hh>
 #include <dune/istl/owneroverlapcopy.hh>
 #include <dune/istl/paamg/pinfo.hh>
 #include <type_traits>
+
+namespace Opm::detail {
+template <typename T>
+struct is_multi_type_block_vector : std::false_type {};
+template <typename... Args>
+struct is_multi_type_block_vector<Dune::MultiTypeBlockVector<Args...>> : std::true_type {};
+template <typename T>
+inline constexpr bool is_multi_type_block_vector_v = is_multi_type_block_vector<T>::value;
+} // namespace Opm::detail
 
 #if HAVE_CUDA
 #if USE_HIP
@@ -85,7 +96,11 @@ namespace Dune
     apply(VectorType& x, VectorType& rhs, Dune::InverseOperatorResult& res)
     {
         if (direct_solver_) {
-            recreateDirectSolver();
+            auto* direct_precond = dynamic_cast<Dune::DirectSolverUpdatePreconditioner<VectorType, VectorType>*>(preconditioner_.get());
+            if (direct_precond && direct_precond->needsRebuild()) {
+                recreateDirectSolver();
+                direct_precond->resetNeedsRebuild();
+            }
         }
         linsolver_->apply(x, rhs, res);
     }
@@ -96,7 +111,11 @@ namespace Dune
     apply(VectorType& x, VectorType& rhs, double reduction, Dune::InverseOperatorResult& res)
     {
         if (direct_solver_) {
-            recreateDirectSolver();
+            auto* direct_precond = dynamic_cast<Dune::DirectSolverUpdatePreconditioner<VectorType, VectorType>*>(preconditioner_.get());
+            if (direct_precond && direct_precond->needsRebuild()) {
+                recreateDirectSolver();
+                direct_precond->resetNeedsRebuild();
+            }
         }
         linsolver_->apply(x, rhs, reduction, res);
     }
@@ -131,12 +150,18 @@ namespace Dune
     {
         // Parallel case.
         linearoperator_for_solver_ = &op;
+        const std::string solver_type = prm.get<std::string>("solver", "bicgstab");
         auto child = prm.get_child_optional("preconditioner");
-        preconditioner_ = Opm::PreconditionerFactory<Operator, Comm>::create(op,
-                                                                             child ? *child : Opm::PropertyTree(),
-                                                                             weightsCalculator,
-                                                                             comm,
-                                                                             pressureIndex);
+        if (solver_type == "umfpack") {
+            preconditioner_ = std::make_shared<Dune::DirectSolverUpdatePreconditioner<VectorType, VectorType>>(
+                linearoperator_for_solver_->category());
+        } else {
+            preconditioner_ = Opm::PreconditionerFactory<Operator, Comm>::create(op,
+                                                                                 child ? *child : Opm::PropertyTree(),
+                                                                                 weightsCalculator,
+                                                                                 comm,
+                                                                                 pressureIndex);
+        }
         scalarproduct_ = Dune::createScalarProduct<VectorType, Comm>(comm, op.category());
     }
 
@@ -151,11 +176,17 @@ namespace Dune
     {
         // Sequential case.
         linearoperator_for_solver_ = &op;
+        const std::string solver_type = prm.get<std::string>("solver", "bicgstab");
         auto child = prm.get_child_optional("preconditioner");
-        preconditioner_ = Opm::PreconditionerFactory<Operator,Dune::Amg::SequentialInformation>::create(op,
-                                                                       child ? *child : Opm::PropertyTree(),
-                                                                       weightsCalculator,
-                                                                       pressureIndex);
+        if (solver_type == "umfpack") {
+            preconditioner_ = std::make_shared<Dune::DirectSolverUpdatePreconditioner<VectorType, VectorType>>(
+                linearoperator_for_solver_->category());
+        } else {
+            preconditioner_ = Opm::PreconditionerFactory<Operator, Dune::Amg::SequentialInformation>::create(op,
+                                                                                                              child ? *child : Opm::PropertyTree(),
+                                                                                                              weightsCalculator,
+                                                                                                              pressureIndex);
+        }
         scalarproduct_ = std::make_shared<Dune::SeqScalarProduct<VectorType>>();
     }
 
@@ -178,6 +209,7 @@ namespace Dune
         // simply because we will check if it is at the end of this function and need to keep this invariant
         // (that it is nullptr at the start of this function).
         linsolver_.reset();
+        direct_solver_ = false;
         if (solver_type == "bicgstab") {
             linsolver_ = std::make_shared<Dune::BiCGSTABSolver<VectorType>>(*linearoperator_for_solver_,
                                                                             *scalarproduct_,
@@ -189,6 +221,8 @@ namespace Dune
           } else if (solver_type == "mixed-bicgstab") {
               if constexpr (Opm::is_gpu_operator_v<Operator>) {
                 OPM_THROW(std::invalid_argument, "mixed-bicgstab solver not supported for GPU operatorsg");
+            } else if constexpr (Opm::detail::is_multi_type_block_vector_v<VectorType>) {
+                OPM_THROW(std::invalid_argument, "mixed-bicgstab solver not supported for multi-type block vectors.");
             } else if constexpr (std::is_same_v<typename VectorType::field_type, float>){
                 OPM_THROW(std::invalid_argument, "mixed-bicgstab solver not supported for single precision.");
             } else {
@@ -219,19 +253,29 @@ namespace Dune
                                                                                   restart,
                                                                                   maxiter, // maximum number of iterations
                                                                                   verbosity);
+        } else if (solver_type == "flexgmres") {
+            if constexpr (Opm::is_gpu_operator_v<Operator>) {
+                OPM_THROW(std::invalid_argument, "flexgmres solver not supported for GPU operators.");
+            } else {
+                int restart = prm.get<int>("restart", 15);
+                linsolver_ = std::make_shared<Dune::RestartedFlexibleGMResSolver<VectorType>>(*linearoperator_for_solver_,
+                                                                                        *scalarproduct_,
+                                                                                        *preconditioner_,
+                                                                                        tol,// desired residual reduction factor
+                                                                                        restart,
+                                                                                        maxiter, // maximum number of iterations
+                                                                                        verbosity);
+            }
+        } else if (solver_type == "preconditioner2inverseoperator") {
+            if (!preconditioner_) {
+                OPM_THROW(std::invalid_argument,
+                          "Properties: Solver preconditioner2inverseoperator requires a preconditioner.");
+            }
+            linsolver_ = std::make_shared<Dune::Preconditioner2InverseOperator<VectorType>>(preconditioner_);
         } else {
-            if constexpr (!Opm::is_gpu_operator_v<Operator>) {
-                if (solver_type == "flexgmres") {
-                    int restart = prm.get<int>("restart", 15);
-                    linsolver_ = std::make_shared<Dune::RestartedFlexibleGMResSolver<VectorType>>(*linearoperator_for_solver_,
-                                                                                            *scalarproduct_,
-                                                                                            *preconditioner_,
-                                                                                            tol,// desired residual reduction factor
-                                                                                            restart,
-                                                                                            maxiter, // maximum number of iterations
-                                                                                            verbosity);
+            if constexpr (!Opm::is_gpu_operator_v<Operator> && !Opm::detail::is_multi_type_block_vector_v<VectorType>) {
 #if HAVE_SUITESPARSE_UMFPACK
-                } else if (solver_type == "umfpack") {
+                if (solver_type == "umfpack") {
                     if constexpr (std::is_same_v<typename VectorType::field_type,float>) {
                         OPM_THROW(std::invalid_argument, "UMFPack cannot be used with floats");
                     } else {
@@ -272,7 +316,7 @@ namespace Dune
     recreateDirectSolver()
     {
 #if HAVE_SUITESPARSE_UMFPACK
-        if constexpr (!Opm::is_gpu_operator_v<Operator>) {
+        if constexpr (!Opm::is_gpu_operator_v<Operator> && !Opm::detail::is_multi_type_block_vector_v<VectorType>) {
             if constexpr (std::is_same_v<typename VectorType::field_type, float>) {
                 OPM_THROW(std::invalid_argument, "UMFPack cannot be used with floats");
             } else {

--- a/opm/simulators/linalg/FlowLinearSolverParameters.cpp
+++ b/opm/simulators/linalg/FlowLinearSolverParameters.cpp
@@ -87,6 +87,7 @@ void FlowLinearSolverParameters::init(bool cprRequestedInDataFile)
             linsolver_ = "cpr_trueimpes";
         }
     }
+
 }
 
 void FlowLinearSolverParameters::registerParameters()
@@ -133,7 +134,7 @@ void FlowLinearSolverParameters::registerParameters()
     Parameters::Register<Parameters::ScaleLinearSystem>
         ("Scale linear system according to equation scale and primary variable types");
     Parameters::Register<Parameters::LinearSolver>
-        ("Configuration of solver. Valid options are: cprw (default), "
+        ("Configuration of solver. Valid options are: cprw (default), system_cpr (CPU-only), "
          "ilu0, dilu, cpr (an alias for cprw), cpr_quasiimpes, "
          "cpr_trueimpes, cpr_trueimpesanalytic, amg or hybrid (experimental). "
          "Alternatively, you can request a configuration to be read from a "

--- a/opm/simulators/linalg/ISTLSolverRuntimeOptionProxy.hpp
+++ b/opm/simulators/linalg/ISTLSolverRuntimeOptionProxy.hpp
@@ -21,6 +21,7 @@
 #include <opm/simulators/linalg/setupPropertyTree.hpp>
 #include <opm/simulators/linalg/AbstractISTLSolver.hpp>
 #include <opm/simulators/linalg/ISTLSolver.hpp>
+#include <opm/models/utils/propertysystem.hh>
 #if COMPILE_GPU_BRIDGE
 #include <opm/simulators/linalg/ISTLSolverGpuBridge.hpp>
 #endif
@@ -31,6 +32,9 @@
 #include <opm/simulators/linalg/gpuistl/ISTLSolverGPUISTL.hpp>
 #endif
 
+#include <opm/simulators/linalg/system/ISTLSolverSystem.hpp>
+
+#include <filesystem>
 #include <fmt/format.h>
 
 namespace Opm
@@ -150,6 +154,38 @@ private:
     template <class... Args>
     void createSolver(const Simulator& simulator, Args&&... args)
     {
+        auto linSolverConf = Parameters::Get<Parameters::LinearSolver>();
+        bool useSystemCpr = (linSolverConf == "system_cpr");
+        if (!useSystemCpr && linSolverConf.size() > 5
+            && linSolverConf.ends_with(".json")
+            && std::filesystem::exists(linSolverConf)) {
+            try {
+                PropertyTree prm(linSolverConf);
+                useSystemCpr = (prm.get<std::string>("preconditioner.type", "") == "system_cpr");
+            } catch (...) {}
+        }
+        if (useSystemCpr) {
+            using Indices = GetPropType<TypeTag, Properties::Indices>;
+            const auto backend = Parameters::linearSolverAcceleratorTypeFromCLI();
+            if (backend != Parameters::LinearSolverAcceleratorType::CPU) {
+                OPM_THROW(std::invalid_argument,
+                          "The system_cpr preconditioner currently only "
+                          "supports --linear-solver-accelerator=cpu");
+            }
+            // System solver types are hardcoded for 3-equation blackoil (see SystemTypes.hpp).
+            if constexpr (Indices::numEq == 3) {
+                istlSolver_ = std::make_unique<ISTLSolverSystem<TypeTag>>(
+                    simulator, std::forward<Args>(args)...);
+            } else {
+                OPM_THROW(std::invalid_argument,
+                          "The system_cpr preconditioner is only supported for "
+                          "standard 3-phase blackoil (3 equations). This model has " +
+                              std::to_string(Indices::numEq) + " equations.");
+            }
+            checkSystemCPRMatrixAddWell(Parameters::Get<Parameters::MatrixAddWellContributions>());
+            return;
+        }
+
         const auto backend = Parameters::linearSolverAcceleratorTypeFromCLI();
         if (backend == Parameters::LinearSolverAcceleratorType::CPU) {
         // Note that for now we keep the old behavior of using the bridge solver if it is available.

--- a/opm/simulators/linalg/MatrixMarketSpecializations.hpp
+++ b/opm/simulators/linalg/MatrixMarketSpecializations.hpp
@@ -10,6 +10,7 @@
 #define OPM_MATRIXMARKETSPECIALIZATIONS_HEADER_INCLUDED
 
 #include <dune/istl/matrixmarket.hh>
+#include <dune/istl/multitypeblockvector.hh>
 
 namespace Opm
 {
@@ -19,6 +20,16 @@ class MatrixBlock;
 
 namespace Dune
 {
+    template <typename... Args>
+    void writeMatrixMarket(const Dune::MultiTypeBlockVector<Args...>& vector, std::ostream& os)
+    {
+        os << "%%MatrixMarket matrix array real general" << std::endl;
+        using namespace Dune::Hybrid;
+        forEach(integralRange(Hybrid::size(vector)), [&](auto&& i)
+        {
+            Dune::writeMatrixMarket(vector[i], os);
+        });
+    };
 
 namespace MatrixMarketImpl
 {

--- a/opm/simulators/linalg/Preconditioner2InverseOperator.hpp
+++ b/opm/simulators/linalg/Preconditioner2InverseOperator.hpp
@@ -1,0 +1,95 @@
+/*
+  Copyright Equinor ASA 2026
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_PRECONDITIONER2INVERSEOPERATOR_HEADER_INCLUDED
+#define OPM_PRECONDITIONER2INVERSEOPERATOR_HEADER_INCLUDED
+
+#include <dune/common/shared_ptr.hh>
+#include <dune/istl/preconditioner.hh>
+#include <dune/istl/solver.hh>
+
+#include <memory>
+
+namespace Dune
+{
+
+/*!
+    \brief Adapter exposing a preconditioner through the inverse-operator interface.
+
+    Each apply() call performs one preconditioner application. Unlike
+    LoopSolver it does not update the defect with the linear operator or run
+    iterative convergence checks.
+ */
+template<class X>
+class Preconditioner2InverseOperator : public InverseOperator<X, X>
+{
+public:
+    using typename InverseOperator<X, X>::domain_type;
+    using typename InverseOperator<X, X>::range_type;
+    using typename InverseOperator<X, X>::field_type;
+    using typename InverseOperator<X, X>::real_type;
+    using typename InverseOperator<X, X>::scalar_real_type;
+
+    using PreconditionerType = Preconditioner<X, X>;
+
+    explicit Preconditioner2InverseOperator(PreconditionerType& prec)
+        : prec_(stackobject_to_shared_ptr(prec))
+    {
+    }
+
+    explicit Preconditioner2InverseOperator(std::shared_ptr<PreconditionerType> prec)
+        : prec_(std::move(prec))
+    {
+    }
+
+    void apply(X& x, X& b, InverseOperatorResult& res) override
+    {
+        prec_->pre(x, b);
+        // Preconditioners compute a correction/update, so start from zero to
+        // interpret this adapter as x = M^{-1} b.
+        x = 0;
+        prec_->apply(x, b);
+        prec_->post(x);
+
+        // No residual norm is evaluated here; report one successful
+        // application rather than an iterative solve.
+        res.clear();
+        res.iterations = 1;
+        res.reduction = 1.0;
+        res.converged = true;
+    }
+
+    void apply(X& x, X& b, [[maybe_unused]] double reduction, InverseOperatorResult& res) override
+    {
+        apply(x, b, res);
+    }
+
+    SolverCategory::Category category() const override
+    {
+        return SolverCategory::category(*prec_);
+    }
+
+private:
+    // Non-owning alias when constructed from a reference, shared ownership
+    // when constructed from a shared_ptr.
+    std::shared_ptr<PreconditionerType> prec_;
+};
+
+} // namespace Dune
+
+#endif // OPM_PRECONDITIONER2INVERSEOPERATOR_HEADER_INCLUDED

--- a/opm/simulators/linalg/PreconditionerWithUpdate.hpp
+++ b/opm/simulators/linalg/PreconditionerWithUpdate.hpp
@@ -93,6 +93,58 @@ getDummyUpdateWrapper(Args&&... args)
     return std::make_shared<DummyUpdatePreconditioner<OriginalPreconditioner>>(std::forward<Args>(args)...);
 }
 
+template <class X, class Y>
+class DirectSolverUpdatePreconditioner : public PreconditionerWithUpdate<X, Y>
+{
+public:
+    explicit DirectSolverUpdatePreconditioner(SolverCategory::Category category)
+        : category_(category)
+        , needs_rebuild_(false)
+    {
+    }
+
+    void update() override
+    {
+        needs_rebuild_ = true;
+    }
+
+    bool hasPerfectUpdate() const override
+    {
+        return true;
+    }
+
+    bool needsRebuild() const
+    {
+        return needs_rebuild_;
+    }
+
+    void resetNeedsRebuild()
+    {
+        needs_rebuild_ = false;
+    }
+
+    void pre([[maybe_unused]] X& x, [[maybe_unused]] Y& y) override
+    {
+    }
+
+    void post([[maybe_unused]] X& x) override
+    {
+    }
+
+    void apply([[maybe_unused]] X& x, [[maybe_unused]] const Y& y) override
+    {
+    }
+
+    SolverCategory::Category category() const override
+    {
+        return category_;
+    }
+
+private:
+    SolverCategory::Category category_;
+    bool needs_rebuild_;
+};
+
 /// @brief Interface class ensuring make function is overriden
 /// @tparam OriginalPreconditioner - An arbitrary Preconditioner type
 template <class OriginalPreconditioner>

--- a/opm/simulators/linalg/setupPropertyTree.cpp
+++ b/opm/simulators/linalg/setupPropertyTree.cpp
@@ -191,12 +191,15 @@ setupPropertyTree(FlowLinearSolverParameters p, // Note: copying the parameters 
         if ( !std::filesystem::exists(conf) ) {
             OPM_THROW(std::invalid_argument, "JSON file " + conf + " does not exist.");
         }
+        PropertyTree tree;
         try {
-            return PropertyTree(conf);
+            tree = PropertyTree(conf);
         }
         catch (...) {
             OPM_THROW(std::invalid_argument, "Failed reading linear solver configuration from JSON file " + conf);
         }
+        validateSystemCPRTree(tree);
+        return tree;
     }
 
     // We use lower case as the internal canonical representation of solver names.
@@ -226,6 +229,17 @@ setupPropertyTree(FlowLinearSolverParameters p, // Note: copying the parameters 
                 p.linear_solver_reduction_ = 0.005;
             }
             return setupCPRW(conf, p);
+        }
+        
+        // System CPR configuration (coupled reservoir-well system solver).
+        if (conf == "system_cpr") {
+            if (!linearSolverMaxIterSet) {
+                p.linear_solver_maxiter_ = 20;
+            }
+            if (!linearSolverReductionSet) {
+                p.linear_solver_reduction_ = 0.005;
+            }
+            return setupSystemCPR(conf, p);
         }
     }
 
@@ -273,8 +287,10 @@ setupPropertyTree(FlowLinearSolverParameters p, // Note: copying the parameters 
     else {
         OPM_THROW(std::invalid_argument,
                 conf + " is not a valid setting for --linear-solver-configuration."
-                " Please use ilu0, dilu, cpr, cprw, cpr_trueimpes, cpr_quasiimpes, cpr_trueimpesanalytic or isai");
+                " Please use ilu0, dilu, isai, cpr, cprw, cpr_trueimpes, cpr_quasiimpes, cpr_trueimpesanalytic, or system_cpr");
     }
+
+
 }
 
 std::string getSolverString(const FlowLinearSolverParameters& p)
@@ -457,6 +473,100 @@ setupUMFPack([[maybe_unused]] const std::string& conf, const FlowLinearSolverPar
     prm.put("verbosity", p.linear_solver_verbosity_);
     prm.put("solver", "umfpack"s);
     return prm;
+}
+
+
+PropertyTree
+setupSystemCPR([[maybe_unused]] const std::string& conf, const FlowLinearSolverParameters& p)
+{
+    using namespace std::string_literals;
+    PropertyTree prm;
+
+    // Outer solver
+    prm.put("maxiter", p.linear_solver_maxiter_);
+    prm.put("tol", p.linear_solver_reduction_);
+    prm.put("verbosity", p.linear_solver_verbosity_);
+    prm.put("solver", getSolverString(p));
+
+    // Top-level preconditioner: system_cpr
+    prm.put("preconditioner.type", "system_cpr"s);
+
+    // --- Reservoir smoother ---
+    prm.put("preconditioner.reservoir_smoother.maxiter", 1);
+    prm.put("preconditioner.reservoir_smoother.tol", p.linear_solver_reduction_);
+    prm.put("preconditioner.reservoir_smoother.verbosity", 0);
+    // Apply the configured smoother once without loopsolver's extra defect
+    // updates and convergence bookkeeping.
+    prm.put("preconditioner.reservoir_smoother.solver", "preconditioner2inverseoperator"s);
+    prm.put("preconditioner.reservoir_smoother.preconditioner.type", "paroverilu0"s);
+    prm.put("preconditioner.reservoir_smoother.preconditioner.relaxation", 1.0);
+
+    // --- Reservoir solver (CPR with AMG coarse solver) ---
+    prm.put("preconditioner.reservoir_solver.maxiter", 1);
+    prm.put("preconditioner.reservoir_solver.tol", p.linear_solver_reduction_);
+    prm.put("preconditioner.reservoir_solver.verbosity", 0);
+    // Apply the configured reservoir preconditioner once without loopsolver's
+    // extra defect updates and convergence bookkeeping.
+    prm.put("preconditioner.reservoir_solver.solver", "preconditioner2inverseoperator"s);
+    prm.put("preconditioner.reservoir_solver.preconditioner.type", "cpr"s);
+    prm.put("preconditioner.reservoir_solver.preconditioner.relaxation", 1.0);
+    prm.put("preconditioner.reservoir_solver.preconditioner.use_well_weights", "false"s);
+    prm.put("preconditioner.reservoir_solver.preconditioner.add_wells", "false"s);
+    prm.put("preconditioner.reservoir_solver.preconditioner.weight_type", "trueimpes"s);
+    prm.put("preconditioner.reservoir_solver.preconditioner.pre_smooth", 0);
+    prm.put("preconditioner.reservoir_solver.preconditioner.post_smooth", 0);
+    // Set unused finesmoother to jac to avoid spending time setuping an ILU smoother that won't be used.
+    prm.put("preconditioner.reservoir_solver.preconditioner.finesmoother.type", "jac"s);
+    prm.put("preconditioner.reservoir_solver.preconditioner.finesmoother.relaxation", 1.0);
+    prm.put("preconditioner.reservoir_solver.preconditioner.verbosity", 0);
+    prm.put("preconditioner.reservoir_solver.preconditioner.coarsesolver.maxiter", 1);
+    prm.put("preconditioner.reservoir_solver.preconditioner.coarsesolver.tol", 1e-1);
+    prm.put("preconditioner.reservoir_solver.preconditioner.coarsesolver.solver", "loopsolver"s);
+    prm.put("preconditioner.reservoir_solver.preconditioner.coarsesolver.verbosity", 0);
+    prm.put("preconditioner.reservoir_solver.preconditioner.coarsesolver.preconditioner.type", "amg"s);
+    setupDuneAMG(prm, "preconditioner.reservoir_solver.preconditioner.coarsesolver.preconditioner.");
+
+    // --- Well solver ---
+    prm.put("preconditioner.well_solver.maxiter", 1);
+    prm.put("preconditioner.well_solver.tol", p.linear_solver_reduction_);
+    prm.put("preconditioner.well_solver.verbosity", 0);
+    prm.put("preconditioner.well_solver.solver", "umfpack"s);
+    return prm;
+}
+
+
+void validateSystemCPRTree(const PropertyTree& prm)
+{
+    if (prm.get("preconditioner.type", std::string{}) != "system_cpr") {
+        return;
+    }
+    for (const char* sub : {"reservoir_solver", "reservoir_smoother", "well_solver"}) {
+        if (!prm.get_child_optional(std::string("preconditioner.") + sub).has_value()) {
+            OPM_THROW(std::invalid_argument,
+                      fmt::format("system_cpr JSON configuration is missing the required "
+                                  "'preconditioner.{}' sub-tree.", sub));
+        }
+    }
+    // Ensure reservoir_solver uses CPR preconditioner
+    auto reservoir_solver = prm.get_child_optional("preconditioner.reservoir_solver");
+    if (reservoir_solver) {
+        std::string precond_type = reservoir_solver->get<std::string>("preconditioner.type", "");
+        if (precond_type != "cpr") {
+            OPM_THROW(std::invalid_argument,
+                      "In system_cpr configuration, the reservoir_solver must use the CPR preconditioner "
+                      "(preconditioner.reservoir_solver.preconditioner.type = 'cpr').");
+        }
+    }
+}
+
+
+void checkSystemCPRMatrixAddWell(bool matrixAddWellContributions)
+{
+    if (matrixAddWellContributions) {
+        OPM_THROW(std::invalid_argument,
+                  "--matrix-add-well-contributions=true is incompatible with "
+                  "--linear-solver=system_cpr because the system CPR implementation assumes that well contributions are not added to the matrix.");
+    }
 }
 
 

--- a/opm/simulators/linalg/setupPropertyTree.hpp
+++ b/opm/simulators/linalg/setupPropertyTree.hpp
@@ -36,6 +36,16 @@ PropertyTree setupPropertyTree(FlowLinearSolverParameters p,
 
 PropertyTree setupCPRW(const std::string& conf, const FlowLinearSolverParameters& p);
 PropertyTree setupCPR(const std::string& conf, const FlowLinearSolverParameters& p);
+PropertyTree setupSystemCPR(const std::string& conf, const FlowLinearSolverParameters& p);
+
+// Validates that a PropertyTree with preconditioner.type == "system_cpr" contains
+// all three required sub-trees. Throws std::invalid_argument if any are missing.
+// No-op when the preconditioner type is not system_cpr.
+void validateSystemCPRTree(const PropertyTree& prm);
+
+// Throws std::invalid_argument when system_cpr is combined with
+// --matrix-add-well-contributions=true. Call this after detecting system_cpr is active.
+void checkSystemCPRMatrixAddWell(bool matrixAddWellContributions);
 PropertyTree setupAMG(const std::string& conf, const FlowLinearSolverParameters& p);
 PropertyTree setupILU(const std::string& conf, const FlowLinearSolverParameters& p);
 PropertyTree setupMixedILU(const std::string& conf, const FlowLinearSolverParameters& p);

--- a/opm/simulators/linalg/system/ISTLSolverSystem.hpp
+++ b/opm/simulators/linalg/system/ISTLSolverSystem.hpp
@@ -1,0 +1,291 @@
+/*
+  Copyright Equinor ASA 2026
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_ISTLSOLVERSYSTEM_HEADER_INCLUDED
+#define OPM_ISTLSOLVERSYSTEM_HEADER_INCLUDED
+
+#include <opm/simulators/linalg/system/SystemTypes.hpp>
+#include <opm/simulators/linalg/system/SystemPreconditionerFactory.hpp>
+#include <opm/simulators/linalg/system/WellMatrixMerger.hpp>
+
+#include <opm/simulators/linalg/FlexibleSolver.hpp>
+#include <opm/simulators/linalg/ISTLSolver.hpp>
+
+namespace Opm
+{
+
+template <class TypeTag>
+class ISTLSolverSystem : public ISTLSolver<TypeTag>
+{
+protected:
+    using Scalar = GetPropType<TypeTag, Properties::Scalar>;
+    using Vector = GetPropType<TypeTag, Properties::GlobalEqVector>;
+    using SparseMatrixAdapter = GetPropType<TypeTag, Properties::SparseMatrixAdapter>;
+    using Matrix = typename SparseMatrixAdapter::IstlMatrix;
+    using Simulator = GetPropType<TypeTag, Properties::Simulator>;
+    using Indices = GetPropType<TypeTag, Properties::Indices>;
+
+    // Compile-time validation: SystemPreconditionerFactory and related types
+    // are hardcoded for standard 3-phase blackoil (3 reservoir equations, 4 well equations).
+    // See SystemTypes.hpp for details.
+    static_assert(Indices::numEq == 3,
+                  "ISTLSolverSystem (with system_cpr preconditioner) only supports "
+                  "3-equation blackoil models. This model has different equation count.");
+
+    constexpr static std::size_t pressureIndex
+        = Indices::pressureSwitchIdx;
+
+    enum { enablePolymerMolarWeight = getPropValue<TypeTag, Properties::EnablePolymerMW>() };
+    constexpr static bool isIncompatibleWithCprw = enablePolymerMolarWeight;
+
+#if HAVE_MPI
+    using CommunicationType = Dune::OwnerOverlapCopyCommunication<int, int>;
+#else
+    using CommunicationType = Dune::Communication<int>;
+#endif
+    using Parent = ISTLSolver<TypeTag>;
+
+    static constexpr auto _0 = Dune::Indices::_0;
+    static constexpr auto _1 = Dune::Indices::_1;
+
+public:
+    ISTLSolverSystem(const Simulator& simulator,
+                     const FlowLinearSolverParameters& parameters,
+                     bool forceSerial = false)
+        : Parent(simulator, parameters, forceSerial)
+    {
+    }
+
+    explicit ISTLSolverSystem(const Simulator& simulator)
+        : Parent(simulator)
+    {
+    }
+
+    void prepare(const SparseMatrixAdapter& M, Vector& b) override
+    {
+        OPM_TIMEBLOCK(istlSolverPrepare);
+        this->initPrepare(M.istlMatrix(), b);
+        prepareSystemSolver();
+    }
+
+    void prepare(const Matrix& M, Vector& b) override
+    {
+        OPM_TIMEBLOCK(istlSolverPrepare);
+        this->initPrepare(M, b);
+        prepareSystemSolver();
+    }
+
+    bool solve(Vector& x) override
+    {
+        OPM_TIMEBLOCK(istlSolverSolve);
+        ++this->solveCount_;
+
+        const std::size_t numRes = Parent::matrix_->N();
+        const std::size_t numWell = cachedWellStructure_.totalWellBlocks;
+
+        sysX_[_0].resize(numRes);
+        sysX_[_0] = 0.0;
+        sysX_[_1].resize(numWell);
+        sysX_[_1] = 0.0;
+
+        sysRhs_[_0].resize(numRes);
+        sysRhs_[_0] = *Parent::rhs_;
+        sysRhs_[_1].resize(numWell);
+        sysRhs_[_1] = 0.0;
+
+        Dune::InverseOperatorResult result;
+        sysSolver_->apply(sysX_, sysRhs_, result);
+        this->iterations_ = result.iterations;
+
+        x = sysX_[_0];
+
+        return this->checkConvergence(result);
+    }
+
+private:
+    bool sysInitialized_ = false;
+    WellMatrixStructure cachedWellStructure_;
+
+    // Current per-well B/C/D blocks for the explicit 2x2 system matrix.
+    std::vector<WRMatrix<Scalar>> wellBMatrices_;
+    std::vector<RWMatrix<Scalar>> wellCMatrices_;
+    std::vector<WWMatrix<Scalar>> wellDMatrices_;
+    Opm::SparseTable<int> wellCells_;
+
+    // Owned storage for merged well matrices; SystemMatrix points into these.
+    WRMatrix<Scalar> mergedB_;
+    RWMatrix<Scalar> mergedC_;
+    WWMatrix<Scalar> mergedD_;
+
+    SystemMatrix<Scalar> sysMatrix_;
+    SystemVector<Scalar> sysX_;
+    SystemVector<Scalar> sysRhs_;
+
+    // Serial solver components
+    std::unique_ptr<SystemSeqOp<Scalar>> sysOp_;
+    std::unique_ptr<Dune::FlexibleSolver<SystemSeqOp<Scalar>>> sysFlexSolverSeq_;
+
+    // Parallel solver components
+#if HAVE_MPI
+    using WellComm = Dune::JacComm;
+    std::unique_ptr<WellComm> wellComm_;
+    std::unique_ptr<SystemComm> systemComm_;
+    std::unique_ptr<SystemParOp<Scalar>> sysOpPar_;
+    std::unique_ptr<Dune::FlexibleSolver<SystemParOp<Scalar>>> sysFlexSolverPar_;
+#endif
+
+    using SysSolverType = Dune::InverseOperator<SystemVector<Scalar>, SystemVector<Scalar>>;
+    using SysPrecondType = Dune::PreconditionerWithUpdate<SystemVector<Scalar>, SystemVector<Scalar>>;
+    using SeqSysPrecondType = SystemPreconditioner<Scalar, SeqResOperator<Scalar>>;
+#if HAVE_MPI
+    using ParSysPrecondType = SystemPreconditioner<Scalar, ParResOperator<Scalar>, ParResComm>;
+#endif
+    SysSolverType* sysSolver_ = nullptr;
+    SysPrecondType* sysPrecond_ = nullptr;
+
+    void prepareSystemSolver()
+    {
+        OPM_TIMEBLOCK(flexibleSolverPrepare);
+
+        wellBMatrices_.clear();
+        wellCMatrices_.clear();
+        wellDMatrices_.clear();
+        wellCells_.clear();
+
+        this->simulator_.problem().wellModel().addBCDMatrix(
+            wellBMatrices_, wellCMatrices_, wellDMatrices_, wellCells_);
+
+        const Opm::WellMatrixMerger<Scalar> merger(
+            Parent::matrix_->N(), wellBMatrices_, wellCMatrices_, wellDMatrices_, wellCells_);
+
+        const bool localStructureChanged = !sysInitialized_
+            || !merger.hasSameStructure(cachedWellStructure_);
+
+        // All ranks must agree on whether to take the structure-change path,
+        // because the distributed solver create and update paths use different
+        // MPI-collective sequences.
+#if HAVE_MPI
+        const bool globalStructureChanged = this->comm_->communicator().max(
+            static_cast<int>(localStructureChanged)) > 0;
+#else
+        const bool globalStructureChanged = localStructureChanged;
+#endif
+        const bool needStructureRefresh = !sysInitialized_ || globalStructureChanged;
+
+        const auto& prm = this->prm_[this->activeSolverNum_];
+
+        if (needStructureRefresh) {
+            OPM_TIMEBLOCK(flexibleSolverCreate);
+            merger.buildMatrices(mergedB_, mergedC_, mergedD_);
+            sysMatrix_.A = Parent::matrix_;
+            sysMatrix_.B = &mergedB_;
+            sysMatrix_.C = &mergedC_;
+            sysMatrix_.D = &mergedD_;
+            cachedWellStructure_ = merger.buildStructure();
+
+            refreshSystemSolverForChangedWellStructure(prm);
+            sysInitialized_ = true;
+        } else {
+            OPM_TIMEBLOCK(flexibleSolverUpdate);
+            // Pattern unchanged: write fresh values into the existing merged
+            // matrices without any (de)allocation.
+            merger.updateValues(mergedB_, mergedC_, mergedD_);
+
+            // Refresh A pointer in case the reservoir matrix was reallocated.
+            sysMatrix_.A = Parent::matrix_;
+            sysMatrix_.B = &mergedB_;
+            sysMatrix_.C = &mergedC_;
+            sysMatrix_.D = &mergedD_;
+            sysPrecond_->update();
+        }
+    }
+
+    void refreshSystemSolverForChangedWellStructure(const Opm::PropertyTree& prm)
+    {
+        if (!sysInitialized_ || !sysPrecond_) {
+            createSystemSolver(prm);
+            return;
+        }
+
+#if HAVE_MPI
+        if (this->comm_->communicator().size() > 1) {
+            if (auto* precond = dynamic_cast<ParSysPrecondType*>(sysPrecond_)) {
+                precond->updateForChangedWellStructure();
+            } else
+            { // Rebuild the parallel solver if the parallel preconditioner cannot be updated in-place.
+                createSystemSolver(prm);
+            }
+            return;
+        }
+#endif
+
+        if (auto* precond = dynamic_cast<SeqSysPrecondType*>(sysPrecond_)) {
+            precond->updateForChangedWellStructure();
+        } else
+        { // Rebuild the solver if the sequential preconditioner cannot be updated in-place
+            createSystemSolver(prm);
+        }
+    }
+
+    void createSystemSolver(const Opm::PropertyTree& prm)
+    {
+        // Derive weights from the reservoir sub-block config (which uses CPR internally)
+        auto resSolverPrm = prm.get_child("preconditioner.reservoir_solver");
+        std::function<ResVector<Scalar>()> resWeightCalc
+            = this->getWeightsCalculator(resSolverPrm, this->getMatrix(), pressureIndex);
+
+        std::function<SystemVector<Scalar>()> sysWeightCalc;
+        if (resWeightCalc) {
+            sysWeightCalc = [resWeightCalc]() {
+                SystemVector<Scalar> w;
+                w[_0] = resWeightCalc();
+                return w;
+            };
+        }
+
+#if HAVE_MPI
+        const bool is_parallel = this->comm_->communicator().size() > 1;
+        if (is_parallel) {
+            wellComm_ = std::make_unique<WellComm>();
+            systemComm_ = std::make_unique<SystemComm>(*(this->comm_), *wellComm_);
+
+            sysOpPar_ = std::make_unique<SystemParOp<Scalar>>(sysMatrix_, *systemComm_);
+
+            sysFlexSolverPar_ = std::make_unique<Dune::FlexibleSolver<SystemParOp<Scalar>>>(
+                *sysOpPar_, *systemComm_, prm, sysWeightCalc, pressureIndex);
+
+            sysSolver_ = sysFlexSolverPar_.get();
+            sysPrecond_ = &sysFlexSolverPar_->preconditioner();
+        }
+        else
+#endif
+        {
+            sysOp_ = std::make_unique<SystemSeqOp<Scalar>>(sysMatrix_);
+
+            sysFlexSolverSeq_ = std::make_unique<Dune::FlexibleSolver<SystemSeqOp<Scalar>>>(
+                *sysOp_, prm, sysWeightCalc, pressureIndex);
+
+            sysSolver_ = sysFlexSolverSeq_.get();
+            sysPrecond_ = &sysFlexSolverSeq_->preconditioner();
+        }
+    }
+};
+
+} // namespace Opm
+
+#endif // OPM_ISTLSOLVERSYSTEM_HEADER_INCLUDED

--- a/opm/simulators/linalg/system/MultiComm.hpp
+++ b/opm/simulators/linalg/system/MultiComm.hpp
@@ -1,0 +1,191 @@
+/*
+  Copyright Equinor ASA 2026
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_MULTICOMM_HEADER_INCLUDED
+#define OPM_MULTICOMM_HEADER_INCLUDED
+
+#include <dune/common/hybridutilities.hh>
+
+#if HAVE_MPI
+#include <mpi.h>
+#include <dune/common/parallel/mpicommunication.hh>
+#endif
+
+#include <cmath>
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+
+namespace Dune
+{
+
+class SeqComm
+{
+public:
+    using size_type = std::size_t;
+
+    static constexpr size_type size()
+    {
+        return 0;
+    }
+    template <typename T>
+    void project(T& /*x*/) const
+    {
+    }
+    template <typename T1, typename T2>
+    void dot(const T1& x, const T1& y, T2& result) const
+    {
+        result = x.dot(y);
+    }
+    template <typename T>
+    double norm(const T& x) const
+    {
+        return x.two_norm();
+    }
+    template <typename T>
+    void copyOwnerToAll(const T& x, T& y) const
+    {
+        y = x;
+    }
+
+    auto communicator() const
+    {
+        return Dune::Communication<int>{};
+    }
+};
+
+#if HAVE_MPI
+class JacComm
+{
+public:
+    using size_type = std::size_t;
+
+    JacComm()
+        : colcom_(MPI_COMM_WORLD)
+    {
+    }
+    static constexpr size_type size()
+    {
+        return 0;
+    }
+    template <typename T>
+    void project(T& /*x*/) const
+    {
+    }
+
+    template <typename T1, typename T2>
+    void dot(const T1& x, const T1& y, T2& result) const
+    {
+        result = x.dot(y);
+        result = colcom_.sum(result);
+    }
+
+    template <typename T>
+    double norm(const T& x) const
+    {
+        double result = x.dot(x);
+        result = colcom_.sum(result);
+        return std::sqrt(result);
+    }
+
+    template <typename T>
+    void copyOwnerToAll(const T& x, T& y) const
+    {
+        y = x;
+    }
+
+private:
+    Communication<MPI_Comm> colcom_;
+};
+#endif
+
+template <typename... Args>
+class MultiCommunicator : public std::tuple<Args...>
+{
+    using TupleType = std::tuple<Args...>;
+    using type = MultiCommunicator<Args...>;
+    using field_type = double;
+
+public:
+    using std::tuple<Args...>::tuple;
+    using size_type = std::size_t;
+
+    static constexpr size_type size()
+    {
+        return sizeof...(Args);
+    }
+
+    template <size_type index>
+    typename std::tuple_element<index, TupleType>::type&
+    operator[]([[maybe_unused]] const std::integral_constant<size_type, index> indexVariable)
+    {
+        return std::get<index>(*this);
+    }
+    template <size_type index>
+    const typename std::tuple_element<index, TupleType>::type&
+    operator[]([[maybe_unused]] const std::integral_constant<size_type, index> indexVariable) const
+    {
+        return std::get<index>(*this);
+    }
+
+    template <typename T>
+    void project(T& x) const
+    {
+        using namespace Dune::Hybrid;
+        forEach(integralRange(Hybrid::size(*this)), [&](auto&& i) { (*this)[i].project(x[i]); });
+    }
+    template <typename T1, typename T2>
+    void dot(const T1& x, const T1& y, T2& result) const
+    {
+        result = field_type(0);
+        using namespace Dune::Hybrid;
+        forEach(integralRange(Hybrid::size(*this)), [&](auto&& i) {
+            double result_tmp = 0;
+            (*this)[i].dot(x[i], y[i], result_tmp);
+            result += result_tmp;
+        });
+    }
+    template <typename T>
+    field_type norm(const T& x) const
+    {
+        field_type result(0);
+        using namespace Dune::Hybrid;
+        forEach(integralRange(Hybrid::size(*this)), [&](auto&& i) {
+            double result_tmp = 0.0;
+            (*this)[i].dot(x[i], x[i], result_tmp);
+            result += result_tmp;
+        });
+        return std::sqrt(result);
+    }
+    template <typename T>
+    void copyOwnerToAll(const T& x, T& y) const
+    {
+        using namespace Dune::Hybrid;
+        forEach(integralRange(Hybrid::size(*this)),
+                [&](auto&& i) { (*this)[i].copyOwnerToAll(x[i], y[i]); });
+    }
+
+    decltype(auto) communicator() const
+    {
+        return std::get<0>(*this).communicator();
+    }
+};
+
+} // namespace Dune
+
+#endif // OPM_MULTICOMM_HEADER_INCLUDED

--- a/opm/simulators/linalg/system/SystemPreconditioner.cpp
+++ b/opm/simulators/linalg/system/SystemPreconditioner.cpp
@@ -1,0 +1,56 @@
+/*
+  Copyright Equinor ASA 2026
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <config.h>
+#include <opm/simulators/linalg/FlexibleSolver_impl.hpp>
+#include <opm/simulators/linalg/PreconditionerFactory_impl.hpp>
+#include <opm/simulators/linalg/system/SystemPreconditioner.hpp>
+#include <opm/simulators/linalg/system/SystemPreconditionerFactory.hpp>
+
+#define INSTANTIATE_SYSTEM_PF_SEQ(T)                                                                  \
+    template class Opm::SystemPreconditioner<T, Opm::SeqResOperator<T>>;                             \
+    template class Dune::FlexibleSolver<                                                               \
+        Dune::MatrixAdapter<Opm::WWMatrix<T>, Opm::WellVector<T>, Opm::WellVector<T>>>;           \
+    template class Dune::FlexibleSolver<Opm::SystemSeqOp<T>>;                                        \
+    template class Opm::PreconditionerFactory<Opm::SystemSeqOp<T>, Dune::Amg::SequentialInformation>;
+
+#if HAVE_MPI
+#define INSTANTIATE_SYSTEM_PF_PAR(T)                                                                  \
+    template class Opm::SystemPreconditioner<T, Opm::ParResOperator<T>, Opm::ParResComm>;            \
+    template class Dune::FlexibleSolver<Opm::SystemParOp<T>>;                                        \
+    template Dune::FlexibleSolver<Opm::SystemParOp<T>>::FlexibleSolver(                               \
+        Opm::SystemParOp<T>& op,                                                                     \
+        const Opm::SystemComm& comm,                                                                  \
+        const Opm::PropertyTree& prm,                                                                 \
+        const std::function<Opm::SystemVector<T>()>& weightsCalculator,                              \
+        std::size_t pressureIndex);                                                                    \
+    template class Opm::PreconditionerFactory<Opm::SystemParOp<T>, Opm::SystemComm>;                 \
+    template class Opm::PreconditionerFactory<Opm::SystemParOp<T>, Dune::Amg::SequentialInformation>;
+
+#define INSTANTIATE_SYSTEM_PF(T) \
+    INSTANTIATE_SYSTEM_PF_PAR(T) \
+    INSTANTIATE_SYSTEM_PF_SEQ(T)
+#else
+#define INSTANTIATE_SYSTEM_PF(T) INSTANTIATE_SYSTEM_PF_SEQ(T)
+#endif
+
+INSTANTIATE_SYSTEM_PF(double)
+
+#if FLOW_INSTANTIATE_FLOAT
+INSTANTIATE_SYSTEM_PF(float)
+#endif

--- a/opm/simulators/linalg/system/SystemPreconditioner.hpp
+++ b/opm/simulators/linalg/system/SystemPreconditioner.hpp
@@ -1,0 +1,292 @@
+/*
+  Copyright Equinor ASA 2026
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_SYSTEMPRECONDITIONER_HEADER_INCLUDED
+#define OPM_SYSTEMPRECONDITIONER_HEADER_INCLUDED
+
+#include <opm/simulators/linalg/system/MultiComm.hpp>
+#include <opm/simulators/linalg/system/SystemTypes.hpp>
+#include <opm/simulators/linalg/FlexibleSolver.hpp>
+#include <opm/simulators/linalg/PreconditionerWithUpdate.hpp>
+#include <opm/simulators/linalg/PropertyTree.hpp>
+
+#include <dune/istl/operators.hh>
+#include <dune/istl/paamg/pinfo.hh>
+
+
+namespace Opm
+{
+
+// Reservoir operator/comm types used as template arguments.
+template<typename Scalar>
+using SeqResOperator = Dune::MatrixAdapter<RRMatrix<Scalar>, ResVector<Scalar>, ResVector<Scalar>>;
+
+#if HAVE_MPI
+using ParResComm = Dune::OwnerOverlapCopyCommunication<int, int>;
+template<typename Scalar>
+using ParResOperator = Dune::OverlappingSchwarzOperator<RRMatrix<Scalar>, ResVector<Scalar>, ResVector<Scalar>, ParResComm>;
+#endif
+
+// Preconditioner for the coupled reservoir-well system.
+//
+// Templated on scalar type, reservoir operator and communication types to
+// unify sequential and parallel implementations. The 3-stage algorithm:
+//   1. Reservoir CPR solve
+//   2. Well solve + reservoir smoothing
+//   3. Final well solve
+//
+// For parallel runs, copyOwnerToAll synchronises overlap DOFs before
+// each reservoir sub-solve.
+template <class Scalar, class ResOp, class ResComm = Dune::Amg::SequentialInformation>
+class SystemPreconditioner : public Dune::PreconditionerWithUpdate<SystemVector<Scalar>, SystemVector<Scalar>>
+{
+public:
+    static constexpr bool isParallel = !std::is_same_v<ResComm, Dune::Amg::SequentialInformation>;
+
+    using ResFlexibleSolverType = Dune::FlexibleSolver<ResOp>;
+    using WellOperator = Dune::MatrixAdapter<WWMatrix<Scalar>, WellVector<Scalar>, WellVector<Scalar>>;
+    using WellFlexibleSolverType = Dune::FlexibleSolver<WellOperator>;
+
+    static constexpr auto _0 = Dune::Indices::_0;
+    static constexpr auto _1 = Dune::Indices::_1;
+
+    // Sequential constructor (enabled only for non-parallel specializations).
+    SystemPreconditioner(const SystemMatrix<Scalar>& S,
+                         const std::function<ResVector<Scalar>()>& weightsCalculator,
+                         int pressureIndex,
+                         const Opm::PropertyTree& prm)
+        requires (!isParallel)
+        : S_(S)
+        , pressureIndex_(pressureIndex)
+    {
+        initSubSolvers(prm, weightsCalculator);
+        initWorkVectors();
+    }
+
+    // Parallel constructor (enabled only for parallel specializations).
+    SystemPreconditioner(const SystemMatrix<Scalar>& S,
+                         const std::function<ResVector<Scalar>()>& weightsCalculator,
+                         int pressureIndex,
+                         const Opm::PropertyTree& prm,
+                         const ResComm& resComm)
+        requires (isParallel)
+        : S_(S)
+        , resComm_(&resComm)
+        , pressureIndex_(pressureIndex)
+    {
+        initSubSolvers(prm, weightsCalculator);
+        initWorkVectors();
+    }
+
+    void pre(SystemVector<Scalar>&, SystemVector<Scalar>&) override
+    {
+    }
+
+    void post(SystemVector<Scalar>&) override
+    {
+    }
+
+    Dune::SolverCategory::Category category() const override
+    {
+        if constexpr (isParallel)
+            return Dune::SolverCategory::overlapping;
+        else
+            return Dune::SolverCategory::sequential;
+    }
+
+    void update() override
+    {
+        resSolver_->preconditioner().update();
+        resSmoother_->preconditioner().update();
+        wellSolver_->preconditioner().update();
+    }
+
+    void updateForChangedWellStructure()
+    {
+        resSolver_->preconditioner().update();
+        resSmoother_->preconditioner().update();
+        initWellSolver();
+        resizeWellWorkVectors();
+    }
+
+    bool hasPerfectUpdate() const override
+    {
+        return true;
+    }
+
+//   System matrix block structure:
+//
+//       [ A  C ] [ x_res ]   [ resRes ]
+//   S = [ B  D ] [ x_well ] = [ wRes  ]
+//
+//   A = reservoir-reservoir (top-left)
+//   C = reservoir-well coupling (top-right)
+//   B = well-reservoir coupling (bottom-left)
+//   D = well-well (bottom-right)
+     void apply(SystemVector<Scalar>& v, const SystemVector<Scalar>& d) override
+    {
+        // Extract blocks using the agreed convention
+        const auto& A = S_[_0][_0];
+        const auto& C = S_[_0][_1];
+        const auto& B = S_[_1][_0];
+        const auto& D = S_[_1][_1];
+
+        resRes_ = d[_0];
+        wRes_ = d[_1];
+        resSol_ = 0.0;
+        wSol_ = 0.0;
+
+        // Stage 1: Reservoir CPR solve
+        {
+            Dune::InverseOperatorResult res_result;
+            dresSol_ = 0.0;
+            tmp_resRes_ = resRes_;
+            syncResVector(tmp_resRes_);
+            resSolver_->apply(dresSol_, tmp_resRes_, res_result);
+            resSol_ += dresSol_;
+            // resRes_ -= A * dresSol_
+            A.mmv(dresSol_, resRes_);
+            // wRes_ -= B * dresSol_
+            B.mmv(dresSol_, wRes_);
+        }
+
+        // Stage 2: Well solve + reservoir system smoothing
+        {
+            Dune::InverseOperatorResult well_result;
+            dwSol_ = 0.0;
+            tmp_wRes_ = wRes_;
+            wellSolver_->apply(dwSol_, tmp_wRes_, well_result);
+            wSol_ += dwSol_;
+            // resRes_ -= C * dwSol_
+            C.mmv(dwSol_, resRes_);
+            // resRes_ -= D * dwSol_
+            D.mmv(dwSol_, wRes_);
+
+            Dune::InverseOperatorResult res_result;
+            dresSol_ = 0.0;
+            tmp_resRes_ = resRes_;
+            syncResVector(tmp_resRes_);
+            resSmoother_->apply(dresSol_, tmp_resRes_, res_result);
+            resSol_ += dresSol_;
+            // wRes_ -= B * dresSol_
+            B.mmv(dresSol_, wRes_);
+        }
+
+        // Stage 3: Final well solve
+        {
+            Dune::InverseOperatorResult well_result;
+            dwSol_ = 0.0;
+            tmp_wRes_ = wRes_;
+            wellSolver_->apply(dwSol_, tmp_wRes_, well_result);
+            wSol_ += dwSol_;
+        }
+
+        syncResVector(resSol_);
+        v[_0] = resSol_;
+        v[_1] = wSol_;
+    }
+
+private:
+    const SystemMatrix<Scalar>& S_;
+    const ResComm* resComm_ = nullptr;
+    int pressureIndex_ = 0;
+    static constexpr int dummyWellPressureIndex = std::numeric_limits<int>::min();
+    Opm::PropertyTree wellprm_;
+
+    std::unique_ptr<ResOp> rop_;
+    std::unique_ptr<WellOperator> wop_;
+    std::unique_ptr<ResFlexibleSolverType> resSolver_;
+    std::unique_ptr<ResFlexibleSolverType> resSmoother_;
+    std::unique_ptr<WellFlexibleSolverType> wellSolver_;
+
+    WellVector<Scalar> wSol_;
+    ResVector<Scalar> resSol_;
+    ResVector<Scalar> dresSol_;
+    WellVector<Scalar> dwSol_;
+    ResVector<Scalar> tmp_resRes_;
+    WellVector<Scalar> tmp_wRes_;
+    ResVector<Scalar> resRes_;
+    WellVector<Scalar> wRes_;
+
+    void syncResVector(ResVector<Scalar>& v)
+    {
+        if constexpr (isParallel) {
+            resComm_->copyOwnerToAll(v, v);
+        }
+    }
+
+    void initWellSolver()
+    {
+        wop_ = std::make_unique<WellOperator>(S_[_1][_1]);
+        std::function<WellVector<Scalar>()> weightsCalculatorWell;
+        wellSolver_ = std::make_unique<WellFlexibleSolverType>(
+            *wop_, wellprm_, weightsCalculatorWell, dummyWellPressureIndex);
+    }
+
+    void initSubSolvers(const Opm::PropertyTree& prm,
+                        const std::function<ResVector<Scalar>()>& weightsCalculator)
+    {
+        auto resprm = prm.get_child("reservoir_solver");
+        auto resprmsmoother = prm.get_child("reservoir_smoother");
+        wellprm_ = prm.get_child("well_solver");
+
+        if constexpr (isParallel) {
+            rop_ = std::make_unique<ResOp>(S_[_0][_0], *resComm_);
+            resSolver_ = std::make_unique<ResFlexibleSolverType>(
+                *rop_, *resComm_, resprm, weightsCalculator, pressureIndex_);
+            resSmoother_ = std::make_unique<ResFlexibleSolverType>(
+                *rop_, *resComm_, resprmsmoother, weightsCalculator, pressureIndex_);
+        } else {
+            rop_ = std::make_unique<ResOp>(S_[_0][_0]);
+            resSolver_ = std::make_unique<ResFlexibleSolverType>(
+                *rop_, resprm, weightsCalculator, pressureIndex_);
+            resSmoother_ = std::make_unique<ResFlexibleSolverType>(
+                *rop_, resprmsmoother, weightsCalculator, pressureIndex_);
+        }
+
+        initWellSolver();
+    }
+
+    void initWorkVectors()
+    {
+        resizeReservoirWorkVectors();
+        resizeWellWorkVectors();
+    }
+
+    void resizeReservoirWorkVectors()
+    {
+        const auto numRes = S_[_0][_0].N();
+        resSol_.resize(numRes);
+        dresSol_.resize(numRes);
+        tmp_resRes_.resize(numRes);
+        resRes_.resize(numRes);
+    }
+
+    void resizeWellWorkVectors()
+    {
+        const auto numWell = S_[_1][_1].N();
+        wSol_.resize(numWell);
+        dwSol_.resize(numWell);
+        tmp_wRes_.resize(numWell);
+        wRes_.resize(numWell);
+    }
+};
+
+} // namespace Opm
+
+#endif // OPM_SYSTEMPRECONDITIONER_HEADER_INCLUDED

--- a/opm/simulators/linalg/system/SystemPreconditionerFactory.hpp
+++ b/opm/simulators/linalg/system/SystemPreconditionerFactory.hpp
@@ -1,0 +1,168 @@
+/*
+  Copyright Equinor ASA 2026
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_SYSTEMPRECONDITIONERFACTORY_HEADER_INCLUDED
+#define OPM_SYSTEMPRECONDITIONERFACTORY_HEADER_INCLUDED
+
+#include <opm/simulators/linalg/system/MultiComm.hpp>
+#include <opm/simulators/linalg/system/SystemPreconditioner.hpp>
+#include <opm/simulators/linalg/PreconditionerFactory.hpp>
+#include <opm/simulators/linalg/system/SystemTypes.hpp>
+
+#include <dune/istl/operators.hh>
+#include <dune/istl/paamg/pinfo.hh>
+
+namespace Opm
+{
+
+template <class Operator, class Comm, typename>
+struct StandardPreconditioners;
+
+template<typename Scalar>
+using SystemSeqOp = Dune::MatrixAdapter<SystemMatrix<Scalar>, SystemVector<Scalar>, SystemVector<Scalar>>;
+
+#if HAVE_MPI
+using SystemComm = Dune::MultiCommunicator<const Dune::OwnerOverlapCopyCommunication<int, int>&,
+                                           const Dune::JacComm&>;
+template<typename Scalar>
+using SystemParOp = Dune::OverlappingSchwarzOperator<SystemMatrix<Scalar>, SystemVector<Scalar>,
+                                                      SystemVector<Scalar>, SystemComm>;
+#endif
+
+// Full specialisations of StandardPreconditioners for the coupled system
+// operators.  Partial specialisations would be ambiguous with the generic
+// serial factory (!is_gpu_operator_v guard), so full specialisations are
+// used; detail:: helpers factor out the shared logic.
+
+namespace detail {
+
+template<typename Scalar>
+void addSystemCprSeq()
+{
+    using O = SystemSeqOp<Scalar>;
+    using F = PreconditionerFactory<O, Dune::Amg::SequentialInformation>;
+    using V = SystemVector<Scalar>;
+    using P = PropertyTree;
+
+    F::addCreator("system_cpr",
+                  [](const O& op, const P& prm,
+                     const std::function<V()>& sysWeightCalc,
+                     std::size_t pressureIndex) {
+                      std::function<ResVector<Scalar>()> resWeightCalc;
+                      if (sysWeightCalc) {
+                          resWeightCalc = [sysWeightCalc]() {
+                              return sysWeightCalc()[Dune::Indices::_0];
+                          };
+                      }
+                      return std::make_shared<SystemPreconditioner<Scalar, SeqResOperator<Scalar>>>(
+                          op.getmat(), resWeightCalc, pressureIndex, prm);
+                  });
+}
+
+#if HAVE_MPI
+// Register a sequential (non-MPI) version of the system_cpr preconditioner
+// for the parallel operator.  This allows each MPI rank to apply a local,
+// communication‑free CPR preconditioner inside the overlapping Schwarz
+// framework.  It is a lightweight alternative to the fully parallel
+// preconditioner registered by addSystemCprPar().
+template<typename Scalar>
+void addSystemCprParSeq()
+{
+    using O = SystemParOp<Scalar>;
+    using F = PreconditionerFactory<O, Dune::Amg::SequentialInformation>;
+    using V = SystemVector<Scalar>;
+    using P = PropertyTree;
+
+    F::addCreator("system_cpr",
+                  [](const O& op, const P& prm,
+                     const std::function<V()>& sysWeightCalc,
+                     std::size_t pressureIndex) {
+                      std::function<ResVector<Scalar>()> resWeightCalc;
+                      if (sysWeightCalc) {
+                          resWeightCalc = [sysWeightCalc]() {
+                              return sysWeightCalc()[Dune::Indices::_0];
+                          };
+                      }
+                      return std::make_shared<SystemPreconditioner<Scalar, SeqResOperator<Scalar>>>(
+                          op.getmat(), resWeightCalc, pressureIndex, prm);
+                  });
+}
+
+template<typename Scalar>
+void addSystemCprPar()
+{
+    using O = SystemParOp<Scalar>;
+    using F = PreconditionerFactory<O, SystemComm>;
+    using V = SystemVector<Scalar>;
+    using P = PropertyTree;
+
+    F::addCreator("system_cpr",
+                  [](const O& op, const P& prm,
+                     const std::function<V()>& sysWeightCalc,
+                     std::size_t pressureIndex,
+                     const SystemComm& comm) {
+                      std::function<ResVector<Scalar>()> resWeightCalc;
+                      if (sysWeightCalc) {
+                          resWeightCalc = [sysWeightCalc]() {
+                              return sysWeightCalc()[Dune::Indices::_0];
+                          };
+                      }
+                      const auto& resComm = comm[Dune::Indices::_0];
+                      return std::make_shared<SystemPreconditioner<Scalar, ParResOperator<Scalar>, ParResComm>>(
+                          op.getmat(), resWeightCalc, pressureIndex, prm, resComm);
+                  });
+}
+#endif
+
+} // namespace detail
+
+template <>
+struct StandardPreconditioners<SystemSeqOp<double>, Dune::Amg::SequentialInformation, void> {
+    static void add() { detail::addSystemCprSeq<double>(); }
+};
+
+template <>
+struct StandardPreconditioners<SystemSeqOp<float>, Dune::Amg::SequentialInformation, void> {
+    static void add() { detail::addSystemCprSeq<float>(); }
+};
+
+#if HAVE_MPI
+template <>
+struct StandardPreconditioners<SystemParOp<double>, Dune::Amg::SequentialInformation, void> {
+    static void add() { detail::addSystemCprParSeq<double>(); }
+};
+
+template <>
+struct StandardPreconditioners<SystemParOp<float>, Dune::Amg::SequentialInformation, void> {
+    static void add() { detail::addSystemCprParSeq<float>(); }
+};
+
+template <>
+struct StandardPreconditioners<SystemParOp<double>, SystemComm, void> {
+    static void add() { detail::addSystemCprPar<double>(); }
+};
+
+template <>
+struct StandardPreconditioners<SystemParOp<float>, SystemComm, void> {
+    static void add() { detail::addSystemCprPar<float>(); }
+};
+#endif
+
+} // namespace Opm
+
+#endif // OPM_SYSTEMPRECONDITIONERFACTORY_HEADER_INCLUDED

--- a/opm/simulators/linalg/system/SystemTypes.hpp
+++ b/opm/simulators/linalg/system/SystemTypes.hpp
@@ -1,0 +1,151 @@
+/*
+  Copyright Equinor ASA 2026
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_SYSTEMTYPES_HEADER_INCLUDED
+#define OPM_SYSTEMTYPES_HEADER_INCLUDED
+
+#include <opm/simulators/linalg/matrixblock.hh>
+
+#include <dune/istl/bcrsmatrix.hh>
+#include <dune/istl/bvector.hh>
+#include <dune/istl/multitypeblockmatrix.hh>
+#include <dune/istl/multitypeblockvector.hh>
+
+namespace Opm
+{
+
+// NOTE: These dimensions are hardcoded for standard 3-phase blackoil models
+// (3 reservoir equations, 4 well equations). Models with a different number
+// of conservation equations (e.g. EnablePolymerMW which adds an extra
+// equation) are NOT supported by ISTLSolverSystem. A static_assert in
+// ISTLSolverSystem guards against accidental misuse.
+//
+// To generalise, the types below (and the entire SystemPreconditioner /
+// SystemPreconditionerFactory / WellMatrixMerger stack) would need to be
+// templated on the dimension pair and the corresponding explicit
+// instantiations updated.
+inline constexpr int numResDofs = 3;
+inline constexpr int numWellDofs = 4;
+
+template<typename Scalar>
+using RRMatrix = Dune::BCRSMatrix<Opm::MatrixBlock<Scalar, numResDofs, numResDofs>>;
+template<typename Scalar>
+using RWMatrix = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, numResDofs, numWellDofs>>;
+template<typename Scalar>
+using WRMatrix = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, numWellDofs, numResDofs>>;
+template<typename Scalar>
+using WWMatrix = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, numWellDofs, numWellDofs>>;
+
+template<typename Scalar>
+using ResVector = Dune::BlockVector<Dune::FieldVector<Scalar, numResDofs>>;
+template<typename Scalar>
+using WellVector = Dune::BlockVector<Dune::FieldVector<Scalar, numWellDofs>>;
+template<typename Scalar>
+using SystemVector = Dune::MultiTypeBlockVector<ResVector<Scalar>, WellVector<Scalar>>;
+
+// --------------------------------------------------------------------------
+// SystemMatrix: a lightweight read-only view over a 2×2 block-matrix
+// structure.  All four sub-blocks are stored as const pointers; the actual
+// data lives elsewhere (the reservoir block in ISTLSolver::matrix_, the
+// well/coupling blocks in ISTLSolverSystem's merged-matrix members).
+//
+// Provides the operator interface required by Dune::MatrixAdapter and
+// Dune::OverlappingSchwarzOperator (mv, usmv, N, M, field_type) as well as
+// sub-block access via the index syntax  S[_0][_0]  used by
+// SystemPreconditioner.
+// --------------------------------------------------------------------------
+template<typename Scalar> struct SystemMatrixRow0;  // forward
+template<typename Scalar> struct SystemMatrixRow1;
+
+template<typename Scalar>
+class SystemMatrix
+{
+public:
+    using size_type  = std::size_t;
+    using field_type = Scalar;
+
+    static constexpr size_type N() { return 2; }
+    static constexpr size_type M() { return 2; }
+
+    // Block pointers — set directly by the owning solver.
+    const RRMatrix<Scalar>* A = nullptr;  // (0,0) reservoir
+    const RWMatrix<Scalar>* C = nullptr;  // (0,1) reservoir–well coupling
+    const WRMatrix<Scalar>* B = nullptr;  // (1,0) well–reservoir coupling
+    const WWMatrix<Scalar>* D = nullptr;  // (1,1) well
+
+    // Sub-block access: S[_0][_0], S[_0][_1], S[_1][_0], S[_1][_1]
+    inline SystemMatrixRow0<Scalar> operator[](Dune::index_constant<0>) const;
+    inline SystemMatrixRow1<Scalar> operator[](Dune::index_constant<1>) const;
+
+    // Matrix-vector products required by Dune linear operators.
+    // y = S * x  =  (A*x0 + C*x1;  B*x0 + D*x1)
+    // Achieved by: y0 = A*x0 (mv), then y0 += C*x1 (umv); similarly for y1.
+    void mv(const SystemVector<Scalar>& x, SystemVector<Scalar>& y) const
+    {
+        using namespace Dune::Indices;
+        A->mv (x[_0], y[_0]);   C->umv(x[_1], y[_0]);
+        B->mv (x[_0], y[_1]);   D->umv(x[_1], y[_1]);
+    }
+
+    // y += S * x  =  (y0 += A*x0 + C*x1;  y1 += B*x0 + D*x1)
+    void umv(const SystemVector<Scalar>& x, SystemVector<Scalar>& y) const
+    {
+        using namespace Dune::Indices;
+        A->umv(x[_0], y[_0]);   C->umv(x[_1], y[_0]);
+        B->umv(x[_0], y[_1]);   D->umv(x[_1], y[_1]);
+    }
+
+    // y += alpha * S * x  =  (y0 += alpha*(A*x0 + C*x1);  y1 += alpha*(B*x0 + D*x1))
+    void usmv(field_type alpha, const SystemVector<Scalar>& x, SystemVector<Scalar>& y) const
+    {
+        using namespace Dune::Indices;
+        A->usmv(alpha, x[_0], y[_0]);   C->usmv(alpha, x[_1], y[_0]);
+        B->usmv(alpha, x[_0], y[_1]);   D->usmv(alpha, x[_1], y[_1]);
+    }
+};
+
+// Row proxies for  S[row][col]  — simple aggregates, no back-pointers.
+template<typename Scalar>
+struct SystemMatrixRow0
+{
+    const RRMatrix<Scalar>& A;
+    const RWMatrix<Scalar>& C;
+    const RRMatrix<Scalar>& operator[](Dune::index_constant<0>) const { return A; }
+    const RWMatrix<Scalar>& operator[](Dune::index_constant<1>) const { return C; }
+};
+
+template<typename Scalar>
+struct SystemMatrixRow1
+{
+    const WRMatrix<Scalar>& B;
+    const WWMatrix<Scalar>& D;
+    const WRMatrix<Scalar>& operator[](Dune::index_constant<0>) const { return B; }
+    const WWMatrix<Scalar>& operator[](Dune::index_constant<1>) const { return D; }
+};
+
+template<typename Scalar>
+SystemMatrixRow0<Scalar> SystemMatrix<Scalar>::operator[](Dune::index_constant<0>) const
+{ return {*A, *C}; }
+
+template<typename Scalar>
+SystemMatrixRow1<Scalar> SystemMatrix<Scalar>::operator[](Dune::index_constant<1>) const
+{ return {*B, *D}; }
+
+} // namespace Opm
+
+#endif // OPM_SYSTEMTYPES_HEADER_INCLUDED

--- a/opm/simulators/linalg/system/WellMatrixMerger.hpp
+++ b/opm/simulators/linalg/system/WellMatrixMerger.hpp
@@ -1,0 +1,486 @@
+/*
+  Copyright Equinor ASA 2026
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_WELLMATRIXMERGER_HEADER_INCLUDED
+#define OPM_WELLMATRIXMERGER_HEADER_INCLUDED
+
+#include <opm/simulators/linalg/system/SystemTypes.hpp>
+#include <opm/grid/utility/SparseTable.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <iterator>
+#include <vector>
+
+namespace Opm
+{
+
+// Exact sparsity signature for one assembled well matrix.
+//
+// Matrix dimensions alone are not sufficient for MSW wells: the D block
+// connectivity depends on the current segment topology, so we keep the full
+// per-row column pattern and compare that directly.
+struct MatrixSparsityPattern
+{
+    std::size_t rows = 0;
+    std::size_t cols = 0;
+    std::vector<std::size_t> rowOffsets;
+    std::vector<int> columnIndices;
+
+    bool operator==(const MatrixSparsityPattern& other) const
+    {
+        return rows == other.rows
+            && cols == other.cols
+            && rowOffsets == other.rowOffsets
+            && columnIndices == other.columnIndices;
+    }
+
+    bool operator!=(const MatrixSparsityPattern& other) const
+    {
+        return !(*this == other);
+    }
+};
+
+// Structural cache key for the merged well part of the system matrix.
+//  totalWellBlocks is the sum of all individual well D-matrix dimensions,
+//  i.e., the total number of well degrees of freedom.  It is stored here
+//  so that the well-vector size and the structure-rebuild decision stay
+//  in the same place.
+struct WellMatrixStructure
+{
+    std::size_t numResDofs = 0;
+    std::size_t totalWellBlocks = 0;  // Aggregated well DOFs (sum of D_i.N())
+    Opm::SparseTable<int> wellCells;
+    std::vector<MatrixSparsityPattern> bPatterns;
+    std::vector<MatrixSparsityPattern> cPatterns;
+    std::vector<MatrixSparsityPattern> dPatterns;
+
+    bool operator==(const WellMatrixStructure& other) const
+    {
+        return numResDofs == other.numResDofs
+            && totalWellBlocks == other.totalWellBlocks
+            && wellCells == other.wellCells
+            && bPatterns == other.bPatterns
+            && cPatterns == other.cPatterns
+            && dPatterns == other.dPatterns;
+    }
+
+    bool operator!=(const WellMatrixStructure& other) const
+    {
+        return !(*this == other);
+    }
+};
+
+template<class Matrix>
+MatrixSparsityPattern
+captureMatrixSparsity(const Matrix& matrix)
+{
+    MatrixSparsityPattern pattern;
+    pattern.rows = matrix.N();
+    pattern.cols = matrix.M();
+    pattern.rowOffsets.reserve(matrix.N() + 1);
+    if constexpr (requires { matrix.nonzeroes(); }) {
+        pattern.columnIndices.reserve(matrix.nonzeroes());
+    }
+    pattern.rowOffsets.push_back(0);
+
+    for (std::size_t rowIdx = 0; rowIdx < matrix.N(); ++rowIdx) {
+        for (auto colIt = matrix[rowIdx].begin(); colIt != matrix[rowIdx].end(); ++colIt) {
+            pattern.columnIndices.push_back(colIt.index());
+        }
+        pattern.rowOffsets.push_back(pattern.columnIndices.size());
+    }
+
+    return pattern;
+}
+
+template<class Matrix> bool hasSameMatrixSparsity(const Matrix& matrix,
+                                                  const MatrixSparsityPattern& pattern)
+{
+    if (matrix.N() != pattern.rows || matrix.M() != pattern.cols) {
+        return false;
+    }
+
+    if (pattern.rowOffsets.size() != pattern.rows + 1
+        || pattern.rowOffsets.empty()
+        || pattern.rowOffsets.front() != 0)
+    {
+        return false;
+    }
+
+    std::size_t entryOffset = 0;
+    for (std::size_t rowIdx = 0; rowIdx < matrix.N(); ++rowIdx) {
+        if (pattern.rowOffsets[rowIdx] != entryOffset) {
+            return false;
+        }
+
+        for (auto colIt = matrix[rowIdx].begin(); colIt != matrix[rowIdx].end(); ++colIt) {
+            if (entryOffset >= pattern.columnIndices.size()
+                || static_cast<std::size_t>(pattern.columnIndices[entryOffset]) != colIt.index())
+            {
+                return false;
+            }
+            ++entryOffset;
+        }
+
+        if (pattern.rowOffsets[rowIdx + 1] != entryOffset) {
+            return false;
+        }
+    }
+
+    return entryOffset == pattern.columnIndices.size();
+}
+
+// WellMatrixMerger assembles the global coupled well part of
+//
+//     [ A  C ]
+//     [ B  D ]
+//
+// from the per-well blocks B_j, C_j and D_j. It preserves each well's local
+// sparsity pattern and only does two structural operations: concatenate the
+// well blocks and remap perforation-related rows/columns through the list of
+// perforated reservoir cells for each well.
+
+// Give each block a distinctive value pattern so it is easy to see where it
+// ended up after merging.
+template<typename Scalar>
+class WellMatrixMerger
+{
+public:
+    using BMatrix = WRMatrix<Scalar>;
+    using CMatrix = RWMatrix<Scalar>;
+    using DMatrix = WWMatrix<Scalar>;
+
+    WellMatrixMerger(const std::size_t nResDofs,
+                     const std::vector<BMatrix>& bMatrices,
+                     const std::vector<CMatrix>& cMatrices,
+                     const std::vector<DMatrix>& dMatrices,
+                     const Opm::SparseTable<int>& wellCells)
+        : numResDofs_(nResDofs)
+        , bMatrices_(bMatrices)
+        , cMatrices_(cMatrices)
+        , dMatrices_(dMatrices)
+        , wellCells_(wellCells)
+    {
+        validateInputs();
+    }
+
+    bool hasSameStructure(const WellMatrixStructure& cachedStructure) const
+    {
+        const auto numWells = bMatrices_.size();
+        if (cachedStructure.numResDofs != numResDofs_
+            || static_cast<std::size_t>(cachedStructure.wellCells.size()) != numWells
+            || cachedStructure.bPatterns.size() != numWells
+            || cachedStructure.cPatterns.size() != numWells
+            || cachedStructure.dPatterns.size() != numWells)
+        {
+            return false;
+        }
+
+        std::size_t totalWellDofs = 0;
+        for (std::size_t well = 0; well < numWells; ++well) {
+            totalWellDofs += dMatrices_[well].N();
+
+            const auto& cachedRow = cachedStructure.wellCells[well];
+            const auto& currentRow = wellCells_[well];
+            if (!std::ranges::equal(cachedRow.begin(), cachedRow.end(), currentRow.begin(), currentRow.end())
+                || !hasSameMatrixSparsity(bMatrices_[well], cachedStructure.bPatterns[well])
+                || !hasSameMatrixSparsity(cMatrices_[well], cachedStructure.cPatterns[well])
+                || !hasSameMatrixSparsity(dMatrices_[well], cachedStructure.dPatterns[well]))
+            {
+                return false;
+            }
+        }
+
+        return cachedStructure.totalWellBlocks == totalWellDofs;
+    }
+
+    WellMatrixStructure buildStructure() const
+    {
+        WellMatrixStructure structure;
+        structure.numResDofs = numResDofs_;
+        structure.totalWellBlocks = 0;
+        structure.wellCells = wellCells_;
+        structure.bPatterns.reserve(bMatrices_.size());
+        structure.cPatterns.reserve(cMatrices_.size());
+        structure.dPatterns.reserve(dMatrices_.size());
+
+        for (std::size_t well = 0; well < bMatrices_.size(); ++well) {
+            structure.bPatterns.push_back(captureMatrixSparsity(bMatrices_[well]));
+            structure.cPatterns.push_back(captureMatrixSparsity(cMatrices_[well]));
+            structure.dPatterns.push_back(captureMatrixSparsity(dMatrices_[well]));
+            structure.totalWellBlocks += dMatrices_[well].N();
+        }
+
+        return structure;
+    }
+
+    void buildMatrices(BMatrix& mergedB,
+                       CMatrix& mergedC,
+                       DMatrix& mergedD) const
+    {
+        mergeBMatrix(mergedB);
+        mergeCMatrix(mergedC);
+        mergeDMatrix(mergedD);
+    }
+
+    void updateValues(BMatrix& mergedB,
+                      CMatrix& mergedC,
+                      DMatrix& mergedD) const
+    {
+        fillBValues(mergedB);
+        fillCValues(mergedC);
+        fillDValues(mergedD);
+    }
+
+private:
+    void validateInputs() const
+    {
+        const auto numWells = bMatrices_.size();
+        assert(cMatrices_.size() == numWells);
+        assert(dMatrices_.size() == numWells);
+        assert(static_cast<std::size_t>(wellCells_.size()) == numWells);
+
+        for (std::size_t well = 0; well < numWells; ++well) {
+            const auto& B = bMatrices_[well];
+            const auto& C = cMatrices_[well];
+            const auto& D = dMatrices_[well];
+            const auto& cells = wellCells_[well];
+
+            assert(cells.size() == B.M());
+            assert(cells.size() == C.N());
+            assert(B.N() == C.M());
+            assert(B.N() == D.N());
+            assert(C.M() == D.M());
+            assert(D.N() == D.M());
+        }
+    }
+
+    template<class Matrix>
+    static void initializeEmptyMatrix(Matrix& matrix, std::size_t rows, std::size_t cols)
+    {
+        matrix.setSize(rows, cols);
+        matrix.setBuildMode(Matrix::random);
+        for (std::size_t row = 0; row < rows; ++row) {
+            matrix.setrowsize(row, 0);
+        }
+        matrix.endrowsizes();
+        matrix.endindices();
+    }
+
+    template<class MatrixVectorT, class DimensionFn>
+    static std::size_t sumMatrixDimension(const MatrixVectorT& matrices, DimensionFn&& dimension)
+    {
+        std::size_t total = 0;
+        for (const auto& matrix : matrices) {
+            total += dimension(matrix);
+        }
+        return total;
+    }
+
+    template<class Row>
+    static std::size_t countRowEntries(const Row& row)
+    {
+        return static_cast<std::size_t>(std::distance(row.begin(), row.end()));
+    }
+
+    template<class Row, class Matrix, class ColumnMapper>
+    static void assignRowValues(const Row& row,
+                                Matrix& mergedMatrix,
+                                std::size_t mergedRow,
+                                ColumnMapper&& mapColumn)
+    {
+        for (auto colIt = row.begin(); colIt != row.end(); ++colIt) {
+            mergedMatrix[mergedRow][mapColumn(colIt.index())] = *colIt;
+        }
+    }
+
+    void fillBValues(BMatrix& mergedMatrix) const
+    {
+        std::size_t rowOffset = 0;
+        for (std::size_t well = 0; well < bMatrices_.size(); ++well) {
+            const auto& matrix = bMatrices_[well];
+            const auto& cells = wellCells_[well];
+            for (std::size_t row = 0; row < matrix.N(); ++row) {
+                assignRowValues(matrix[row], mergedMatrix, rowOffset + row,
+                                [&cells](auto localColumn) {
+                                    assert(cells[localColumn] >= 0);
+                                    return static_cast<std::size_t>(cells[localColumn]);
+                                });
+            }
+            rowOffset += matrix.N();
+        }
+    }
+
+    void fillCValues(CMatrix& mergedMatrix) const
+    {
+        std::size_t colOffset = 0;
+        for (std::size_t well = 0; well < cMatrices_.size(); ++well) {
+            const auto& matrix = cMatrices_[well];
+            const auto& cells = wellCells_[well];
+            for (std::size_t row = 0; row < matrix.N(); ++row) {
+                assert(cells[row] >= 0);
+                const auto cell = static_cast<std::size_t>(cells[row]);
+                assignRowValues(matrix[row], mergedMatrix, cell,
+                                [colOffset](auto localColumn) { return colOffset + localColumn; });
+            }
+            colOffset += matrix.M();
+        }
+    }
+
+    void fillDValues(DMatrix& mergedMatrix) const
+    {
+        std::size_t rowOffset = 0;
+        for (const auto& matrix : dMatrices_) {
+            for (std::size_t row = 0; row < matrix.N(); ++row) {
+                assignRowValues(matrix[row], mergedMatrix, rowOffset + row,
+                                [rowOffset](auto localColumn) { return rowOffset + localColumn; });
+            }
+            rowOffset += matrix.N();
+        }
+    }
+
+    void mergeBMatrix(BMatrix& mergedMatrix) const
+    {
+        if (bMatrices_.empty()) {
+            initializeEmptyMatrix(mergedMatrix, 0, numResDofs_);
+            return;
+        }
+
+        const auto totalRows = sumMatrixDimension(bMatrices_, [](const auto& matrix) { return matrix.N(); });
+
+        mergedMatrix.setSize(totalRows, numResDofs_);
+        mergedMatrix.setBuildMode(BMatrix::random);
+
+        std::size_t rowOffset = 0;
+        for (const auto& matrix : bMatrices_) {
+            for (std::size_t row = 0; row < matrix.N(); ++row) {
+                mergedMatrix.setrowsize(rowOffset + row, countRowEntries(matrix[row]));
+            }
+            rowOffset += matrix.N();
+        }
+        mergedMatrix.endrowsizes();
+
+        rowOffset = 0;
+        for (std::size_t well = 0; well < bMatrices_.size(); ++well) {
+            const auto& matrix = bMatrices_[well];
+            const auto& cells = wellCells_[well];
+            for (std::size_t row = 0; row < matrix.N(); ++row) {
+                for (auto colIt = matrix[row].begin(); colIt != matrix[row].end(); ++colIt) {
+                    assert(cells[colIt.index()] >= 0);
+                    mergedMatrix.addindex(rowOffset + row,
+                                          static_cast<std::size_t>(cells[colIt.index()]));
+                }
+            }
+            rowOffset += matrix.N();
+        }
+        mergedMatrix.endindices();
+
+        fillBValues(mergedMatrix);
+    }
+
+    void mergeCMatrix(CMatrix& mergedMatrix) const
+    {
+        if (cMatrices_.empty()) {
+            initializeEmptyMatrix(mergedMatrix, numResDofs_, 0);
+            return;
+        }
+
+        const auto totalCols = sumMatrixDimension(cMatrices_, [](const auto& matrix) { return matrix.M(); });
+
+        mergedMatrix.setSize(numResDofs_, totalCols);
+        mergedMatrix.setBuildMode(CMatrix::random);
+
+        std::vector<std::size_t> rowSizes(numResDofs_, 0);
+        for (std::size_t well = 0; well < cMatrices_.size(); ++well) {
+            const auto& matrix = cMatrices_[well];
+            const auto& cells = wellCells_[well];
+            for (std::size_t rowIdx = 0; rowIdx < matrix.N(); ++rowIdx) {
+                assert(cells[rowIdx] >= 0);
+                rowSizes[static_cast<std::size_t>(cells[rowIdx])] += countRowEntries(matrix[rowIdx]);
+            }
+        }
+        for (std::size_t row = 0; row < numResDofs_; ++row) {
+            mergedMatrix.setrowsize(row, rowSizes[row]);
+        }
+        mergedMatrix.endrowsizes();
+
+        std::size_t colOffset = 0;
+        for (std::size_t well = 0; well < cMatrices_.size(); ++well) {
+            const auto& matrix = cMatrices_[well];
+            const auto& cells = wellCells_[well];
+            for (std::size_t rowIdx = 0; rowIdx < matrix.N(); ++rowIdx) {
+                assert(cells[rowIdx] >= 0);
+                const auto cell = static_cast<std::size_t>(cells[rowIdx]);
+                for (auto colIt = matrix[rowIdx].begin(); colIt != matrix[rowIdx].end(); ++colIt) {
+                    mergedMatrix.addindex(cell, colOffset + colIt.index());
+                }
+            }
+            colOffset += matrix.M();
+        }
+        mergedMatrix.endindices();
+
+        fillCValues(mergedMatrix);
+    }
+
+    void mergeDMatrix(DMatrix& mergedMatrix) const
+    {
+        if (dMatrices_.empty()) {
+            initializeEmptyMatrix(mergedMatrix, 0, 0);
+            return;
+        }
+
+        const auto totalSize = sumMatrixDimension(dMatrices_, [](const auto& matrix) { return matrix.N(); });
+
+        mergedMatrix.setSize(totalSize, totalSize);
+        mergedMatrix.setBuildMode(DMatrix::random);
+
+        std::size_t rowOffset = 0;
+        for (const auto& matrix : dMatrices_) {
+            for (std::size_t rowIdx = 0; rowIdx < matrix.N(); ++rowIdx) {
+                mergedMatrix.setrowsize(rowOffset + rowIdx, countRowEntries(matrix[rowIdx]));
+            }
+            rowOffset += matrix.N();
+        }
+        mergedMatrix.endrowsizes();
+
+        rowOffset = 0;
+        for (const auto& matrix : dMatrices_) {
+            for (std::size_t rowIdx = 0; rowIdx < matrix.N(); ++rowIdx) {
+                for (auto colIt = matrix[rowIdx].begin(); colIt != matrix[rowIdx].end(); ++colIt) {
+                    mergedMatrix.addindex(rowOffset + rowIdx, rowOffset + colIt.index());
+                }
+            }
+            rowOffset += matrix.N();
+        }
+        mergedMatrix.endindices();
+
+        fillDValues(mergedMatrix);
+    }
+
+    std::size_t numResDofs_;
+    const std::vector<BMatrix>& bMatrices_;
+    const std::vector<CMatrix>& cMatrices_;
+    const std::vector<DMatrix>& dMatrices_;
+    const Opm::SparseTable<int>& wellCells_;
+};
+
+} // namespace Opm
+
+#endif // OPM_WELLMATRIXMERGER_HEADER_INCLUDED

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -29,6 +29,7 @@
 #include <dune/istl/matrixmatrix.hh>
 
 #include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/grid/utility/SparseTable.hpp>
 
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRate.hpp>
@@ -41,6 +42,7 @@
 #include <opm/simulators/flow/FlowBaseVanguard.hpp>
 
 #include <opm/simulators/linalg/matrixblock.hh>
+#include <opm/simulators/linalg/system/SystemTypes.hpp>
 
 #include <opm/simulators/timestepping/SimulatorReport.hpp>
 #include <opm/simulators/timestepping/gatherConvergenceReport.hpp>
@@ -283,6 +285,18 @@ template<class Scalar> class WellContributions;
             bool updateGroupControls(const Group& group,
                                     DeferredLogger& deferred_logger,
                                     const int reportStepIdx);
+
+            static constexpr int numResDofs = Indices::numEq;
+            static constexpr int numWellDofs = numResDofs + 1;//NB will fail for for thermal for now
+            using BMatrix = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, numWellDofs, numResDofs>>;
+            using CMatrix = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, numResDofs, numWellDofs>>;
+            using DMatrix = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, numWellDofs, numWellDofs>>;
+            using WVector = Dune::BlockVector<Dune::FieldVector<Scalar, numWellDofs>>;
+
+            void addBCDMatrix(std::vector<BMatrix>& b_matrices,
+                                            std::vector<CMatrix>& c_matrices,
+                                            std::vector<DMatrix>& d_matrices,
+                                            Opm::SparseTable<int>& wcells) const;
 
             const WellInterface<TypeTag>& getWell(const std::string& well_name) const;
 
@@ -726,6 +740,14 @@ template<class Scalar> class WellContributions;
 
             // Store cell rates after assembling to avoid iterating all wells and connections for every element
             std::map<int, RateVector> cellRates_;
+
+            // Cached well solution from the system solver, consumed by
+            // recoverWellSolutionAndUpdateWellState during postSolve.
+            std::optional<WellVector<Scalar>> cachedSystemWellSolution_;
+            std::vector<int> cachedWellDofOffsets_;
+
+            void assignWellTracerRates(data::Wells& wsrpt) const;
+            void assignWellSpeciesRates(data::Wells& wsrpt) const;
 
             [[nodiscard]] auto rsConstInfo() const
                 -> typename WellState<Scalar,IndexTraits>::RsConstInfo;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1468,6 +1468,19 @@ namespace Opm {
 
     template<typename TypeTag>
     void
+    BlackoilWellModel<TypeTag>::addBCDMatrix(std::vector<BMatrix>& b_matrices,
+                                            std::vector<CMatrix>& c_matrices,
+                                            std::vector<DMatrix>& d_matrices,
+                                            Opm::SparseTable<int>& wcells) const
+    {
+        wcells.clear();
+        for ( const auto& well: well_container_ ) {
+            well->addBCDMatrix(b_matrices, c_matrices, d_matrices, wcells);
+        }
+    }
+
+    template<typename TypeTag>
+    void
     BlackoilWellModel<TypeTag>::
     addWellPressureEquations(PressureMatrix& jacobian,
                              const BVector& weights,

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -24,6 +24,7 @@
 
 #include <opm/models/common/multiphasebaseproperties.hh>
 
+#include <opm/common/Exceptions.hpp>
 #include <opm/simulators/wells/WellInterface.hpp>
 #include <opm/simulators/wells/MultisegmentWellEval.hpp>
 
@@ -73,6 +74,10 @@ namespace Opm {
         using typename Base::PressureMatrix;
         using FSInfo = std::tuple<Scalar, Scalar>;
 
+        using BMatrix = typename Base::BMatrix;
+        using CMatrix = typename Base::CMatrix;
+        using DMatrix = typename Base::DMatrix;
+        using WVector = typename Base::WVector;
         MultisegmentWell(const Well& well,
                          const ParallelWellInfo<Scalar>& pw_info,
                          const int time_step,
@@ -163,6 +168,21 @@ namespace Opm {
         std::vector<Scalar> getPrimaryVars() const override;
 
         int setPrimaryVars(typename std::vector<Scalar>::const_iterator it) override;
+        void addBCDMatrix(std::vector<typename Base::BMatrix>& b_matrices,
+                          std::vector<typename Base::CMatrix>& c_matrices,
+                          std::vector<typename Base::DMatrix>& d_matrices,
+                          Opm::SparseTable<int>& wcells) const override
+        {
+            // System_cpr preconditioner is only supported when well DOF dimensions
+            // match between WellInterface and MultisegmentWellEval (standard 3-phase blackoil).
+            if constexpr (Base::numWellDofs == MSWEval::numWellDofs) {
+                MSWEval::addBCDMatrix(b_matrices, c_matrices, d_matrices, wcells);
+            } else {
+                OPM_THROW(std::runtime_error,
+                          "system_cpr preconditioner with multisegment wells is only supported for standard "
+                          "3-phase blackoil (Indices::numEq == 3). This model has different equation count.");
+            }
+        }
 
         void getScaledWellFractions(std::vector<Scalar>& scaled_fractions,
                                     DeferredLogger& deferred_logger) const override;

--- a/opm/simulators/wells/MultisegmentWellEquations.hpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.hpp
@@ -135,7 +135,12 @@ public:
         return resWell_;
     }
 
-  private:
+    const OffDiagMatWell& getB() const { return duneB_; }
+    const OffDiagMatWell& getC() const { return duneC_; }
+    const DiagMatWell& getD() const { return duneD_; }
+    const std::vector<int>& cells() const { return cells_; }
+
+private:
     friend class MultisegmentWellEquationAccess<Scalar,IndexTraits,numWellEq,numEq>;
     // two off-diagonal matrices
     OffDiagMatWell duneB_;

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -75,6 +75,60 @@ initMatrixAndVectors(const ParallelWellInfo<Scalar>& parallel_well_info)
     primary_variables_.resize(this->numberOfSegments());
 }
 
+
+template<typename BlockType, typename BlockTypeTransposed>
+Dune::BCRSMatrix<BlockTypeTransposed>
+transposeMatrix(const Dune::BCRSMatrix<BlockType>& A)
+{
+    const size_t rows = A.N();
+    const size_t cols = A.M();
+
+    std::vector<std::vector<int>> rowind(cols);
+    for (size_t i = 0; i < rows; ++i) {
+        for (auto it = A[i].begin(); it != A[i].end(); ++it) {
+            rowind[it.index()].push_back(i);
+        }
+    }
+
+    // Create the transposed matrix
+    Dune::BCRSMatrix<BlockTypeTransposed> AT(cols, rows, A.nonzeroes(),
+                                             Dune::BCRSMatrix<BlockTypeTransposed>::row_wise);
+
+    for (auto row = AT.createbegin(); row != AT.createend(); ++row) {
+        for (int col_idx : rowind[row.index()]) {
+            row.insert(col_idx);
+        }
+    }
+
+    // Fill in the entries
+    for (size_t i = 0; i < rows; ++i) {
+        for (auto it = A[i].begin(); it != A[i].end(); ++it) {
+            size_t j = it.index();
+            AT[j][i] = it->transposed();  // transpose the block
+        }
+    }
+
+    return AT;
+}
+
+template<class FluidSystem, class Indices>
+void
+MultisegmentWellEval<FluidSystem,Indices>::
+addBCDMatrix(std::vector<BMatrix>& b_matrices,
+             std::vector<CMatrix>& c_matrices,
+             std::vector<DMatrix>& d_matrices,
+             Opm::SparseTable<int>& wcells) const
+{
+    b_matrices.push_back(linSys_.getB());
+
+    using BlockType = Dune::FieldMatrix<Scalar, PrimaryVariables::numWellEq, Indices::numEq>;
+    using BlockTypeTransposed = typename CMatrix::block_type;
+    c_matrices.push_back(transposeMatrix<BlockType, BlockTypeTransposed>(linSys_.getC()));
+
+    d_matrices.push_back(linSys_.getD());
+    wcells.appendRow(linSys_.cells().begin(), linSys_.cells().end());
+}
+
 template<typename FluidSystem, typename Indices>
 ConvergenceReport
 MultisegmentWellEval<FluidSystem,Indices>::

--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -28,6 +28,8 @@
 #include <opm/simulators/wells/MultisegmentWellSegments.hpp>
 #include <opm/simulators/wells/ParallelWellInfo.hpp>
 
+#include <opm/grid/utility/SparseTable.hpp>
+
 #include <opm/material/densead/Evaluation.hpp>
 
 #include <utility>
@@ -46,10 +48,12 @@ template<typename FluidSystem, typename Indices>
 class MultisegmentWellEval : public MultisegmentWellGeneric<typename FluidSystem::Scalar,
                                                             typename FluidSystem::IndexTraitsType>
 {
-protected:
+public:
     using Scalar = typename FluidSystem::Scalar;
-    using IndexTraits = typename FluidSystem::IndexTraitsType;
     using PrimaryVariables = MultisegmentWellPrimaryVariables<FluidSystem,Indices>;
+
+protected:
+    using IndexTraits = typename FluidSystem::IndexTraitsType;
     static constexpr int numWellEq = PrimaryVariables::numWellEq;
     static constexpr int SPres = PrimaryVariables::SPres;
     static constexpr int WQTotal = PrimaryVariables::WQTotal;
@@ -71,6 +75,17 @@ public:
     const Equations& linSys() const
     { return linSys_; }
 
+    static constexpr int numResDofs = Indices::numEq;
+    static constexpr int numWellDofs = PrimaryVariables::numWellEq;// numResDofs + 1; // NB will fail for for thermal for now
+    using BMatrix = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, numWellDofs, numResDofs>>;
+    using CMatrix = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, numResDofs, numWellDofs>>;
+    using DMatrix = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, numWellDofs, numWellDofs>>;
+    using WVector = Dune::BlockVector<Dune::FieldVector<Scalar, numWellDofs>>;
+
+    void addBCDMatrix(std::vector<BMatrix>& b_matrices,
+                std::vector<CMatrix>& c_matrices,
+                std::vector<DMatrix>& d_matrices,
+                Opm::SparseTable<int>& wcells) const;
 protected:
     MultisegmentWellEval(WellInterfaceIndices<FluidSystem, Indices>& baseif, const ParallelWellInfo<Scalar>& parallel_well_info);
 

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -247,6 +247,23 @@ namespace Opm
         void getScaledWellFractions(std::vector<Scalar>& scaled_fractions,
                                     DeferredLogger& deferred_logger) const override;
 
+
+        void addBCDMatrix(std::vector<typename Base::BMatrix>& b_matrices,
+                          std::vector<typename Base::CMatrix>& c_matrices,
+                          std::vector<typename Base::DMatrix>& d_matrices,
+                          Opm::SparseTable<int>& wcells) const override
+        {
+            // System_cpr preconditioner is only supported when well DOF dimensions
+            // match between WellInterface and StandardWellEval (standard 3-phase blackoil).
+            if constexpr (Base::numWellDofs == StdWellEval::numWellDofs) {
+                StdWellEval::addBCDMatrix(b_matrices, c_matrices, d_matrices, wcells);
+            } else {
+                OPM_THROW(std::runtime_error,
+                          "system_cpr preconditioner with standard wells is only supported for standard "
+                          "3-phase blackoil (Indices::numEq == 3). This model has different equation count.");
+            }
+        }
+
     protected:
         bool regularize_;
 

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -129,6 +129,11 @@ public:
         return resWell_;
     }
 
+    const OffDiagMatWell& getB() const { return duneB_; }
+    const OffDiagMatWell& getC() const { return duneC_; }
+    const DiagMatWell& getD() const { return duneD_; }
+    const std::vector<int>& cells() const { return cells_; }
+
 private:
     friend class StandardWellEquationAccess<Scalar, IndexTraits, numEq>;
 

--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -80,6 +80,77 @@ computeAccumWell()
 }
 
 template<class FluidSystem, class Indices>
+void
+StandardWellEval<FluidSystem,Indices>::
+addBCDMatrix(std::vector<BMatrix>& b_matrices,
+             std::vector<CMatrix>& c_matrices,
+             std::vector<DMatrix>& d_matrices,
+             Opm::SparseTable<int>& wcells) const
+{
+    const auto& srcB = linSys_.getB();
+    const auto& srcC = linSys_.getC();
+    const auto& srcD = linSys_.getD();
+    const size_t numPerfs = srcB.M();
+
+    // Copy D matrix (1x1 block, DynamicMatrix -> FieldMatrix)
+    DMatrix duneD;
+    duneD.setSize(1, 1, 1);
+    for (auto row = duneD.createbegin(); row != duneD.createend(); ++row) {
+        // Add nonzeros for diagonal
+        row.insert(row.index());
+    }
+    {
+        auto& dest = duneD[0][0];
+        const auto& src = srcD[0][0];
+        for (size_t i = 0; i < dest.N(); ++i) {
+            for (size_t j = 0; j < dest.M(); ++j) {
+                dest[i][j] = src[i][j];
+            }
+        }
+    }
+
+    // Copy B matrix (DynamicMatrix -> FieldMatrix)
+    BMatrix duneB;
+    assert(srcB.N() == 1);
+    duneB.setSize(srcB.N(), srcB.M(), srcB.M());
+    for (auto row = duneB.createbegin(); row != duneB.createend(); ++row) {
+        for (size_t perf = 0; perf < numPerfs; ++perf) {
+            row.insert(perf);
+        }
+    }
+    for (size_t i = 0; i < srcB.M(); ++i) {
+        const auto& src = srcB[0][i];
+        auto& dest = duneB[0][i];
+        for (size_t j = 0; j < src.N(); ++j) {
+            for (size_t k = 0; k < src.M(); ++k) {
+                dest[j][k] = src[j][k];
+            }
+        }
+    }
+
+    // Build C as transpose of internal C^T layout
+    CMatrix duneC;
+    duneC.setSize(srcC.M(), srcC.N(), srcC.M());
+    for (auto row = duneC.createbegin(); row != duneC.createend(); ++row) {
+        row.insert(0);  // Only one well dofs
+    }
+    for (size_t perf = 0; perf < numPerfs; ++perf) {
+        auto& dest = duneC[perf][0];
+        const auto& src = srcC[0][perf];
+        for (size_t i = 0; i < src.N(); ++i) {
+            for (size_t j = 0; j < src.M(); ++j) {
+                dest[j][i] = src[i][j];
+            }
+        }
+    }
+
+    b_matrices.push_back(duneB);
+    c_matrices.push_back(duneC);
+    d_matrices.push_back(duneD);
+    wcells.appendRow(linSys_.cells().begin(), linSys_.cells().end());
+}
+
+template<class FluidSystem, class Indices>
 ConvergenceReport
 StandardWellEval<FluidSystem,Indices>::
 getWellConvergence(const WellState<Scalar, IndexTraits>& well_state,

--- a/opm/simulators/wells/StandardWellEval.hpp
+++ b/opm/simulators/wells/StandardWellEval.hpp
@@ -26,6 +26,8 @@
 #include <opm/simulators/wells/StandardWellEquations.hpp>
 #include <opm/simulators/wells/StandardWellPrimaryVariables.hpp>
 
+#include <opm/grid/utility/SparseTable.hpp>
+
 #include <opm/material/densead/Evaluation.hpp>
 
 #include <vector>
@@ -44,8 +46,10 @@ template<typename FluidSystem, typename Indices> class WellState;
 template<class FluidSystem, class Indices>
 class StandardWellEval
 {
-protected:
+public:
     using Scalar = typename FluidSystem::Scalar;
+
+protected:
     using IndexTraits = typename FluidSystem::IndexTraitsType;
     using PrimaryVariables = StandardWellPrimaryVariables<FluidSystem,Indices>;
     using StdWellConnections = StandardWellConnections<FluidSystem,Indices>;
@@ -58,7 +62,6 @@ protected:
     static constexpr int WFrac = PrimaryVariables::WFrac;
     static constexpr int GFrac = PrimaryVariables::GFrac;
     static constexpr int SFrac = PrimaryVariables::SFrac;
-
 public:
     using EvalWell = typename PrimaryVariables::EvalWell;
     using Eval = DenseAd::Evaluation<Scalar, Indices::numDerivatives>;
@@ -68,6 +71,17 @@ public:
     const StandardWellEquations<Scalar, IndexTraits, Indices::numEq>& linSys() const
     { return linSys_; }
 
+    static constexpr int numResDofs = Indices::numEq;
+    static constexpr int numWellDofs = numResDofs + 1;// NB will fail for for thermal for now
+    using BMatrix = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, numWellDofs, numResDofs>>;
+    using CMatrix = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, numResDofs, numWellDofs>>;
+    using DMatrix = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, numWellDofs, numWellDofs>>;
+    using WVector = Dune::BlockVector<Dune::FieldVector<Scalar, numWellDofs>>;
+
+    void addBCDMatrix(std::vector<BMatrix>& b_matrices,
+                std::vector<CMatrix>& c_matrices,
+                std::vector<DMatrix>& d_matrices,
+                Opm::SparseTable<int>& wcells) const;
 protected:
     explicit StandardWellEval(const WellInterfaceIndices<FluidSystem,Indices>& baseif);
 

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -368,6 +368,18 @@ public:
                                    const GroupStateHelperType& groupStateHelper,
                                    WellStateType& well_state) = 0;
 
+    static constexpr int numResDofs = Indices::numEq;
+    static constexpr int numWellDofs = numResDofs + 1;  // NB will fail for for thermal for now
+    using BMatrix = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, numWellDofs, numResDofs>>;
+    using CMatrix = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, numResDofs, numWellDofs>>;
+    using DMatrix = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, numWellDofs, numWellDofs>>;
+    using WVector = Dune::BlockVector<Dune::FieldVector<Scalar, numWellDofs>>;
+
+    virtual void addBCDMatrix(std::vector<BMatrix>& b_matrices,
+        std::vector<CMatrix>& c_matrices,
+        std::vector<DMatrix>& d_matrices,
+        Opm::SparseTable<int>& wcells) const = 0;
+
 protected:
     // simulation parameters
     std::vector<RateVector> connectionRates_;

--- a/tests/options_system_cpr_complete.json
+++ b/tests/options_system_cpr_complete.json
@@ -1,0 +1,40 @@
+{
+    "maxiter": "20",
+    "tol": "0.005",
+    "verbosity": "0",
+    "solver": "bicgstab",
+    "preconditioner": {
+        "type": "system_cpr",
+        "reservoir_smoother": {
+            "maxiter": "1",
+            "tol": "0.005",
+            "verbosity": "0",
+            "solver": "preconditioner2inverseoperator",
+            "preconditioner": {
+                "type": "paroverilu0",
+                "relaxation": "1"
+            }
+        },
+        "reservoir_solver": {
+            "maxiter": "1",
+            "tol": "0.005",
+            "verbosity": "0",
+            "solver": "preconditioner2inverseoperator",
+            "preconditioner": {
+                "type": "cpr",
+                "relaxation": "1",
+                "use_well_weights": "false",
+                "add_wells": "false",
+                "weight_type": "trueimpes",
+                "pre_smooth": "0",
+                "post_smooth": "0"
+            }
+        },
+        "well_solver": {
+            "maxiter": "1",
+            "tol": "0.005",
+            "verbosity": "0",
+            "solver": "umfpack"
+        }
+    }
+}

--- a/tests/options_system_cpr_missing_precond_type.json
+++ b/tests/options_system_cpr_missing_precond_type.json
@@ -1,0 +1,70 @@
+{
+    "maxiter": "20",
+    "tol": "0.0050000000000000001",
+    "verbosity": "0",
+    "solver": "bicgstab",
+    "preconditioner": {
+        "type": "system_cpr",
+        "reservoir_smoother": {
+            "maxiter": "1",
+            "tol": "0.0050000000000000001",
+            "verbosity": "0",
+            "solver": "preconditioner2inverseoperator",
+            "preconditioner": {
+                "type": "paroverilu0",
+                "relaxation": "1"
+            }
+        },
+        "reservoir_solver": {
+            "maxiter": "1",
+            "tol": "0.0050000000000000001",
+            "verbosity": "0",
+            "solver": "preconditioner2inverseoperator",
+            "preconditioner": {
+                "relaxation": "1",
+                "use_well_weights": "false",
+                "add_wells": "false",
+                "weight_type": "trueimpes",
+                "pre_smooth": "0",
+                "post_smooth": "0",
+                "finesmoother": {
+                    "type": "jac",
+                    "relaxation": "1"
+                },
+                "verbosity": "0",
+                "coarsesolver": {
+                    "maxiter": "1",
+                    "tol": "0.10000000000000001",
+                    "solver": "loopsolver",
+                    "verbosity": "0",
+                    "preconditioner": {
+                        "type": "amg",
+                        "alpha": "0.33333333333300003",
+                        "relaxation": "1",
+                        "iterations": "1",
+                        "coarsenTarget": "1200",
+                        "pre_smooth": "1",
+                        "post_smooth": "1",
+                        "beta": "0",
+                        "smoother": "ilu0",
+                        "verbosity": "0",
+                        "maxlevel": "15",
+                        "skip_isolated": "0",
+                        "accumulate": "1",
+                        "prolongationdamping": "1",
+                        "maxdistance": "2",
+                        "maxconnectivity": "15",
+                        "maxaggsize": "6",
+                        "minaggsize": "4"
+                    }
+                }
+            }
+        },
+        "well_solver": {
+            "maxiter": "1",
+            "tol": "0.0050000000000000001",
+            "verbosity": "0",
+            "solver": "umfpack"
+        }
+    }
+}

--- a/tests/options_system_cpr_missing_ressolver.json
+++ b/tests/options_system_cpr_missing_ressolver.json
@@ -1,0 +1,25 @@
+{
+    "maxiter": "20",
+    "tol": "0.005",
+    "verbosity": "0",
+    "solver": "bicgstab",
+    "preconditioner": {
+        "type": "system_cpr",
+        "reservoir_smoother": {
+            "maxiter": "1",
+            "tol": "0.005",
+            "verbosity": "0",
+            "solver": "preconditioner2inverseoperator",
+            "preconditioner": {
+                "type": "paroverilu0",
+                "relaxation": "1"
+            }
+        },
+        "well_solver": {
+            "maxiter": "1",
+            "tol": "0.005",
+            "verbosity": "0",
+            "solver": "umfpack"
+        }
+    }
+}

--- a/tests/options_system_cpr_missing_smoother.json
+++ b/tests/options_system_cpr_missing_smoother.json
@@ -1,0 +1,24 @@
+{
+    "maxiter": "20",
+    "tol": "0.005",
+    "verbosity": "0",
+    "solver": "bicgstab",
+    "preconditioner": {
+        "type": "system_cpr",
+        "reservoir_solver": {
+            "maxiter": "1",
+            "tol": "0.005",
+            "verbosity": "0",
+            "solver": "preconditioner2inverseoperator",
+            "preconditioner": {
+                "type": "cpr"
+            }
+        },
+        "well_solver": {
+            "maxiter": "1",
+            "tol": "0.005",
+            "verbosity": "0",
+            "solver": "umfpack"
+        }
+    }
+}

--- a/tests/options_system_cpr_missing_well.json
+++ b/tests/options_system_cpr_missing_well.json
@@ -1,0 +1,28 @@
+{
+    "maxiter": "20",
+    "tol": "0.005",
+    "verbosity": "0",
+    "solver": "bicgstab",
+    "preconditioner": {
+        "type": "system_cpr",
+        "reservoir_smoother": {
+            "maxiter": "1",
+            "tol": "0.005",
+            "verbosity": "0",
+            "solver": "preconditioner2inverseoperator",
+            "preconditioner": {
+                "type": "paroverilu0",
+                "relaxation": "1"
+            }
+        },
+        "reservoir_solver": {
+            "maxiter": "1",
+            "tol": "0.005",
+            "verbosity": "0",
+            "solver": "preconditioner2inverseoperator",
+            "preconditioner": {
+                "type": "cpr"
+            }
+        }
+    }
+}

--- a/tests/options_system_cpr_res_precond_not_cpr.json
+++ b/tests/options_system_cpr_res_precond_not_cpr.json
@@ -1,0 +1,71 @@
+{
+    "maxiter": "20",
+    "tol": "0.0050000000000000001",
+    "verbosity": "0",
+    "solver": "bicgstab",
+    "preconditioner": {
+        "type": "system_cpr",
+        "reservoir_smoother": {
+            "maxiter": "1",
+            "tol": "0.0050000000000000001",
+            "verbosity": "0",
+            "solver": "preconditioner2inverseoperator",
+            "preconditioner": {
+                "type": "paroverilu0",
+                "relaxation": "1"
+            }
+        },
+        "reservoir_solver": {
+            "maxiter": "1",
+            "tol": "0.0050000000000000001",
+            "verbosity": "0",
+            "solver": "preconditioner2inverseoperator",
+            "preconditioner": {
+                "type": "ilu0",
+                "relaxation": "1",
+                "use_well_weights": "false",
+                "add_wells": "false",
+                "weight_type": "trueimpes",
+                "pre_smooth": "0",
+                "post_smooth": "0",
+                "finesmoother": {
+                    "type": "jac",
+                    "relaxation": "1"
+                },
+                "verbosity": "0",
+                "coarsesolver": {
+                    "maxiter": "1",
+                    "tol": "0.10000000000000001",
+                    "solver": "loopsolver",
+                    "verbosity": "0",
+                    "preconditioner": {
+                        "type": "amg",
+                        "alpha": "0.33333333333300003",
+                        "relaxation": "1",
+                        "iterations": "1",
+                        "coarsenTarget": "1200",
+                        "pre_smooth": "1",
+                        "post_smooth": "1",
+                        "beta": "0",
+                        "smoother": "ilu0",
+                        "verbosity": "0",
+                        "maxlevel": "15",
+                        "skip_isolated": "0",
+                        "accumulate": "1",
+                        "prolongationdamping": "1",
+                        "maxdistance": "2",
+                        "maxconnectivity": "15",
+                        "maxaggsize": "6",
+                        "minaggsize": "4"
+                    }
+                }
+            }
+        },
+        "well_solver": {
+            "maxiter": "1",
+            "tol": "0.0050000000000000001",
+            "verbosity": "0",
+            "solver": "umfpack"
+        }
+    }
+}

--- a/tests/test_WellMatrixMerger.cpp
+++ b/tests/test_WellMatrixMerger.cpp
@@ -1,0 +1,489 @@
+#include <config.h>
+#define BOOST_TEST_MODULE OPM_test_WellMatrixMerger
+#include <boost/test/unit_test.hpp>
+
+#include <opm/simulators/linalg/system/WellMatrixMerger.hpp>
+#include <opm/grid/utility/SparseTable.hpp>
+
+#include <array>
+#include <cstddef>
+#include <vector>
+
+namespace {
+
+using Scalar = double;
+using WRMatrix = Opm::WRMatrix<Scalar>;
+using RWMatrix = Opm::RWMatrix<Scalar>;
+using WWMatrix = Opm::WWMatrix<Scalar>;
+using WRBlock = WRMatrix::block_type;
+using RWBlock = RWMatrix::block_type;
+using WWBlock = WWMatrix::block_type;
+constexpr std::size_t numResDof = 5;
+
+template<class Block>
+Block makeBlock(const Scalar base)
+{
+    Block block;
+    for (int row = 0; row < Block::rows; ++row) {
+        for (int col = 0; col < Block::cols; ++col) {
+            block[row][col] = base + row * 10.0 + col;
+        }
+    }
+    return block;
+}
+
+struct BlockSpec
+{
+    int column;
+    Scalar base;
+};
+
+BlockSpec entry(const int column, const Scalar base)
+{
+    return {column, base};
+}
+
+using MatrixRow = std::vector<BlockSpec>;
+using MatrixPattern = std::vector<std::vector<BlockSpec>>;
+
+// Small helper for hand-written BCRS matrices used throughout the test.
+template<class Matrix>
+Matrix buildMatrix(const std::size_t rows,
+                   const std::size_t cols,
+                   const MatrixPattern& pattern)
+{
+    std::size_t nonzeroes = 0;
+    for (const auto& row : pattern) {
+        nonzeroes += row.size();
+    }
+
+    Matrix matrix(rows, cols, nonzeroes, Matrix::row_wise);
+    for (auto row = matrix.createbegin(); row != matrix.createend(); ++row) {
+        for (const auto& entry : pattern[row.index()]) {
+            row.insert(entry.column);
+        }
+    }
+
+    for (std::size_t row = 0; row < rows; ++row) {
+        for (const auto& entry : pattern[row]) {
+            matrix[row][entry.column] = makeBlock<typename Matrix::block_type>(entry.base);
+        }
+    }
+
+    return matrix;
+}
+
+template<class Block>
+void checkBlockEqual(const Block& actual, const Block& expected)
+{
+    for (int row = 0; row < Block::rows; ++row) {
+        for (int col = 0; col < Block::cols; ++col) {
+            BOOST_CHECK_EQUAL(actual[row][col], expected[row][col]);
+        }
+    }
+}
+
+template<class Matrix>
+void checkMatrixEqual(const Matrix& actual, const Matrix& expected)
+{
+    BOOST_REQUIRE_EQUAL(actual.N(), expected.N());
+    BOOST_REQUIRE_EQUAL(actual.M(), expected.M());
+
+    for (std::size_t row = 0; row < actual.N(); ++row) {
+        auto actualIt = actual[row].begin();
+        auto expectedIt = expected[row].begin();
+        for (; actualIt != actual[row].end() && expectedIt != expected[row].end(); ++actualIt, ++expectedIt) {
+            BOOST_CHECK_EQUAL(actualIt.index(), expectedIt.index());
+            checkBlockEqual(*actualIt, *expectedIt);
+        }
+        BOOST_CHECK(actualIt == actual[row].end());
+        BOOST_CHECK(expectedIt == expected[row].end());
+    }
+}
+
+struct TestMatrices
+{
+    std::vector<WRMatrix> bMatrices;
+    std::vector<RWMatrix> cMatrices;
+    std::vector<WWMatrix> dMatrices;
+    Opm::SparseTable<int> wellCells;
+};
+    
+struct MergedMatrices
+{
+    WRMatrix b;
+    RWMatrix c;
+    WWMatrix d;
+};
+
+// Two wells:
+// - well 0 is a toy multisegment well with two segment blocks and two
+//   perforated reservoir cells, 1 and 3. Each segment sees exactly one
+//   perforation, and D contains the segment-to-segment coupling.
+// - well 1 is a toy standard well with one well block and two perforated
+//   reservoir cells, 0 and 4. Its single well block couples to both
+//   perforations, so B is dense across the two perforation columns and C is
+//   dense down the two perforation rows.
+// The B/C/D matrices below are the local per-well matrices before merging.
+TestMatrices buildTestMatrices()
+{
+    TestMatrices matrices;
+
+    // wellCells[well][local perforation] = global reservoir cell index.
+    // The first well perforates cells 1 and 3, the second well perforates
+    // cells 0 and 4.
+    matrices.wellCells.clear();
+    {
+        std::vector<int> cells{1, 3};
+        matrices.wellCells.appendRow(cells.begin(), cells.end());
+    }
+    {
+        std::vector<int> cells{0, 4};
+        matrices.wellCells.appendRow(cells.begin(), cells.end());
+    }
+
+    // Toy MSW: two segment rows/columns and one local perforation attached to
+    // each segment. B and C therefore have one entry per row. D has the full
+    // 2x2 segment-coupling pattern, which is the part that matters for the
+    // structure-cache test later.
+    const MatrixPattern multisegmentB{{
+        MatrixRow{entry(0, 10.0)},
+        MatrixRow{entry(1, 20.0)}
+    }};
+    const MatrixPattern multisegmentC{{
+        MatrixRow{entry(0, 30.0)},
+        MatrixRow{entry(1, 40.0)}
+    }};
+    const MatrixPattern multisegmentD{{
+        MatrixRow{entry(0, 50.0), entry(1, 60.0)},
+        MatrixRow{entry(0, 70.0), entry(1, 80.0)}
+    }};
+
+    // Toy standard well: one well row/column block coupled to both local
+    // perforations. B is therefore dense across its two perforation columns,
+    // C has one entry in each perforated-cell row, and D is just 1x1.
+    const MatrixPattern standardWellB{{
+        MatrixRow{entry(0, 90.0), entry(1, 100.0)}
+    }};
+    const MatrixPattern standardWellC{{
+        MatrixRow{entry(0, 110.0)},
+        MatrixRow{entry(0, 120.0)}
+    }};
+    const MatrixPattern standardWellD{{
+        MatrixRow{entry(0, 130.0)}
+    }};
+
+    // The vectors are ordered as [multisegment well, standard well].
+    matrices.bMatrices.emplace_back(buildMatrix<WRMatrix>(
+        2,
+        2,
+        multisegmentB));
+    matrices.bMatrices.emplace_back(buildMatrix<WRMatrix>(
+        1,
+        2,
+        standardWellB));
+
+    matrices.cMatrices.emplace_back(buildMatrix<RWMatrix>(
+        2,
+        2,
+        multisegmentC));
+    matrices.cMatrices.emplace_back(buildMatrix<RWMatrix>(
+        2,
+        1,
+        standardWellC));
+
+    matrices.dMatrices.emplace_back(buildMatrix<WWMatrix>(
+        2,
+        2,
+        multisegmentD));
+    matrices.dMatrices.emplace_back(buildMatrix<WWMatrix>(
+        1,
+        1,
+        standardWellD));
+
+    return matrices;
+}
+
+WRMatrix expectedMergedB()
+{
+    // After merging, the well rows are concatenated in well order. The local
+    // perforation columns are replaced by the corresponding global perforated
+    // reservoir cells from wellCells: {0,1} -> {1,3} for the MSW and
+    // {0,1} -> {0,4} for the standard well.
+    return buildMatrix<WRMatrix>(
+        3,
+        5,
+        MatrixPattern{{
+            MatrixRow{entry(1, 10.0)},
+            MatrixRow{entry(3, 20.0)},
+            MatrixRow{entry(0, 90.0), entry(4, 100.0)}
+        }});
+}
+
+RWMatrix expectedMergedC()
+{
+    // C writes to global reservoir rows. Only the perforated reservoir cells
+    // get entries, and the well columns are appended in well order.
+    return buildMatrix<RWMatrix>(
+        5,
+        3,
+        MatrixPattern{{
+            MatrixRow{entry(2, 110.0)},
+            MatrixRow{entry(0, 30.0)},
+            {},
+            MatrixRow{entry(1, 40.0)},
+            MatrixRow{entry(2, 120.0)}
+        }});
+}
+
+WWMatrix expectedMergedD()
+{
+    // D is the block-diagonal concatenation of the per-well well/well blocks.
+    return buildMatrix<WWMatrix>(
+        3,
+        3,
+        MatrixPattern{{
+            MatrixRow{entry(0, 50.0), entry(1, 60.0)},
+            MatrixRow{entry(0, 70.0), entry(1, 80.0)},
+            MatrixRow{entry(2, 130.0)}
+        }});
+}
+
+// Change one existing entry in each local matrix so updateValues() can be
+// checked without changing the sparsity pattern.
+void updateSourceValues(TestMatrices& matrices)
+{
+    matrices.bMatrices[0][0][0] = makeBlock<WRBlock>(210.0);
+    matrices.cMatrices[1][1][0] = makeBlock<RWBlock>(220.0);
+    matrices.dMatrices[0][1][1] = makeBlock<WWBlock>(230.0);
+}
+
+MergedMatrices buildMergedMatrices(const TestMatrices& matrices)
+{
+    MergedMatrices merged;
+    const Opm::WellMatrixMerger<Scalar> merger(
+        numResDof,
+        matrices.bMatrices,
+        matrices.cMatrices,
+        matrices.dMatrices,
+        matrices.wellCells);
+    merger.buildMatrices(merged.b, merged.c, merged.d);
+    return merged;
+}
+
+void checkMergedMatrices(const MergedMatrices& merged)
+{
+    checkMatrixEqual(merged.b, expectedMergedB());
+    checkMatrixEqual(merged.c, expectedMergedC());
+    checkMatrixEqual(merged.d, expectedMergedD());
+}
+
+void checkUpdatedMergedMatrices(const MergedMatrices& merged)
+{
+    auto expectedB = expectedMergedB();
+    auto expectedC = expectedMergedC();
+    auto expectedD = expectedMergedD();
+    expectedB[0][1] = makeBlock<WRBlock>(210.0);
+    expectedC[4][2] = makeBlock<RWBlock>(220.0);
+    expectedD[1][1] = makeBlock<WWBlock>(230.0);
+
+    checkMatrixEqual(merged.b, expectedB);
+    checkMatrixEqual(merged.c, expectedC);
+    checkMatrixEqual(merged.d, expectedD);
+}
+
+void checkEmptyMergedMatrices(const MergedMatrices& merged)
+{
+    BOOST_CHECK_EQUAL(merged.b.N(), std::size_t{0});
+    BOOST_CHECK_EQUAL(merged.b.M(), numResDof);
+    BOOST_CHECK_EQUAL(merged.c.N(), numResDof);
+    BOOST_CHECK_EQUAL(merged.c.M(), std::size_t{0});
+    BOOST_CHECK_EQUAL(merged.d.N(), std::size_t{0});
+    BOOST_CHECK_EQUAL(merged.d.M(), std::size_t{0});
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(MergeHandlesEmptyWellSet)
+{
+    const TestMatrices matrices;
+    const Opm::WellMatrixMerger<Scalar> merger(
+        numResDof,
+        matrices.bMatrices,
+        matrices.cMatrices,
+        matrices.dMatrices,
+        matrices.wellCells);
+    const auto structure = merger.buildStructure();
+
+    BOOST_CHECK_EQUAL(structure.numResDofs, numResDof);
+    BOOST_CHECK_EQUAL(structure.totalWellBlocks, std::size_t{0});
+
+    const auto merged = buildMergedMatrices(matrices);
+    checkEmptyMergedMatrices(merged);
+}
+
+BOOST_AUTO_TEST_CASE(MergeBuildsExpectedMatricesAndStructure)
+{
+    const auto matrices = buildTestMatrices();
+    const Opm::WellMatrixMerger<Scalar> merger(
+        numResDof,
+        matrices.bMatrices,
+        matrices.cMatrices,
+        matrices.dMatrices,
+        matrices.wellCells);
+    const auto structure = merger.buildStructure();
+
+    // The cached structure records both the perforated-cell mapping and the
+    // exact sparsity of every per-well B, C and D block.
+    BOOST_CHECK_EQUAL(structure.totalWellBlocks, std::size_t{3});
+    BOOST_CHECK(structure.wellCells == matrices.wellCells);
+    BOOST_REQUIRE_EQUAL(structure.bPatterns.size(), matrices.bMatrices.size());
+    BOOST_REQUIRE_EQUAL(structure.cPatterns.size(), matrices.cMatrices.size());
+    BOOST_REQUIRE_EQUAL(structure.dPatterns.size(), matrices.dMatrices.size());
+    BOOST_CHECK(structure.bPatterns[0] == Opm::captureMatrixSparsity(matrices.bMatrices[0]));
+    BOOST_CHECK(structure.cPatterns[1] == Opm::captureMatrixSparsity(matrices.cMatrices[1]));
+    BOOST_CHECK(structure.dPatterns[0] == Opm::captureMatrixSparsity(matrices.dMatrices[0]));
+    BOOST_CHECK(merger.hasSameStructure(structure));
+
+    const auto merged = buildMergedMatrices(matrices);
+    checkMergedMatrices(merged);
+}
+
+BOOST_AUTO_TEST_CASE(UpdateValuesReusesMergedStructure)
+{
+    auto matrices = buildTestMatrices();
+    const Opm::WellMatrixMerger<Scalar> merger(
+        numResDof,
+        matrices.bMatrices,
+        matrices.cMatrices,
+        matrices.dMatrices,
+        matrices.wellCells);
+    auto merged = buildMergedMatrices(matrices);
+
+    const auto mergedBPattern = Opm::captureMatrixSparsity(merged.b);
+    const auto mergedCPattern = Opm::captureMatrixSparsity(merged.c);
+    const auto mergedDPattern = Opm::captureMatrixSparsity(merged.d);
+
+    updateSourceValues(matrices);
+    const Opm::WellMatrixMerger<Scalar> updatedMerger(
+        numResDof,
+        matrices.bMatrices,
+        matrices.cMatrices,
+        matrices.dMatrices,
+        matrices.wellCells);
+    updatedMerger.updateValues(merged.b, merged.c, merged.d);
+
+    BOOST_CHECK(mergedBPattern == Opm::captureMatrixSparsity(merged.b));
+    BOOST_CHECK(mergedCPattern == Opm::captureMatrixSparsity(merged.c));
+    BOOST_CHECK(mergedDPattern == Opm::captureMatrixSparsity(merged.d));
+    BOOST_CHECK(merger.hasSameStructure(updatedMerger.buildStructure()));
+    checkUpdatedMergedMatrices(merged);
+}
+
+BOOST_AUTO_TEST_CASE(StructureChangesWhenWellPatternChanges)
+{
+    const auto matrices = buildTestMatrices();
+    auto changedDMatrices = matrices.dMatrices;
+    changedDMatrices[0] = buildMatrix<WWMatrix>(
+        2,
+        2,
+        MatrixPattern{{
+            MatrixRow{entry(0, 50.0)},
+            MatrixRow{entry(1, 80.0)}
+        }});
+
+    // Mimic an MSW topology change: same number of segments, but the segment
+    // connections disappear from D. The cached well structure must change
+    // even though the matrix dimensions stay the same.
+    const Opm::WellMatrixMerger<Scalar> referenceMerger(
+        numResDof,
+        matrices.bMatrices,
+        matrices.cMatrices,
+        matrices.dMatrices,
+        matrices.wellCells);
+    const Opm::WellMatrixMerger<Scalar> changedMerger(
+        numResDof,
+        matrices.bMatrices,
+        matrices.cMatrices,
+        changedDMatrices,
+        matrices.wellCells);
+    const auto reference = referenceMerger.buildStructure();
+    const auto changed = changedMerger.buildStructure();
+
+    BOOST_CHECK(referenceMerger.hasSameStructure(reference));
+    BOOST_CHECK(!changedMerger.hasSameStructure(reference));
+    BOOST_CHECK_EQUAL(reference.totalWellBlocks, changed.totalWellBlocks);
+    BOOST_CHECK(reference != changed);
+    BOOST_CHECK(reference.dPatterns[0] != changed.dPatterns[0]);
+}
+
+BOOST_AUTO_TEST_CASE(StructureChangesWhenCouplingPatternChanges)
+{
+    const auto matrices = buildTestMatrices();
+    auto changedBMatrices = matrices.bMatrices;
+    // Remove one of the standard well's B couplings while keeping the block
+    // dimensions unchanged. That should only change the cached B pattern for
+    // well 1, leaving the corresponding C and D patterns untouched.
+    changedBMatrices[1] = buildMatrix<WRMatrix>(
+        1,
+        2,
+        MatrixPattern{{
+            MatrixRow{entry(0, 90.0)}
+        }});
+
+    const Opm::WellMatrixMerger<Scalar> referenceMerger(
+        numResDof,
+        matrices.bMatrices,
+        matrices.cMatrices,
+        matrices.dMatrices,
+        matrices.wellCells);
+    const Opm::WellMatrixMerger<Scalar> changedMerger(
+        numResDof,
+        changedBMatrices,
+        matrices.cMatrices,
+        matrices.dMatrices,
+        matrices.wellCells);
+    const auto reference = referenceMerger.buildStructure();
+    const auto changed = changedMerger.buildStructure();
+
+    BOOST_CHECK(!changedMerger.hasSameStructure(reference));
+    BOOST_CHECK(reference.bPatterns[1] != changed.bPatterns[1]);
+    BOOST_CHECK(reference.cPatterns[1] == changed.cPatterns[1]);
+    BOOST_CHECK(reference.dPatterns[1] == changed.dPatterns[1]);
+}
+
+BOOST_AUTO_TEST_CASE(StructureChangesWhenPerforationMappingChanges)
+{
+
+    const auto matrices = buildTestMatrices();
+
+    // Build a new wellCells table with row 1 swapped
+    Opm::SparseTable<int> changedWellCells;
+    changedWellCells.clear();
+    // Row 0 unchanged: copy from the original matrices
+    changedWellCells.appendRow(matrices.wellCells[0].begin(),
+                               matrices.wellCells[0].end());
+    // Row 1: swap the two perforation cells (4 and 0)
+    constexpr std::array<int, 2> newRow{4, 0};
+    changedWellCells.appendRow(newRow.begin(), newRow.end());
+
+    const Opm::WellMatrixMerger<Scalar> referenceMerger(
+        numResDof,
+        matrices.bMatrices,
+        matrices.cMatrices,
+        matrices.dMatrices,
+        matrices.wellCells);
+    const Opm::WellMatrixMerger<Scalar> changedMerger(
+        numResDof,
+        matrices.bMatrices,
+        matrices.cMatrices,
+        matrices.dMatrices,
+        changedWellCells);
+    const auto reference = referenceMerger.buildStructure();
+    const auto changed = changedMerger.buildStructure();
+
+    BOOST_CHECK(!changedMerger.hasSameStructure(reference));
+    BOOST_CHECK(reference != changed);
+    BOOST_CHECK(reference.wellCells != changed.wellCells);
+}
+

--- a/tests/test_setuppropertytree.cpp
+++ b/tests/test_setuppropertytree.cpp
@@ -1,0 +1,90 @@
+/*
+  Copyright 2025 SINTEF Digital, Mathematics and Cybernetics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#define BOOST_TEST_MODULE TestSetupPropertyTree
+
+#ifndef HAVE_MPI
+#define HAVE_MPI 0
+#endif
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/simulators/linalg/PropertyTree.hpp>
+#include <opm/simulators/linalg/setupPropertyTree.hpp>
+
+#include <stdexcept>
+
+BOOST_AUTO_TEST_SUITE(SystemCPR)
+
+// Unit test 1: JSON file with system_cpr but missing well_solver must throw.
+//
+// options_system_cpr_missing_well.json contains reservoir_smoother and
+// reservoir_solver but no well_solver. validateSystemCPRTree must catch this
+// at setup time so the error is clear rather than a cryptic PropertyTree
+// exception from deep inside SystemPreconditioner::initSubSolvers.
+BOOST_AUTO_TEST_CASE(JSONMissingWellSolver)
+{
+    Opm::PropertyTree prm("options_system_cpr_missing_well.json");
+    BOOST_CHECK_THROW(Opm::validateSystemCPRTree(prm), std::invalid_argument);
+}
+
+// Unit test 2: JSON file with system_cpr but missing reservoir_solver must throw.
+BOOST_AUTO_TEST_CASE(JSONMissingReservoirSolver)
+{
+    Opm::PropertyTree prm("options_system_cpr_missing_ressolver.json");
+    BOOST_CHECK_THROW(Opm::validateSystemCPRTree(prm), std::invalid_argument);
+}
+
+// Unit test 3: JSON file with system_cpr but missing reservoir_smoother must throw.
+BOOST_AUTO_TEST_CASE(JSONMissingReservoirSmoother)
+{
+    Opm::PropertyTree prm("options_system_cpr_missing_smoother.json");
+    BOOST_CHECK_THROW(Opm::validateSystemCPRTree(prm), std::invalid_argument);
+}
+
+// Unit test 3: JSON has reservoir_solver but no preconditioner.type (or no preconditioner at all)
+BOOST_AUTO_TEST_CASE(JSONReservoirSolverPreconditionerTypeMissingOrWrong)
+{
+    // Test missing type
+    Opm::PropertyTree prm("options_system_cpr_missing_precond_type.json");
+    BOOST_CHECK_THROW(Opm::validateSystemCPRTree(prm), std::invalid_argument);
+
+    // Test wrong type (e.g., "ilu")
+    Opm::PropertyTree prm2("options_system_cpr_res_precond_not_cpr.json");
+    BOOST_CHECK_THROW(Opm::validateSystemCPRTree(prm2), std::invalid_argument);
+}
+
+// Regression test: --matrix-add-well-contributions=true is incompatible
+// with system_cpr and must throw in both serial and parallel (MPI) runs.
+//
+// system_cpr handles reservoir-well coupling in the outer three-stage
+// SystemPreconditioner. Enabling matrix well contributions merges well rows
+// into the reservoir block before that preconditioner runs, which would
+// double-count the coupling and corrupt the linear system.
+// ISTLSolverRuntimeOptionProxy::createSolver delegates to this function,
+// making the invariant unit-testable without the full simulator framework.
+BOOST_AUTO_TEST_CASE(MatrixAddWellContributionsIncompatible)
+{
+    BOOST_CHECK_THROW(Opm::checkSystemCPRMatrixAddWell(true),  std::invalid_argument);
+    BOOST_CHECK_NO_THROW(Opm::checkSystemCPRMatrixAddWell(false));
+}
+
+BOOST_AUTO_TEST_SUITE_END() // SystemCPR


### PR DESCRIPTION
We will close https://github.com/OPM/opm-simulators/pull/6751 and make a new PR from @jakobtorben and @hnil 

**Draft PR: Coupled Reservoir–Well Linear Solver (system_cpr)**
This PR introduces a prototype for solving the reservoir and well degrees of freedom as a single coupled linear system, rather than handling wells separately through Schur complement elimination.
The preconditioner is functionally equivalent to the existing cpr (not cprw) and serves as a baseline to validate correctness before further tuning.
 **Features**
- Linear solve operates on the full coupled system (reservoir + well DOFs)
- The underlying linear solver works with standard sparse matrices — no special well-aware operators required 
- Preconditioner is configurable to reproduce standard CPR behavior exactly
- Supports an approximate well-block solve; performance impact to be benchmarked
- The new preconditioner can be used with --linear-solver=system_cpr