### PR TITLE
blackoilconvectivemixingmodule.hh: only include where needed

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -716,6 +716,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/models/blackoil/blackoilbrinemodules.hh
   opm/models/blackoil/blackoilbrineparams.hpp
   opm/models/blackoil/blackoilconvectivemixingmodule.hh
+  opm/models/blackoil/blackoilconvectivemixingmoduleparam.hpp
   opm/models/blackoil/blackoildarcyfluxmodule.hh
   opm/models/blackoil/blackoildiffusionmodule.hh
   opm/models/blackoil/blackoildispersionmodule.hh

--- a/examples/reservoir_blackoil_ecfv.cpp
+++ b/examples/reservoir_blackoil_ecfv.cpp
@@ -30,6 +30,7 @@
 
 #include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoilmodel.hh>
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>

--- a/flow/flow_biofilm.cpp
+++ b/flow/flow_biofilm.cpp
@@ -18,16 +18,20 @@
 
 #include <flow/flow_biofilm.hpp>
 
+#include <opm/grid/CpGrid.hpp>
+
 #include <opm/material/common/ResetLocale.hpp>
+#include <opm/material/thermal/EnergyModuleType.hpp>
+
 #include <opm/models/blackoil/blackoilbioeffectsmodules.hh>
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/blackoil/blackoiltwophaseindices.hh>
+
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 
-#include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/Main.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
-#include <opm/material/thermal/EnergyModuleType.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_blackoil.cpp
+++ b/flow/flow_blackoil.cpp
@@ -23,6 +23,7 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 

--- a/flow/flow_blackoil_alugrid.cpp
+++ b/flow/flow_blackoil_alugrid.cpp
@@ -28,12 +28,15 @@
 // For more details, refer to the files gridfactory.hh and aluinline.hh located in the dune-alugrid/3d/
 
 #include <dune/alugrid/grid.hh>
-#include <opm/simulators/flow/Main.hpp>
 
 // for equilgrid in writer
 // need to include this before eclgenericwriter_impl.hh due to specializations.
 #include <opm/grid/CpGrid.hpp>
 #include <opm/grid/cpgrid/GridHelpers.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+
+#include <opm/simulators/flow/Main.hpp>
 
 // these are not explicitly instanced in library
 #include <opm/simulators/flow/AluGridVanguard.hpp>

--- a/flow/flow_blackoil_float_main.cpp
+++ b/flow/flow_blackoil_float_main.cpp
@@ -18,8 +18,11 @@
 */
 #include <config.h>
 
-#include <opm/simulators/flow/Main.hpp>
 #include <flow/flow_blackoil.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+
+#include <opm/simulators/flow/Main.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_blackoil_legacyassembly.cpp
+++ b/flow/flow_blackoil_legacyassembly.cpp
@@ -19,8 +19,11 @@
 #include <flow/flow_blackoil_legacyassembly.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+
 #include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm {
 

--- a/flow/flow_blackoil_nohyst.cpp
+++ b/flow/flow_blackoil_nohyst.cpp
@@ -25,6 +25,7 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 

--- a/flow/flow_blackoil_polyhedralgrid.cpp
+++ b/flow/flow_blackoil_polyhedralgrid.cpp
@@ -20,11 +20,13 @@
 
 #include <opm/grid/polyhedralgrid.hh>
 
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 
-#include <opm/simulators/flow/PolyhedralGridVanguard.hpp>
 #include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/PolyhedralGridVanguard.hpp>
 
 // these are not explicitly instanced in library
 #include <opm/simulators/flow/CollectDataOnIORank_impl.hpp>

--- a/flow/flow_blackoil_temp.cpp
+++ b/flow/flow_blackoil_temp.cpp
@@ -18,14 +18,18 @@
 
 #include <flow/flow_blackoil_temp.hpp>
 
-#include <opm/material/common/ResetLocale.hpp>
 #include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
-#include <opm/simulators/flow/Main.hpp>
 
-#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
-#include <opm/models/discretization/common/tpfalinearizer.hh>
+#include <opm/material/common/ResetLocale.hpp>
 #include <opm/material/thermal/EnergyModuleType.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+
+#include <opm/models/discretization/common/tpfalinearizer.hh>
+
+#include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_blackoil_tpsa.cpp
+++ b/flow/flow_blackoil_tpsa.cpp
@@ -20,7 +20,9 @@
 */
 #include "config.h"
 
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 
 #include <opm/simulators/flow/BlackoilModelProperties.hpp>

--- a/flow/flow_brine.cpp
+++ b/flow/flow_brine.cpp
@@ -18,14 +18,18 @@
 
 #include <flow/flow_brine.hpp>
 
+#include <opm/grid/CpGrid.hpp>
+
 #include <opm/material/common/ResetLocale.hpp>
+
 #include <opm/models/blackoil/blackoilbrinemodules.hh>
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 
-#include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_brine_energy.cpp
+++ b/flow/flow_brine_energy.cpp
@@ -16,11 +16,15 @@
 */
 #include "config.h"
 
-#include <opm/models/blackoil/blackoilbrinemodules.hh>
-#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
-#include <opm/models/discretization/common/tpfalinearizer.hh>
-#include <opm/simulators/flow/Main.hpp>
 #include <opm/material/thermal/EnergyModuleType.hpp>
+
+#include <opm/models/blackoil/blackoilbrinemodules.hh>
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+
+#include <opm/models/discretization/common/tpfalinearizer.hh>
+
+#include <opm/simulators/flow/Main.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_brine_precsalt_vapwat.cpp
+++ b/flow/flow_brine_precsalt_vapwat.cpp
@@ -18,14 +18,18 @@
 
 #include <flow/flow_brine_precsalt_vapwat.hpp>
 
+#include <opm/grid/CpGrid.hpp>
+
 #include <opm/material/common/ResetLocale.hpp>
+
 #include <opm/models/blackoil/blackoilbrinemodules.hh>
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 
-#include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_brine_saltprecipitation.cpp
+++ b/flow/flow_brine_saltprecipitation.cpp
@@ -18,14 +18,18 @@
 
 #include <flow/flow_brine_saltprecipitation.hpp>
 
+#include <opm/grid/CpGrid.hpp>
+
 #include <opm/material/common/ResetLocale.hpp>
+
 #include <opm/models/blackoil/blackoilbrinemodules.hh>
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 
-#include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_energy.cpp
+++ b/flow/flow_energy.cpp
@@ -18,13 +18,18 @@
 
 #include <flow/flow_energy.hpp>
 
-#include <opm/material/common/ResetLocale.hpp>
 #include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
-#include <opm/simulators/flow/Main.hpp>
+
+#include <opm/material/common/ResetLocale.hpp>
 #include <opm/material/thermal/EnergyModuleType.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+
 #include <opm/models/discretization/common/tpfalinearizer.hh>
+
+#include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_extbo.cpp
+++ b/flow/flow_extbo.cpp
@@ -18,10 +18,14 @@
 
 #include <flow/flow_extbo.hpp>
 
-#include <opm/material/common/ResetLocale.hpp>
 #include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
+
+#include <opm/material/common/ResetLocale.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+
 #include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_foam.cpp
+++ b/flow/flow_foam.cpp
@@ -18,10 +18,14 @@
 
 #include <flow/flow_foam.hpp>
 
-#include <opm/material/common/ResetLocale.hpp>
 #include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
+
+#include <opm/material/common/ResetLocale.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+
 #include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_gasoil.cpp
+++ b/flow/flow_gasoil.cpp
@@ -18,16 +18,19 @@
 
 #include <flow/flow_gasoil.hpp>
 
+#include <opm/grid/CpGrid.hpp>
+
 #include <opm/material/common/ResetLocale.hpp>
+#include <opm/material/thermal/EnergyModuleType.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/blackoil/blackoiltwophaseindices.hh>
 
-#include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
-#include <opm/simulators/flow/Main.hpp>
-
-#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
-#include <opm/material/thermal/EnergyModuleType.hpp>
+
+#include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_gasoil_energy.cpp
+++ b/flow/flow_gasoil_energy.cpp
@@ -18,15 +18,18 @@
 
 #include <flow/flow_gasoil_energy.hpp>
 
-#include <opm/material/common/ResetLocale.hpp>
-#include <opm/models/blackoil/blackoiltwophaseindices.hh>
-
 #include <opm/grid/CpGrid.hpp>
+
+#include <opm/material/common/ResetLocale.hpp>
+#include <opm/material/thermal/EnergyModuleType.hpp>
+
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+#include <opm/models/blackoil/blackoiltwophaseindices.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
-#include <opm/material/thermal/EnergyModuleType.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_gasoildiffuse.cpp
+++ b/flow/flow_gasoildiffuse.cpp
@@ -18,15 +18,19 @@
 
 #include <flow/flow_gasoil.hpp>
 
-#include <opm/material/common/ResetLocale.hpp>
-#include <opm/models/blackoil/blackoiltwophaseindices.hh>
-
 #include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
-#include <opm/simulators/flow/Main.hpp>
-#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
-#include <opm/models/discretization/common/tpfalinearizer.hh>
+
+#include <opm/material/common/ResetLocale.hpp>
 #include <opm/material/thermal/EnergyModuleType.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+#include <opm/models/blackoil/blackoiltwophaseindices.hh>
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+
+#include <opm/models/discretization/common/tpfalinearizer.hh>
+
+#include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_gaswater.cpp
+++ b/flow/flow_gaswater.cpp
@@ -18,15 +18,18 @@
 
 #include <flow/flow_gaswater.hpp>
 
+#include <opm/grid/CpGrid.hpp>
+
 #include <opm/material/common/ResetLocale.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/blackoil/blackoiltwophaseindices.hh>
 
-#include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
-#include <opm/simulators/flow/Main.hpp>
-
-#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
+
+#include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_gaswater_brine.cpp
+++ b/flow/flow_gaswater_brine.cpp
@@ -18,16 +18,20 @@
 
 #include <flow/flow_gaswater_brine.hpp>
 
+#include <opm/grid/CpGrid.hpp>
+
 #include <opm/material/common/ResetLocale.hpp>
+#include <opm/material/thermal/EnergyModuleType.hpp>
+
 #include <opm/models/blackoil/blackoilbrinemodules.hh>
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/blackoil/blackoiltwophaseindices.hh>
+
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 
-#include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
-#include <opm/material/thermal/EnergyModuleType.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_gaswater_dissolution.cpp
+++ b/flow/flow_gaswater_dissolution.cpp
@@ -18,16 +18,19 @@
 
 #include <flow/flow_gaswater_dissolution.hpp>
 
+#include <opm/grid/CpGrid.hpp>
+
 #include <opm/material/common/ResetLocale.hpp>
+#include <opm/material/thermal/EnergyModuleType.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/blackoil/blackoiltwophaseindices.hh>
 
-#include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
-#include <opm/simulators/flow/Main.hpp>
-
-#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
-#include <opm/material/thermal/EnergyModuleType.hpp>
+
+#include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_gaswater_dissolution_diffuse.cpp
+++ b/flow/flow_gaswater_dissolution_diffuse.cpp
@@ -25,6 +25,7 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 #include <opm/material/thermal/EnergyModuleType.hpp>

--- a/flow/flow_gaswater_dissolution_tpsa.cpp
+++ b/flow/flow_gaswater_dissolution_tpsa.cpp
@@ -20,8 +20,10 @@
 */
 #include "config.h"
 
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/blackoil/blackoiltwophaseindices.hh>
+
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 
 #include <opm/simulators/flow/BlackoilModelProperties.hpp>

--- a/flow/flow_gaswater_energy.cpp
+++ b/flow/flow_gaswater_energy.cpp
@@ -18,13 +18,15 @@
 
 #include <flow/flow_gaswater_energy.hpp>
 
+#include <opm/grid/CpGrid.hpp>
+
 #include <opm/material/common/ResetLocale.hpp>
 
-#include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
-#include <opm/simulators/flow/Main.hpp>
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 
 #include <opm/simulators/flow/FlowGasWaterEnergyTypeTag.hpp>
+#include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm {
 

--- a/flow/flow_gaswater_saltprec_energy.cpp
+++ b/flow/flow_gaswater_saltprec_energy.cpp
@@ -18,16 +18,20 @@
 
 #include <flow/flow_gaswater_saltprec_energy.hpp>
 
+#include <opm/grid/CpGrid.hpp>
+
 #include <opm/material/common/ResetLocale.hpp>
+#include <opm/material/thermal/EnergyModuleType.hpp>
+
 #include <opm/models/blackoil/blackoilbrinemodules.hh>
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/blackoil/blackoiltwophaseindices.hh>
+
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 
-#include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
-#include <opm/material/thermal/EnergyModuleType.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_gaswater_saltprec_vapwat.cpp
+++ b/flow/flow_gaswater_saltprec_vapwat.cpp
@@ -18,16 +18,20 @@
 
 #include <flow/flow_gaswater_saltprec_vapwat.hpp>
 
+#include <opm/grid/CpGrid.hpp>
+
 #include <opm/material/common/ResetLocale.hpp>
+#include <opm/material/thermal/EnergyModuleType.hpp>
+
 #include <opm/models/blackoil/blackoilbrinemodules.hh>
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/blackoil/blackoiltwophaseindices.hh>
+
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 
-#include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
-#include <opm/material/thermal/EnergyModuleType.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_gaswater_solvent.cpp
+++ b/flow/flow_gaswater_solvent.cpp
@@ -18,12 +18,15 @@
 
 #include <flow/flow_gaswater_solvent.hpp>
 
+#include <opm/grid/CpGrid.hpp>
+
 #include <opm/material/common/ResetLocale.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoiltwophaseindices.hh>
 
-#include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_micp.cpp
+++ b/flow/flow_micp.cpp
@@ -21,9 +21,12 @@
 #include <opm/grid/CpGrid.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>
+
 #include <opm/models/blackoil/blackoilbioeffectsmodules.hh>
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/blackoil/blackoilonephaseindices.hh>
+
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 
 #include <opm/simulators/flow/Main.hpp>

--- a/flow/flow_oilwater.cpp
+++ b/flow/flow_oilwater.cpp
@@ -18,15 +18,18 @@
 
 #include <flow/flow_oilwater.hpp>
 
+#include <opm/grid/CpGrid.hpp>
+
 #include <opm/material/common/ResetLocale.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/blackoil/blackoiltwophaseindices.hh>
 
-#include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
-#include <opm/simulators/flow/Main.hpp>
-
-#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
+
+#include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_oilwater_brine.cpp
+++ b/flow/flow_oilwater_brine.cpp
@@ -20,6 +20,7 @@
 
 #include <opm/material/common/ResetLocale.hpp>
 #include <opm/models/blackoil/blackoilbrinemodules.hh>
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/blackoil/blackoiltwophaseindices.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>

--- a/flow/flow_oilwater_polymer.cpp
+++ b/flow/flow_oilwater_polymer.cpp
@@ -18,12 +18,15 @@
 
 #include <flow/flow_oilwater_polymer.hpp>
 
+#include <opm/grid/CpGrid.hpp>
+
 #include <opm/material/common/ResetLocale.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoiltwophaseindices.hh>
 
-#include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_oilwater_polymer_injectivity.cpp
+++ b/flow/flow_oilwater_polymer_injectivity.cpp
@@ -18,12 +18,15 @@
 
 #include <flow/flow_oilwater_polymer_injectivity.hpp>
 
+#include <opm/grid/CpGrid.hpp>
+
 #include <opm/material/common/ResetLocale.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoiltwophaseindices.hh>
 
-#include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_onephase.cpp
+++ b/flow/flow_onephase.cpp
@@ -19,11 +19,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "config.h"
-#include <opm/simulators/flow/Main.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/blackoil/blackoilonephaseindices.hh>
 
-#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
+
+#include <opm/simulators/flow/Main.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_onephase_energy.cpp
+++ b/flow/flow_onephase_energy.cpp
@@ -22,9 +22,12 @@
 
 #include <flow/flow_onephase_energy.hpp>
 
-#include <opm/simulators/flow/Main.hpp>
-#include <opm/models/blackoil/blackoilonephaseindices.hh>
 #include <opm/material/common/ResetLocale.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+#include <opm/models/blackoil/blackoilonephaseindices.hh>
+
+#include <opm/simulators/flow/Main.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_onephase_tpsa.cpp
+++ b/flow/flow_onephase_tpsa.cpp
@@ -20,8 +20,10 @@
 */
 #include "config.h"
 
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/blackoil/blackoilonephaseindices.hh>
+
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 
 #include <opm/simulators/flow/BlackoilModelProperties.hpp>

--- a/flow/flow_polymer.cpp
+++ b/flow/flow_polymer.cpp
@@ -18,10 +18,14 @@
 
 #include <flow/flow_polymer.hpp>
 
-#include <opm/material/common/ResetLocale.hpp>
 #include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
+
+#include <opm/material/common/ResetLocale.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+
 #include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_solvent.cpp
+++ b/flow/flow_solvent.cpp
@@ -18,10 +18,14 @@
 
 #include <flow/flow_solvent.hpp>
 
-#include <opm/material/common/ResetLocale.hpp>
 #include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
+
+#include <opm/material/common/ResetLocale.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+
 #include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/flow/flow_solvent_foam.cpp
+++ b/flow/flow_solvent_foam.cpp
@@ -18,10 +18,14 @@
 
 #include <flow/flow_solvent_foam.hpp>
 
-#include <opm/material/common/ResetLocale.hpp>
 #include <opm/grid/CpGrid.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
+
+#include <opm/material/common/ResetLocale.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+
 #include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 namespace Opm::Properties {
 

--- a/opm/models/blackoil/blackoilconvectivemixingmodule.hh
+++ b/opm/models/blackoil/blackoilconvectivemixingmodule.hh
@@ -36,6 +36,7 @@
 #include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/common/Valgrind.hpp>
 
+#include <opm/models/blackoil/blackoilmodules.hpp>
 #include <opm/models/blackoil/blackoilconvectivemixingmoduleparam.hpp>
 #include <opm/models/blackoil/blackoilenergymodules.hh>
 #include <opm/models/common/multiphasebaseproperties.hh>
@@ -48,7 +49,6 @@
 namespace Opm {
 
 /*!
- * \copydoc Opm::BlackOilConvectiveMixingModule
  * \brief Provides the convective term in the transport flux for the brine
  * when convective mixing (enhanced dissolution of CO2 in brine) occurs.
  * Controlled by the regimes for a controlvolume:
@@ -59,18 +59,6 @@ namespace Opm {
  * iv) decline phase (Convection ceases at the large-scale when the CO2
  * has been completely dissolved)
  */
-
-template <class TypeTag, bool enableConvectiveMixing>
-class BlackOilConvectiveMixingModule;
-
-/*!
- * \copydoc Opm::BlackOilConvectiveMixingModule
- */
-
-template <class TypeTag>
-class BlackOilConvectiveMixingModule<TypeTag, /*enableConvectiveMixing=*/false>
-{
-};
 
 template <class TypeTag>
 class BlackOilConvectiveMixingModule<TypeTag, /*enableConvectiveMixing=*/true>
@@ -89,7 +77,8 @@ class BlackOilConvectiveMixingModule<TypeTag, /*enableConvectiveMixing=*/true>
     enum { dimWorld = GridView::dimensionworld };
     enum { waterPhaseIdx = FluidSystem::waterPhaseIdx };
     enum { oilPhaseIdx = FluidSystem::oilPhaseIdx };
-    static constexpr bool enableFullyImplicitThermal = (getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal);
+    static constexpr bool enableFullyImplicitThermal =
+        getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal;
     static constexpr unsigned contiEnergyEqIdx = Indices::contiEnergyEqIdx;
 
 public:
@@ -345,9 +334,6 @@ public:
     }
 };
 
-template <class TypeTag, bool enableConvectiveMixingV>
-class BlackOilConvectiveMixingIntensiveQuantities;
-
 /*!
  * \ingroup BlackOil
  * \class Opm::BlackOilConvectiveMixingIntensiveQuantities
@@ -389,11 +375,6 @@ protected:
     { return *static_cast<Implementation*>(this); }
 
     Evaluation saturatedDissolutionFactor_;
-};
-
-template <class TypeTag>
-class BlackOilConvectiveMixingIntensiveQuantities<TypeTag, false>
-{
 };
 
 }

--- a/opm/models/blackoil/blackoilconvectivemixingmodule.hh
+++ b/opm/models/blackoil/blackoilconvectivemixingmodule.hh
@@ -36,51 +36,16 @@
 #include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/common/Valgrind.hpp>
 
-#include <opm/models/common/multiphasebaseproperties.hh>
+#include <opm/models/blackoil/blackoilconvectivemixingmoduleparam.hpp>
 #include <opm/models/blackoil/blackoilenergymodules.hh>
+#include <opm/models/common/multiphasebaseproperties.hh>
 #include <opm/models/discretization/common/fvbaseproperties.hh>
-
-#include <opm/common/utility/VectorWithDefaultAllocator.hpp>
 
 #include <opm/common/utility/gpuistl_if_available.hpp>
 
 #include <cstddef>
 
 namespace Opm {
-
-    template<class Scalar, template<class> class Storage = Opm::VectorWithDefaultAllocator>
-    struct ConvectiveMixingModuleParam
-    {
-        Storage<bool> active_;
-        Storage<Scalar> Xhi_;
-        Storage<Scalar> Psi_;
-    };
-
-#ifdef HAVE_CUDA
-namespace gpuistl
-{
-    template <class Scalar>
-    ConvectiveMixingModuleParam<Scalar, GpuView> make_view(ConvectiveMixingModuleParam<Scalar, GpuBuffer>& params)
-    {
-        ConvectiveMixingModuleParam<Scalar, GpuView> view;
-        view.active_ = gpuistl::make_view(params.active_);
-        view.Xhi_ = gpuistl::make_view(params.Xhi_);
-        view.Psi_ = gpuistl::make_view(params.Psi_);
-        return view;
-    }
-
-    template <class Scalar>
-    ConvectiveMixingModuleParam<Scalar, GpuBuffer> copy_to_gpu(const ConvectiveMixingModuleParam<Scalar, Opm::VectorWithDefaultAllocator>& params)
-    {
-        return ConvectiveMixingModuleParam<Scalar, GpuBuffer>{
-            gpuistl::GpuBuffer(params.active_),
-            gpuistl::GpuBuffer(params.Xhi_),
-            gpuistl::GpuBuffer(params.Psi_)
-        };
-    }
-}
-
-#endif
 
 /*!
  * \copydoc Opm::BlackOilConvectiveMixingModule

--- a/opm/models/blackoil/blackoilconvectivemixingmoduleparam.hpp
+++ b/opm/models/blackoil/blackoilconvectivemixingmoduleparam.hpp
@@ -1,0 +1,79 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief Classes required for dynamic convective mixing.
+ */
+#ifndef OPM_CONVECTIVEMIXING_MODULE_PARAM_HPP
+#define OPM_CONVECTIVEMIXING_MODULE_PARAM_HPP
+
+#include <opm/common/utility/VectorWithDefaultAllocator.hpp>
+
+#ifdef HAVE_CUDA
+#include <opm/simulators/linalg/gpuistl/GpuBuffer.hpp>
+#include <opm/simulators/linalg/gpuistl/GpuView.hpp>
+#endif
+
+namespace Opm {
+
+template<class Scalar, template<class> class Storage = VectorWithDefaultAllocator>
+struct ConvectiveMixingModuleParam
+{
+    Storage<bool> active_;
+    Storage<Scalar> Xhi_;
+    Storage<Scalar> Psi_;
+};
+
+#ifdef HAVE_CUDA
+namespace gpuistl
+{
+
+template <class Scalar>
+ConvectiveMixingModuleParam<Scalar, GpuView>
+make_view(ConvectiveMixingModuleParam<Scalar, GpuBuffer>& params)
+{
+    ConvectiveMixingModuleParam<Scalar, GpuView> view;
+    view.active_ = gpuistl::make_view(params.active_);
+    view.Xhi_ = gpuistl::make_view(params.Xhi_);
+    view.Psi_ = gpuistl::make_view(params.Psi_);
+    return view;
+}
+
+template <class Scalar>
+ConvectiveMixingModuleParam<Scalar, GpuBuffer>
+copy_to_gpu(const ConvectiveMixingModuleParam<Scalar, VectorWithDefaultAllocator>& params)
+{
+    return ConvectiveMixingModuleParam<Scalar, GpuBuffer>{
+        gpuistl::GpuBuffer(params.active_),
+        gpuistl::GpuBuffer(params.Xhi_),
+        gpuistl::GpuBuffer(params.Psi_)
+    };
+}
+
+}
+#endif
+
+}
+
+#endif

--- a/opm/models/blackoil/blackoildiffusionmodule.hh
+++ b/opm/models/blackoil/blackoildiffusionmodule.hh
@@ -38,6 +38,7 @@
 #include <opm/material/common/Valgrind.hpp>
 
 #include <opm/models/blackoil/blackoilmodules.hpp>
+#include <opm/models/blackoil/blackoilproperties.hh>
 #include <opm/models/common/multiphasebaseproperties.hh>
 #include <opm/models/discretization/common/fvbaseproperties.hh>
 

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -38,7 +38,6 @@
 #include <opm/material/common/Valgrind.hpp>
 
 #include <opm/models/blackoil/blackoilmodules.hpp>
-#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoildiffusionmodule.hh>
 #include <opm/models/blackoil/blackoildispersionmodule.hh>
 #include <opm/models/blackoil/blackoilenergymodules.hh>

--- a/opm/models/blackoil/blackoillocalresidual.hh
+++ b/opm/models/blackoil/blackoillocalresidual.hh
@@ -32,7 +32,6 @@
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
 
 #include <opm/models/blackoil/blackoilmodules.hpp>
-#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/blackoil/blackoildiffusionmodule.hh>
 #include <opm/models/blackoil/blackoilenergymodules.hh>
 #include <opm/models/blackoil/blackoilextbomodules.hh>

--- a/opm/models/blackoil/blackoillocalresidualtpfa.hh
+++ b/opm/models/blackoil/blackoillocalresidualtpfa.hh
@@ -36,7 +36,7 @@
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
 
 #include <opm/models/blackoil/blackoilmodules.hpp>
-#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+#include <opm/models/blackoil/blackoilconvectivemixingmoduleparam.hpp>
 #include <opm/models/blackoil/blackoildiffusionmodule.hh>
 #include <opm/models/blackoil/blackoildispersionmodule.hh>
 #include <opm/models/blackoil/blackoilenergymodules.hh>

--- a/opm/models/blackoil/blackoilmodules.hpp
+++ b/opm/models/blackoil/blackoilmodules.hpp
@@ -42,6 +42,7 @@ namespace Opm {
 
 DECLARE_MODULE(BlackOilBioeffects)
 DECLARE_MODULE(BlackOilBrine)
+DECLARE_MODULE(BlackOilConvectiveMixing)
 
 #undef DECLARE_MODULE
 

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -40,8 +40,9 @@
 #include <opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp>
 #include <opm/material/fluidsystems/blackoilpvt/ConstantRsDeadOilPvt.hpp>
 
-#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+#include <opm/models/blackoil/blackoilconvectivemixingmoduleparam.hpp>
 #include <opm/models/blackoil/blackoilmoduleparams.hh>
+#include <opm/models/blackoil/blackoilmodules.hpp>
 
 #include <opm/output/eclipse/EclipseIO.hpp>
 

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -69,10 +69,17 @@ namespace Opm::Properties {
 // this is a dummy type tag that is used to setup the parameters before the actual
 // simulator.
 namespace TTag {
+
 struct FlowEarlyBird {
     using InheritsFrom = std::tuple<FlowProblem>;
 };
+
 }
+
+// Disable convective mixing
+template<class TypeTag>
+struct EnableConvectiveMixing<TypeTag, TTag::FlowEarlyBird>
+{ static constexpr bool value = false; };
 
 } // namespace Opm::Properties
 

--- a/opm/simulators/flow/NewTranFluxModule.hpp
+++ b/opm/simulators/flow/NewTranFluxModule.hpp
@@ -41,12 +41,14 @@
 
 #include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/common/Valgrind.hpp>
+#include <opm/material/thermal/EnergyModuleType.hpp>
 
 #include <opm/models/discretization/common/fvbaseproperties.hh>
+#include <opm/models/blackoil/blackoilmodules.hpp>
+#include <opm/models/blackoil/blackoilconvectivemixingmoduleparam.hpp>
 #include <opm/models/blackoil/blackoilproperties.hh>
 #include <opm/models/utils/signum.hh>
 #include <opm/models/blackoil/blackoilmoduleparams.hh>
-#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 
 #include <opm/common/utility/gpuDecorators.hpp>
 
@@ -358,7 +360,7 @@ public:
         Scalar rhoEx = Toolbox::value(intQuantsEx.fluidState().density(phaseIdx));
         Evaluation rhoAvg = (rhoIn + rhoEx)/2;
 
-        if constexpr(enableConvectiveMixing) {
+        if constexpr (enableConvectiveMixing) {
             ConvectiveMixingModule::modifyAvgDensity(rhoAvg, intQuantsIn, intQuantsEx, phaseIdx, moduleParams.convectiveMixingModuleParam);
         }
 

--- a/python/simulators/PyBlackOilSimulator.cpp
+++ b/python/simulators/PyBlackOilSimulator.cpp
@@ -18,13 +18,15 @@
 */
 
 #include "config.h"
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+
 #include <opm/simulators/flow/python/PyBlackOilSimulator.hpp>
 // NOTE: This file will be generated at compile time and placed in the build directory
 // See python/generate_docstring_hpp.py, and python/simulators/CMakeLists.txt for details
 #include <PyBlackOilSimulatorDoc.hpp>
 // NOTE: EXIT_SUCCESS, EXIT_FAILURE is defined in cstdlib
 #include <cstdlib>
-#include <stdexcept>
 #include <string>
 
 namespace py = pybind11;

--- a/python/simulators/PyGasWaterSimulator.cpp
+++ b/python/simulators/PyGasWaterSimulator.cpp
@@ -18,13 +18,15 @@
 */
 
 #include "config.h"
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+
 #include <opm/simulators/flow/python/PyGasWaterSimulator.hpp>
 // NOTE: This file will be generated at compile time and placed in the build directory
 // See python/generate_docstring_hpp.py, and python/simulators/CMakeLists.txt for details
 #include <PyGasWaterSimulatorDoc.hpp>
 // NOTE: EXIT_SUCCESS, EXIT_FAILURE is defined in cstdlib
 #include <cstdlib>
-#include <stdexcept>
 #include <string>
 
 namespace Opm {

--- a/python/simulators/PyOnePhaseSimulator.cpp
+++ b/python/simulators/PyOnePhaseSimulator.cpp
@@ -17,14 +17,16 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "config.h"
+
 #include <opm/models/blackoil/blackoilonephaseindices.hh>
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+
 #include <opm/simulators/flow/python/PyOnePhaseSimulator.hpp>
 // NOTE: This file will be generated at compile time and placed in the build directory
 // See python/generate_docstring_hpp.py, and python/simulators/CMakeLists.txt for details
 #include <PyOnePhaseSimulatorDoc.hpp>
 // NOTE: EXIT_SUCCESS, EXIT_FAILURE is defined in cstdlib
 #include <cstdlib>
-#include <stdexcept>
 #include <string>
 
 namespace Opm::Properties {

--- a/tests/TestTypeTag.hpp
+++ b/tests/TestTypeTag.hpp
@@ -97,6 +97,11 @@ struct LinearSolverBackend<TTag::TestTypeTag, TTag::FlowIstlSolverParams> {
     using type = ISTLSolver<TTag::TestTypeTag>;
 };
 
+// Disable convective mixing
+template<class TypeTag>
+struct EnableConvectiveMixing<TypeTag, TTag::TestTypeTag>
+{ static constexpr bool value = false; };
+
 } // namespace Opm::Properties
 
 #endif // OPM_TEST_TYPETAG_HPP

--- a/tests/gpuistl/test_primaryvarswithdifferentvector.cpp
+++ b/tests/gpuistl/test_primaryvarswithdifferentvector.cpp
@@ -31,11 +31,12 @@
 #include <opm/simulators/linalg/gpuistl/MiniVector.hpp>
 #include <opm/simulators/linalg/gpuistl/detail/gpu_safe_call.hpp>
 #include <opm/simulators/linalg/gpuistl/gpu_smart_pointer.hpp>
+#include <tests/TestTypeTag.hpp>
 
 BOOST_AUTO_TEST_CASE(TestPrimaryVariablesCreationWithFieldVector)
 {
     // Just make sure we can instantiate
-    using TypeTag = Opm::Properties::TTag::FlowProblem;
+    using TypeTag = Opm::Properties::TTag::TestTypeTag;
     Opm::BlackOilPrimaryVariables<TypeTag> primaryVariables;
     for (std::size_t i = 0; i < primaryVariables.size(); ++i) {
         primaryVariables[i] = static_cast<double>(i);

--- a/tests/rescoup/test_chopstep.cpp
+++ b/tests/rescoup/test_chopstep.cpp
@@ -56,12 +56,30 @@
 #include <boost/test/tools/floating_point_comparison.hpp>
 #endif
 
+#include <tuple>
+
+namespace Opm::Properties::TTag {
+
+struct TestTypeTag
+{ using InheritsFrom = std::tuple<FlowProblemTPFA>; };
+
+}
+
+namespace Opm::Properties {
+
+// Disable convective mixing
+template<class TypeTag>
+struct EnableConvectiveMixing<TypeTag, TTag::TestTypeTag>
+{ static constexpr bool value = false; };
+
+}
+
 namespace Opm {
 
 class MainTestWrapper : public Main
 {
 public:
-    using TypeTag = Properties::TTag::FlowProblemTPFA;
+    using TypeTag = Properties::TTag::TestTypeTag;
     using FlowMainPtr = std::unique_ptr<FlowMain<TypeTag>>;
     using Simulator = GetPropType<TypeTag, Properties::Simulator>;
 

--- a/tests/test_equil.cpp
+++ b/tests/test_equil.cpp
@@ -104,6 +104,16 @@ struct EnableVapwat<TypeTag, TTag::TestEquilVapwatTypeTag> {
     static constexpr bool value = true;
 };
 
+// Disable convective mixing
+template<class TypeTag>
+struct EnableConvectiveMixing<TypeTag, TTag::TestEquilTypeTag>
+{ static constexpr bool value = false; };
+
+// Disable convective mixing
+template<class TypeTag>
+struct EnableConvectiveMixing<TypeTag, TTag::TestEquilVapwatTypeTag>
+{ static constexpr bool value = false; };
+
 } // namespace Opm::Properties
 
 namespace {

--- a/tests/test_tpsa_localresidual.cpp
+++ b/tests/test_tpsa_localresidual.cpp
@@ -83,6 +83,11 @@ namespace Opm::Properties {
                                              /*enabledCompIdx=*/FluidSystem::waterCompIdx,
                                              getPropValue<TypeTag, Properties::EnableBioeffects>()>;
     };
+
+    // Disable convective mixing
+    template<class TypeTag>
+    struct EnableConvectiveMixing<TypeTag, TTag::TpsaTestTypeTag>
+    { static constexpr bool value = false; };
 }
 
 namespace {

--- a/tests/test_tpsa_primaryvariables.cpp
+++ b/tests/test_tpsa_primaryvariables.cpp
@@ -41,6 +41,13 @@ namespace Opm::Properties::TTag {
     };
 }
 
+namespace Opm::Properties {
+    // Disable convective mixing
+    template<class TypeTag>
+    struct EnableConvectiveMixing<TypeTag, TTag::TpsaTestTypeTag>
+    { static constexpr bool value = false; };
+}
+
 BOOST_AUTO_TEST_CASE(ElasticityPrimVarTest) {
     using TypeTag = Opm::Properties::TTag::TpsaTestTypeTag;
     using Scalar = Opm::GetPropType<TypeTag, Opm::Properties::Scalar>;

--- a/tests/test_wellmodel.cpp
+++ b/tests/test_wellmodel.cpp
@@ -65,9 +65,26 @@
 
 #include <memory>
 #include <stdexcept>
+#include <tuple>
 #include <vector>
 
-using StandardWell = Opm::StandardWell<Opm::Properties::TTag::FlowProblem>;
+namespace Opm::Properties {
+
+namespace TTag {
+
+struct WellModelTestTypeTag
+{ using InheritsFrom = std::tuple<FlowProblem>; };
+
+}
+
+// Disable convective mixing
+template<class TypeTag>
+struct EnableConvectiveMixing<TypeTag, TTag::WellModelTestTypeTag>
+{ static constexpr bool value = false; };
+
+}
+
+using StandardWell = Opm::StandardWell<Opm::Properties::TTag::WellModelTestTypeTag>;
 
 struct SetupTest {
 
@@ -113,7 +130,7 @@ struct GlobalFixture {
         Dune::MPIHelper::instance(argcDummy, argvDummy);
 #endif
 
-        Opm::FlowMain<Opm::Properties::TTag::FlowProblem>::setupParameters_(argcDummy, argvDummy, Dune::MPIHelper::getCommunication());
+        Opm::FlowMain<Opm::Properties::TTag::WellModelTestTypeTag>::setupParameters_(argcDummy, argvDummy, Dune::MPIHelper::getCommunication());
     }
 };
 


### PR DESCRIPTION
Gains here are smaller since it's basically enabled in every simulator. Does this make sense?

| | Before | After
|- | --------- | --------
|Objects built| 89 | 46
|Binaries linked | 223 | 48
