### PR TITLE
Guard FLD/NONE injection group constraint path

### DIFF
--- a/opm/simulators/wells/GroupConstraintCalculator.cpp
+++ b/opm/simulators/wells/GroupConstraintCalculator.cpp
@@ -341,6 +341,12 @@ getGroupConstraintNoGuideRate(const Group& group)
     //   to the slave group. Alternatively, we could also throw an error here for that case
     if (this->isInjectionConstraint()) {
         const auto& control_mode = this->groupState().injection_control(group.name(), this->injectionPhase_());
+        // FLD/NONE means no own local constraint for this phase.
+        // Let the caller use a higher-level distributed target instead.
+        if (control_mode == Group::InjectionCMode::FLD ||
+            control_mode == Group::InjectionCMode::NONE) {
+            return std::nullopt;
+        }
         return ConstraintInfo{
             this->groupStateHelper().getInjectionGroupTarget(group, this->injectionPhase_(), this->resvCoeffsInj()),
             control_mode

--- a/opm/simulators/wells/GroupStateHelper.cpp
+++ b/opm/simulators/wells/GroupStateHelper.cpp
@@ -2017,7 +2017,9 @@ getInjectionGroupTargetForMode_(
     }
     default:
         OPM_DEFLOG_THROW(std::logic_error,
-                         "Invalid Group::InjectionCMode in getInjectionGroupTargetForMode_",
+                         fmt::format("Invalid Group::InjectionCMode in getInjectionGroupTargetForMode_ for {} cmode: {}",
+                                     group.name(),
+                                     Group::InjectionCMode2String(cmode)),
                          this->deferredLogger());
         return 0.0;
     }


### PR DESCRIPTION
Apply the same fix that was applied to production groups in https://github.com/OPM/opm-simulators/pull/6966 to injectors. 