### PR TITLE
Fix master-group potential double conversion

### DIFF
--- a/opm/simulators/wells/GuideRateHandler.cpp
+++ b/opm/simulators/wells/GuideRateHandler.cpp
@@ -444,21 +444,6 @@ update()
 // Inner class UpdateGuideRates private methods sorted alphabetically
 // --------------------------------------------------------------------
 
-#ifdef RESERVOIR_COUPLING_ENABLED
-template<typename Scalar, typename IndexTraits>
-bool
-GuideRateHandler<Scalar, IndexTraits>::UpdateGuideRates::
-isMasterGroup_(const Group& group)
-{
-    if (this->isReservoirCouplingMaster()) {
-        return this->reservoirCouplingMaster().isMasterGroup(group.name());
-    }
-    else {
-        return false;
-    }
-}
-#endif
-
 template<typename Scalar, typename IndexTraits>
 void
 GuideRateHandler<Scalar, IndexTraits>::UpdateGuideRates::
@@ -564,8 +549,9 @@ updateGuideRatesForProductionGroups_(const Group& group, std::vector<Scalar>& po
     // NOTE: Even if this is a pure injection group, we still need to compute the
     // group potentials since they may be used by a production group at a higher
     // level in the group hierarchy. See MOD4_UDQ_ACTIONX.DATA for an example.
+    const bool is_master_group = this->isMasterGroup_(group);
 #ifdef RESERVOIR_COUPLING_ENABLED
-    if (this->isMasterGroup_(group)) {
+    if (is_master_group) {
         // This is a master group, so we do not need to compute potentials
         // for sub groups. We just set the guide rates for the master group
         // as submitted from its corresponding slave group.
@@ -595,9 +581,17 @@ updateGuideRatesForProductionGroups_(const Group& group, std::vector<Scalar>& po
 
     // Synchronize potentials across all ranks
     this->comm().sum(potentials.data(), potentials.size());
-    oil_pot = this->unit_system_.from_si(UnitSystem::measure::liquid_surface_rate, oil_pot);
-    water_pot = this->unit_system_.from_si(UnitSystem::measure::liquid_surface_rate, water_pot);
-    gas_pot = this->unit_system_.from_si(UnitSystem::measure::gas_surface_rate, gas_pot);
+    if (!is_master_group) {
+        // Non-master group potentials are accumulated from sub-groups in SI;
+        // convert them to the display units (e.g. SM3/DAY for METRIC) that
+        // GuideRate::compute() and the stored group potential use. A master
+        // group's potential already arrives in display units from its slave
+        // group (the slave applied from_si before storing and sending it), so
+        // it must not be converted again here.
+        oil_pot = this->unit_system_.from_si(UnitSystem::measure::liquid_surface_rate, oil_pot);
+        water_pot = this->unit_system_.from_si(UnitSystem::measure::liquid_surface_rate, water_pot);
+        gas_pot = this->unit_system_.from_si(UnitSystem::measure::gas_surface_rate, gas_pot);
+    }
     this->guideRate().compute(
         group.name(), this->report_step_idx_, this->sim_time_, oil_pot, gas_pot, water_pot
     );

--- a/opm/simulators/wells/GuideRateHandler.hpp
+++ b/opm/simulators/wells/GuideRateHandler.hpp
@@ -134,9 +134,9 @@ public:
         void update();
 
     private:
-#ifdef RESERVOIR_COUPLING_ENABLED
-        bool isMasterGroup_(const Group& group);
-#endif
+        bool isMasterGroup_(const Group& group) const {
+            return this->parent_.rescoup().isMasterGroup(group.name());
+        }
         void updateGuideRatesForInjectionGroups_(const Group& group);
         /**
          * @brief Updates guide rates for all production groups recursively.


### PR DESCRIPTION
A reservoir-coupling **master group** takes its production potential from the corresponding slave group, which reports it in **display units** (e.g. SM3/DAY for METRIC): the slave applies `from_si` before storing the value in its `GroupState` and sending it to the master. `GuideRateHandler::updateGuideRatesForProductionGroups_` then applied `from_si` **a second time** to that value, inflating a master group's potential by the seconds-per-day factor (86400 in METRIC).

#### Fix

- Apply `from_si` **only to non-master groups**, whose potentials are accumulated from sub-groups in SI. A master group's potential is already in display units and must not be converted again. The function already branches on `is_master_group` to choose the potential source, so the conversion is now gated on the same flag.
- **Minor cleanup**: `isMasterGroup_` becomes a small inline facade over the reservoir-coupling proxy (`rescoup().isMasterGroup(...)`), which returns `false` in non-coupling builds. It no longer needs its own `RESERVOIR_COUPLING_ENABLED` guard or an out-of-line definition, and the only remaining guard in this path is around the genuinely coupling-only slave-group lookup.

#### Why the physical solution is unchanged

The GUIDERAT guide rate is `pot^A / (B + C·R1^D + E·R2^F)` with `R1 = wat/oil` and `R2 = gas/oil`; the denominator is built from **rate ratios**, so a uniform scaling of all potentials cancels in the guide-rate **fractions** that drive distribution. When every producing group under a parent is a master group (all scaled by the same factor), the distribution — and the physical solution — is unchanged. What the double conversion *does* corrupt is the reported group production guide rates (`GOPGR`/`GVPGR`), and it would distort the split in a **mixed** hierarchy of master and ordinary producing groups.

#### Validation

On a coupled test case:

- **Master-group guide rates corrected** — `GOPGR:B1_M / D1_M / E1_M` drop by **exactly** the 86400 factor to physical magnitudes (e.g. `GOPGR:B1_M` 1.2e8 → 1.4e3).
- **Physical solution unchanged to round-off** — all other summary vectors agree to ~1e-7 relative; the residual is floating-point round-off from evaluating the (scale-invariant) guide-rate fractions at corrected magnitudes, not a behavior change, and the only differing vectors are guide-rate-derived quantities, as expected.
- **Non-coupled runs are unaffected** by construction — `isMasterGroup_` is always `false` without reservoir coupling, so the conversion is applied exactly as before.
