### PR TITLE
opm/models/(io|parallel|utils): address clang-tidy warnings

### DIFF
--- a/opm/models/io/restart.cpp
+++ b/opm/models/io/restart.cpp
@@ -71,7 +71,7 @@ void Restart::deserializeSectionEnd()
     std::string dummy;
     std::getline(inStream_, dummy);
     for (unsigned i = 0; i < dummy.length(); ++i) {
-        if (!std::isspace(dummy[i])) {
+        if (std::isspace(dummy[i]) == 0) {
             throw std::logic_error("Encountered unread values while deserializing");
         }
     }

--- a/opm/models/parallel/tasklets.cpp
+++ b/opm/models/parallel/tasklets.cpp
@@ -37,7 +37,7 @@ thread_local TaskletRunner* TaskletRunner::taskletRunner_ = nullptr;
 thread_local int TaskletRunner::workerThreadIndex_ = -1;
 
 TaskletRunner::BarrierTasklet::BarrierTasklet(unsigned numWorkers)
-    : TaskletInterface(/*refCount=*/numWorkers)
+    : TaskletInterface(/*refCount=*/static_cast<int>(numWorkers))
 {
     numWorkers_ = numWorkers;
     numWaiting_ = 0;

--- a/opm/models/utils/parametersystem.cpp
+++ b/opm/models/utils/parametersystem.cpp
@@ -664,6 +664,13 @@ std::string parseCommandLineOptions(int argc,
         return "Help called";
     }
 
+    auto handleUsage = [&helpPreamble](const std::string& msg)
+    {
+        if (!helpPreamble.empty()) {
+            printUsage(helpPreamble, std::cerr, msg);
+        }
+    };
+
     std::set<std::string> seenKeys;
     int numPositionalParams = 0;
     for (int i = 1; i < argc; ++i) {
@@ -673,17 +680,17 @@ std::string parseCommandLineOptions(int argc,
             || argv[i][1] != '-')
         {
             std::string errorMsg;
-            int numHandled = posArgCallback([](const std::string& k, const std::string& v)
-                                            {
-                                                MetaData::tree()[k] = v;
-                                            }, seenKeys, errorMsg,
-                                            argc, argv, i, numPositionalParams);
+            const int numHandled = posArgCallback([](const std::string& k, const std::string& v)
+                                                    { MetaData::tree()[k] = v; },
+                                                  seenKeys,
+                                                  errorMsg,
+                                                  argc,
+                                                  argv,
+                                                  i,
+                                                  numPositionalParams);
 
             if (numHandled < 1) {
-                if (!helpPreamble.empty()) {
-                    printUsage(helpPreamble, std::cerr, errorMsg);
-                }
-
+                handleUsage(errorMsg);
                 return errorMsg;
             }
             else {
@@ -706,10 +713,7 @@ std::string parseCommandLineOptions(int argc,
                 << " ('" << argv[i] << "') "
                 << "is invalid because it does not start with a letter.";
 
-            if (!helpPreamble.empty()) {
-                printUsage(helpPreamble, std::cerr, oss.str());
-            }
-
+            handleUsage(oss.str());
             return oss.str();
         }
 
@@ -723,9 +727,7 @@ std::string parseCommandLineOptions(int argc,
                                     "' specified multiple times as a "
                                     "command line parameter";
 
-            if (!helpPreamble.empty()) {
-                printUsage(helpPreamble, std::cerr, msg);
-            }
+            handleUsage(msg);
             return msg;
         }
         seenKeys.insert(paramName);
@@ -735,9 +737,7 @@ std::string parseCommandLineOptions(int argc,
                                     "' is missing a value. "
                                     " Please use " + argv[i] + "=value.";
 
-            if (!helpPreamble.empty()) {
-                printUsage(helpPreamble, std::cerr, msg);
-            }
+            handleUsage(msg);
             return msg;
         }
 

--- a/opm/models/utils/parametersystem.cpp
+++ b/opm/models/utils/parametersystem.cpp
@@ -354,6 +354,26 @@ std::string transformKey(const std::string& s,
     return result;
 }
 
+bool handleHelp(const std::string& helpPreamble, int argc, const char** argv)
+{
+    if (helpPreamble.empty()) {
+        return false;
+    }
+    for (int i = 1; i < argc; ++i) {
+        if (std::string("-h") == argv[i] ||
+            std::string("--help") == argv[i]) {
+            Opm::Parameters::printUsage(helpPreamble, std::cout, /*errorMsg=*/"");
+            return true;
+        }
+        if (std::string("--help-all") == argv[i]) {
+            Opm::Parameters::printUsage(helpPreamble, std::cout, /*errorMsg=*/"",  true);
+            return true;
+        }
+    }
+
+    return false;
+}
+
 } // anonymous namespace
 
 namespace Opm::Parameters {
@@ -640,18 +660,8 @@ std::string parseCommandLineOptions(int argc,
                                     const std::string& helpPreamble)
 {
     // handle the "--help" parameter
-    if (!helpPreamble.empty()) {
-        for (int i = 1; i < argc; ++i) {
-            if (std::string("-h") == argv[i] ||
-                std::string("--help") == argv[i]) {
-                printUsage(helpPreamble, std::cout, /*errorMsg=*/"");
-                return "Help called";
-            }
-            if (std::string("--help-all") == argv[i]) {
-                printUsage(helpPreamble, std::cout, /*errorMsg=*/"",  true);
-                return "Help called";
-            }
-        }
+    if (handleHelp(helpPreamble, argc, argv)) {
+        return "Help called";
     }
 
     std::set<std::string> seenKeys;

--- a/opm/models/utils/parametersystem.cpp
+++ b/opm/models/utils/parametersystem.cpp
@@ -45,7 +45,9 @@
 #include <charconv>
 #include <fstream>
 #include <memory>
+#include <ranges>
 #include <stdexcept>
+#include <string_view>
 #include <sys/ioctl.h>
 #include <unistd.h>
 
@@ -359,16 +361,23 @@ bool handleHelp(const std::string& helpPreamble, int argc, const char** argv)
     if (helpPreamble.empty()) {
         return false;
     }
-    for (int i = 1; i < argc; ++i) {
-        if (std::string("-h") == argv[i] ||
-            std::string("--help") == argv[i]) {
-            Opm::Parameters::printUsage(helpPreamble, std::cout, /*errorMsg=*/"");
-            return true;
+    auto args = std::views::counted(argv, argc)
+        | std::views::drop(1) // Skip argv[0]
+        | std::views::transform([](const char* p) { return std::string_view(p); });
+
+    auto first_help = std::ranges::find_if(args, [](std::string_view arg) {
+        return arg == "-h" || arg == "--help" || arg == "--help-all";
+    });
+
+    if (first_help != std::ranges::end(args)) {
+        if (*first_help == "--help-all") {
+            Opm::Parameters::printUsage(helpPreamble, std::cout, "", true);
         }
-        if (std::string("--help-all") == argv[i]) {
-            Opm::Parameters::printUsage(helpPreamble, std::cout, /*errorMsg=*/"",  true);
-            return true;
+        else {
+            Opm::Parameters::printUsage(helpPreamble, std::cout, "");
         }
+
+        return true;
     }
 
     return false;

--- a/opm/models/utils/parametersystem.cpp
+++ b/opm/models/utils/parametersystem.cpp
@@ -139,7 +139,7 @@ std::string parseKey(std::string& s)
 {
     const auto it = std::ranges::find_if(s,
                                          [](const char ch)
-                                         { return std::isspace(ch) || ch == '='; });
+                                         { return std::isspace(ch) != 0 || ch == '='; });
     std::string ret {s.begin(), it};
     s.erase(s.begin(), it);
     return ret;
@@ -222,7 +222,7 @@ void printParamUsage(std::ostream& os,
     std::string cmdLineName = "-";
     const std::string camelCaseName = paramInfo.paramName;
     for (unsigned i = 0; i < camelCaseName.size(); ++i) {
-        if (isupper(camelCaseName[i])) {
+        if (isupper(camelCaseName[i]) != 0) {
             cmdLineName += "-";
         }
         cmdLineName += static_cast<char>(std::tolower(camelCaseName[i]));
@@ -310,7 +310,7 @@ void removeLeadingSpace(std::string& s)
 {
     s.erase(s.begin(),
             std::ranges::find_if(s,
-                                 [](const char ch) { return !std::isspace(ch); }));
+                                 [](const char ch) { return std::isspace(ch) == 0; }));
 }
 
 std::string transformKey(const std::string& s,
@@ -323,7 +323,7 @@ std::string transformKey(const std::string& s,
         throw std::runtime_error(errorPrefix + "Empty parameter names are invalid");
     }
 
-    if (!std::isalpha(s[0])) {
+    if (std::isalpha(s[0]) == 0) {
         throw std::runtime_error(errorPrefix +" Parameter name '" + s +
                                  "' is invalid: First character must be a letter");
     }
@@ -338,12 +338,12 @@ std::string transformKey(const std::string& s,
     for (unsigned i = 1; i < s.size(); ++i) {
         if (s[i] == '-') {
             ++i;
-            if (s.size() <= i || !std::isalpha(s[i])) {
+            if (s.size() <= i || std::isalpha(s[i]) == 0) {
                 throw std::runtime_error(errorPrefix + "Invalid parameter name '" + s + "'");
             }
             result += static_cast<char>(std::toupper(s[i]));
         }
-        else if (!std::isalnum(s[i])) {
+        else if (std::isalnum(s[i]) == 0) {
             throw std::runtime_error(errorPrefix + "Invalid parameter name '" + s + "'");
         }
         else {
@@ -690,7 +690,7 @@ std::string parseCommandLineOptions(int argc,
         // "abc"
 
         // There is nothing after the '-'
-        if (argv[i][2] == 0 || !std::isalpha(argv[i][2])) {
+        if (argv[i][2] == 0 || std::isalpha(argv[i][2]) == 0) {
             std::ostringstream oss;
             oss << "Parameter name of argument " << i
                 << " ('" << argv[i] << "') "

--- a/opm/models/utils/terminal.cpp
+++ b/opm/models/utils/terminal.cpp
@@ -76,7 +76,7 @@ std::string breakLines(const std::string& msg,
             continue;
         }
 
-        if (std::isspace(msg[inPos])) {
+        if (std::isspace(msg[inPos]) != 0) {
             lastBreakPos = inPos;
         }
 
@@ -110,7 +110,7 @@ std::string breakLines(const std::string& msg,
 int getTtyWidth()
 {
     int ttyWidth = 10*1000; // effectively do not break lines at all.
-    if (isatty(STDOUT_FILENO)) {
+    if (isatty(STDOUT_FILENO) != 0) {
 #if defined TIOCGWINSZ
         // This is a bit too linux specific, IMO. let's do it anyway
         struct winsize ttySize;
@@ -129,7 +129,7 @@ void assignResetTerminalSignalHandlers()
 {
     // set the signal handlers to reset the TTY to a well defined state on unexpected
     // program aborts
-    if (isatty(STDIN_FILENO)) {
+    if (isatty(STDIN_FILENO) != 0) {
         signal(SIGINT, resetTerminal);
         signal(SIGHUP, resetTerminal);
         signal(SIGABRT, resetTerminal);
@@ -178,7 +178,7 @@ void resetTerminal(int signum)
     }
 #endif
 
-    if (isatty(fileno(stdout)) && isatty(fileno(stdin))) {
+    if (isatty(fileno(stdout)) != 0 && isatty(fileno(stdin)) != 0) {
         std::cout << "\n\nReceived signal " << signum
                   << " (\"" << getSignalAbbrev(signum) << "\")."
                   << " Trying to reset the terminal.\n";

--- a/opm/models/utils/terminal.cpp
+++ b/opm/models/utils/terminal.cpp
@@ -30,9 +30,29 @@
 
 #include <csignal>
 #include <iostream>
-#include <string.h>             // strsignal()
+#include <unordered_map>
 #include <sys/ioctl.h>
 #include <unistd.h>
+
+namespace {
+
+const char* getSignalAbbrev(int sig)
+{
+    const auto sig_map = std::unordered_map<int, const char*>{
+        {SIGINT, "INT"},
+        {SIGILL, "ILL"},
+        {SIGABRT, "ABRT"},
+        {SIGFPE, "FPE"},
+        {SIGKILL, "KILL"},
+        {SIGSEGV, "SEGV"},
+        {SIGTERM, "TERM"},
+    };
+
+    const auto it = sig_map.find(sig);
+    return it != sig_map.end() ? it->second : "UNKNOWN";
+}
+
+}
 
 namespace Opm {
 
@@ -160,7 +180,7 @@ void resetTerminal(int signum)
 
     if (isatty(fileno(stdout)) && isatty(fileno(stdin))) {
         std::cout << "\n\nReceived signal " << signum
-                  << " (\"" << strsignal(signum) << "\")."
+                  << " (\"" << getSignalAbbrev(signum) << "\")."
                   << " Trying to reset the terminal.\n";
 
         resetTerminal();


### PR DESCRIPTION
Implicit bool conversions, implicit narrowing, cognitive complexity reduction