### PR TITLE
SHUT the well when all the completions are closed due to CON workover procedure with WECON

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1981,6 +1981,19 @@ operator==(const BlackoilWellModelGeneric& rhs) const
 }
 
 
+template<typename Scalar, typename IndexTraits>
+bool BlackoilWellModelGeneric<Scalar, IndexTraits>::
+allConnectionsClosed(const Well& well_ecl) const
+{
+    return std::ranges::all_of(well_ecl.getConnections(),
+                               [this, &well_name = well_ecl.name()](const auto& connection)
+                               {
+                                   return connection.state() != Connection::State::OPEN
+                                       || this->wellTestState().completion_is_closed(well_name,
+                                                                                     connection.complnum());
+                               });
+}
+
 template class BlackoilWellModelGeneric<double, BlackOilDefaultFluidSystemIndices>;
 
 #if FLOW_INSTANTIATE_FLOAT

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -587,6 +587,8 @@ protected:
 
     BlackoilWellModelNetworkGeneric<Scalar,IndexTraits>& genNetwork_;
 
+    bool allConnectionsClosed(const Well& well_ecl) const;
+
 private:
     WellInterfaceGeneric<Scalar, IndexTraits>* getGenWell(const std::string& well_name);
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -909,30 +909,10 @@ namespace Opm {
                 // something like wellTestState().hasWell(well_name)?
                 if (this->wellTestState().well_is_closed(well_name))
                 {
-                    if (well_ecl.getAutomaticShutIn()) {
-                        // shut wells are not added to the well container
-                        this->wellState().shutWell(w);
-                        this->well_close_times_.erase(well_name);
-                        this->well_open_times_.erase(well_name);
-                        continue;
-                    }
-                    if (!well_ecl.getAllowCrossFlow()) {
-                        // stopped wells where cross flow is not allowed
-                        // are not added to the well container
-                        this->wellState().shutWell(w);
-                        this->well_close_times_.erase(well_name);
-                        this->well_open_times_.erase(well_name);
-                        continue;
-                    }
-
-                    const bool all_open_completions_closed =
-                        std::ranges::all_of(well_ecl.getConnections(), [this, &well_name](const auto& connection) {
-                            return connection.state() != Connection::State::OPEN
-                                || this->wellTestState().completion_is_closed(well_name, connection.complnum());
-                        });
-                    if (all_open_completions_closed) {
-                        // If all open completions/connections are closed due to
-                        // well testing, the well can only be SHUT.
+                    if (well_ecl.getAutomaticShutIn() ||
+                        !well_ecl.getAllowCrossFlow() ||
+                        this->allConnectionsClosed(well_ecl))
+                    {
                         this->wellState().shutWell(w);
                         this->well_close_times_.erase(well_name);
                         this->well_open_times_.erase(well_name);

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -915,18 +915,31 @@ namespace Opm {
                         this->well_close_times_.erase(well_name);
                         this->well_open_times_.erase(well_name);
                         continue;
-                    } else {
-                        if (!well_ecl.getAllowCrossFlow()) {
-                            // stopped wells where cross flow is not allowed
-                            // are not added to the well container
-                            this->wellState().shutWell(w);
-                            this->well_close_times_.erase(well_name);
-                            this->well_open_times_.erase(well_name);
-                            continue;
-                        }
-                        // stopped wells are added to the container but marked as stopped
-                        this->wellState().stopWell(w);
                     }
+                    if (!well_ecl.getAllowCrossFlow()) {
+                        // stopped wells where cross flow is not allowed
+                        // are not added to the well container
+                        this->wellState().shutWell(w);
+                        this->well_close_times_.erase(well_name);
+                        this->well_open_times_.erase(well_name);
+                        continue;
+                    }
+
+                    const bool all_open_completions_closed =
+                        std::ranges::all_of(well_ecl.getConnections(), [this, &well_name](const auto& connection) {
+                            return connection.state() != Connection::State::OPEN
+                                || this->wellTestState().completion_is_closed(well_name, connection.complnum());
+                        });
+                    if (all_open_completions_closed) {
+                        // If all open completions/connections are closed due to
+                        // well testing, the well can only be SHUT.
+                        this->wellState().shutWell(w);
+                        this->well_close_times_.erase(well_name);
+                        this->well_open_times_.erase(well_name);
+                        continue;
+                    }
+                    // stopped wells are added to the container but marked as stopped
+                    this->wellState().stopWell(w);
                 }
 
                 // shut wells with zero rante constraints and disallowing

--- a/opm/simulators/wells/WellTest.cpp
+++ b/opm/simulators/wells/WellTest.cpp
@@ -417,14 +417,10 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
 
                 if (allCompletionsClosed) {
                     well_test_state.close_well(well_.name(), WellTestConfig::Reason::ECONOMIC, simulation_time);
+                    // if all the completion/connections are closed, the well can only be SHUT
                     if (write_message_to_opmlog) {
-                        if (well_.wellEcl().getAutomaticShutIn()) {
-                            const std::string msg = well_.name() + std::string(" will be shut due to last completion closed");
-                            deferred_logger.info(msg);
-                        } else {
-                            const std::string msg = well_.name() + std::string(" will be stopped due to last completion closed");
-                            deferred_logger.info(msg);
-                        }
+                        const std::string msg = well_.name() + std::string(" will be shut due to last completion closed");
+                        deferred_logger.info(msg);
                     }
                 }
                 break;


### PR DESCRIPTION
With master branch, because getAutomaticShutIn() of the well is true, the well will be STOPPed while without any opening completion. It will has numerical difficulties to solve. 

In this PR, when all the completions are closed, we will SHUT the well. The way in this PR is doing the following before STOPPing the well. 

```c++
                    const bool all_open_completions_closed =
                        std::ranges::all_of(well_ecl.getConnections(), [this, &well_name](const auto& connection) {
                            return connection.state() != Connection::State::OPEN
                                || this->wellTestState().completion_is_closed(well_name, connection.complnum());
                        });
                    if (all_open_completions_closed) {
                        // If all open completions/connections are closed due to
                        // well testing, the well can only be SHUT.
                        this->wellState().shutWell(w);
                        this->well_close_times_.erase(well_name);
                        this->well_open_times_.erase(well_name);
                        continue;
                    }
```


The other approach is to add a `closed_due_to_all_completions_closed` member to the class `WTestWell` and a function `bool well_closed_due_to_all_completions_closed(const std::string& well_name) const;` to the WellTestState, but that way we introduces extra state variables. 

Please let me know if you prefer the second way. 

