### PR TITLE
[LGR Summary] Produce per-LGR-cell LB* block-summary values and gather them to the I/O rank

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -496,6 +496,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_interregflows.cpp
   tests/test_invert.cpp
   tests/test_keyword_validator.cpp
+  tests/test_LgrBlockData.cpp
   tests/test_linearleastsquares.cpp
   tests/test_LogOutputHelper.cpp
   tests/test_milu.cpp

--- a/opm/simulators/flow/CollectDataOnIORank.hpp
+++ b/opm/simulators/flow/CollectDataOnIORank.hpp
@@ -41,6 +41,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -89,6 +90,9 @@ public:
 
     const std::map<std::pair<std::string, int>, double>& globalBlockData() const
     { return globalBlockData_; }
+
+    const std::map<std::tuple<std::string, int, int>, double>& globalLgrBlockData() const
+    { return globalLgrBlockData_; }
 
     const data::Solution& globalCellData() const
     { return globalCellData_; }
@@ -156,6 +160,7 @@ protected:
     std::vector<int> globalRanks_;
     data::Solution globalCellData_;
     std::map<std::pair<std::string, int>, double> globalBlockData_;
+    std::map<std::tuple<std::string, int, int>, double> globalLgrBlockData_;
     data::Wells globalWellData_;
     data::WellBlockAveragePressures globalWBPData_;
     data::GroupAndNetworkValues globalGroupAndNetworkData_;

--- a/opm/simulators/flow/CollectDataOnIORank.hpp
+++ b/opm/simulators/flow/CollectDataOnIORank.hpp
@@ -86,7 +86,8 @@ public:
                  const WellTestState&                                 localWellTestState,
                  const InterRegFlowMap&                               interRegFlows,
                  const std::array<FlowsData<double>, 3>&              localFlowsn,
-                 const std::array<FlowsData<double>, 3>&              localFloresn);
+                 const std::array<FlowsData<double>, 3>&              localFloresn,
+                 const std::map<std::tuple<std::string, int, int>, double>& localLgrBlockData);
 
     const std::map<std::pair<std::string, int>, double>& globalBlockData() const
     { return globalBlockData_; }

--- a/opm/simulators/flow/CollectDataOnIORank_impl.hpp
+++ b/opm/simulators/flow/CollectDataOnIORank_impl.hpp
@@ -559,8 +559,9 @@ public:
     void pack(int link, MessageBufferType& buffer)
     {
         // we should only get one link
-        if (link != 0)
+        if (link != 0) {
             throw std::logic_error("link in method pack is not 0 as expected");
+        }
 
         packKeyedBlockMap(localLgrBlockData_, buffer);
     }

--- a/opm/simulators/flow/CollectDataOnIORank_impl.hpp
+++ b/opm/simulators/flow/CollectDataOnIORank_impl.hpp
@@ -1025,10 +1025,12 @@ collect(const data::Solution&                                localCellData,
         const WellTestState&                                 localWellTestState,
         const InterRegFlowMap&                               localInterRegFlows,
         const std::array<FlowsData<double>, 3>&              localFlowsn,
-        const std::array<FlowsData<double>, 3>&              localFloresn)
+        const std::array<FlowsData<double>, 3>&              localFloresn,
+        const std::map<std::tuple<std::string, int, int>, double>& localLgrBlockData)
 {
     globalCellData_ = {};
     globalBlockData_.clear();
+    globalLgrBlockData_.clear();
     std::map<std::pair<std::string,int>,double> globalExtraBlockData;
     globalWellData_.clear();
     globalWBPData_.values.clear();
@@ -1090,6 +1092,12 @@ collect(const data::Solution&                                localCellData,
         this->isIORank()
     };
 
+    PackUnPackLgrBlockData packUnpackLgrBlockData {
+        localLgrBlockData,
+        this->globalLgrBlockData_,
+        this->isIORank()
+    };
+
     PackUnPackWBPData packUnpackWBPData {
         localWBPData,
         this->globalWBPData_,
@@ -1131,6 +1139,7 @@ collect(const data::Solution&                                localCellData,
     toIORankComm_.exchange(packUnpackGroupAndNetworkData);
     toIORankComm_.exchange(packUnpackBlockData);
     toIORankComm_.exchange(packUnpackExtraBlockData);
+    toIORankComm_.exchange(packUnpackLgrBlockData);
     toIORankComm_.exchange(packUnpackWBPData);
     toIORankComm_.exchange(packUnpackAquiferData);
     toIORankComm_.exchange(packUnpackWellTestState);

--- a/opm/simulators/flow/CollectDataOnIORank_impl.hpp
+++ b/opm/simulators/flow/CollectDataOnIORank_impl.hpp
@@ -37,6 +37,8 @@
 #include <cassert>
 #include <stdexcept>
 #include <string>
+#include <tuple>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -461,6 +463,37 @@ public:
     { this->globalGroupAndNetworkData_.read(buffer); }
 };
 
+// Shared serialisation for the block-summary gather handles.  The global B* map is
+// keyed by std::pair<keyword, cartesian-index>; the LGR LB* map by
+// std::tuple<keyword, level, level-local-cartesian-index>.  std::apply serialises
+// either key shape: write the map size, then every key field (pair or tuple) followed
+// by the value -- one body, thin per-key callers (mirrors the producer-side
+// makeExtractor de-duplication).
+template <class KeyedMap, class MessageBufferType>
+void packKeyedBlockMap(const KeyedMap& localData, MessageBufferType& buffer)
+{
+    const unsigned int size = localData.size();
+    buffer.write(size);
+    for (const auto& [key, value] : localData) {
+        std::apply([&buffer](const auto&... field) { (buffer.write(field), ...); }, key);
+        buffer.write(value);
+    }
+}
+
+template <class KeyedMap, class MessageBufferType>
+void unpackKeyedBlockMap(KeyedMap& globalData, MessageBufferType& buffer)
+{
+    unsigned int size = 0;
+    buffer.read(size);
+    for (unsigned int i = 0; i < size; ++i) {
+        typename KeyedMap::key_type key{};
+        std::apply([&buffer](auto&... field) { (buffer.read(field), ...); }, key);
+        typename KeyedMap::mapped_type value{};
+        buffer.read(value);
+        globalData[key] = value;
+    }
+}
+
 class PackUnPackBlockData : public P2PCommunicatorType::DataHandleInterface
 {
     const std::map<std::pair<std::string, int>, double>& localBlockData_;
@@ -490,31 +523,52 @@ public:
         if (link != 0)
             throw std::logic_error("link in method pack is not 0 as expected");
 
-        // write all block data
-        unsigned int size = localBlockData_.size();
-        buffer.write(size);
-        for (const auto& map : localBlockData_) {
-            buffer.write(map.first.first);
-            buffer.write(map.first.second);
-            buffer.write(map.second);
-        }
+        packKeyedBlockMap(localBlockData_, buffer);
     }
 
     // unpack all data associated with link
     void unpack(int /*link*/, MessageBufferType& buffer)
     {
-        // read all block data
-        unsigned int size = 0;
-        buffer.read(size);
-        for (std::size_t i = 0; i < size; ++i) {
-            std::string name;
-            int idx;
-            double data;
-            buffer.read(name);
-            buffer.read(idx);
-            buffer.read(data);
-            globalBlockValues_[std::make_pair(name, idx)] = data;
+        unpackKeyedBlockMap(globalBlockValues_, buffer);
+    }
+};
+
+class PackUnPackLgrBlockData : public P2PCommunicatorType::DataHandleInterface
+{
+    const std::map<std::tuple<std::string, int, int>, double>& localLgrBlockData_;
+    std::map<std::tuple<std::string, int, int>, double>& globalLgrBlockValues_;
+
+public:
+    PackUnPackLgrBlockData(const std::map<std::tuple<std::string, int, int>, double>& localLgrBlockData,
+                           std::map<std::tuple<std::string, int, int>, double>& globalLgrBlockValues,
+                           bool isIORank)
+        : localLgrBlockData_(localLgrBlockData)
+        , globalLgrBlockValues_(globalLgrBlockValues)
+    {
+        if (isIORank) {
+            MessageBufferType buffer;
+            pack(0, buffer);
+
+            // pass a dummyLink to satisfy virtual class
+            int dummyLink = -1;
+            unpack(dummyLink, buffer);
         }
+    }
+
+    // pack all data associated with link
+    void pack(int link, MessageBufferType& buffer)
+    {
+        // we should only get one link
+        if (link != 0)
+            throw std::logic_error("link in method pack is not 0 as expected");
+
+        packKeyedBlockMap(localLgrBlockData_, buffer);
+    }
+
+    // unpack all data associated with link
+    void unpack(int /*link*/, MessageBufferType& buffer)
+    {
+        unpackKeyedBlockMap(globalLgrBlockValues_, buffer);
     }
 };
 

--- a/opm/simulators/flow/CollectDataOnIORank_impl.hpp
+++ b/opm/simulators/flow/CollectDataOnIORank_impl.hpp
@@ -35,9 +35,13 @@
 
 #include <algorithm>
 #include <cassert>
+#include <concepts>
+#include <cstddef>
+#include <ranges>
 #include <stdexcept>
 #include <string>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -469,7 +473,31 @@ public:
 // either key shape: write the map size, then every key field (pair or tuple) followed
 // by the value -- one body, thin per-key callers (mirrors the producer-side
 // makeExtractor de-duplication).
-template <class KeyedMap, class MessageBufferType>
+// Constrain the container to a map-like type (key_type/mapped_type +
+// insert_or_assign) rather than hard-coding std::map/std::unordered_map.
+template <typename C>
+concept MapLikeContainer =
+    std::ranges::input_range<C> &&
+    requires {
+        typename C::key_type;
+        typename C::mapped_type;
+    } &&
+    requires (C& container,
+              const typename C::key_type& key,
+              typename C::mapped_type     value)
+    {
+        { container.insert_or_assign(key, std::move(value)) };
+    };
+
+// range_value_t of a map is std::pair<const Key, Value>, so first_type is
+// const-qualified; strip the const so the unpack side can fill a writable key.
+template <MapLikeContainer C>
+using KeyTypeOf = std::remove_const_t<typename std::ranges::range_value_t<C>::first_type>;
+
+template <MapLikeContainer C>
+using MappedTypeOf = typename std::ranges::range_value_t<C>::second_type;
+
+template <MapLikeContainer KeyedMap, class MessageBufferType>
 void packKeyedBlockMap(const KeyedMap& localData, MessageBufferType& buffer)
 {
     const unsigned int size = localData.size();
@@ -480,17 +508,29 @@ void packKeyedBlockMap(const KeyedMap& localData, MessageBufferType& buffer)
     }
 }
 
-template <class KeyedMap, class MessageBufferType>
+template <MapLikeContainer KeyedMap, class MessageBufferType>
 void unpackKeyedBlockMap(KeyedMap& globalData, MessageBufferType& buffer)
 {
     unsigned int size = 0;
     buffer.read(size);
+
+    // std::map has no reserve(); the probe compiles the call out for it, but keeps
+    // the helper correct should a hashed container be substituted later.
+    if constexpr (requires (KeyedMap& m, std::size_t n) { m.reserve(n); }) {
+        globalData.reserve(globalData.size() + size);
+    }
+
     for (unsigned int i = 0; i < size; ++i) {
-        typename KeyedMap::key_type key{};
+        KeyTypeOf<KeyedMap> key{};
         std::apply([&buffer](auto&... field) { (buffer.read(field), ...); }, key);
-        typename KeyedMap::mapped_type value{};
+
+        MappedTypeOf<KeyedMap> value{};
         buffer.read(value);
-        globalData[key] = value;
+
+        // Duplicate keys are not expected here -- they would mean two ranks claim
+        // the same cell. Were one to occur, insert_or_assign() overwrites (last
+        // wins) and try_emplace() would keep the first; we overwrite.
+        globalData.insert_or_assign(std::move(key), std::move(value));
     }
 }
 

--- a/opm/simulators/flow/EclGenericWriter.hpp
+++ b/opm/simulators/flow/EclGenericWriter.hpp
@@ -146,6 +146,7 @@ protected:
                      const data::GroupAndNetworkValues&                   localGroupAndNetworkData,
                      const std::map<int,data::AquiferData>&               localAquiferData,
                      const std::map<std::pair<std::string, int>, double>& blockData,
+                     const std::map<std::tuple<std::string, int, int>, double>& lgrBlockData,
                      const std::map<std::string, double>&                 miscSummaryData,
                      const std::map<std::string, std::vector<double>>&    regionData,
                      const Inplace&                                       inplace,

--- a/opm/simulators/flow/EclGenericWriter_impl.hpp
+++ b/opm/simulators/flow/EclGenericWriter_impl.hpp
@@ -1025,6 +1025,7 @@ evalSummary(const int                                            reportStepNum,
             const data::GroupAndNetworkValues&                   localGroupAndNetworkData,
             const std::map<int,data::AquiferData>&               localAquiferData,
             const std::map<std::pair<std::string, int>, double>& blockData,
+            const std::map<std::tuple<std::string, int, int>, double>& lgrBlockData,
             const std::map<std::string, double>&                 miscSummaryData,
             const std::map<std::string, std::vector<double>>&    regionData,
             const Inplace&                                       inplace,
@@ -1068,7 +1069,8 @@ evalSummary(const int                                            reportStepNum,
             /* inplace                 = */ {
                 /* current = */ &inplace,
                 /* initial = */ initialInPlace
-            }
+            },
+            /* lgr_block_values        = */ &lgrBlockData
         };
 
         summary.eval(reportStepNum, curTime, values, summaryState);

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -265,7 +265,8 @@ public:
                                            localWellTestState,
                                            this->outputModule_->getInterRegFlows(),
                                            {},
-                                           {});
+                                           {},
+                                           this->outputModule_->getLgrBlockData());
 
             if (this->collectOnIORank_.isIORank()) {
                 auto& iregFlows = this->collectOnIORank_.globalInterRegFlows();
@@ -336,9 +337,9 @@ public:
                 ? this->collectOnIORank_.globalBlockData()
                 : this->outputModule_->getBlockData();
 
-            // LGR block summary values: single-process only.  Parallel
-            // is a separate part of the project.
-            const auto& lgrBlockData = this->outputModule_->getLgrBlockData();
+            const auto& lgrBlockData = this->collectOnIORank_.isParallel()
+                ? this->collectOnIORank_.globalLgrBlockData()
+                : this->outputModule_->getLgrBlockData();
 
             const auto& interRegFlows = this->collectOnIORank_.isParallel()
                 ? this->collectOnIORank_.globalInterRegFlows()
@@ -506,7 +507,8 @@ public:
                                            localWellTestState,
                                            /* interRegFlows = */ {},
                                            flowsn,
-                                           floresn);
+                                           floresn,
+                                           /* lgrBlockData = */ {});
             if (this->collectOnIORank_.isIORank()) {
                 this->outputModule_->assignGlobalFieldsToSolution(this->collectOnIORank_.globalCellData());
             }

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -336,6 +336,10 @@ public:
                 ? this->collectOnIORank_.globalBlockData()
                 : this->outputModule_->getBlockData();
 
+            // LGR block summary values: single-process only.  Parallel
+            // is a separate part of the project.
+            const auto& lgrBlockData = this->outputModule_->getLgrBlockData();
+
             const auto& interRegFlows = this->collectOnIORank_.isParallel()
                 ? this->collectOnIORank_.globalInterRegFlows()
                 : this->outputModule_->getInterRegFlows();
@@ -347,6 +351,7 @@ public:
                               localGroupAndNetworkData,
                               localAquiferData,
                               blockData,
+                              lgrBlockData,
                               miscSummaryData,
                               regionData,
                               inplace,

--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -1170,6 +1170,39 @@ setupBlockData(std::function<bool(int)> isCartIdxOnThisRank)
 
 template<class FluidSystem>
 void GenericOutputBlackoilModule<FluidSystem>::
+setupLgrBlockData(const EclipseGrid& eclGrid)
+{
+    // Allocate one lgrBlockData_ slot per LB* summary node.  The level
+    // component of the key is the same value data::Connection carries as
+    // lgr_grid for LC* connection vectors -- get_lgr_cell_index returns the
+    // 0-based position of the label in the GLOBAL-stripped LGR list, so a
+    // +1 recovers the on-disk level id (0 = GLOBAL, 1..N = LGRs).  The
+    // level-local linearised Cartesian cell index is recovered from
+    // node.number() - 1 (SummaryConfig::keywordLB stored NUMS = index + 1
+    // via GridDims::getGlobalIndex on the LGR's dimensions at parse time).
+    //
+    // No rank check here: ownership for LGR leaf cells is decided in the
+    // element walk via Dune::InteriorEntity; the existing
+    // isCartIdxOnThisRank predicate is a global-Cartesian check that does
+    // not apply to LGR cells.
+    for (const auto& node : summaryConfig_) {
+        if (node.category() != SummaryConfigNode::Category::Block) {
+            continue;
+        }
+        if (! node.lgr_name().has_value()) {
+            continue;
+        }
+
+        const int level = static_cast<int>(
+            eclGrid.get_lgr_cell_index(*node.lgr_name())) + 1;
+        const int local = node.number() - 1;
+
+        this->lgrBlockData_[std::make_tuple(node.keyword(), level, local)] = 0.0;
+    }
+}
+
+template<class FluidSystem>
+void GenericOutputBlackoilModule<FluidSystem>::
 setupExtraBlockData(const std::size_t        reportStepNum,
                     std::function<bool(int)> isCartIdxOnThisRank)
 {

--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -1170,21 +1170,26 @@ setupBlockData(std::function<bool(int)> isCartIdxOnThisRank)
 
 template<class FluidSystem>
 void GenericOutputBlackoilModule<FluidSystem>::
-setupLgrBlockData(const EclipseGrid& eclGrid)
+setupLgrBlockData(const std::map<std::string, int>& lgrNameToLevel,
+                  const std::function<bool(int, int)>& isLgrCellOnThisRank)
 {
     // Allocate one lgrBlockData_ slot per LB* summary node.  The level
     // component of the key is the same value data::Connection carries as
-    // lgr_grid for LC* connection vectors -- get_lgr_cell_index returns the
-    // 0-based position of the label in the GLOBAL-stripped LGR list, so a
-    // +1 recovers the on-disk level id (0 = GLOBAL, 1..N = LGRs).  The
-    // level-local linearised Cartesian cell index is recovered from
-    // node.number() - 1 (SummaryConfig::keywordLB stored NUMS = index + 1
-    // via GridDims::getGlobalIndex on the LGR's dimensions at parse time).
+    // lgr_grid for LC* connection vectors -- lgrNameToLevel maps the summary
+    // node's LGR name to that level id (0 = GLOBAL, 1..N = LGRs).  It is the
+    // CpGrid name->level map (getLgrNameToLevel), populated on every rank --
+    // the parallel-safe replacement for EclipseGrid::get_lgr_cell_index, which
+    // is root-only on a ParallelEclipseState.  The level-local linearised
+    // Cartesian cell index is recovered from node.number() - 1 (SummaryConfig::
+    // keywordLB stored NUMS = index + 1 via GridDims::getGlobalIndex at parse).
     //
-    // No rank check here: ownership for LGR leaf cells is decided in the
-    // element walk via Dune::InteriorEntity; the existing
-    // isCartIdxOnThisRank predicate is a global-Cartesian check that does
-    // not apply to LGR cells.
+    // Allocate a slot only for an LGR cell this rank owns, so lgrBlockData_ is
+    // per-rank disjoint before setupLgrExecMap captures pointers into it -- the
+    // direct LGR analogue of setupBlockData's isCartIdxOnThisRank filter.  The
+    // caller builds isLgrCellOnThisRank from the same InteriorEntity leaf walk
+    // and level-local Cartesian index (levelCartesianIndexMapper) the fill walk
+    // uses, which coincides with the node.number()-1 'local' below; the global
+    // isCartIdxOnThisRank does not apply to LGR cells.
     for (const auto& node : summaryConfig_) {
         if (node.category() != SummaryConfigNode::Category::Block) {
             continue;
@@ -1193,11 +1198,18 @@ setupLgrBlockData(const EclipseGrid& eclGrid)
             continue;
         }
 
-        const int level = static_cast<int>(
-            eclGrid.get_lgr_cell_index(*node.lgr_name())) + 1;
+        const auto level_it = lgrNameToLevel.find(*node.lgr_name());
+        if (level_it == lgrNameToLevel.end()) {
+            // LGR not present on this grid (e.g. a non-CpGrid build passes an
+            // empty map) -- nothing to allocate for it.
+            continue;
+        }
+        const int level = level_it->second;
         const int local = node.number() - 1;
 
-        this->lgrBlockData_[std::make_tuple(node.keyword(), level, local)] = 0.0;
+        if (isLgrCellOnThisRank(level, local)) {
+            this->lgrBlockData_[std::make_tuple(node.keyword(), level, local)] = 0.0;
+        }
     }
 }
 

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -386,7 +386,8 @@ protected:
     // Caller-supplied via parameter rather than read from a member to keep
     // this module decoupled from EclipseState ownership (matching how the
     // existing block path receives its rank predicate as an argument).
-    void setupLgrBlockData(const EclipseGrid& eclGrid);
+    void setupLgrBlockData(const std::map<std::string, int>& lgrNameToLevel,
+                           const std::function<bool(int, int)>& isLgrCellOnThisRank);
 
     virtual bool isDefunctParallelWell(const std::string& wname) const = 0;
     virtual bool isOwnedByCurrentRank(const std::string& wname) const = 0;

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -53,6 +53,7 @@
 #include <functional>
 #include <map>
 #include <optional>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -68,6 +69,7 @@ namespace Opm {
 
 namespace data { class Solution; }
 class EclHysteresisConfig;
+class EclipseGrid;
 class EclipseState;
 class Schedule;
 class SummaryConfig;
@@ -248,6 +250,16 @@ public:
         return extraBlockData_;
     }
 
+    // Per-LGR-cell block-summary results.  Cell identity is the
+    // (keyword, grid level, level-local linearised Cartesian cell index)
+    // tuple — the same identity data::Connection carries as
+    // (lgr_grid, index) for LC* connection vectors.  Empty for runs
+    // without LB* summary requests.
+    const std::map<std::tuple<std::string, int, int>, double>& getLgrBlockData() const
+    {
+        return lgrBlockData_;
+    }
+
     const Inplace* initialInplace() const
     {
         return this->initialInplace_.has_value()
@@ -360,6 +372,22 @@ protected:
     void setupExtraBlockData(const std::size_t        reportStepNum,
                              std::function<bool(int)> isCartIdxOnThisRank);
 
+    // Allocate lgrBlockData_ slots for every Block-category summary node
+    // that names an LGR cell.  The level component of the key is resolved
+    // through EclipseGrid::get_lgr_cell_index (the same call data::Connection
+    // uses for lgr_grid on LC* connection vectors); the level-local
+    // linearised Cartesian index is recovered from node.number - 1.
+    //
+    // No rank check here — ownership for LGR leaf cells is decided in the
+    // walk via Dune::InteriorEntity on the leaf entity; the existing
+    // isCartIdxOnThisRank predicate operates in the global Cartesian space,
+    // which LGR cells do not inhabit.
+    //
+    // Caller-supplied via parameter rather than read from a member to keep
+    // this module decoupled from EclipseState ownership (matching how the
+    // existing block path receives its rank predicate as an argument).
+    void setupLgrBlockData(const EclipseGrid& eclGrid);
+
     virtual bool isDefunctParallelWell(const std::string& wname) const = 0;
     virtual bool isOwnedByCurrentRank(const std::string& wname) const = 0;
     virtual bool isOnCurrentRank(const std::string& wname) const = 0;
@@ -470,6 +498,13 @@ protected:
     // Extra block data required for non-summary output reasons
     // Example is the block pressures for RPTSCHED WELLS=2
     std::map<std::pair<std::string, int>, double> extraBlockData_;
+
+    // Per-LGR-cell block-summary results.  Keyed by (keyword, grid level,
+    // level-local linearised Cartesian cell index).  The map type matches
+    // Summary::DynamicSimulatorState::LgrBlockValues so the writer can hand
+    // a pointer to this member directly to the summary engine.  Empty for
+    // runs that request no LB* summary vectors (zero non-LGR cost).
+    std::map<std::tuple<std::string, int, int>, double> lgrBlockData_;
 
     std::optional<Inplace> initialInplace_;
     bool local_data_valid_{false};

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -183,8 +183,13 @@ public:
         this->setupBlockData(isCartIdxOnThisRank);
 
         // Allocate slots for LB* summary nodes that name a cell inside an
-        // LGR.  Empty for runs without LB* requests (zero non-LGR cost).
-        this->setupLgrBlockData(simulator.vanguard().eclState().getInputGrid());
+        // LGR.  Single-process only: the gather of LGR-cell values to the I/O
+        // rank is a separate change, so skip setup under MPI to keep the LGR
+        // producer path inert and avoid desyncing the ranks in the collective
+        // output walk.  Empty for runs without LB* requests (zero non-LGR cost).
+        if (! collectOnIORank.isParallel()) {
+            this->setupLgrBlockData(simulator.vanguard().eclState().getInputGrid());
+        }
 
         if (! Parameters::Get<Parameters::OwnerCellsFirst>()) {
             const std::string msg = "The output code does not support --owner-cells-first=false.";

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -29,6 +29,8 @@
 
 #include <dune/common/fvector.hh>
 
+#include <opm/grid/CpGrid.hpp>
+
 #include <opm/simulators/utils/moduleVersion.hpp>
 
 #include <opm/common/Exceptions.hpp>
@@ -308,19 +310,66 @@ public:
             return;
         }
 
-        if (this->blockExtractors_.empty() && this->extraBlockExtractors_.empty()) {
+        if (this->blockExtractors_.empty() &&
+            this->extraBlockExtractors_.empty() &&
+            this->lgrBlockExtractors_.empty())
+        {
             return;
         }
 
-        for (unsigned dofIdx = 0; dofIdx < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++dofIdx) {
-            // Adding block data
-            const auto globalDofIdx = elemCtx.globalSpaceIndex(dofIdx, /*timeIdx=*/0);
-            const auto cartesianIdx = elemCtx.simulator().vanguard().cartesianIndex(globalDofIdx);
+        // For EcfvDiscretization there is one degree of freedom per
+        // element, so the element's level determines whether the cell
+        // sits in the global grid (level == 0) or inside a local grid
+        // refinement (level > 0).  Branching here keeps the global B*
+        // lookup off the LGR-cell path and vice versa; non-LGR runs
+        // never enter the LGR branch.
+        const auto& element = elemCtx.element();
+        const int   level   = element.level();
 
-            const auto be_it = this->blockExtractors_.find(cartesianIdx);
-            const auto bee_it = this->extraBlockExtractors_.find(cartesianIdx);
-            if (be_it == this->blockExtractors_.end() &&
-                bee_it == this->extraBlockExtractors_.end())
+        for (unsigned dofIdx = 0; dofIdx < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++dofIdx) {
+            const auto globalDofIdx = elemCtx.globalSpaceIndex(dofIdx, /*timeIdx=*/0);
+
+            const std::vector<typename BlockExtractor::Exec>* be_extractors  = nullptr;
+            const std::vector<typename BlockExtractor::Exec>* bee_extractors = nullptr;
+            const std::vector<typename BlockExtractor::Exec>* lgr_extractors = nullptr;
+
+            if (level == 0) {
+                const auto cartesianIdx = elemCtx.simulator().vanguard().cartesianIndex(globalDofIdx);
+                const auto be_it  = this->blockExtractors_.find(cartesianIdx);
+                const auto bee_it = this->extraBlockExtractors_.find(cartesianIdx);
+                if (be_it  != this->blockExtractors_.end())      be_extractors  = &be_it->second;
+                if (bee_it != this->extraBlockExtractors_.end()) bee_extractors = &bee_it->second;
+            }
+            else if constexpr (std::is_same_v<Grid, Dune::CpGrid>) {
+                // Cells inside a local grid refinement.  LGRs are a
+                // CpGrid-only feature today; ALU and Polyhedral grids
+                // keep element.level() at 0 and never enter this
+                // branch, but the constexpr if filters it out at
+                // compile time on those builds so the CpGrid-specific
+                // getLevelElem() call never has to be instantiated
+                // for an unsupported entity type.  Ownership at the
+                // leaf level is decided by Dune::InteriorEntity; the
+                // global-Cartesian isCartIdxOnThisRank predicate used
+                // at setup time does not apply to LGR cells (they do
+                // not inhabit the global Cartesian space).
+                const auto level_it = this->lgrBlockExtractors_.find(level);
+                if (level_it != this->lgrBlockExtractors_.end() &&
+                    element.partitionType() == Dune::InteriorEntity)
+                {
+                    const int levelCompressed = element.getLevelElem().index();
+                    const int levelCart       = elemCtx.simulator().vanguard()
+                                                    .levelCartesianIndexMapper()
+                                                    .cartesianIndex(levelCompressed, level);
+                    const auto cell_it = level_it->second.find(levelCart);
+                    if (cell_it != level_it->second.end()) {
+                        lgr_extractors = &cell_it->second;
+                    }
+                }
+            }
+
+            if (be_extractors  == nullptr &&
+                bee_extractors == nullptr &&
+                lgr_extractors == nullptr)
             {
                 continue;
             }
@@ -336,12 +385,9 @@ public:
                 elemCtx,
             };
 
-            if (be_it != this->blockExtractors_.end()) {
-                BlockExtractor::process(be_it->second, ectx);
-            }
-            if (bee_it != this->extraBlockExtractors_.end()) {
-                BlockExtractor::process(bee_it->second, ectx);
-            }
+            if (be_extractors  != nullptr) BlockExtractor::process(*be_extractors,  ectx);
+            if (bee_extractors != nullptr) BlockExtractor::process(*bee_extractors, ectx);
+            if (lgr_extractors != nullptr) BlockExtractor::process(*lgr_extractors, ectx);
         }
     }
 

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -365,8 +365,8 @@ public:
                 const auto cartesianIdx = elemCtx.simulator().vanguard().cartesianIndex(globalDofIdx);
                 const auto be_it  = this->blockExtractors_.find(cartesianIdx);
                 const auto bee_it = this->extraBlockExtractors_.find(cartesianIdx);
-                if (be_it  != this->blockExtractors_.end())      be_extractors  = &be_it->second;
-                if (bee_it != this->extraBlockExtractors_.end()) bee_extractors = &bee_it->second;
+                if (be_it  != this->blockExtractors_.end())      { be_extractors  = &be_it->second; }
+                if (bee_it != this->extraBlockExtractors_.end()) { bee_extractors = &bee_it->second; }
             }
             else if constexpr (std::is_same_v<Grid, Dune::CpGrid>) {
                 // Cells inside a local grid refinement.  LGRs are a
@@ -413,9 +413,9 @@ public:
                 elemCtx,
             };
 
-            if (be_extractors  != nullptr) BlockExtractor::process(*be_extractors,  ectx);
-            if (bee_extractors != nullptr) BlockExtractor::process(*bee_extractors, ectx);
-            if (lgr_extractors != nullptr) BlockExtractor::process(*lgr_extractors, ectx);
+            if (be_extractors  != nullptr) { BlockExtractor::process(*be_extractors,  ectx); }
+            if (bee_extractors != nullptr) { BlockExtractor::process(*bee_extractors, ectx); }
+            if (lgr_extractors != nullptr) { BlockExtractor::process(*lgr_extractors, ectx); }
         }
     }
 

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -248,6 +248,7 @@ public:
         this->extractors_.clear();
         this->blockExtractors_.clear();
         this->extraBlockExtractors_.clear();
+        this->lgrBlockExtractors_.clear();
     }
 
     /*!
@@ -3099,6 +3100,12 @@ private:
 
         this->blockExtractors_ = BlockExtractor::setupExecMap(this->blockData_, handlers);
 
+        // The LGR-cell extractors reuse the same handler list -- the
+        // physics is identical, only the cell identification differs.
+        // Empty for runs without LB* requests (zero non-LGR cost).
+        this->lgrBlockExtractors_ =
+            BlockExtractor::setupLgrExecMap(this->lgrBlockData_, handlers);
+
         this->extraBlockData_.clear();
         if (reportStepNum > 0 && !isSubStep) {
             // check we need extra block pressures for RPTSCHED
@@ -3122,6 +3129,12 @@ private:
     std::vector<typename Extractor::Entry> extractors_;
     typename BlockExtractor::ExecMap blockExtractors_;
     typename BlockExtractor::ExecMap extraBlockExtractors_;
+
+    // Per-LGR-cell extractor executor map.  Outer key is the grid level,
+    // inner key is the level-local linearised Cartesian cell index, so
+    // the per-DOF lookup in processElementBlockData short-circuits O(1)
+    // on levels with no LB* requests.  Empty for non-LGR runs.
+    typename BlockExtractor::LgrExecMap lgrBlockExtractors_;
 };
 
 } // namespace Opm

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -180,6 +180,10 @@ public:
 
         this->setupBlockData(isCartIdxOnThisRank);
 
+        // Allocate slots for LB* summary nodes that name a cell inside an
+        // LGR.  Empty for runs without LB* requests (zero non-LGR cost).
+        this->setupLgrBlockData(simulator.vanguard().eclState().getInputGrid());
+
         if (! Parameters::Get<Parameters::OwnerCellsFirst>()) {
             const std::string msg = "The output code does not support --owner-cells-first=false.";
             if (collectOnIORank.isIORank()) {

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -65,6 +65,8 @@
 #include <cstddef>
 #include <functional>
 #include <limits>
+#include <map>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -182,14 +184,35 @@ public:
 
         this->setupBlockData(isCartIdxOnThisRank);
 
-        // Allocate slots for LB* summary nodes that name a cell inside an
-        // LGR.  Single-process only: the gather of LGR-cell values to the I/O
-        // rank is a separate change, so skip setup under MPI to keep the LGR
-        // producer path inert and avoid desyncing the ranks in the collective
-        // output walk.  Empty for runs without LB* requests (zero non-LGR cost).
-        if (! collectOnIORank.isParallel()) {
-            this->setupLgrBlockData(simulator.vanguard().eclState().getInputGrid());
+        // Allocate slots for LB* summary nodes that name a cell inside an LGR.
+        // Runs per-rank (serial and parallel): each rank allocates only the LGR
+        // leaf cells it owns, so lgrBlockData_ is per-rank disjoint and the
+        // gather to the I/O rank is a clean union.  Ownership is taken from the
+        // same InteriorEntity leaf-level decision the fill walk uses, collected
+        // here once.  Empty for runs without LB* requests (zero non-LGR cost);
+        // constexpr-elided on non-CpGrid builds (LGRs are CpGrid-only).
+        std::set<std::pair<int, int>> ownedLgrCells;
+        std::map<std::string, int> lgrNameToLevel;
+        if constexpr (std::is_same_v<Grid, Dune::CpGrid>) {
+            // CpGrid name->level map is replicated on every rank (unlike the
+            // root-only EclipseState input grid).
+            lgrNameToLevel = simulator.vanguard().grid().getLgrNameToLevel();
+            for (const auto& element : elements(simulator.gridView())) {
+                const int level = element.level();
+                if (level > 0 && element.partitionType() == Dune::InteriorEntity) {
+                    const int levelCompressed = element.getLevelElem().index();
+                    const int levelCart = simulator.vanguard()
+                                              .levelCartesianIndexMapper()
+                                              .cartesianIndex(levelCompressed, level);
+                    ownedLgrCells.emplace(level, levelCart);
+                }
+            }
         }
+        this->setupLgrBlockData(
+            lgrNameToLevel,
+            [&ownedLgrCells](const int level, const int levelCart) {
+                return ownedLgrCells.count(std::make_pair(level, levelCart)) > 0;
+            });
 
         if (! Parameters::Get<Parameters::OwnerCellsFirst>()) {
             const std::string msg = "The output code does not support --owner-cells-first=false.";

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -127,13 +127,15 @@ public:
 
         this->setupBlockData(isCartIdxOnThisRank);
 
-        // Allocate slots for LB* summary nodes that name a cell inside an
-        // LGR.  Single-process only: the gather of LGR-cell values to the I/O
-        // rank is a separate change, so skip setup under MPI to keep the LGR
-        // producer path inert and avoid desyncing the ranks in the collective
-        // output walk.  Empty for runs without LB* requests (zero non-LGR cost).
+        // Allocate LB* summary slots.  The compositional block-data fill
+        // (processElementBlockData) is a stub, so no LB* values are produced
+        // here and the parallel gather has nothing to collect; the allocation
+        // is kept single-process and the ownership predicate is trivially true
+        // (there are no per-rank values to keep disjoint).
         if (! collectToIORank.isParallel()) {
-            this->setupLgrBlockData(simulator.vanguard().eclState().getInputGrid());
+            // Empty name->level map: the compositional block-data fill is a stub,
+            // so no LB* values are produced and nothing needs allocating.
+            this->setupLgrBlockData({}, [](const int, const int) { return true; });
         }
 
         if (! Parameters::Get<Parameters::OwnerCellsFirst>()) {

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -128,8 +128,13 @@ public:
         this->setupBlockData(isCartIdxOnThisRank);
 
         // Allocate slots for LB* summary nodes that name a cell inside an
-        // LGR.  Empty for runs without LB* requests (zero non-LGR cost).
-        this->setupLgrBlockData(simulator.vanguard().eclState().getInputGrid());
+        // LGR.  Single-process only: the gather of LGR-cell values to the I/O
+        // rank is a separate change, so skip setup under MPI to keep the LGR
+        // producer path inert and avoid desyncing the ranks in the collective
+        // output walk.  Empty for runs without LB* requests (zero non-LGR cost).
+        if (! collectToIORank.isParallel()) {
+            this->setupLgrBlockData(simulator.vanguard().eclState().getInputGrid());
+        }
 
         if (! Parameters::Get<Parameters::OwnerCellsFirst>()) {
             const std::string msg = "The output code does not support --owner-cells-first=false.";

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -127,6 +127,10 @@ public:
 
         this->setupBlockData(isCartIdxOnThisRank);
 
+        // Allocate slots for LB* summary nodes that name a cell inside an
+        // LGR.  Empty for runs without LB* requests (zero non-LGR cost).
+        this->setupLgrBlockData(simulator.vanguard().eclState().getInputGrid());
+
         if (! Parameters::Get<Parameters::OwnerCellsFirst>()) {
             const std::string msg = "The output code does not support --owner-cells-first=false.";
             if (collectToIORank.isIORank()) {

--- a/opm/simulators/flow/OutputExtractor.hpp
+++ b/opm/simulators/flow/OutputExtractor.hpp
@@ -368,6 +368,130 @@ struct BlockExtractor
                              [&ectx](auto& bdata)
                              { *bdata.data = bdata.extract(ectx); });
     }
+
+    /// A two-level map of extraction executors for cells inside an LGR,
+    /// keyed by (grid level, level-local linearised Cartesian cell index).
+    ///
+    /// Outer level identifies the LGR (0 = GLOBAL, 1..N = LGRs).  Inner
+    /// key is the cell's level-local linearised Cartesian index.  Both
+    /// keys come from the LgrBlockValues tuple the opm-common
+    /// LgrBlockValue evaluator reads.
+    using LgrExecMap = std::unordered_map<int,
+                                          std::unordered_map<int,
+                                                             std::vector<Exec>>>;
+
+    //! \brief Setup an LGR-cell extractor executor map.
+    //!
+    //! Mirrors setupExecMap above for cells inside a local grid
+    //! refinement.  The keyword in lgrBlockData carries the LB* prefix
+    //! ("LBPR", "LBOSAT", ...); the leading 'L' is stripped before
+    //! looking the keyword up in the handler array (which is keyed by
+    //! the underlying B* name, "BPR", "BOSAT", ...).  Extractors are
+    //! grouped by grid level first so a per-DOF lookup short-circuits
+    //! O(1) on levels that have no LB* requests in this run.
+    template<std::size_t size>
+    static LgrExecMap setupLgrExecMap(std::map<std::tuple<std::string,int,int>,
+                                               double>& lgrBlockData,
+                                      const std::array<Entry,size>& handlers)
+    {
+        using PhaseViewArray = std::array<std::string_view, numPhases>;
+        using StringViewVec = std::vector<std::string_view>;
+
+        LgrExecMap extractors;
+
+        std::ranges::for_each(
+            lgrBlockData,
+            [&handlers, &extractors](auto& bd_info)
+            {
+                unsigned phase{};
+                const auto& [lgr_kw, level, localCart] = bd_info.first;
+                const auto base_kw = std::string_view{lgr_kw}.substr(1);
+
+                const auto& handler_info =
+                    std::ranges::find_if(
+                        handlers,
+                        [&base_kw, &phase](const auto& handler)
+                        {
+                            const auto gen_handlers =
+                                std::visit(VisitorOverloadSet{
+                                              [](const ScalarEntry& entry)
+                                              {
+                                                  return std::visit(VisitorOverloadSet{
+                                                                        [](const std::string_view& kw) -> StringViewVec
+                                                                        {
+                                                                            return {kw};
+                                                                        },
+                                                                        [](const StringViewVec& kws) -> StringViewVec
+                                                                        { return kws; }
+                                                                    }, entry.kw);
+                                              },
+                                              [](const PhaseEntry& entry)
+                                              {
+                                                  return std::visit(VisitorOverloadSet{
+                                                                        [](const PhaseViewArray& data)
+                                                                        {
+                                                                            return StringViewVec{data.begin(), data.end()};
+                                                                        },
+                                                                        [](const std::array<PhaseViewArray,2>& data)
+                                                                        {
+                                                                            StringViewVec res;
+                                                                            res.reserve(2*numPhases);
+                                                                            res.insert(res.end(),
+                                                                                       data[0].begin(),
+                                                                                       data[0].end());
+                                                                            res.insert(res.end(),
+                                                                                       data[1].begin(),
+                                                                                       data[1].end());
+                                                                            return res;
+                                                                        }
+                                                                    }, entry.kw);
+                                              }
+                                          }, handler);
+
+                            const auto found_handler =
+                                std::ranges::find(gen_handlers, base_kw);
+                            if (found_handler != gen_handlers.end()) {
+                                phase = std::distance(gen_handlers.begin(), found_handler) % numPhases;
+                            }
+                            return found_handler != gen_handlers.end();
+                        }
+                    );
+
+                if (handler_info != handlers.end()) {
+                    extractors[level][localCart].emplace_back(
+                        &bd_info.second,
+                        std::visit(VisitorOverloadSet{
+                                       [](const ScalarEntry& e)
+                                       {
+                                           return e.extract;
+                                       },
+                                       [phase](const PhaseEntry& e) -> ScalarFunc
+                                       {
+                                           return [phase, extract = e.extract]
+                                                  (const Context& ectx)
+                                                  {
+                                                      static constexpr auto phaseMap = std::array{
+                                                          waterPhaseIdx,
+                                                          oilPhaseIdx,
+                                                          gasPhaseIdx,
+                                                      };
+                                                      return extract(phaseMap[phase], ectx);
+                                                  };
+                                       }
+                                   }, *handler_info)
+                    );
+                }
+                else {
+                    OpmLog::warning("Unhandled LGR output keyword",
+                                    fmt::format("Keyword '{}' (LGR mirror of '{}') is "
+                                                "unhandled for output to summary file.",
+                                                lgr_kw, base_kw));
+                }
+            }
+        );
+
+        return extractors;
+    }
 };
 
 } // namespace Opm::detail

--- a/opm/simulators/flow/OutputExtractor.hpp
+++ b/opm/simulators/flow/OutputExtractor.hpp
@@ -39,6 +39,7 @@
 
 #include <algorithm>
 #include <array>
+#include <optional>
 #include <unordered_map>
 #include <set>
 #include <variant>
@@ -258,96 +259,113 @@ struct BlockExtractor
     /// A map of extraction executors, keyed by cartesian cell index
     using ExecMap = std::unordered_map<int, std::vector<Exec>>;
 
+    //! \brief Resolve a block-summary keyword to its bound extraction lambda.
+    //!
+    //! Searches the handler table for \p base_kw (the underlying B*-family
+    //! name, e.g. "BPR", "BOSAT") and, when found, returns the extraction
+    //! function ready to call -- selecting the correct phase for phase-valued
+    //! keywords.  Shared by setupExecMap (global B*, level 0) and
+    //! setupLgrExecMap (LGR-cell LB*, which pass the keyword with its leading
+    //! 'L' stripped).  Returns nullopt when no handler matches.
+    template<std::size_t size>
+    static std::optional<ScalarFunc>
+    makeExtractor(const std::string_view base_kw,
+                  const std::array<Entry,size>& handlers)
+    {
+        using PhaseViewArray = std::array<std::string_view, numPhases>;
+        using StringViewVec = std::vector<std::string_view>;
+
+        unsigned phase{};
+        const auto handler_info =
+            std::ranges::find_if(
+                handlers,
+                [&base_kw, &phase](const auto& handler)
+                {
+                    // Extract list of keyword names from handler
+                    const auto gen_handlers =
+                        std::visit(VisitorOverloadSet{
+                                      [](const ScalarEntry& entry)
+                                      {
+                                          return std::visit(VisitorOverloadSet{
+                                                                [](const std::string_view& kw) -> StringViewVec
+                                                                {
+                                                                    return {kw};
+                                                                },
+                                                                [](const StringViewVec& kws) -> StringViewVec
+                                                                { return kws; }
+                                                            }, entry.kw);
+                                      },
+                                      [](const PhaseEntry& entry)
+                                      {
+                                          return std::visit(VisitorOverloadSet{
+                                                                [](const PhaseViewArray& data)
+                                                                {
+                                                                    return StringViewVec{data.begin(), data.end()};
+                                                                },
+                                                                [](const std::array<PhaseViewArray,2>& data)
+                                                                {
+                                                                    StringViewVec res;
+                                                                    res.reserve(2*numPhases);
+                                                                    res.insert(res.end(),
+                                                                               data[0].begin(),
+                                                                               data[0].end());
+                                                                    res.insert(res.end(),
+                                                                               data[1].begin(),
+                                                                               data[1].end());
+                                                                    return res;
+                                                                }
+                                                            }, entry.kw);
+                                      }
+                                  }, handler);
+
+                    const auto found_handler =
+                        std::ranges::find(gen_handlers, base_kw);
+                    if (found_handler != gen_handlers.end()) {
+                        phase = std::distance(gen_handlers.begin(), found_handler) % numPhases;
+                    }
+                    return found_handler != gen_handlers.end();
+                }
+            );
+
+        if (handler_info == handlers.end()) {
+            return std::nullopt;
+        }
+
+        return std::visit(VisitorOverloadSet{
+                              [](const ScalarEntry& e) -> ScalarFunc
+                              {
+                                  return e.extract;
+                              },
+                              [phase](const PhaseEntry& e) -> ScalarFunc
+                              {
+                                  return [phase, extract = e.extract]
+                                         (const Context& ectx)
+                                         {
+                                             static constexpr auto phaseMap = std::array{
+                                                 waterPhaseIdx,
+                                                 oilPhaseIdx,
+                                                 gasPhaseIdx,
+                                             };
+                                             return extract(phaseMap[phase], ectx);
+                                         };
+                              }
+                          }, *handler_info);
+    }
+
     //! \brief Setup an extractor executor map from a map of evaluations to perform.
     template<std::size_t size>
     static ExecMap setupExecMap(std::map<std::pair<std::string, int>, double>& blockData,
                                 const std::array<Entry,size>& handlers)
     {
-        using PhaseViewArray = std::array<std::string_view, numPhases>;
-        using StringViewVec = std::vector<std::string_view>;
-
         ExecMap extractors;
 
         std::ranges::for_each(
             blockData,
             [&handlers, &extractors](auto& bd_info)
             {
-                unsigned phase{};
                 const auto& [key, cell] = bd_info.first;
-                const auto& handler_info =
-                    std::ranges::find_if(
-                        handlers,
-                        [&kw_name = bd_info.first.first, &phase](const auto& handler)
-                        {
-                           // Extract list of keyword names from handler
-                           const auto gen_handlers =
-                              std::visit(VisitorOverloadSet{
-                                            [](const ScalarEntry& entry)
-                                            {
-                                                return std::visit(VisitorOverloadSet{
-                                                                      [](const std::string_view& kw) -> StringViewVec
-                                                                      {
-                                                                          return {kw};
-                                                                      },
-                                                                      [](const StringViewVec& kws) -> StringViewVec
-                                                                      { return kws; }
-                                                                  }, entry.kw);
-                                            },
-                                            [](const PhaseEntry& entry)
-                                            {
-                                                return std::visit(VisitorOverloadSet{
-                                                                      [](const PhaseViewArray& data)
-                                                                      {
-                                                                          return StringViewVec{data.begin(), data.end()};
-                                                                      },
-                                                                      [](const std::array<PhaseViewArray,2>& data)
-                                                                      {
-                                                                          StringViewVec res;
-                                                                          res.reserve(2*numPhases);
-                                                                          res.insert(res.end(),
-                                                                                     data[0].begin(),
-                                                                                     data[0].end());
-                                                                          res.insert(res.end(),
-                                                                                     data[1].begin(),
-                                                                                     data[1].end());
-                                                                          return res;
-                                                                      }
-                                                                  }, entry.kw);
-                                            }
-                                        }, handler);
-
-                            const auto found_handler =
-                                std::ranges::find(gen_handlers, kw_name);
-                            if (found_handler != gen_handlers.end()) {
-                                phase = std::distance(gen_handlers.begin(), found_handler) % numPhases;
-                            }
-                            return found_handler != gen_handlers.end();
-                        }
-                    );
-
-                if (handler_info != handlers.end()) {
-                    extractors[cell - 1].emplace_back(
-                        &bd_info.second,
-                        std::visit(VisitorOverloadSet{
-                                       [](const ScalarEntry& e)
-                                       {
-                                           return e.extract;
-                                       },
-                                       [phase](const PhaseEntry& e) -> ScalarFunc
-                                       {
-                                           return [phase, extract = e.extract]
-                                                  (const Context& ectx)
-                                                  {
-                                                      static constexpr auto phaseMap = std::array{
-                                                          waterPhaseIdx,
-                                                          oilPhaseIdx,
-                                                          gasPhaseIdx,
-                                                      };
-                                                      return extract(phaseMap[phase], ectx);
-                                                  };
-                                       }
-                                   }, *handler_info)
-                     );
+                if (auto extract = makeExtractor(std::string_view{key}, handlers)) {
+                    extractors[cell - 1].emplace_back(&bd_info.second, std::move(*extract));
                 }
                 else {
                     OpmLog::warning("Unhandled output keyword",
@@ -382,104 +400,30 @@ struct BlockExtractor
 
     //! \brief Setup an LGR-cell extractor executor map.
     //!
-    //! Mirrors setupExecMap above for cells inside a local grid
-    //! refinement.  The keyword in lgrBlockData carries the LB* prefix
-    //! ("LBPR", "LBOSAT", ...); the leading 'L' is stripped before
-    //! looking the keyword up in the handler array (which is keyed by
-    //! the underlying B* name, "BPR", "BOSAT", ...).  Extractors are
-    //! grouped by grid level first so a per-DOF lookup short-circuits
-    //! O(1) on levels that have no LB* requests in this run.
+    //! The LGR analogue of setupExecMap: identical per-keyword resolution
+    //! (shared via makeExtractor), but keyed by (grid level, level-local
+    //! linearised Cartesian index) instead of a single global Cartesian
+    //! index.  The keyword in lgrBlockData carries the LB* prefix ("LBPR",
+    //! "LBOSAT", ...); the leading 'L' is stripped before the handler lookup.
+    //! Extractors are grouped by grid level first so a per-DOF lookup
+    //! short-circuits O(1) on levels that have no LB* requests in this run.
     template<std::size_t size>
     static LgrExecMap setupLgrExecMap(std::map<std::tuple<std::string,int,int>,
                                                double>& lgrBlockData,
                                       const std::array<Entry,size>& handlers)
     {
-        using PhaseViewArray = std::array<std::string_view, numPhases>;
-        using StringViewVec = std::vector<std::string_view>;
-
         LgrExecMap extractors;
 
         std::ranges::for_each(
             lgrBlockData,
             [&handlers, &extractors](auto& bd_info)
             {
-                unsigned phase{};
                 const auto& [lgr_kw, level, localCart] = bd_info.first;
+                // LB* keywords mirror the global B* names; drop the leading
+                // 'L' so the shared handler lookup sees "BPR", "BOSAT", ...
                 const auto base_kw = std::string_view{lgr_kw}.substr(1);
-
-                const auto& handler_info =
-                    std::ranges::find_if(
-                        handlers,
-                        [&base_kw, &phase](const auto& handler)
-                        {
-                            const auto gen_handlers =
-                                std::visit(VisitorOverloadSet{
-                                              [](const ScalarEntry& entry)
-                                              {
-                                                  return std::visit(VisitorOverloadSet{
-                                                                        [](const std::string_view& kw) -> StringViewVec
-                                                                        {
-                                                                            return {kw};
-                                                                        },
-                                                                        [](const StringViewVec& kws) -> StringViewVec
-                                                                        { return kws; }
-                                                                    }, entry.kw);
-                                              },
-                                              [](const PhaseEntry& entry)
-                                              {
-                                                  return std::visit(VisitorOverloadSet{
-                                                                        [](const PhaseViewArray& data)
-                                                                        {
-                                                                            return StringViewVec{data.begin(), data.end()};
-                                                                        },
-                                                                        [](const std::array<PhaseViewArray,2>& data)
-                                                                        {
-                                                                            StringViewVec res;
-                                                                            res.reserve(2*numPhases);
-                                                                            res.insert(res.end(),
-                                                                                       data[0].begin(),
-                                                                                       data[0].end());
-                                                                            res.insert(res.end(),
-                                                                                       data[1].begin(),
-                                                                                       data[1].end());
-                                                                            return res;
-                                                                        }
-                                                                    }, entry.kw);
-                                              }
-                                          }, handler);
-
-                            const auto found_handler =
-                                std::ranges::find(gen_handlers, base_kw);
-                            if (found_handler != gen_handlers.end()) {
-                                phase = std::distance(gen_handlers.begin(), found_handler) % numPhases;
-                            }
-                            return found_handler != gen_handlers.end();
-                        }
-                    );
-
-                if (handler_info != handlers.end()) {
-                    extractors[level][localCart].emplace_back(
-                        &bd_info.second,
-                        std::visit(VisitorOverloadSet{
-                                       [](const ScalarEntry& e)
-                                       {
-                                           return e.extract;
-                                       },
-                                       [phase](const PhaseEntry& e) -> ScalarFunc
-                                       {
-                                           return [phase, extract = e.extract]
-                                                  (const Context& ectx)
-                                                  {
-                                                      static constexpr auto phaseMap = std::array{
-                                                          waterPhaseIdx,
-                                                          oilPhaseIdx,
-                                                          gasPhaseIdx,
-                                                      };
-                                                      return extract(phaseMap[phase], ectx);
-                                                  };
-                                       }
-                                   }, *handler_info)
-                    );
+                if (auto extract = makeExtractor(base_kw, handlers)) {
+                    extractors[level][localCart].emplace_back(&bd_info.second, std::move(*extract));
                 }
                 else {
                     OpmLog::warning("Unhandled LGR output keyword",

--- a/tests/test_LgrBlockData.cpp
+++ b/tests/test_LgrBlockData.cpp
@@ -1,0 +1,91 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#define BOOST_TEST_MODULE LgrBlockDataGather
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/simulators/flow/CollectDataOnIORank_impl.hpp>
+
+#include <map>
+#include <string>
+#include <tuple>
+
+namespace {
+    // Key = (summary keyword, LGR level, level-local linearised Cartesian index),
+    // matching opm-common's Summary::DynamicSimulatorState::LgrBlockValues.
+    using Key = std::tuple<std::string, int, int>;
+    using LgrBlockMap = std::map<Key, double>;
+}
+
+// Opm::PackUnPackLgrBlockData is the gather handle for the tuple-keyed LB* per-LGR-cell
+// summary map. Its IO-rank constructor self-packs the local map into a message buffer and
+// unpacks it back into the supplied global map -- which is exactly how the IO rank folds in
+// each rank's contribution during collect(). Constructing it with isIORank == true therefore
+// exercises the pack -> unpack round-trip, and constructing it twice into the same global map
+// exercises the disjoint union of two ranks' contributions -- all without needing MPI.
+
+BOOST_AUTO_TEST_CASE(RoundTripPreservesEntries)
+{
+    const LgrBlockMap local = {
+        { Key{"LBPR",   1, 0}, 250.0 },
+        { Key{"LBPR",   1, 3}, 251.5 },
+        { Key{"LBOSAT", 2, 0}, 0.30  },
+    };
+
+    LgrBlockMap gathered;
+    Opm::PackUnPackLgrBlockData{ local, gathered, /*isIORank=*/true };
+
+    BOOST_CHECK(gathered == local);
+}
+
+BOOST_AUTO_TEST_CASE(DisjointMergeAccumulatesBothRanks)
+{
+    const LgrBlockMap rank0 = {
+        { Key{"LBPR", 1, 0}, 250.0 },
+        { Key{"LBPR", 1, 3}, 251.5 },
+    };
+    const LgrBlockMap rank1 = {
+        { Key{"LBPR",   1, 7}, 252.0 },
+        { Key{"LBOSAT", 2, 0}, 0.30  },
+    };
+
+    LgrBlockMap gathered;
+    Opm::PackUnPackLgrBlockData{ rank0, gathered, /*isIORank=*/true };
+    Opm::PackUnPackLgrBlockData{ rank1, gathered, /*isIORank=*/true };
+
+    LgrBlockMap expected = rank0;
+    expected.insert(rank1.begin(), rank1.end());
+
+    BOOST_CHECK(gathered == expected);
+    BOOST_CHECK_EQUAL(gathered.size(), 4u);
+    BOOST_CHECK_EQUAL(gathered.at(Key{"LBPR",   1, 0}), 250.0);
+    BOOST_CHECK_EQUAL(gathered.at(Key{"LBPR",   1, 7}), 252.0);
+    BOOST_CHECK_EQUAL(gathered.at(Key{"LBOSAT", 2, 0}), 0.30);
+}
+
+BOOST_AUTO_TEST_CASE(EmptyMapGathersNothing)
+{
+    const LgrBlockMap empty;
+
+    LgrBlockMap gathered;
+    Opm::PackUnPackLgrBlockData{ empty, gathered, /*isIORank=*/true };
+
+    BOOST_CHECK(gathered.empty());
+}


### PR DESCRIPTION
## Summary

The opm-common `LgrBlockValue` evaluator (merged in OPM/opm-common#5197)
reads its data from `Summary::DynamicSimulatorState::lgr_block_values` —
a `std::map<std::tuple<std::string /*keyword*/, int /*level*/, int /*level-local Cartesian*/>, double>`.

This PR adds two things on the simulator side:

1. the **producer** that fills that map each timestep by walking the active
   LGR leaf cells and extracting the requested block quantities for `LB*`
   summary nodes, and
2. the **machinery to collect that per-rank map to the I/O rank** under domain
   decomposition, mirroring how the existing global `B*` block values are
   gathered.

The producer allocates and fills only the LGR cells each rank owns, and the
gather handle merges those per-rank maps on the I/O rank — so the same `LB*`
values are available whether `flow` runs on one rank or many.

The one piece deliberately **left out** is the final wiring that switches the
gather on for a live parallel+LGR run; see *Parallel status* below. As a
result this change is additive and inert under MPI today: serial output is
unchanged, and multi-rank runs behave exactly as before.

## Producer — filling the map

The producer is the LGR-cell analogue of the existing global block-value setup
(`GenericOutputBlackoilModule::setupBlockData` + `BlockExtractor::setupExecMap`).
The global `B*` path is left byte-identical for cells at level 0; only level > 0
cells route into the new LGR map. Runs without LGRs allocate nothing new (the
new map is empty; a single `.empty()` short-circuit at the top of the per-step
walk skips the LGR branch entirely).

`opm/simulators/flow/GenericOutputBlackoilModule.[ch]pp`
- New member `lgrBlockData_` of type
  `std::map<std::tuple<std::string, int, int>, double>`, mirroring `blockData_`.
- New member `lgrBlockExtractors_` of type
  `std::unordered_map<int /*level*/, std::unordered_map<int /*levelCart*/, std::vector<typename BlockExtractor::Exec>>>`
  for O(1) extractor lookup per LGR cell, with an O(1) early-out for levels
  that have no `LB*` requests.
- `setupLgrBlockData(const std::map<std::string,int>& lgrNameToLevel, const std::function<bool(int,int)>& isLgrCellOnThisRank)`
  iterates `summaryConfig_`, filters Block-category nodes with
  `lgr_name().has_value()`, resolves the level from the supplied
  name→level map, and allocates a slot under `{keyword, level, node.number() - 1}`
  **only when `isLgrCellOnThisRank(level, levelCart)`** — so each rank allocates
  exactly the LGR cells it owns and the gathered map is disjoint (no
  overwrite-by-key when the per-rank maps are merged).
- New `getLgrBlockData()` accessor mirroring `getBlockData()`.

`opm/simulators/flow/OutputExtractor.hpp`
- New `BlockExtractor::setupLgrExecMap` builds the LGR-cell extractor map
  (keyed by `{level, level-local Cartesian}`) alongside the existing
  `setupExecMap` (keyed by global Cartesian index). The per-keyword resolution
  — handler lookup, phase selection, executor binding — is factored into a
  single shared `makeExtractor(base_kw, handlers)` helper that both setup
  functions call, so no extraction logic is duplicated. `LB*` keywords reuse
  the underlying `B*` handlers verbatim by stripping the leading `L` before the
  lookup. Existing `setupExecMap` call sites are unchanged.

`opm/simulators/flow/OutputBlackoilModule.hpp`
- The output setup builds, per rank, the set of interior-owned LGR leaf cells
  (`element.partitionType() == Dune::InteriorEntity`) and a name→level map from
  `vanguard().grid().getLgrNameToLevel()` (available on every rank), then calls
  `setupLgrBlockData(...)` with that ownership predicate. The name→level source
  is the distributed grid, not `EclipseState::getInputGrid()` (which is
  root-only under MPI).
- `processElementBlockData` extended. It short-circuits when the global, extra,
  and LGR extractor maps are all empty. Per element it branches on
  `element.level()`: level 0 takes the existing global path verbatim; level > 0
  takes a new path **gated by `if constexpr (std::is_same_v<Grid, Dune::CpGrid>)`**
  (so ALU and Polyhedral builds elide it at compile time) that early-outs if the
  level has no `LB*` requests, filters on `Dune::InteriorEntity`, computes
  `levelCart = vanguard.levelCartesianIndexMapper().cartesianIndex(element.getLevelElem().index(), level)`,
  and runs the same `BlockExtractor::process(...)` the global path uses. The
  `Context` handed to each extractor is identical to the global call, so the
  extractor lambdas need no change.

`opm/simulators/flow/OutputCompositionalModule.hpp`
- The compositional output path makes the matching `setupLgrBlockData(...)` call
  so it produces LGR block values too.

## Gather — collecting to the I/O rank

`opm/simulators/flow/CollectDataOnIORank.[hpp|_impl.hpp]`
- New `PackUnPackLgrBlockData` gather handle keyed by
  `{keyword, level, level-local Cartesian}`, the direct analogue of the existing
  `PackUnPackBlockData` (which is keyed by `{keyword, global Cartesian}`). The
  pack/unpack body is shared between the two so the tuple key is the only
  difference — the extra `level` is what an LGR cell needs and a global cell does
  not.
- `collect()` carries the producer's per-rank LGR block map and exchanges it into
  a new `globalLgrBlockData_` on the I/O rank; a `globalLgrBlockData()` accessor
  is added next to `globalBlockData()`.

`opm/simulators/flow/EclWriter.hpp`, `EclGenericWriter.hpp`, `EclGenericWriter_impl.hpp`
- `EclWriter` hands the producer's map to `collect()` and, when reading it back
  for evaluation, selects the gathered `globalLgrBlockData()` under MPI and the
  local `getLgrBlockData()` in serial — exactly as it already does for the
  global `block_values`. `evalSummary` sets
  `DynamicSimulatorState::lgr_block_values` immediately after the existing
  `block_values` line.

`LC*` (connection) and `LW*` (well) LGR vectors need no new handle here: they
ride the existing well-data gather, since `data::Connection` already serializes
its `lgr_grid` and the producer already sets it.

## Parallel status

The gather machinery above is present but **not yet switched on** for a live
parallel+LGR run. Enabling it means building the I/O-rank communicator links in
the `CollectDataOnIORank` constructor for the parallel+LGR case (today that case
short-circuits, leaving the communicator with no links, so the new exchange is a
no-op). That wiring is intentionally a follow-up because it can only be verified
end-to-end once parallel ECL output for refined grids is available — the refined
`INIT` transmissibility/NNC export is single-process today, so enabling ECL
output on a multi-rank LGR run currently fails earlier, before any summary
gather is reached. Splitting it out also keeps this change reviewable on its own.

Net effect today: serial output is unchanged; non-LGR runs are unchanged; global
`B*` output is byte-identical; and multi-rank LGR runs are inert (the machinery
is dormant until the follow-up lands).

## Test

`tests/test_LgrBlockData.cpp` unit-tests the gather handle directly: it packs
two ranks' tuple-keyed maps and asserts the I/O-rank merge is the disjoint union
(round-trip, two-rank merge, and empty-map cases).

The opm-common-side dispatch and tuple lookup for `LB*` is covered by the
`Summary/LGR_block_factory_dispatch` test in OPM/opm-common#5197. The producer
mirrors the global `B*` producer one-to-one, and the shared extractor lambdas —
the only code that touches simulator state — are unchanged and already exercised
by every regression test that runs `flow` on a deck with `B*` requests.

End-to-end coverage on a real `flow` run with a CARFIN deck (serial, and parallel
once the switch-on lands) belongs in a separate opm-tests + opm-simulators
regression-test PR that ships a small LGR reference deck and compares the
produced `SMSPEC`/`UNSMRY` against committed reference outputs.

## Out of scope

- The parallel switch-on (see *Parallel status*).
- Wildcard `LB*` records (`LBPR 'LGR' /` — all cells of an LGR); the opm-common
  parser currently requires explicit `(I, J, K)` for `LB*`, a separate
  parse-side change.
- Non-`EcfvDiscretization` decks; the existing global `B*` path already
  early-returns there and the new LGR branch sits inside the same guard.

## Dependencies

- **OPM/opm-common#5197** (merged) — the `LgrBlockValue` evaluator and the
  `Summary::DynamicSimulatorState::lgr_block_values` type. This PR fills the map;
  that one reads it.
