### PR TITLE
bioeffectsmodule: only include where needed

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -732,6 +732,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/models/blackoil/blackoilmeanings.hh
   opm/models/blackoil/blackoilmodel.hh
   opm/models/blackoil/blackoilmoduleparams.hh
+  opm/models/blackoil/blackoilmodules.hpp
   opm/models/blackoil/blackoilnewtonmethod.hpp
   opm/models/blackoil/blackoilnewtonmethodparams.hpp
   opm/models/blackoil/blackoilonephaseindices.hh

--- a/flow/flow_biofilm.cpp
+++ b/flow/flow_biofilm.cpp
@@ -19,6 +19,7 @@
 #include <flow/flow_biofilm.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>
+#include <opm/models/blackoil/blackoilbioeffectsmodules.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/blackoil/blackoiltwophaseindices.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>

--- a/flow/flow_micp.cpp
+++ b/flow/flow_micp.cpp
@@ -21,6 +21,7 @@
 #include <opm/grid/CpGrid.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>
+#include <opm/models/blackoil/blackoilbioeffectsmodules.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/blackoil/blackoilonephaseindices.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>

--- a/flowexperimental/BlackOilIntensiveQuantitiesGlobalIndex.hpp
+++ b/flowexperimental/BlackOilIntensiveQuantitiesGlobalIndex.hpp
@@ -40,6 +40,7 @@
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
 #include <opm/material/common/Valgrind.hpp>
 
+#include <opm/models/blackoil/blackoilmodules.hpp>
 #include <opm/models/blackoil/blackoilproperties.hh>
 #include <opm/models/blackoil/blackoilsolventmodules.hh>
 #include <opm/models/blackoil/blackoilextbomodules.hh>
@@ -48,7 +49,6 @@
 #include <opm/models/blackoil/blackoilbrinemodules.hh>
 #include <opm/models/blackoil/blackoilenergymodules.hh>
 #include <opm/models/blackoil/blackoildiffusionmodule.hh>
-#include <opm/models/blackoil/blackoilbioeffectsmodules.hh>
 #include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/common/directionalmobility.hh>
 

--- a/opm/models/blackoil/blackoilbioeffectsmodules.hh
+++ b/opm/models/blackoil/blackoilbioeffectsmodules.hh
@@ -32,6 +32,7 @@
 
 #include <opm/common/utility/gpuDecorators.hpp>
 
+#include <opm/models/blackoil/blackoilmodules.hpp>
 #include <opm/models/blackoil/blackoilbioeffectsparams.hpp>
 #include <opm/models/blackoil/blackoilproperties.hh>
 
@@ -40,12 +41,8 @@
 #include <cmath>
 #include <memory>
 #include <numeric>
-#include <stdexcept>
 
 namespace Opm {
-
-template <class TypeTag, bool enableBioeffectsV>
-class BlackOilBioeffectsModule;
 
 /*!
  * \ingroup BlackOil
@@ -513,10 +510,6 @@ template <class TypeTag>
 BlackOilBioeffectsParams<typename BlackOilBioeffectsModule<TypeTag, true>::Scalar>
 BlackOilBioeffectsModule<TypeTag, true>::params_;
 
-
-template <class TypeTag, bool enableBioeffectsV>
-class BlackOilBioeffectsIntensiveQuantities;
-
 /*!
  * \ingroup BlackOil
  * \class Opm::BlackOilBioeffectsIntensiveQuantities
@@ -611,16 +604,7 @@ protected:
     Evaluation calciteMass_;
     Evaluation permFactor_;
     Evaluation pcFactor_;
-
 };
-
-template <class TypeTag>
-class BlackOilBioeffectsIntensiveQuantities<TypeTag, false>
-{
-};
-
-template <class, bool>
-class BlackOilBioeffectsExtensiveQuantities;
 
 /*!
  * \ingroup BlackOil
@@ -631,11 +615,6 @@ class BlackOilBioeffectsExtensiveQuantities;
  */
 template <class TypeTag>
 class BlackOilBioeffectsExtensiveQuantities<TypeTag, true>
-{
-};
-
-template <class TypeTag>
-class BlackOilBioeffectsExtensiveQuantities<TypeTag, false>
 {
 };
 

--- a/opm/models/blackoil/blackoildiffusionmodule.hh
+++ b/opm/models/blackoil/blackoildiffusionmodule.hh
@@ -34,9 +34,11 @@
 
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 
+#include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/common/Valgrind.hpp>
 
-#include <opm/models/blackoil/blackoilbioeffectsmodules.hh>
+#include <opm/models/blackoil/blackoilmodules.hpp>
+#include <opm/models/common/multiphasebaseproperties.hh>
 #include <opm/models/discretization/common/fvbaseproperties.hh>
 
 #include <array>

--- a/opm/models/blackoil/blackoilextensivequantities.hh
+++ b/opm/models/blackoil/blackoilextensivequantities.hh
@@ -28,7 +28,7 @@
 #ifndef EWOMS_BLACK_OIL_EXTENSIVE_QUANTITIES_HH
 #define EWOMS_BLACK_OIL_EXTENSIVE_QUANTITIES_HH
 
-#include <opm/models/blackoil/blackoilbioeffectsmodules.hh>
+#include <opm/models/blackoil/blackoilmodules.hpp>
 #include <opm/models/blackoil/blackoildiffusionmodule.hh>
 #include <opm/models/blackoil/blackoilenergymodules.hh>
 #include <opm/models/blackoil/blackoilpolymermodules.hh>

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -37,7 +37,7 @@
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
 #include <opm/material/common/Valgrind.hpp>
 
-#include <opm/models/blackoil/blackoilbioeffectsmodules.hh>
+#include <opm/models/blackoil/blackoilmodules.hpp>
 #include <opm/models/blackoil/blackoilbrinemodules.hh>
 #include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoildiffusionmodule.hh>
@@ -59,7 +59,6 @@
 #include <cstring>
 #include <stdexcept>
 #include <utility>
-#include <vector>
 
 namespace Opm {
 

--- a/opm/models/blackoil/blackoillocalresidual.hh
+++ b/opm/models/blackoil/blackoillocalresidual.hh
@@ -31,7 +31,7 @@
 #include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
 
-#include <opm/models/blackoil/blackoilbioeffectsmodules.hh>
+#include <opm/models/blackoil/blackoilmodules.hpp>
 #include <opm/models/blackoil/blackoilbrinemodules.hh>
 #include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoildiffusionmodule.hh>

--- a/opm/models/blackoil/blackoillocalresidualtpfa.hh
+++ b/opm/models/blackoil/blackoillocalresidualtpfa.hh
@@ -35,7 +35,7 @@
 #include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
 
-#include <opm/models/blackoil/blackoilbioeffectsmodules.hh>
+#include <opm/models/blackoil/blackoilmodules.hpp>
 #include <opm/models/blackoil/blackoilbrinemodules.hh>
 #include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoildiffusionmodule.hh>

--- a/opm/models/blackoil/blackoilmodel.hh
+++ b/opm/models/blackoil/blackoilmodel.hh
@@ -32,7 +32,7 @@
 
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 
-#include <opm/models/blackoil/blackoilbioeffectsmodules.hh>
+#include <opm/models/blackoil/blackoilmodules.hpp>
 #include <opm/models/blackoil/blackoilboundaryratevector.hh>
 #include <opm/models/blackoil/blackoilbrinemodules.hh>
 #include <opm/models/blackoil/blackoildarcyfluxmodule.hh>
@@ -59,6 +59,8 @@
 #include <opm/models/io/vtkblackoilmodule.hpp>
 #include <opm/models/io/vtkcompositionmodule.hpp>
 #include <opm/models/io/vtkdiffusionmodule.hpp>
+
+#include <opm/models/utils/propertysystem.hh>
 
 #include <cassert>
 #include <istream>

--- a/opm/models/blackoil/blackoilmodules.hpp
+++ b/opm/models/blackoil/blackoilmodules.hpp
@@ -1,0 +1,49 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief Contains classes extending the black-oil model.
+ * \detail This file holds dummy definitions,
+ *         actual implementation is in separate headers.
+ */
+#ifndef OPM_BLACK_OIL_MODULES_HPP
+#define OPM_BLACK_OIL_MODULES_HPP
+
+namespace Opm {
+
+#define DECLARE_MODULE(T) \
+    template<class TypeTag, bool enable> class T##Module; \
+    template<class TypeTag, bool enable> class T##IntensiveQuantities;  \
+    template<class TypeTag, bool enable> class T##ExtensiveQuantities; \
+    template<class TypeTag> struct T##Params; \
+    template<class TypeTag> class T##IntensiveQuantities<TypeTag, false> {}; \
+    template<class TypeTag> class T##ExtensiveQuantities<TypeTag, false> {};
+
+DECLARE_MODULE(BlackOilBioeffects)
+
+#undef DECLARE_MODULE
+
+} // namespace Opm
+
+#endif

--- a/opm/models/blackoil/blackoilnewtonmethod.hpp
+++ b/opm/models/blackoil/blackoilnewtonmethod.hpp
@@ -30,7 +30,7 @@
 
 #include <opm/common/Exceptions.hpp>
 
-#include <opm/models/blackoil/blackoilbioeffectsmodules.hh>
+#include <opm/models/blackoil/blackoilmodules.hpp>
 #include <opm/models/blackoil/blackoilnewtonmethodparams.hpp>
 #include <opm/models/blackoil/blackoilproperties.hh>
 

--- a/opm/models/blackoil/blackoilprimaryvariables.hh
+++ b/opm/models/blackoil/blackoilprimaryvariables.hh
@@ -33,7 +33,7 @@
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 #include <opm/material/fluidstates/SimpleModularFluidState.hpp>
 
-#include <opm/models/blackoil/blackoilbioeffectsmodules.hh>
+#include <opm/models/blackoil/blackoilmodules.hpp>
 #include <opm/models/blackoil/blackoilbrinemodules.hh>
 #include <opm/models/blackoil/blackoilenergymodules.hh>
 #include <opm/models/blackoil/blackoilextbomodules.hh>

--- a/opm/models/blackoil/blackoilratevector.hh
+++ b/opm/models/blackoil/blackoilratevector.hh
@@ -34,7 +34,7 @@
 #include <opm/material/common/Valgrind.hpp>
 #include <opm/material/constraintsolvers/NcpFlash.hpp>
 
-#include <opm/models/blackoil/blackoilbioeffectsmodules.hh>
+#include <opm/models/blackoil/blackoilmodules.hpp>
 #include <opm/models/blackoil/blackoilbrinemodules.hh>
 #include <opm/models/blackoil/blackoilfoammodules.hh>
 #include <opm/models/blackoil/blackoilpolymermodules.hh>

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -2660,7 +2660,7 @@ private:
                                              model.dofTotalVolume(ectx.globalDofIdx);
                                   }
                                   else {
-                                      return 0.0;
+                                      return Scalar{0};
                                   }
                               }
                   }
@@ -2674,7 +2674,7 @@ private:
                                              model.dofTotalVolume(ectx.globalDofIdx);
                                   }
                                   else {
-                                      return 0.0;
+                                      return Scalar{0};
                                   }
                               }
                   }
@@ -2688,7 +2688,7 @@ private:
                                              model.dofTotalVolume(ectx.globalDofIdx);
                                   }
                                   else {
-                                      return 0.0;
+                                      return Scalar{0};
                                   }
                               }
                   }
@@ -2701,7 +2701,7 @@ private:
                                             getValue(ectx.intQuants.biofilmMass());
                                   }
                                   else {
-                                      return 0.0;
+                                      return Scalar{0};
                                   }
                               }
                   }
@@ -2714,7 +2714,7 @@ private:
                                              getValue(ectx.intQuants.calciteMass());
                                   }
                                   else {
-                                      return 0.0;
+                                      return Scalar{0};
                                   }
                               }
                   }

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -37,7 +37,7 @@
 #include <opm/models/blackoil/blackoilextbomodules.hh>
 #include <opm/models/blackoil/blackoilfoammodules.hh>
 #include <opm/models/blackoil/blackoilbrinemodules.hh>
-#include <opm/models/blackoil/blackoilbioeffectsmodules.hh>
+#include <opm/models/blackoil/blackoilmodules.hpp>
 
 #include <opm/material/densead/Evaluation.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>


### PR DESCRIPTION
Time to start reaping some benefits from recent refactoring/fixes.

Move declaration and dummy instance of BlackOilBioeffectsModule with friends to a separate header ```blackoilmodules.hpp```. Now we only need to include the ```blackoilbioffectsmodule.hh``` where required.

This has great benefits.

touch opm/models/blackoil/blackoilbioeffectsmodule.hh

| | Before | After
|- | --------- | --------
|Objects built| 88 | 2
|Binaries linked | 185 | 4

in particular we only build ```flow_biofilm.cpp```, ```flow_micp.cpp```, and link the associated simulator binaries. The "before" numbers obviously depend a little on the build configuration.