### PR TITLE
Tighten reservoir-coupling network exchange

### DIFF
--- a/opm/simulators/flow/BlackoilModelParameters.cpp
+++ b/opm/simulators/flow/BlackoilModelParameters.cpp
@@ -111,6 +111,7 @@ BlackoilModelParameters<Scalar>::BlackoilModelParameters()
     network_max_strict_outer_iterations_ = Parameters::Get<Parameters::NetworkMaxStrictOuterIterations>();
     network_max_outer_iterations_ = Parameters::Get<Parameters::NetworkMaxOuterIterations>();
     network_max_sub_iterations_ = Parameters::Get<Parameters::NetworkMaxSubIterations>();
+    rc_network_loose_coupling_ = Parameters::Get<Parameters::RcNetworkLooseCoupling>();
     network_pressure_update_damping_factor_ = Parameters::Get<Parameters::NetworkPressureUpdateDampingFactor<Scalar>>();
     network_max_pressure_update_in_bars_ = Parameters::Get<Parameters::NetworkMaxPressureUpdateInBars<Scalar>>();
     local_domains_ordering_ = domainOrderingMeasureFromString(Parameters::Get<Parameters::LocalDomainsOrderingMeasure>());
@@ -262,6 +263,9 @@ void BlackoilModelParameters<Scalar>::registerParameters()
         ("Maximum outer number of iterations in the network solver before giving up");
     Parameters::Register<Parameters::NetworkMaxSubIterations>
         ("Maximum number of sub-iterations to update network pressures (within a single well/group control update)");
+    Parameters::Register<Parameters::RcNetworkLooseCoupling>
+        ("Reservoir coupling: exchange master/slave network pressures and rates only once per master outer "
+         "network iteration (loose coupling) instead of the default once per inner sub-iteration (tight coupling)");
     Parameters::Register<Parameters::NetworkPressureUpdateDampingFactor<Scalar>>
         ("Damping factor in the inner network pressure update iterations");
     Parameters::Register<Parameters::NetworkMaxPressureUpdateInBars<Scalar>>

--- a/opm/simulators/flow/BlackoilModelParameters.hpp
+++ b/opm/simulators/flow/BlackoilModelParameters.hpp
@@ -152,6 +152,11 @@ template<class Scalar>
 struct NetworkPressureUpdateDampingFactor { static constexpr Scalar value = 0.1; };
 template<class Scalar>
 struct NetworkMaxPressureUpdateInBars { static constexpr Scalar value = 5.0; };
+// Reservoir coupling: when false (default) the master exchanges node pressures
+// and slave rates with the slaves once per master inner network sub-iteration
+// (tight coupling).  When true, the exchange happens only once per master outer network
+// iteration (loose coupling).
+struct RcNetworkLooseCoupling { static constexpr bool value = false; };
 struct NonlinearSolver { static constexpr auto value = "newton"; };
 struct LocalSolveApproach { static constexpr auto value = "gauss-seidel"; };
 struct MaxLocalSolveIterations { static constexpr int value = 20; };
@@ -346,6 +351,10 @@ public:
 
     /// Maximum pressure update in the inner network pressure update iterations
     Scalar network_max_pressure_update_in_bars_;
+
+    /// Reservoir coupling: use loose (per-outer-iteration) master/slave network
+    /// coupling instead of the default tight (per-sub-iteration) coupling.
+    bool rc_network_loose_coupling_;
 
     /// Maximum number of iterations in the well/group switch algorithm
     int well_group_constraints_max_iterations_;

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -469,6 +469,19 @@ template<class Scalar> class WellContributions;
             const ModelParameters& param() const
             { return param_; }
 
+            /// @brief True when tight (per-sub-iteration) reservoir-coupling network
+            ///   coupling is in effect.  This is the default; --rc-network-loose-coupling=true
+            ///   selects the loose (per-outer-iteration) coupling instead.
+            bool useTightRcNetworkCoupling() const
+            { return !param_.rc_network_loose_coupling_; }
+
+#ifdef RESERVOIR_COUPLING_ENABLED
+            /// @brief Access the reservoir-coupling flow helper (RC builds only).
+            ///   Used e.g. by the network solver to drive the per-sub-iteration
+            ///   cross-rescoup node-pressure / rate exchange.
+            BlackoilWellModelRescoup<TypeTag>& rescoupHelper() { return rescoupHelper_; }
+#endif
+
 
             template<class FluidState, class SingleWellState>
             static Scalar computeTemperatureWeightFactor(const int perf_index, const int np, const FluidState& fs, const SingleWellState& ws)

--- a/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
@@ -127,6 +127,14 @@ update(const bool mandatory_network_balance,
                 relax_network_tolerance ? relaxation_factor * balance.pressure_tolerance()
                                         : balance.pressure_tolerance();
             more_network_sub_update = this->active() && network_imbalance > tolerance;
+#ifdef RESERVOIR_COUPLING_ENABLED
+            if (well_model_.isReservoirCouplingMaster()) {
+                // Tight reservoir-coupling: exchange node pressures and slave rates with the
+                // slaves per inner sub-iteration. Must run before the break below so the converged
+                // sub-iteration still feeds back the slaves' rates.
+                well_model_.rescoupHelper().maybeExchangeNetworkSubIterationWithSlaves();
+            }
+#endif
             if (!more_network_sub_update) {
                 break;
             }

--- a/opm/simulators/wells/BlackoilWellModelRescoup.hpp
+++ b/opm/simulators/wells/BlackoilWellModelRescoup.hpp
@@ -119,6 +119,13 @@ public:
     /// at every call site including the very first beginTimeStep call.
     bool masterNetworkHasMasterGroupLeaves() const;
 
+    /// \brief True when this process is the reservoir-coupling master on the
+    ///   first substep of a sync step, its network has master-group leaves,
+    ///   and it has not yet sent the terminating (is_final) node-pressure
+    ///   message.  Gates the cross-rescoup node-pressure exchange (both the
+    ///   per-outer-iteration send and the per-sub-iteration tight exchange).
+    bool masterIsInCoupledNetworkIteration() const;
+
     /// \brief Slave-side counterpart of sendCoupledNetworkActiveStatus().
     ///
     /// Blocking receive of the master's per-sync-step "is the cross-rescoup
@@ -188,6 +195,31 @@ public:
     ///
     /// Side effect: updates last_sent_master_group_node_pressures_is_final_.
     void sendMasterGroupNodePressuresToSlaves(bool is_final);
+
+    /// \brief Master-side, tight reservoir-coupling only: from inside the
+    ///   network inner sub-iteration loop, ship the freshly-computed node
+    ///   pressures to the slaves and receive their updated rates, so the next
+    ///   updatePressures() sees fresh leaf-node rates -- the per-iteration rate
+    ///   feedback the loose (per-outer-iteration) coupling lacks.  Always a
+    ///   non-final exchange: the inner loop cannot know whether the master's
+    ///   outer network loop will iterate again, so termination (is_final=true)
+    ///   is owned by the per-outer send in updateWellControlsAndNetworkIteration()
+    ///   and by sendSlaveNetworkLoopTerminationSignal_().  No-op unless tight
+    ///   coupling is active and masterIsInCoupledNetworkIteration().
+    void maybeExchangeNetworkSubIterationWithSlaves();
+
+    /// \brief Master-side: per master OUTER network iteration exchange, the
+    ///   counterpart of maybeExchangeNetworkSubIterationWithSlaves().  In tight
+    ///   coupling it emits only the single terminating (is_final) message --
+    ///   the inner sub-loop already performed every non-final exchange, and a
+    ///   non-final send here would just resend the same node pressures.  In
+    ///   loose coupling it is the sole master<->slave exchange and runs every
+    ///   outer iteration (send + receive while not final).  No-op unless
+    ///   masterIsInCoupledNetworkIteration().
+    /// \param more_network_update True if the master's outer network loop will
+    ///   iterate again (network_.update() reported more updates needed); the
+    ///   send is final when this is false.
+    void maybeExchangeNetworkOuterIterationWithSlaves(bool more_network_update);
 
     /// \brief Slave-side counterpart of receiveSlaveGroupData().
     ///

--- a/opm/simulators/wells/BlackoilWellModelRescoup_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelRescoup_impl.hpp
@@ -57,6 +57,18 @@ BlackoilWellModelRescoup(BlackoilWellModel<TypeTag>& well_model)
 template<typename TypeTag>
 bool
 BlackoilWellModelRescoup<TypeTag>::
+masterIsInCoupledNetworkIteration() const
+{
+    return this->isReservoirCouplingMaster()
+        && this->reservoirCouplingMaster().isFirstSubstepOfSyncTimestep()
+        && this->masterNetworkHasMasterGroupLeaves()
+        && !this->lastSentMasterGroupNodePressuresIsFinal();
+}
+
+
+template<typename TypeTag>
+bool
+BlackoilWellModelRescoup<TypeTag>::
 masterNetworkHasMasterGroupLeaves() const
 {
     // Query the parsed Schedule topology (`network.has_node(...)`) rather than the runtime
@@ -72,6 +84,66 @@ masterNetworkHasMasterGroupLeaves() const
         }
     }
     return false;
+}
+
+template<typename TypeTag>
+void
+BlackoilWellModelRescoup<TypeTag>::
+maybeExchangeNetworkOuterIterationWithSlaves(bool more_network_update)
+{
+    if (!this->masterIsInCoupledNetworkIteration()) {
+        return;
+    }
+    const bool is_final = !more_network_update;
+    // In tight coupling the inner sub-loop (maybeExchangeNetworkSubIterationWithSlaves)
+    // performs every non-final exchange, so here we only emit the single
+    // terminating (is_final) message -- the non-final case would just resend the
+    // same node pressures the last sub-iteration already shipped, and get the same
+    // rates back.  The retained final send still covers the case where the network
+    // is not balanced this iteration (the inner loop never runs).  In loose coupling
+    // this per-outer send is the sole master<->slave coupling and runs every outer
+    // iteration.
+    if (is_final || !this->well_model_.useTightRcNetworkCoupling()) {
+        // send the pressures freshly computed by network_.update() to all activated slaves
+        this->sendMasterGroupNodePressuresToSlaves(is_final);
+        if (!is_final) {
+            // receive slaves' updated network_surface_rates for the next outer iteration.
+            this->receiveSlaveGroupData();
+        }
+    }
+}
+
+template<typename TypeTag>
+void
+BlackoilWellModelRescoup<TypeTag>::
+maybeExchangeNetworkSubIterationWithSlaves()
+{
+    // Called for rescoup master for the tight master-slave coupling (--rc-network-loose-coupling=false)
+    // mode at the sub-iteration level: Send node pressures and receive slave rates per master inner
+    // network sub-iteration.
+    // In the loose mode (--rc-network-loose-coupling=true) the exchange happens only once
+    // per master outer iteration (see updateWellControlsAndNetworkIteration), so
+    // the inner loop converges the node pressures against a frozen slave rate.
+    // This loose mode is faster but has been observed in some cases to overshoot to a value that
+    // incorrectly shuts the slave wells in.
+    // To avoid this, the tight coupling is therefore the default coupling.
+    //
+    // NOTE: This is always a non-final exchange.  The inner sub-iteration loop cannot
+    // know whether the master's outer network loop will iterate again (the inner
+    // loop ending on max_sub_iter, or on a THP update, still leaves
+    // more_inner_network_update true), so it must not declare termination here.
+    // The single is_final = true send is owned by the per-outer send in
+    // updateWellControlsAndNetworkIteration() (when the outer loop converges)
+    // and by sendSlaveNetworkLoopTerminationSignal_() (when the outer loop hits
+    // max_iter).
+    if (!this->well_model_.useTightRcNetworkCoupling()) {
+        return;
+    }
+    if (!this->masterIsInCoupledNetworkIteration()) {
+        return;
+    }
+    this->sendMasterGroupNodePressuresToSlaves(/*is_final=*/false);
+    this->receiveSlaveGroupData();
 }
 
 template<typename TypeTag>

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1248,14 +1248,8 @@ namespace Opm {
                                       local_deferredLogger,
                                       relax_network_tolerance);
 #ifdef RESERVOIR_COUPLING_ENABLED
-        if (this->isRescoupMasterCoupledNetworkIteration_()) {
-            const bool is_final = !more_inner_network_update;
-            // send the pressures freshly computed by network_.update() to all activated slaves
-            this->rescoupHelper_.sendMasterGroupNodePressuresToSlaves(is_final);
-            if (!is_final) {
-                // receive slaves' updated network_surface_rates for the next outer iteration.
-                this->rescoupHelper_.receiveSlaveGroupData();
-            }
+        if (this->isReservoirCouplingMaster()) {
+            this->rescoupHelper_.maybeExchangeNetworkOuterIterationWithSlaves(more_inner_network_update);
         }
 #endif
 
@@ -2229,10 +2223,7 @@ namespace Opm {
     bool BlackoilWellModel<TypeTag>::isRescoupMasterCoupledNetworkIteration_() const
     {
 #ifdef RESERVOIR_COUPLING_ENABLED
-        return this->isReservoirCouplingMaster()
-            && this->reservoirCouplingMaster().isFirstSubstepOfSyncTimestep()
-            && this->rescoupHelper_.masterNetworkHasMasterGroupLeaves()
-            && !this->rescoupHelper_.lastSentMasterGroupNodePressuresIsFinal();
+        return this->rescoupHelper_.masterIsInCoupledNetworkIteration();
 #else
         return false;
 #endif


### PR DESCRIPTION
In a coupled network run the master process balances the global network by iterating its node pressures in an inner sub-iteration loop. Until now, the master exchanged node pressures and slave flow rates with the slave processes **only once per master outer network iteration**, so the inner sub-iteration loop ran against a *frozen* slave rate. When a slave's deliverability changes during the master's time step, that lagged feedback lets the inner loop drive a master-group node pressure to a value the slave's wells cannot produce against; the slave wells then stop, and with zero flow the node pressure latches at a degenerate low value for the rest of the run.

This PR makes the master/slave network exchange happen **once per inner sub-iteration** (tight coupling), which is now the default. The previous per-outer-iteration behaviour remains available via `--rc-network-loose-coupling=true`.

#### What changed

- **New parameter** `--rc-network-loose-coupling` (`RcNetworkLooseCoupling`, default `false`). Default is the new tight coupling; setting it `true` restores the old per-outer-iteration exchange.
- **Per-sub-iteration exchange** (`BlackoilWellModelRescoup::maybeExchangeNetworkSubIterationWithSlaves`, called from the network inner loop in `BlackoilWellModelNetwork::update`): after each pressure update the master sends the freshly computed master-group node pressures to the activated slaves and receives their updated flow rates, so the next pressure update uses fresh rates. This is **always a non-final exchange** — the inner loop cannot know whether the master's outer loop will iterate again, so it never declares termination.
- **Per-outer-iteration send** refactored into `maybeExchangeNetworkOuterIterationWithSlaves`: in tight coupling it emits only the single **terminating** message (when the outer loop has converged, or when the inner loop is not entered because the network is not balanced this iteration); in loose coupling it is the sole exchange and runs every outer iteration. The trailing termination signal and this send skip automatically once the terminating message has been sent, so no duplicate is emitted.
- **Slave side is unchanged**: its existing per-outer-iteration receive/solve/send loop provides exactly one iteration per master message, pairing one-to-one with the new sub-iteration sends. A single terminating flag ends the exchange.
- Helpers: `BlackoilWellModel::useTightRcNetworkCoupling()` and a guarded `rescoupHelper()` accessor; `isRescoupMasterCoupledNetworkIteration_()` now delegates to `BlackoilWellModelRescoup::masterIsInCoupledNetworkIteration()`.

#### Why / impact

The loose (per-outer-iteration) exchange is faster but, as above, has been observed to overshoot the master-group node pressure and incorrectly shut the slave wells in. Tight coupling supplies the missing per-iteration slave-rate feedback, so the master converges a consistent (pressure, rate) pair instead of overshooting. It is therefore the default; the loose mode is kept behind the flag for comparison and for runs where the lagged feedback is not a problem.

#### Notes

- **Default behaviour change**: tight coupling is now the default for coupled network runs. Pass `--rc-network-loose-coupling=true` to restore the old per-outer-iteration exchange.
- Non-coupled (single-process) network runs are unaffected.
