### PR TITLE
Reuse producer control mode for guide-rate setup

### DIFF
--- a/opm/simulators/wells/GroupConstraintCalculator.cpp
+++ b/opm/simulators/wells/GroupConstraintCalculator.cpp
@@ -859,24 +859,21 @@ GroupConstraintCalculator<Scalar, IndexTraits>::
 TopToBottomCalculator::
 initForProducer_()
 {
-    if (this->constraintType() == ConstraintType::Limit) {
-        const auto control_mode = this->getProdCmode();
-        // Use the control mode for per-rate-type limit computation
-        this->target_calculator_.template emplace<TargetCalculator>(
-            this->groupStateHelper(),
-            this->resvCoeffsProd(),
-            control_mode
-        );
-    }
-    else {
-        this->target_calculator_.template emplace<TargetCalculator>(
-            this->groupStateHelper(),
-            this->resvCoeffsProd(),
-            this->top_group_
-        );
-    }
-    const auto guide_target_mode = this->groupStateHelper().getProductionGuideTargetMode(this->top_group_);
-    const auto dummy_phase = Phase::OIL; // Dummy phase, not used for producers.
+    // Use the same control mode for both the target calculator and guide-rate logic.
+    const auto control_mode =
+        (this->constraintType() == ConstraintType::Limit)?
+        this->getProdCmode():
+        this->groupState().production_control(this->top_group_.name());
+
+    this->target_calculator_.template emplace<TargetCalculator>(
+        this->groupStateHelper(),
+        this->resvCoeffsProd(),
+        control_mode
+    );
+    // Map that mode once for the fraction calculator.
+    const auto guide_target_mode =
+        this->groupStateHelper().getProductionGuideTargetModeFromControlMode(control_mode);
+    const auto dummy_phase = Phase::OIL;  // Dummy phase, not used for producers.
     this->fraction_calculator_.emplace(
         this->schedule(),
         this->groupStateHelper(),


### PR DESCRIPTION
This change addresses a reservoir-coupling production path where the simulator could end up with [GuideRateModel::Target::NONE] even though the group had a valid production limit. That happened because the guide-rate setup used the group’s active control mode, which can still be [NONE] in this RC flow, while the actual target calculation was already using the limit mode.

The fix derives both the target calculator and the guide-rate target from the same control mode so the fraction calculator no longer receives [NONE] for that path. I also added short comments to make that intent explicit in the code.