### PR TITLE
Include Missing Valgrind Header

### DIFF
--- a/opm/models/blackoil/blackoilnewtonmethod.hpp
+++ b/opm/models/blackoil/blackoilnewtonmethod.hpp
@@ -38,6 +38,8 @@
 
 #include <opm/models/utils/signum.hh>
 
+#include <opm/material/common/Valgrind.hpp>
+
 #include <algorithm>
 #include <cmath>
 #include <vector>


### PR DESCRIPTION
`BlackOilNewtonMethod<>::updatePrimaryVariables_()` unconditionally [invokes Valgrind functions](https://github.com/OPM/opm-simulators/blob/cdc11f250565a73394564831daf99534aba3d5b9/opm/models/blackoil/blackoilnewtonmethod.hpp#L218-L219) and needs declarations for these.

PR #7117 apparently pruned a transitive include statement on which we implicitly depended.