### PR TITLE
Support +CON connection work-over for WECON keyword

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -1237,6 +1237,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/wells/ConnectionIndexMap.hpp
   opm/simulators/wells/ConnFiltrateData.hpp
   opm/simulators/wells/ConnFracStatistics.hpp
+  opm/simulators/wells/EconomicLimitsMessage.hpp
   opm/simulators/wells/FractionCalculator.hpp
   opm/simulators/wells/GasLiftCommon.hpp
   opm/simulators/wells/GasLiftGroupInfo.hpp

--- a/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
@@ -264,7 +264,7 @@ partiallySupported()
          {
             "WECON",
             {
-               {7,{true, allow_values<std::string> {"NONE", "CON", "WELL"}, "WECON(ACTION): Only NONE, CON and WELL options are supported"}}, // ACTION
+               {7,{true, allow_values<std::string> {"NONE", "CON", "+CON", "WELL"}, "WECON(ACTION): Only NONE, CON, +CON and WELL options are supported"}}, // ACTION
                {8,{true, allow_values<std::string> {"NO"}, "WECON(ENDRUN): only the NO option is supported"}}, // END_RUN
                // Item 9 (follow-on well) is supported (but not validated here because it is a string with no specific allowed values).
                {10,{true, allow_values<std::string> {"POTN", "RATE"}, "WECON(ELTOPT): Valid options are POTN and RATE"}}, // ELTOPT

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1836,6 +1836,8 @@ namespace Opm {
                                       /*writeMessageToOPMLog=*/ true,
                                       under_zero_target,
                                       wellTestState,
+                                      this->eclipseState().getUnits(),
+                                      this->schedule().getStartTime(),
                                       local_deferredLogger);
 
             if (!wasClosed && wellTestState.well_is_closed(wname)) {

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1834,6 +1834,7 @@ namespace Opm {
             well->updateWellTestState(this->wellState().well(wname),
                                       simulationTime,
                                       /*writeMessageToOPMLog=*/ true,
+                                      /*during_well_test=*/ false,
                                       under_zero_target,
                                       wellTestState,
                                       this->eclipseState().getUnits(),

--- a/opm/simulators/wells/EconomicLimitsMessage.hpp
+++ b/opm/simulators/wells/EconomicLimitsMessage.hpp
@@ -1,0 +1,55 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_ECONOMIC_LIMITS_MESSAGE_HEADER_INCLUDED
+#define OPM_ECONOMIC_LIMITS_MESSAGE_HEADER_INCLUDED
+
+#include <opm/common/utility/TimeService.hpp>
+
+#include <fmt/chrono.h>
+#include <fmt/format.h>
+
+#include <ctime>
+#include <string>
+
+namespace Opm {
+
+//! \brief Calendar date (DD-Mon-YYYY, UTC) reached at \p start_time plus
+//!        \p sim_time seconds.
+//!
+//! Shared by the well (WECON) and group (GECON) economic-limit workover
+//! messages so both report the same date basis. UTC (gmtime) is used
+//! deliberately so the printed date does not depend on the host time zone.
+inline std::string economicLimitDateString(const std::time_t start_time, const double sim_time)
+{
+    const std::time_t cur_time = TimeService::advance(start_time, sim_time);
+    return fmt::format("{:%d-%b-%Y}", fmt::gmtime(cur_time));
+}
+
+//! \brief Separator line used to frame economic-limit workover messages.
+//!        Built once and returned by reference (all callers use the same line).
+inline const std::string& economicLimitMessageSeparator()
+{
+    static const std::string separator(110, '*');
+    return separator;
+}
+
+} // namespace Opm
+
+#endif // OPM_ECONOMIC_LIMITS_MESSAGE_HEADER_INCLUDED

--- a/opm/simulators/wells/GroupEconomicLimitsChecker.cpp
+++ b/opm/simulators/wells/GroupEconomicLimitsChecker.cpp
@@ -33,32 +33,18 @@
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 
 #include <opm/simulators/wells/BlackoilWellModelGeneric.hpp>
+#include <opm/simulators/wells/EconomicLimitsMessage.hpp>
 #include <opm/simulators/wells/GroupStateHelper.hpp>
 #include <opm/simulators/wells/SingleWellState.hpp>
 #include <opm/simulators/wells/WellState.hpp>
 
 #include <fmt/format.h>
 
-#include <chrono>
 #include <ctime>
-#include <iomanip>
 #include <limits>
-#include <sstream>
 #include <vector>
 
 namespace Opm {
-
-std::string simTimeToString(const std::time_t start_time, const double sim_time)
-{
-    const auto start_timep = std::chrono::system_clock::from_time_t(start_time);
-    const auto sim_duration = std::chrono::duration_cast<std::chrono::system_clock::duration>(
-        std::chrono::duration<double>(sim_time)
-    );
-    const std::time_t cur_time = std::chrono::system_clock::to_time_t(start_timep + sim_duration);
-    std::ostringstream ss;
-    ss << std::put_time(std::localtime(&cur_time), "%d-%b-%Y");
-    return ss.str();
-}
 
 template<typename Scalar, typename IndexTraits>
 GroupEconomicLimitsChecker<Scalar, IndexTraits>::
@@ -73,7 +59,7 @@ GroupEconomicLimitsChecker(const BlackoilWellModelGeneric<Scalar, IndexTraits>& 
     , simulation_time_{simulation_time}
     , report_step_idx_{report_step_idx}
     , deferred_logger_{deferred_logger}
-    , date_string_{simTimeToString(well_model.schedule().getStartTime(),simulation_time)}
+    , date_string_{economicLimitDateString(well_model.schedule().getStartTime(), simulation_time)}
     , unit_system_{well_model.eclipseState().getUnits()}
     , well_state_{well_model.wellState()}
     , well_test_state_{well_test_state}

--- a/opm/simulators/wells/GroupEconomicLimitsChecker.hpp
+++ b/opm/simulators/wells/GroupEconomicLimitsChecker.hpp
@@ -23,6 +23,8 @@
 #include <opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
+#include <opm/simulators/wells/EconomicLimitsMessage.hpp>
+
 #include <array>
 #include <map>
 #include <optional>
@@ -76,9 +78,8 @@ public:
     int numProducersOpenInitially();
     int numProducersOpen();
     void activateEndRun();
-    std::string message_separator(const char sep_char = '*',
-                                  const size_t sep_length = 110) const
-    { return std::string(sep_length, sep_char); }
+    const std::string& message_separator() const
+    { return economicLimitMessageSeparator(); }
 
     static constexpr int NUM_PHASES = 3;
 

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -342,12 +342,14 @@ updateWellTestState(const SingleWellState<Scalar, IndexTraits>& ws,
                     const bool& writeMessageToOPMLog,
                     const bool zero_group_target,
                     WellTestState& wellTestState,
+                    const UnitSystem& unit_system,
+                    const std::time_t start_time,
                     DeferredLogger& deferred_logger) const
 {
     // updating well test state based on Economic limits for operable wells
     if (this->isOperableAndSolvable()) {
         WellTest(*this).updateWellTestStateEconomic(ws, simulationTime, writeMessageToOPMLog, wellTestState,
-                                                    zero_group_target, deferred_logger);
+                                                    zero_group_target, unit_system, start_time, deferred_logger);
     } else {
         // updating well test state based on physical (THP/BHP) limits.
         WellTest(*this).updateWellTestStatePhysical(simulationTime, writeMessageToOPMLog, wellTestState, deferred_logger);
@@ -960,7 +962,7 @@ updateGroupTargetFallbackFlag(WellState<Scalar, IndexTraits>& well_state,
                               DeferredLogger& deferred_logger) const
 {
     auto& ws = well_state.well(this->index_of_well_);
-    if (!wellUnderGroupControl(ws) || this->isInjector() || 
+    if (!wellUnderGroupControl(ws) || this->isInjector() ||
         !ws.group_target_fallback.has_value() || !ws.group_target.has_value())
     {
         ws.use_group_target_fallback = false;
@@ -977,7 +979,7 @@ updateGroupTargetFallbackFlag(WellState<Scalar, IndexTraits>& well_state,
         ws.use_group_target_fallback = false;
         return;
     }
-    // Check whether guiderate ratio or well fraction of production_cmode is too small, 
+    // Check whether guiderate ratio or well fraction of production_cmode is too small,
     // if so, switch to fallback (original) control mode
     const Scalar fraction_tolerance = this->param_.group_control_fraction_tolerance_;
     if (ws.group_target->guiderate_ratio < fraction_tolerance) {
@@ -1017,7 +1019,7 @@ updateGroupTargetFallbackFlag(WellState<Scalar, IndexTraits>& well_state,
             cmode_frac += scaled_well_fractions[gas_pos];
         }
     }
-    ws.use_group_target_fallback = (cmode_frac < fraction_tolerance); 
+    ws.use_group_target_fallback = (cmode_frac < fraction_tolerance);
 }
 
 template class WellInterfaceGeneric<double, BlackOilDefaultFluidSystemIndices>;

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -340,6 +340,7 @@ void WellInterfaceGeneric<Scalar, IndexTraits>::
 updateWellTestState(const SingleWellState<Scalar, IndexTraits>& ws,
                     const double& simulationTime,
                     const bool& writeMessageToOPMLog,
+                    const bool during_well_test,
                     const bool zero_group_target,
                     WellTestState& wellTestState,
                     const UnitSystem& unit_system,
@@ -348,7 +349,8 @@ updateWellTestState(const SingleWellState<Scalar, IndexTraits>& ws,
 {
     // updating well test state based on Economic limits for operable wells
     if (this->isOperableAndSolvable()) {
-        WellTest(*this).updateWellTestStateEconomic(ws, simulationTime, writeMessageToOPMLog, wellTestState,
+        WellTest(*this).updateWellTestStateEconomic(ws, simulationTime, writeMessageToOPMLog,
+                                                    during_well_test, wellTestState,
                                                     zero_group_target, unit_system, start_time, deferred_logger);
     } else {
         // updating well test state based on physical (THP/BHP) limits.

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -28,6 +28,7 @@
 #include <opm/simulators/flow/BlackoilModelParameters.hpp>
 #include <opm/simulators/wells/RuntimePerforation.hpp>
 
+#include <ctime>
 #include <map>
 #include <optional>
 #include <string>
@@ -38,6 +39,7 @@ namespace Opm
 
 class DeferredLogger;
 class GuideRate;
+class UnitSystem;
 template<class Scalar> class ParallelWellInfo;
 template<class Scalar> struct PerforationData;
 class SummaryState;
@@ -182,6 +184,8 @@ public:
                              const bool& writeMessageToOPMLog,
                              const bool zero_group_target,
                              WellTestState& wellTestState,
+                             const UnitSystem& unit_system,
+                             const std::time_t start_time,
                              DeferredLogger& deferred_logger) const;
 
     bool isPressureControlled(const WellStateType& well_state) const;

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -179,9 +179,14 @@ public:
 
     bool changedToOpenThisStep() const { return this->changed_to_open_this_step_; }
 
+    //! \param during_well_test  true when called from WTEST re-open testing,
+    //!        which re-solves the well after every completion closure; false for
+    //!        the regular timestep update. See
+    //!        WellTest::updateWellTestStateEconomic().
     void updateWellTestState(const SingleWellState<Scalar, IndexTraits>& ws,
                              const double& simulationTime,
                              const bool& writeMessageToOPMLog,
+                             const bool during_well_test,
                              const bool zero_group_target,
                              WellTestState& wellTestState,
                              const UnitSystem& unit_system,

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -491,6 +491,7 @@ namespace Opm
             this->updateWellTestState(well_state_copy.well(this->indexOfWell()),
                                      simulation_time,
                                       /*writeMessageToOPMLog=*/ false,
+                                      /*during_well_test=*/ true,
                                       under_zero_target,
                                       welltest_state_temp,
                                       simulator.vanguard().eclState().getUnits(),

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -493,6 +493,8 @@ namespace Opm
                                       /*writeMessageToOPMLog=*/ false,
                                       under_zero_target,
                                       welltest_state_temp,
+                                      simulator.vanguard().eclState().getUnits(),
+                                      simulator.vanguard().schedule().getStartTime(),
                                       deferred_logger);
             this->closeCompletions(welltest_state_temp);
 

--- a/opm/simulators/wells/WellTest.cpp
+++ b/opm/simulators/wells/WellTest.cpp
@@ -40,6 +40,7 @@
 #include <opm/simulators/wells/WellInterfaceGeneric.hpp>
 
 #include <cassert>
+#include <cstddef>
 #include <ctime>
 #include <string>
 #include <unordered_set>
@@ -310,18 +311,31 @@ checkRatioEconLimits(const WellEconProductionLimits& econ_production_limits,
     }
 
     if (report.ratio_limit_violated) {
+        // The "is kept open" warnings only make sense on the first evaluation
+        // (empty excluded_completions). During a CON / +CON workover event some
+        // completions have already been closed, so only the cascade is stopped;
+        // the resets below must still run unconditionally to terminate it.
+        //
         // No worst offending completion is found because all the completions are either injecting or
         // have trivial rates.
         if(report.worst_offending_completion == RatioLimitCheckReport::INVALIDCOMPLETION) {
-            std::string message = "The well ratio limit is violated but all the completion rates are trivial! " + well_.name() + " is kept open";
-            deferred_logger.warning("WECON_INVALIDCOMPLETION", message);
+            if (excluded_completions.empty()) {
+                const std::string message =
+                    "The well ratio limit is violated but all the completion rates "
+                    "are trivial! " + well_.name() + " is kept open";
+                deferred_logger.warning("WECON_INVALIDCOMPLETION", message);
+            }
             report.ratio_limit_violated = false;
         }
         // Due to numerical instability there may exist corner cases where the well breaks
         // the ratio limit but no completion does.
         else if(report.violation_extent <= 1.) {
-            std::string message = "The well ratio limit is violated but no completion ratio limit is violated! " + well_.name() + " is kept open";
-            deferred_logger.warning("WECON_INCONSISTANT_COMPLETION_WELL", message);
+            if (excluded_completions.empty()) {
+                const std::string message =
+                    "The well ratio limit is violated but no completion ratio "
+                    "limit is violated! " + well_.name() + " is kept open";
+                deferred_logger.warning("WECON_INCONSISTANT_COMPLETION_WELL", message);
+            }
             report.ratio_limit_violated = false;
         }
     }
@@ -468,6 +482,7 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
                 std::unordered_set<int> closed_this_event;
                 bool well_shut = false;
                 while (ratio_report.ratio_limit_violated) {
+                    const std::size_t num_closed_before = closed_this_event.size();
                     well_shut =
                         this->closeOffendingCompletion(ratio_report.worst_offending_completion,
                                                        close_connections_below,
@@ -478,6 +493,16 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
                                                        closed_this_event,
                                                        deferred_logger);
                     if (well_shut) {
+                        break;
+                    }
+                    if (closed_this_event.size() == num_closed_before) {
+                        // No progress: the offending completion could not be
+                        // closed (e.g. an unexpected sentinel value). Stop the
+                        // workover event instead of looping forever on the
+                        // unchanged ratio report.
+                        deferred_logger.warning("WECON_WORKOVER_NO_PROGRESS",
+                            fmt::format("Well {}: CON/+CON workover made no progress; "
+                                        "stopping the workover event.", well_.name()));
                         break;
                     }
                     // During well testing (WTEST re-open) the caller re-solves the
@@ -534,8 +559,11 @@ closeOffendingCompletion(const int offending_completion,
                          std::unordered_set<int>& closed_this_event,
                          DeferredLogger& deferred_logger) const
 {
-    // complnum is always >= 1; a non-positive value would be a bug.
-    assert(offending_completion > 0);
+    // complnum is always >= 1, and the INVALIDCOMPLETION sentinel (INT_MAX,
+    // which would pass a plain > 0 check) is filtered by the caller; either
+    // reaching here would be a bug.
+    assert(offending_completion > 0 &&
+           offending_completion != RatioLimitCheckReport::INVALIDCOMPLETION);
 
     // Sentinel for "no offending completion"; normally filtered by the caller.
     if (offending_completion == RatioLimitCheckReport::INVALIDCOMPLETION) {

--- a/opm/simulators/wells/WellTest.cpp
+++ b/opm/simulators/wells/WellTest.cpp
@@ -29,14 +29,12 @@
 
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
-#include <opm/common/utility/TimeService.hpp>
-
 #include <opm/material/fluidsystems/BlackOilDefaultFluidSystemIndices.hpp>
 
-#include <fmt/chrono.h>
 #include <fmt/format.h>
 
 #include <opm/simulators/utils/DeferredLogger.hpp>
+#include <opm/simulators/wells/EconomicLimitsMessage.hpp>
 #include <opm/simulators/wells/ParallelWellInfo.hpp>
 #include <opm/simulators/wells/SingleWellState.hpp>
 #include <opm/simulators/wells/WellInterfaceGeneric.hpp>
@@ -45,17 +43,6 @@
 #include <ctime>
 #include <string>
 #include <unordered_set>
-
-namespace {
-
-//! \brief Calendar date (DD-Mon-YYYY) reached at start_time + sim_time seconds.
-std::string dateString(const std::time_t start_time, const double sim_time)
-{
-    const std::time_t cur_time = Opm::TimeService::advance(start_time, sim_time);
-    return fmt::format("{:%d-%b-%Y}", fmt::gmtime(cur_time));
-}
-
-} // anonymous namespace
 
 namespace Opm {
 
@@ -170,132 +157,27 @@ checkMaxRatioLimitCompletions(const SingleWellState<Scalar, IndexTraits>& ws,
 }
 
 template<typename Scalar, typename IndexTraits>
+template<class RatioFunc>
 void WellTest<Scalar, IndexTraits>::
-checkMaxGORLimit(const WellEconProductionLimits& econ_production_limits,
-                 const SingleWellState<Scalar, IndexTraits>& ws,
-                 const std::unordered_set<int>& excluded_completions,
-                 RatioLimitCheckReport& report) const
+checkMaxRatioLimit(const SingleWellState<Scalar, IndexTraits>& ws,
+                   const Scalar max_ratio_limit,
+                   const RatioFunc& ratioFunc,
+                   const std::unordered_set<int>& excluded_completions,
+                   const std::string& ratio_name,
+                   const UnitSystem::measure ratio_measure,
+                   RatioLimitCheckReport& report) const
 {
-    // function to calculate gor based on rates
-    auto gor = [](const std::vector<Scalar>& rates,
-                  const PhaseUsageInfo<IndexTraits>& pu)
-    {
-        const Scalar oil_rate = -rates[pu.canonicalToActivePhaseIdx(IndexTraits::oilPhaseIdx)];
-        const Scalar gas_rate = -rates[pu.canonicalToActivePhaseIdx(IndexTraits::gasPhaseIdx)];
-        if (gas_rate <= 0.)
-            return Scalar{0};
-        else if (oil_rate <= 0.)
-            return RatioLimitCheckReport::INFINITE_RATIO;
-        else
-            return (gas_rate / oil_rate);
-    };
+    assert(max_ratio_limit > 0.);
 
-    const Scalar max_gor_limit = econ_production_limits.maxGasOilRatio();
-    assert(max_gor_limit > 0.);
+    Scalar well_ratio_value = 0.0;
+    const bool limit_violated =
+        this->checkMaxRatioLimitWell(ws, max_ratio_limit, ratioFunc,
+                                     excluded_completions, well_ratio_value);
 
-    Scalar well_gor = 0.0;
-    const bool gor_limit_violated =
-        this->checkMaxRatioLimitWell(ws, max_gor_limit, gor, excluded_completions, well_gor);
-
-    report.checked_ratios.push_back({"gas-oil ratio",
-                                     UnitSystem::measure::gas_oil_ratio,
-                                     well_gor, max_gor_limit});
-
-    if (gor_limit_violated) {
+    if (limit_violated) {
         report.ratio_limit_violated = true;
-        this->checkMaxRatioLimitCompletions(ws, max_gor_limit, well_gor, gor,
-                                            excluded_completions,
-                                            "gas-oil ratio",
-                                            UnitSystem::measure::gas_oil_ratio,
-                                            report);
-    }
-}
-
-template<typename Scalar, typename IndexTraits>
-void WellTest<Scalar, IndexTraits>::
-checkMaxWGRLimit(const WellEconProductionLimits& econ_production_limits,
-                 const SingleWellState<Scalar, IndexTraits>& ws,
-                 const std::unordered_set<int>& excluded_completions,
-                 RatioLimitCheckReport& report) const
-{
-    // function to calculate wgr based on rates
-    auto wgr = [](const std::vector<Scalar>& rates,
-                  const PhaseUsageInfo<IndexTraits>& pu)
-    {
-        const Scalar water_rate = -rates[pu.canonicalToActivePhaseIdx(IndexTraits::waterPhaseIdx)];
-        const Scalar gas_rate = -rates[pu.canonicalToActivePhaseIdx(IndexTraits::gasPhaseIdx)];
-        if (water_rate <= 0.)
-            return Scalar{0};
-        else if (gas_rate <= 0.)
-            return RatioLimitCheckReport::INFINITE_RATIO;
-        else
-            return (water_rate / gas_rate);
-    };
-
-    const Scalar max_wgr_limit = econ_production_limits.maxWaterGasRatio();
-    assert(max_wgr_limit > 0.);
-
-    Scalar well_wgr = 0.0;
-    const bool wgr_limit_violated =
-        this->checkMaxRatioLimitWell(ws, max_wgr_limit, wgr, excluded_completions, well_wgr);
-
-    report.checked_ratios.push_back({"water-gas ratio",
-                                     UnitSystem::measure::water_gas_ratio,
-                                     well_wgr, max_wgr_limit});
-
-    if (wgr_limit_violated) {
-        report.ratio_limit_violated = true;
-        this->checkMaxRatioLimitCompletions(ws, max_wgr_limit, well_wgr, wgr,
-                                            excluded_completions,
-                                            "water-gas ratio",
-                                            UnitSystem::measure::water_gas_ratio,
-                                            report);
-    }
-}
-
-template<typename Scalar, typename IndexTraits>
-void WellTest<Scalar, IndexTraits>::
-checkMaxWaterCutLimit(const WellEconProductionLimits& econ_production_limits,
-                      const SingleWellState<Scalar, IndexTraits>& ws,
-                      const std::unordered_set<int>& excluded_completions,
-                      RatioLimitCheckReport& report) const
-{
-    // function to calculate water cut based on rates
-    auto waterCut = [](const std::vector<Scalar>& rates,
-                       const PhaseUsageInfo<IndexTraits>& pu)
-    {
-        const Scalar oil_rate = -rates[pu.canonicalToActivePhaseIdx(IndexTraits::oilPhaseIdx)];
-        const Scalar water_rate = -rates[pu.canonicalToActivePhaseIdx(IndexTraits::waterPhaseIdx)];
-        const Scalar liquid_rate = oil_rate + water_rate;
-        if (liquid_rate <= 0.)
-            return Scalar{0};
-        else if (water_rate < 0)
-            return Scalar{0};
-        else if (oil_rate < 0)
-            return Scalar{1};
-        else
-            return (water_rate / liquid_rate);
-
-    };
-
-    const Scalar max_water_cut_limit = econ_production_limits.maxWaterCut();
-    assert(max_water_cut_limit > 0.);
-
-    Scalar well_water_cut = 0.0;
-    const bool watercut_limit_violated =
-        this->checkMaxRatioLimitWell(ws, max_water_cut_limit, waterCut,
-                                     excluded_completions, well_water_cut);
-
-    report.checked_ratios.push_back({"water cut",
-                                     UnitSystem::measure::water_cut,
-                                     well_water_cut, max_water_cut_limit});
-
-    if (watercut_limit_violated) {
-        report.ratio_limit_violated = true;
-        this->checkMaxRatioLimitCompletions(ws, max_water_cut_limit, well_water_cut, waterCut,
-                                            excluded_completions,
-                                            "water cut",
-                                            UnitSystem::measure::water_cut,
+        this->checkMaxRatioLimitCompletions(ws, max_ratio_limit, well_ratio_value, ratioFunc,
+                                            excluded_completions, ratio_name, ratio_measure,
                                             report);
     }
 }
@@ -362,15 +244,65 @@ checkRatioEconLimits(const WellEconProductionLimits& econ_production_limits,
     RatioLimitCheckReport report;
 
     if (econ_production_limits.onMaxWaterCut()) {
-        this->checkMaxWaterCutLimit(econ_production_limits, ws, excluded_completions, report);
+        // function to calculate water cut based on rates
+        auto waterCut = [](const std::vector<Scalar>& rates,
+                           const PhaseUsageInfo<IndexTraits>& pu)
+        {
+            const Scalar oil_rate = -rates[pu.canonicalToActivePhaseIdx(IndexTraits::oilPhaseIdx)];
+            const Scalar water_rate =
+                -rates[pu.canonicalToActivePhaseIdx(IndexTraits::waterPhaseIdx)];
+            const Scalar liquid_rate = oil_rate + water_rate;
+            if (liquid_rate <= 0.)
+                return Scalar{0};
+            else if (water_rate < 0)
+                return Scalar{0};
+            else if (oil_rate < 0)
+                return Scalar{1};
+            else
+                return (water_rate / liquid_rate);
+        };
+        this->checkMaxRatioLimit(ws, econ_production_limits.maxWaterCut(), waterCut,
+                                 excluded_completions, "water cut",
+                                 UnitSystem::measure::water_cut, report);
     }
 
     if (econ_production_limits.onMaxGasOilRatio()) {
-        this->checkMaxGORLimit(econ_production_limits, ws, excluded_completions, report);
+        // function to calculate gor based on rates
+        auto gor = [](const std::vector<Scalar>& rates,
+                      const PhaseUsageInfo<IndexTraits>& pu)
+        {
+            const Scalar oil_rate = -rates[pu.canonicalToActivePhaseIdx(IndexTraits::oilPhaseIdx)];
+            const Scalar gas_rate = -rates[pu.canonicalToActivePhaseIdx(IndexTraits::gasPhaseIdx)];
+            if (gas_rate <= 0.)
+                return Scalar{0};
+            else if (oil_rate <= 0.)
+                return RatioLimitCheckReport::INFINITE_RATIO;
+            else
+                return (gas_rate / oil_rate);
+        };
+        this->checkMaxRatioLimit(ws, econ_production_limits.maxGasOilRatio(), gor,
+                                 excluded_completions, "gas-oil ratio",
+                                 UnitSystem::measure::gas_oil_ratio, report);
     }
 
     if (econ_production_limits.onMaxWaterGasRatio()) {
-        this->checkMaxWGRLimit(econ_production_limits, ws, excluded_completions, report);
+        // function to calculate wgr based on rates
+        auto wgr = [](const std::vector<Scalar>& rates,
+                      const PhaseUsageInfo<IndexTraits>& pu)
+        {
+            const Scalar water_rate =
+                -rates[pu.canonicalToActivePhaseIdx(IndexTraits::waterPhaseIdx)];
+            const Scalar gas_rate = -rates[pu.canonicalToActivePhaseIdx(IndexTraits::gasPhaseIdx)];
+            if (water_rate <= 0.)
+                return Scalar{0};
+            else if (gas_rate <= 0.)
+                return RatioLimitCheckReport::INFINITE_RATIO;
+            else
+                return (water_rate / gas_rate);
+        };
+        this->checkMaxRatioLimit(ws, econ_production_limits.maxWaterGasRatio(), wgr,
+                                 excluded_completions, "water-gas ratio",
+                                 UnitSystem::measure::water_gas_ratio, report);
     }
 
     if (econ_production_limits.onMaxGasLiquidRatio()) {
@@ -402,6 +334,7 @@ void WellTest<Scalar, IndexTraits>::
 updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
                             const double simulation_time,
                             const bool write_message_to_opmlog,
+                            const bool during_well_test,
                             WellTestState& well_test_state,
                             const bool zero_group_target,
                             const UnitSystem& unit_system,
@@ -510,7 +443,7 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
                 "at time {:.2f} {} (date = {})",
                 unit_system.from_si(UnitSystem::measure::time, simulation_time),
                 unit_system.name(UnitSystem::measure::time),
-                dateString(start_time, simulation_time));
+                economicLimitDateString(start_time, simulation_time));
 
             reason = make_reason(ratio_report);
         }
@@ -547,16 +480,14 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
                     if (well_shut) {
                         break;
                     }
-                    // During a WTEST re-opening evaluation (identified by
-                    // write_message_to_opmlog == false), the caller loop in
-                    // WellInterface::wellTesting() re-solves the well after
-                    // every closure and calls this function again, so each
-                    // closure decision is made from re-converged rates.
-                    // Repeating the workover here would instead re-evaluate the
-                    // remaining completions from the frozen pre-closure rates
+                    // During well testing (WTEST re-open) the caller re-solves the
+                    // well after every closure, so each closure decision is made
+                    // from re-converged rates: stop after this one closure and let
+                    // the caller re-solve. Iterating here instead would re-evaluate
+                    // the remaining completions from the frozen pre-closure rates
                     // and could shut a well that re-converged flow would keep
                     // within the limit.
-                    if (!write_message_to_opmlog) {
+                    if (during_well_test) {
                         break;
                     }
                     ratio_report = this->checkRatioEconLimits(econ_production_limits, ws,
@@ -565,40 +496,15 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
                         reason = make_reason(ratio_report);
                     }
                 }
-                if (write_message_to_opmlog && !well_shut) {
-                    // Debug output: the well-level ratios of the remaining
-                    // completions after the workover event has finished.
-                    std::string ratios;
-                    for (const auto& checked : ratio_report.checked_ratios) {
-                        const std::string ratio_unit = unit_system.name(checked.measure);
-                        const std::string unit_suffix = ratio_unit.empty() ? std::string{}
-                                                                           : " " + ratio_unit;
-                        const std::string value =
-                            checked.value >= RatioLimitCheckReport::INFINITE_RATIO
-                                ? "infinite"
-                                : fmt::format("{:.4e}{}",
-                                              unit_system.from_si(checked.measure, checked.value),
-                                              unit_suffix);
-                        ratios += fmt::format(
-                            "{}{} {} (limit {:.4e}{})",
-                            ratios.empty() ? "" : ", ",
-                            checked.name,
-                            value,
-                            unit_system.from_si(checked.measure, checked.limit), unit_suffix);
-                    }
-                    deferred_logger.debug(
-                        fmt::format("Well {}: CON/+CON workover closed {} completion(s) {}; "
-                                    "the well ratios of the remaining completions: {}",
-                                    well_.name(), closed_this_event.size(), when, ratios));
-                }
                 break;
             }
         case WellEconProductionLimits::EconWorkover::WELL:
             {
             well_test_state.close_well(well_.name(), WellTestConfig::Reason::ECONOMIC, simulation_time);
             if (write_message_to_opmlog) {
-                const std::string action = well_.wellEcl().getAutomaticShutIn() ? "shut" : "stopped";
-                const std::string sep = this->message_separator();
+                const std::string action =
+                    well_.wellEcl().getAutomaticShutIn() ? "shut" : "stopped";
+                const std::string& sep = economicLimitMessageSeparator();
                 deferred_logger.info(
                     fmt::format("{}\nWell {} will be {} {},\nBecause {}.\n{}",
                                 sep, well_.name(), action, when, reason, sep));
@@ -674,8 +580,9 @@ closeOffendingCompletion(const int offending_completion,
                           this->completionDescriptor(offending_completion), well_.name())
             : fmt::format("{} in Well {}",
                           this->completionDescriptor(offending_completion), well_.name());
-        const std::string sep = this->message_separator();
-        // WECON-driven: report "the well" ratio (CECON would say "its ...", will be addressed by CECON development).
+        const std::string& sep = economicLimitMessageSeparator();
+        // WECON-driven: report "the well" ratio (CECON would say "its ..."; that
+        // distinction will be addressed by the CECON development).
         deferred_logger.info(
             fmt::format("{}\n{} will be closed {},\nBecause the well {}.\n{}",
                         sep, subject, when, reason, sep));
@@ -693,7 +600,7 @@ closeOffendingCompletion(const int offending_completion,
         well_test_state.close_well(well_.name(), WellTestConfig::Reason::ECONOMIC, simulation_time);
         // if all the completion/connections are closed, the well can only be SHUT
         if (write_message_to_opmlog) {
-            const std::string sep = this->message_separator();
+            const std::string& sep = economicLimitMessageSeparator();
             deferred_logger.info(
                 fmt::format("{}\nWell {} will be shut {},\n"
                             "Because all its completions are closed.\n{}",

--- a/opm/simulators/wells/WellTest.cpp
+++ b/opm/simulators/wells/WellTest.cpp
@@ -29,6 +29,8 @@
 
 #include <opm/material/fluidsystems/BlackOilDefaultFluidSystemIndices.hpp>
 
+#include <fmt/format.h>
+
 #include <opm/simulators/utils/DeferredLogger.hpp>
 #include <opm/simulators/wells/ParallelWellInfo.hpp>
 #include <opm/simulators/wells/SingleWellState.hpp>
@@ -447,6 +449,92 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
                 deferred_logger.warning("NOT_SUPPORTED_WORKOVER_TYPE",
                                         "not supporting workover type " + WellEconProductionLimits::EconWorkover2String(workover));
             }
+        }
+    }
+}
+
+template<typename Scalar, typename IndexTraits>
+void WellTest<Scalar, IndexTraits>::
+closeOffendingCompletion(const int offending_completion,
+                         const bool close_connections_below,
+                         const double simulation_time,
+                         const bool write_message_to_opmlog,
+                         WellTestState& well_test_state,
+                         DeferredLogger& deferred_logger) const
+{
+    // Completion numbers are positive (1-based). Non-positive values are
+    // sentinels from the parallel worst-offender search (e.g. INT_MIN when no
+    // rank holds a valid candidate) and must not be registered as closed.
+    if (offending_completion <= 0) {
+        deferred_logger.warning("ECON_WORKOVER_INVALID_COMPLETION",
+                                fmt::format("Economic limit workover for well {} did not find a "
+                                            "valid completion to close (completion number {}). "
+                                            "No connection will be closed.",
+                                            well_.name(), offending_completion));
+        return;
+    }
+
+    // The wellbore ordering of the connections is the one given by COMPORD and
+    // reflected in the order of the connections returned by getConnections().
+    const auto& connections = well_.wellEcl().getConnections();
+
+    // Build the list of completions to close. For CON it is just the
+    // worst-offending completion; for +CON it additionally contains every
+    // completion located below the worst-offending one in the wellbore.
+    // "Below" means further from the wellhead according to the connection ordering.
+    std::vector<int> completions_to_close;
+    if (!close_connections_below) {
+        completions_to_close.push_back(offending_completion);
+    } else {
+        completions_to_close.push_back(offending_completion);
+        bool below_worst_offender = false;
+        for (const auto& connection : connections) {
+            if (!below_worst_offender &&
+                connection.complnum() == offending_completion) {
+                below_worst_offender = true;
+                continue;
+            }
+            if (below_worst_offender) {
+                completions_to_close.push_back(connection.complnum());
+            }
+        }
+    }
+
+    for (const int completion : completions_to_close) {
+        well_test_state.close_completion(well_.name(), completion, simulation_time);
+    }
+
+    if (write_message_to_opmlog) {
+        const std::string below_msg = close_connections_below
+            ? " and all connections below it" : "";
+        std::string block_msg;
+        for (const auto& connection : connections) {
+            if (connection.complnum() == offending_completion) {
+                block_msg = fmt::format(" - block ({}, {}, {})",
+                                        connection.getI() + 1,
+                                        connection.getJ() + 1,
+                                        connection.getK() + 1);
+                break;
+            }
+        }
+        deferred_logger.info(fmt::format("Completion {}{} for well {}{} will be closed due to economic limit",
+                                         offending_completion, block_msg,
+                                         well_.name(), below_msg));
+    }
+
+    bool allCompletionsClosed = true;
+    for (const auto& connection : connections) {
+        if (connection.state() == Connection::State::OPEN
+            && !well_test_state.completion_is_closed(well_.name(), connection.complnum())) {
+            allCompletionsClosed = false;
+        }
+    }
+
+    if (allCompletionsClosed) {
+        well_test_state.close_well(well_.name(), WellTestConfig::Reason::ECONOMIC, simulation_time);
+        // if all the completion/connections are closed, the well can only be SHUT
+        if (write_message_to_opmlog) {
+            deferred_logger.info(fmt::format("{} will be shut due to last completion closed", well_.name()));
         }
     }
 }

--- a/opm/simulators/wells/WellTest.cpp
+++ b/opm/simulators/wells/WellTest.cpp
@@ -185,7 +185,7 @@ checkMaxGORLimit(const WellEconProductionLimits& econ_production_limits,
         if (gas_rate <= 0.)
             return Scalar{0};
         else if (oil_rate <= 0.)
-            return Scalar{1e30}; // big value to mark it as violated
+            return RatioLimitCheckReport::INFINITE_RATIO;
         else
             return (gas_rate / oil_rate);
     };
@@ -227,7 +227,7 @@ checkMaxWGRLimit(const WellEconProductionLimits& econ_production_limits,
         if (water_rate <= 0.)
             return Scalar{0};
         else if (gas_rate <= 0.)
-            return Scalar{1e30}; // big value to mark it as violated
+            return RatioLimitCheckReport::INFINITE_RATIO;
         else
             return (water_rate / gas_rate);
     };
@@ -493,6 +493,12 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
             const std::string ratio_unit = unit_system.name(report.ratio_measure);
             const std::string unit_suffix = ratio_unit.empty() ? std::string{}
                                                                : " " + ratio_unit;
+            if (report.ratio_value >= RatioLimitCheckReport::INFINITE_RATIO) {
+                return fmt::format(
+                    "{} is infinite and exceeds the limit {:.4e}{}",
+                    report.ratio_name,
+                    unit_system.from_si(report.ratio_measure, report.ratio_limit), unit_suffix);
+            }
             return fmt::format(
                 "{} {:.4e}{} exceeds the limit {:.4e}{}",
                 report.ratio_name,
@@ -517,11 +523,13 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
                 // +CON : shut the worst-offending connection/completion and all
                 //        connections below it in the wellbore.
                 //
-                // The workover is applied repeatedly at the same time instant:
-                // closing completions changes the well ratio, so it is
-                // re-evaluated from the rates of the remaining completions and
-                // the (new) worst offender is closed until the limit is honored
-                // or the well has no open completions left and is shut.
+                // During the regular timestep update the workover is applied
+                // repeatedly at the same time instant: closing completions
+                // changes the well ratio, so it is re-evaluated from the rates
+                // of the remaining completions and the (new) worst offender is
+                // closed until the limit is honored or the well has no open
+                // completions left and is shut. During a WTEST evaluation only
+                // one round is applied per call (see below).
                 const bool close_connections_below =
                     (workover == WellEconProductionLimits::EconWorkover::CONP);
                 std::unordered_set<int> closed_this_event;
@@ -539,9 +547,21 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
                     if (well_shut) {
                         break;
                     }
+                    // During a WTEST re-opening evaluation (identified by
+                    // write_message_to_opmlog == false), the caller loop in
+                    // WellInterface::wellTesting() re-solves the well after
+                    // every closure and calls this function again, so each
+                    // closure decision is made from re-converged rates.
+                    // Repeating the workover here would instead re-evaluate the
+                    // remaining completions from the frozen pre-closure rates
+                    // and could shut a well that re-converged flow would keep
+                    // within the limit.
+                    if (!write_message_to_opmlog) {
+                        break;
+                    }
                     ratio_report = this->checkRatioEconLimits(econ_production_limits, ws,
                                                               closed_this_event, deferred_logger);
-                    if (write_message_to_opmlog && ratio_report.ratio_limit_violated) {
+                    if (ratio_report.ratio_limit_violated) {
                         reason = make_reason(ratio_report);
                     }
                 }
@@ -553,11 +573,17 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
                         const std::string ratio_unit = unit_system.name(checked.measure);
                         const std::string unit_suffix = ratio_unit.empty() ? std::string{}
                                                                            : " " + ratio_unit;
+                        const std::string value =
+                            checked.value >= RatioLimitCheckReport::INFINITE_RATIO
+                                ? "infinite"
+                                : fmt::format("{:.4e}{}",
+                                              unit_system.from_si(checked.measure, checked.value),
+                                              unit_suffix);
                         ratios += fmt::format(
-                            "{}{} {:.4e}{} (limit {:.4e}{})",
+                            "{}{} {} (limit {:.4e}{})",
                             ratios.empty() ? "" : ", ",
                             checked.name,
-                            unit_system.from_si(checked.measure, checked.value), unit_suffix,
+                            value,
                             unit_system.from_si(checked.measure, checked.limit), unit_suffix);
                     }
                     deferred_logger.debug(

--- a/opm/simulators/wells/WellTest.cpp
+++ b/opm/simulators/wells/WellTest.cpp
@@ -392,39 +392,19 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
         const auto workover = econ_production_limits.workover();
         switch (workover) {
         case WellEconProductionLimits::EconWorkover::CON:
+        case WellEconProductionLimits::EconWorkover::CONP:
             {
-                const int worst_offending_completion = ratio_report.worst_offending_completion;
-
-                well_test_state.close_completion(well_.name(), worst_offending_completion, simulation_time);
-                if (write_message_to_opmlog) {
-                    if (worst_offending_completion < 0) {
-                        const std::string msg = std::string("Connection ") + std::to_string(- worst_offending_completion)
-                                + std::string(" for well ") + well_.name() + std::string(" will be closed due to economic limit");
-                        deferred_logger.info(msg);
-                    } else {
-                        const std::string msg = std::string("Completion ") + std::to_string(worst_offending_completion)
-                                + std::string(" for well ") + well_.name() + std::string(" will be closed due to economic limit");
-                        deferred_logger.info(msg);
-                    }
-                }
-
-                bool allCompletionsClosed = true;
-                const auto& connections = well_.wellEcl().getConnections();
-                for (const auto& connection : connections) {
-                    if (connection.state() == Connection::State::OPEN
-                        && !well_test_state.completion_is_closed(well_.name(), connection.complnum())) {
-                        allCompletionsClosed = false;
-                    }
-                }
-
-                if (allCompletionsClosed) {
-                    well_test_state.close_well(well_.name(), WellTestConfig::Reason::ECONOMIC, simulation_time);
-                    // if all the completion/connections are closed, the well can only be SHUT
-                    if (write_message_to_opmlog) {
-                        const std::string msg = well_.name() + std::string(" will be shut due to last completion closed");
-                        deferred_logger.info(msg);
-                    }
-                }
+                // CON  : shut the worst-offending connection/completion only.
+                // +CON : shut the worst-offending connection/completion and all
+                //        connections below it in the wellbore.
+                const bool close_connections_below =
+                    (workover == WellEconProductionLimits::EconWorkover::CONP);
+                this->closeOffendingCompletion(ratio_report.worst_offending_completion,
+                                               close_connections_below,
+                                               simulation_time,
+                                               write_message_to_opmlog,
+                                               well_test_state,
+                                               deferred_logger);
                 break;
             }
         case WellEconProductionLimits::EconWorkover::WELL:

--- a/opm/simulators/wells/WellTest.cpp
+++ b/opm/simulators/wells/WellTest.cpp
@@ -27,8 +27,13 @@
 #include <opm/input/eclipse/Schedule/Well/WellTestConfig.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
 
+#include <opm/input/eclipse/Units/UnitSystem.hpp>
+
+#include <opm/common/utility/TimeService.hpp>
+
 #include <opm/material/fluidsystems/BlackOilDefaultFluidSystemIndices.hpp>
 
+#include <fmt/chrono.h>
 #include <fmt/format.h>
 
 #include <opm/simulators/utils/DeferredLogger.hpp>
@@ -37,7 +42,20 @@
 #include <opm/simulators/wells/WellInterfaceGeneric.hpp>
 
 #include <cassert>
+#include <ctime>
+#include <string>
 #include <unordered_set>
+
+namespace {
+
+//! \brief Calendar date (DD-Mon-YYYY) reached at start_time + sim_time seconds.
+std::string dateString(const std::time_t start_time, const double sim_time)
+{
+    const std::time_t cur_time = Opm::TimeService::advance(start_time, sim_time);
+    return fmt::format("{:%d-%b-%Y}", fmt::gmtime(cur_time));
+}
+
+} // anonymous namespace
 
 namespace Opm {
 
@@ -65,6 +83,8 @@ void WellTest<Scalar, IndexTraits>::
 checkMaxRatioLimitCompletions(const SingleWellState<Scalar, IndexTraits>& ws,
                               const Scalar max_ratio_limit,
                               const RatioFunc& ratioFunc,
+                              const std::string& ratio_name,
+                              const UnitSystem::measure ratio_measure,
                               RatioLimitCheckReport& report) const
 {
     int worst_offending_completion = RatioLimitCheckReport::INVALIDCOMPLETION;
@@ -111,6 +131,13 @@ checkMaxRatioLimitCompletions(const SingleWellState<Scalar, IndexTraits>& ws,
 
         report.worst_offending_completion = worst_offending_completion;
         report.violation_extent = violation_extent;
+        // Record which ratio limit was violated together with the worst
+        // completion's actual value and the limit, so the closing message can
+        // report the offending quantity.
+        report.ratio_name = ratio_name;
+        report.ratio_measure = ratio_measure;
+        report.ratio_value = max_ratio_completion;
+        report.ratio_limit = max_ratio_limit;
     }
 }
 
@@ -141,7 +168,10 @@ checkMaxGORLimit(const WellEconProductionLimits& econ_production_limits,
 
     if (gor_limit_violated) {
         report.ratio_limit_violated = true;
-        this->checkMaxRatioLimitCompletions(ws, max_gor_limit, gor, report);
+        this->checkMaxRatioLimitCompletions(ws, max_gor_limit, gor,
+                                            "gas-oil ratio",
+                                            UnitSystem::measure::gas_oil_ratio,
+                                            report);
     }
 }
 
@@ -172,7 +202,10 @@ checkMaxWGRLimit(const WellEconProductionLimits& econ_production_limits,
 
     if (wgr_limit_violated) {
         report.ratio_limit_violated = true;
-        this->checkMaxRatioLimitCompletions(ws, max_wgr_limit, wgr, report);
+        this->checkMaxRatioLimitCompletions(ws, max_wgr_limit, wgr,
+                                            "water-gas ratio",
+                                            UnitSystem::measure::water_gas_ratio,
+                                            report);
     }
 }
 
@@ -208,8 +241,10 @@ checkMaxWaterCutLimit(const WellEconProductionLimits& econ_production_limits,
 
     if (watercut_limit_violated) {
         report.ratio_limit_violated = true;
-        this->checkMaxRatioLimitCompletions(ws, max_water_cut_limit,
-                                            waterCut, report);
+        this->checkMaxRatioLimitCompletions(ws, max_water_cut_limit, waterCut,
+                                            "water cut",
+                                            UnitSystem::measure::water_cut,
+                                            report);
     }
 }
 
@@ -316,6 +351,8 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
                             const bool write_message_to_opmlog,
                             WellTestState& well_test_state,
                             const bool zero_group_target,
+                            const UnitSystem& unit_system,
+                            const std::time_t start_time,
                             DeferredLogger& deferred_logger) const
 {
     if (well_.wellIsStopped())
@@ -393,6 +430,24 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
 
     if (ratio_report.ratio_limit_violated) {
         const auto workover = econ_production_limits.workover();
+
+        // Build the "at time ... (date = ...)" and ratio-violation clauses that
+        // are shared by all the ratio-limit workover messages below.
+        const std::string when = fmt::format(
+            "at time {:.2f} {} (date = {})",
+            unit_system.from_si(UnitSystem::measure::time, simulation_time),
+            unit_system.name(UnitSystem::measure::time),
+            dateString(start_time, simulation_time));
+
+        const std::string ratio_unit = unit_system.name(ratio_report.ratio_measure);
+        const std::string unit_suffix = ratio_unit.empty() ? std::string{}
+                                                           : " " + ratio_unit;
+        const std::string reason = fmt::format(
+            "{} {:.4e}{} exceeds the limit {:.4e}{}",
+            ratio_report.ratio_name,
+            unit_system.from_si(ratio_report.ratio_measure, ratio_report.ratio_value), unit_suffix,
+            unit_system.from_si(ratio_report.ratio_measure, ratio_report.ratio_limit), unit_suffix);
+
         switch (workover) {
         case WellEconProductionLimits::EconWorkover::CON:
         case WellEconProductionLimits::EconWorkover::CONP:
@@ -407,6 +462,7 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
                                                simulation_time,
                                                write_message_to_opmlog,
                                                well_test_state,
+                                               when, reason,
                                                deferred_logger);
                 break;
             }
@@ -414,14 +470,11 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
             {
             well_test_state.close_well(well_.name(), WellTestConfig::Reason::ECONOMIC, simulation_time);
             if (write_message_to_opmlog) {
-                if (well_.wellEcl().getAutomaticShutIn()) {
-                    // tell the control that the well is closed
-                    const std::string msg = well_.name() + std::string(" will be shut due to ratio economic limit");
-                    deferred_logger.info(msg);
-                } else {
-                    const std::string msg = well_.name() + std::string(" will be stopped due to ratio economic limit");
-                    deferred_logger.info(msg);
-                }
+                const std::string action = well_.wellEcl().getAutomaticShutIn() ? "shut" : "stopped";
+                const std::string sep = this->message_separator();
+                deferred_logger.info(
+                    fmt::format("{}\nWell {} will be {} {},\nBecause {}.\n{}",
+                                sep, well_.name(), action, when, reason, sep));
             }
                 break;
             }
@@ -443,6 +496,8 @@ closeOffendingCompletion(const int offending_completion,
                          const double simulation_time,
                          const bool write_message_to_opmlog,
                          WellTestState& well_test_state,
+                         const std::string& when,
+                         const std::string& reason,
                          DeferredLogger& deferred_logger) const
 {
     assert(offending_completion > 0);
@@ -477,21 +532,17 @@ closeOffendingCompletion(const int offending_completion,
     }
 
     if (write_message_to_opmlog) {
-        const std::string below_msg = close_connections_below
-            ? " and all connections below it" : "";
-        std::string block_msg;
-        for (const auto& connection : connections) {
-            if (connection.complnum() == offending_completion) {
-                block_msg = fmt::format(" - block ({}, {}, {})",
-                                        connection.getI() + 1,
-                                        connection.getJ() + 1,
-                                        connection.getK() + 1);
-                break;
-            }
-        }
-        deferred_logger.info(fmt::format("Completion {}{} for well {}{} will be closed due to economic limit",
-                                         offending_completion, block_msg,
-                                         well_.name(), below_msg));
+        // "and all below" is only appended for the +CON workover, which also
+        // closes every connection below the offending completion.
+        const std::string subject = close_connections_below
+            ? fmt::format("{}, and all below, in Well {}",
+                          this->completionDescriptor(offending_completion), well_.name())
+            : fmt::format("{} in Well {}",
+                          this->completionDescriptor(offending_completion), well_.name());
+        const std::string sep = this->message_separator();
+        deferred_logger.info(
+            fmt::format("{}\n{} will be closed {},\nBecause its {}.\n{}",
+                        sep, subject, when, reason, sep));
     }
 
     bool allCompletionsClosed = true;
@@ -506,9 +557,40 @@ closeOffendingCompletion(const int offending_completion,
         well_test_state.close_well(well_.name(), WellTestConfig::Reason::ECONOMIC, simulation_time);
         // if all the completion/connections are closed, the well can only be SHUT
         if (write_message_to_opmlog) {
-            deferred_logger.info(fmt::format("{} will be shut due to last completion closed", well_.name()));
+            const std::string sep = this->message_separator();
+            deferred_logger.info(
+                fmt::format("{}\nWell {} will be shut {},\n"
+                            "Because all its completions are closed.\n{}",
+                            sep, well_.name(), when, sep));
         }
     }
+}
+
+template<typename Scalar, typename IndexTraits>
+std::string WellTest<Scalar, IndexTraits>::
+completionDescriptor(const int complnum) const
+{
+    const auto& connections = well_.wellEcl().getConnections();
+    const Connection* first = nullptr;
+    int num_connections = 0;
+    for (const auto& connection : connections) {
+        if (connection.complnum() == complnum) {
+            if (first == nullptr) {
+                first = &connection;
+            }
+            ++num_connections;
+        }
+    }
+
+    // A completion that spans several connections/blocks is identified by its
+    // number only; a single-connection completion also reports its block.
+    if (num_connections == 1 && first != nullptr) {
+        return fmt::format("Completion {} - block ({}, {}, {})", complnum,
+                           first->getI() + 1,
+                           first->getJ() + 1,
+                           first->getK() + 1);
+    }
+    return fmt::format("Completion {}", complnum);
 }
 
 template<typename Scalar, typename IndexTraits>

--- a/opm/simulators/wells/WellTest.cpp
+++ b/opm/simulators/wells/WellTest.cpp
@@ -435,22 +435,26 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
     if (ratio_report.ratio_limit_violated) {
         const auto workover = econ_production_limits.workover();
 
-        // Build the "at time ... (date = ...)" and ratio-violation clauses that
-        // are shared by all the ratio-limit workover messages below.
-        const std::string when = fmt::format(
-            "at time {:.2f} {} (date = {})",
-            unit_system.from_si(UnitSystem::measure::time, simulation_time),
-            unit_system.name(UnitSystem::measure::time),
-            dateString(start_time, simulation_time));
+        // Shared "at time ..." and ratio-violation clauses for the messages
+        // below; only built when a message will actually be logged.
+        std::string when;
+        std::string reason;
+        if (write_message_to_opmlog) {
+            when = fmt::format(
+                "at time {:.2f} {} (date = {})",
+                unit_system.from_si(UnitSystem::measure::time, simulation_time),
+                unit_system.name(UnitSystem::measure::time),
+                dateString(start_time, simulation_time));
 
-        const std::string ratio_unit = unit_system.name(ratio_report.ratio_measure);
-        const std::string unit_suffix = ratio_unit.empty() ? std::string{}
-                                                           : " " + ratio_unit;
-        const std::string reason = fmt::format(
-            "{} {:.4e}{} exceeds the limit {:.4e}{}",
-            ratio_report.ratio_name,
-            unit_system.from_si(ratio_report.ratio_measure, ratio_report.ratio_value), unit_suffix,
-            unit_system.from_si(ratio_report.ratio_measure, ratio_report.ratio_limit), unit_suffix);
+            const std::string ratio_unit = unit_system.name(ratio_report.ratio_measure);
+            const std::string unit_suffix = ratio_unit.empty() ? std::string{}
+                                                               : " " + ratio_unit;
+            reason = fmt::format(
+                "{} {:.4e}{} exceeds the limit {:.4e}{}",
+                ratio_report.ratio_name,
+                unit_system.from_si(ratio_report.ratio_measure, ratio_report.ratio_value), unit_suffix,
+                unit_system.from_si(ratio_report.ratio_measure, ratio_report.ratio_limit), unit_suffix);
+        }
 
         switch (workover) {
         case WellEconProductionLimits::EconWorkover::CON:
@@ -504,7 +508,13 @@ closeOffendingCompletion(const int offending_completion,
                          const std::string& reason,
                          DeferredLogger& deferred_logger) const
 {
+    // complnum is always >= 1; a non-positive value would be a bug.
     assert(offending_completion > 0);
+
+    // Sentinel for "no offending completion"; normally filtered by the caller.
+    if (offending_completion == RatioLimitCheckReport::INVALIDCOMPLETION) {
+        return;
+    }
 
     // The wellbore ordering of the connections is the one given by COMPORD and
     // reflected in the order of the connections returned by getConnections().

--- a/opm/simulators/wells/WellTest.cpp
+++ b/opm/simulators/wells/WellTest.cpp
@@ -517,7 +517,7 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
                     }
                     ratio_report = this->checkRatioEconLimits(econ_production_limits, ws,
                                                               closed_this_event, deferred_logger);
-                    if (ratio_report.ratio_limit_violated) {
+                    if (write_message_to_opmlog && ratio_report.ratio_limit_violated) {
                         reason = make_reason(ratio_report);
                     }
                 }
@@ -559,13 +559,13 @@ closeOffendingCompletion(const int offending_completion,
                          std::unordered_set<int>& closed_this_event,
                          DeferredLogger& deferred_logger) const
 {
-    // complnum is always >= 1, and the INVALIDCOMPLETION sentinel (INT_MAX,
-    // which would pass a plain > 0 check) is filtered by the caller; either
-    // reaching here would be a bug.
-    assert(offending_completion > 0 &&
-           offending_completion != RatioLimitCheckReport::INVALIDCOMPLETION);
+    // A real completion number is always >= 1; a non-positive value is a bug.
+    assert(offending_completion > 0);
 
-    // Sentinel for "no offending completion"; normally filtered by the caller.
+    // The INVALIDCOMPLETION sentinel ("no offending completion") is cleared by
+    // checkRatioEconLimits before the workover loop runs, so it should not reach
+    // here. A defensive guard: closing nothing and returning "not shut" lets the
+    // loop's no-progress guard stop the workover event instead of looping.
     if (offending_completion == RatioLimitCheckReport::INVALIDCOMPLETION) {
         return false;
     }

--- a/opm/simulators/wells/WellTest.cpp
+++ b/opm/simulators/wells/WellTest.cpp
@@ -64,7 +64,8 @@ template<class RatioFunc>
 bool WellTest<Scalar, IndexTraits>::
 checkMaxRatioLimitWell(const SingleWellState<Scalar, IndexTraits>& ws,
                        const Scalar max_ratio_limit,
-                       const RatioFunc& ratioFunc) const
+                       const RatioFunc& ratioFunc,
+                       Scalar& well_ratio_value) const
 {
     const int np = well_.numPhases();
 
@@ -73,8 +74,8 @@ checkMaxRatioLimitWell(const SingleWellState<Scalar, IndexTraits>& ws,
         well_rates[p] = ws.surface_rates[p];
     }
 
-    const Scalar well_ratio = ratioFunc(well_rates, well_.phaseUsage());
-    return (well_ratio > max_ratio_limit);
+    well_ratio_value = ratioFunc(well_rates, well_.phaseUsage());
+    return (well_ratio_value > max_ratio_limit);
 }
 
 template<typename Scalar, typename IndexTraits>
@@ -82,6 +83,7 @@ template<class RatioFunc>
 void WellTest<Scalar, IndexTraits>::
 checkMaxRatioLimitCompletions(const SingleWellState<Scalar, IndexTraits>& ws,
                               const Scalar max_ratio_limit,
+                              const Scalar well_ratio_value,
                               const RatioFunc& ratioFunc,
                               const std::string& ratio_name,
                               const UnitSystem::measure ratio_measure,
@@ -131,12 +133,11 @@ checkMaxRatioLimitCompletions(const SingleWellState<Scalar, IndexTraits>& ws,
 
         report.worst_offending_completion = worst_offending_completion;
         report.violation_extent = violation_extent;
-        // Record which ratio limit was violated together with the worst
-        // completion's actual value and the limit, so the closing message can
-        // report the offending quantity.
+        // Report the well-level ratio (WECON); the completion ratio only
+        // selects the worst offender via violation_extent above.
         report.ratio_name = ratio_name;
         report.ratio_measure = ratio_measure;
-        report.ratio_value = max_ratio_completion;
+        report.ratio_value = well_ratio_value;
         report.ratio_limit = max_ratio_limit;
     }
 }
@@ -164,11 +165,12 @@ checkMaxGORLimit(const WellEconProductionLimits& econ_production_limits,
     const Scalar max_gor_limit = econ_production_limits.maxGasOilRatio();
     assert(max_gor_limit > 0.);
 
-    const bool gor_limit_violated = this->checkMaxRatioLimitWell(ws, max_gor_limit, gor);
+    Scalar well_gor = 0.0;
+    const bool gor_limit_violated = this->checkMaxRatioLimitWell(ws, max_gor_limit, gor, well_gor);
 
     if (gor_limit_violated) {
         report.ratio_limit_violated = true;
-        this->checkMaxRatioLimitCompletions(ws, max_gor_limit, gor,
+        this->checkMaxRatioLimitCompletions(ws, max_gor_limit, well_gor, gor,
                                             "gas-oil ratio",
                                             UnitSystem::measure::gas_oil_ratio,
                                             report);
@@ -198,11 +200,12 @@ checkMaxWGRLimit(const WellEconProductionLimits& econ_production_limits,
     const Scalar max_wgr_limit = econ_production_limits.maxWaterGasRatio();
     assert(max_wgr_limit > 0.);
 
-    const bool wgr_limit_violated = this->checkMaxRatioLimitWell(ws, max_wgr_limit, wgr);
+    Scalar well_wgr = 0.0;
+    const bool wgr_limit_violated = this->checkMaxRatioLimitWell(ws, max_wgr_limit, wgr, well_wgr);
 
     if (wgr_limit_violated) {
         report.ratio_limit_violated = true;
-        this->checkMaxRatioLimitCompletions(ws, max_wgr_limit, wgr,
+        this->checkMaxRatioLimitCompletions(ws, max_wgr_limit, well_wgr, wgr,
                                             "water-gas ratio",
                                             UnitSystem::measure::water_gas_ratio,
                                             report);
@@ -236,12 +239,13 @@ checkMaxWaterCutLimit(const WellEconProductionLimits& econ_production_limits,
     const Scalar max_water_cut_limit = econ_production_limits.maxWaterCut();
     assert(max_water_cut_limit > 0.);
 
+    Scalar well_water_cut = 0.0;
     const bool watercut_limit_violated =
-        this->checkMaxRatioLimitWell(ws, max_water_cut_limit, waterCut);
+        this->checkMaxRatioLimitWell(ws, max_water_cut_limit, waterCut, well_water_cut);
 
     if (watercut_limit_violated) {
         report.ratio_limit_violated = true;
-        this->checkMaxRatioLimitCompletions(ws, max_water_cut_limit, waterCut,
+        this->checkMaxRatioLimitCompletions(ws, max_water_cut_limit, well_water_cut, waterCut,
                                             "water cut",
                                             UnitSystem::measure::water_cut,
                                             report);
@@ -540,8 +544,9 @@ closeOffendingCompletion(const int offending_completion,
             : fmt::format("{} in Well {}",
                           this->completionDescriptor(offending_completion), well_.name());
         const std::string sep = this->message_separator();
+        // WECON-driven: report "the well" ratio (CECON would say "its ...", will be addressed by CECON development).
         deferred_logger.info(
-            fmt::format("{}\n{} will be closed {},\nBecause its {}.\n{}",
+            fmt::format("{}\n{} will be closed {},\nBecause the well {}.\n{}",
                         sep, subject, when, reason, sep));
     }
 

--- a/opm/simulators/wells/WellTest.cpp
+++ b/opm/simulators/wells/WellTest.cpp
@@ -36,6 +36,9 @@
 #include <opm/simulators/wells/SingleWellState.hpp>
 #include <opm/simulators/wells/WellInterfaceGeneric.hpp>
 
+#include <cassert>
+#include <unordered_set>
+
 namespace Opm {
 
 template<typename Scalar, typename IndexTraits>
@@ -442,31 +445,20 @@ closeOffendingCompletion(const int offending_completion,
                          WellTestState& well_test_state,
                          DeferredLogger& deferred_logger) const
 {
-    // Completion numbers are positive (1-based). Non-positive values are
-    // sentinels from the parallel worst-offender search (e.g. INT_MIN when no
-    // rank holds a valid candidate) and must not be registered as closed.
-    if (offending_completion <= 0) {
-        deferred_logger.warning("ECON_WORKOVER_INVALID_COMPLETION",
-                                fmt::format("Economic limit workover for well {} did not find a "
-                                            "valid completion to close (completion number {}). "
-                                            "No connection will be closed.",
-                                            well_.name(), offending_completion));
-        return;
-    }
+    assert(offending_completion > 0);
 
     // The wellbore ordering of the connections is the one given by COMPORD and
     // reflected in the order of the connections returned by getConnections().
     const auto& connections = well_.wellEcl().getConnections();
 
-    // Build the list of completions to close. For CON it is just the
+    // Build the set of completions to close. For CON it is just the
     // worst-offending completion; for +CON it additionally contains every
     // completion located below the worst-offending one in the wellbore.
-    // "Below" means further from the wellhead according to the connection ordering.
-    std::vector<int> completions_to_close;
-    if (!close_connections_below) {
-        completions_to_close.push_back(offending_completion);
-    } else {
-        completions_to_close.push_back(offending_completion);
+    // "Below" means further from the wellhead according to the connection
+    // ordering. A set is used because a completion spanning several connections
+    // would otherwise be inserted multiple times.
+    std::unordered_set<int> completions_to_close{offending_completion};
+    if (close_connections_below) {
         bool below_worst_offender = false;
         for (const auto& connection : connections) {
             if (!below_worst_offender &&
@@ -475,7 +467,7 @@ closeOffendingCompletion(const int offending_completion,
                 continue;
             }
             if (below_worst_offender) {
-                completions_to_close.push_back(connection.complnum());
+                completions_to_close.insert(connection.complnum());
             }
         }
     }

--- a/opm/simulators/wells/WellTest.cpp
+++ b/opm/simulators/wells/WellTest.cpp
@@ -65,13 +65,35 @@ bool WellTest<Scalar, IndexTraits>::
 checkMaxRatioLimitWell(const SingleWellState<Scalar, IndexTraits>& ws,
                        const Scalar max_ratio_limit,
                        const RatioFunc& ratioFunc,
+                       const std::unordered_set<int>& excluded_completions,
                        Scalar& well_ratio_value) const
 {
     const int np = well_.numPhases();
 
     std::vector<Scalar> well_rates(np, 0.0);
-    for (int p = 0; p < np; ++p) {
-        well_rates[p] = ws.surface_rates[p];
+    if (excluded_completions.empty()) {
+        for (int p = 0; p < np; ++p) {
+            well_rates[p] = ws.surface_rates[p];
+        }
+    } else {
+        // Re-evaluation during a CON / +CON workover event. The completions
+        // closed so far still carry their converged rates in the well state,
+        // so accumulate the well rates from the remaining completions only.
+        const auto& perf_phase_rates = ws.perf_data.phase_rates;
+        for (const auto& [complnum, conns] : well_.getCompletions()) {
+            if (excluded_completions.count(complnum) > 0) {
+                continue;
+            }
+            for (const int c : conns) {
+                for (int p = 0; p < np; ++p) {
+                    well_rates[p] += perf_phase_rates[c * np + p];
+                }
+            }
+        }
+        const auto& comm = well_.parallelWellInfo().communication();
+        if (comm.size() > 1) {
+            comm.sum(well_rates.data(), np);
+        }
     }
 
     well_ratio_value = ratioFunc(well_rates, well_.phaseUsage());
@@ -85,6 +107,7 @@ checkMaxRatioLimitCompletions(const SingleWellState<Scalar, IndexTraits>& ws,
                               const Scalar max_ratio_limit,
                               const Scalar well_ratio_value,
                               const RatioFunc& ratioFunc,
+                              const std::unordered_set<int>& excluded_completions,
                               const std::string& ratio_name,
                               const UnitSystem::measure ratio_measure,
                               RatioLimitCheckReport& report) const
@@ -100,6 +123,10 @@ checkMaxRatioLimitCompletions(const SingleWellState<Scalar, IndexTraits>& ws,
     const auto& perf_phase_rates = perf_data.phase_rates;
     // look for the worst_offending_completion
     for (const auto& completion : well_.getCompletions()) {
+        if (excluded_completions.count(completion.first) > 0) {
+            // already closed by the ongoing workover event
+            continue;
+        }
         std::vector<Scalar> completion_rates(np, 0.0);
 
         // looping through the connections associated with the completion
@@ -146,6 +173,7 @@ template<typename Scalar, typename IndexTraits>
 void WellTest<Scalar, IndexTraits>::
 checkMaxGORLimit(const WellEconProductionLimits& econ_production_limits,
                  const SingleWellState<Scalar, IndexTraits>& ws,
+                 const std::unordered_set<int>& excluded_completions,
                  RatioLimitCheckReport& report) const
 {
     // function to calculate gor based on rates
@@ -166,11 +194,17 @@ checkMaxGORLimit(const WellEconProductionLimits& econ_production_limits,
     assert(max_gor_limit > 0.);
 
     Scalar well_gor = 0.0;
-    const bool gor_limit_violated = this->checkMaxRatioLimitWell(ws, max_gor_limit, gor, well_gor);
+    const bool gor_limit_violated =
+        this->checkMaxRatioLimitWell(ws, max_gor_limit, gor, excluded_completions, well_gor);
+
+    report.checked_ratios.push_back({"gas-oil ratio",
+                                     UnitSystem::measure::gas_oil_ratio,
+                                     well_gor, max_gor_limit});
 
     if (gor_limit_violated) {
         report.ratio_limit_violated = true;
         this->checkMaxRatioLimitCompletions(ws, max_gor_limit, well_gor, gor,
+                                            excluded_completions,
                                             "gas-oil ratio",
                                             UnitSystem::measure::gas_oil_ratio,
                                             report);
@@ -181,6 +215,7 @@ template<typename Scalar, typename IndexTraits>
 void WellTest<Scalar, IndexTraits>::
 checkMaxWGRLimit(const WellEconProductionLimits& econ_production_limits,
                  const SingleWellState<Scalar, IndexTraits>& ws,
+                 const std::unordered_set<int>& excluded_completions,
                  RatioLimitCheckReport& report) const
 {
     // function to calculate wgr based on rates
@@ -201,11 +236,17 @@ checkMaxWGRLimit(const WellEconProductionLimits& econ_production_limits,
     assert(max_wgr_limit > 0.);
 
     Scalar well_wgr = 0.0;
-    const bool wgr_limit_violated = this->checkMaxRatioLimitWell(ws, max_wgr_limit, wgr, well_wgr);
+    const bool wgr_limit_violated =
+        this->checkMaxRatioLimitWell(ws, max_wgr_limit, wgr, excluded_completions, well_wgr);
+
+    report.checked_ratios.push_back({"water-gas ratio",
+                                     UnitSystem::measure::water_gas_ratio,
+                                     well_wgr, max_wgr_limit});
 
     if (wgr_limit_violated) {
         report.ratio_limit_violated = true;
         this->checkMaxRatioLimitCompletions(ws, max_wgr_limit, well_wgr, wgr,
+                                            excluded_completions,
                                             "water-gas ratio",
                                             UnitSystem::measure::water_gas_ratio,
                                             report);
@@ -216,6 +257,7 @@ template<typename Scalar, typename IndexTraits>
 void WellTest<Scalar, IndexTraits>::
 checkMaxWaterCutLimit(const WellEconProductionLimits& econ_production_limits,
                       const SingleWellState<Scalar, IndexTraits>& ws,
+                      const std::unordered_set<int>& excluded_completions,
                       RatioLimitCheckReport& report) const
 {
     // function to calculate water cut based on rates
@@ -241,11 +283,17 @@ checkMaxWaterCutLimit(const WellEconProductionLimits& econ_production_limits,
 
     Scalar well_water_cut = 0.0;
     const bool watercut_limit_violated =
-        this->checkMaxRatioLimitWell(ws, max_water_cut_limit, waterCut, well_water_cut);
+        this->checkMaxRatioLimitWell(ws, max_water_cut_limit, waterCut,
+                                     excluded_completions, well_water_cut);
+
+    report.checked_ratios.push_back({"water cut",
+                                     UnitSystem::measure::water_cut,
+                                     well_water_cut, max_water_cut_limit});
 
     if (watercut_limit_violated) {
         report.ratio_limit_violated = true;
         this->checkMaxRatioLimitCompletions(ws, max_water_cut_limit, well_water_cut, waterCut,
+                                            excluded_completions,
                                             "water cut",
                                             UnitSystem::measure::water_cut,
                                             report);
@@ -301,6 +349,7 @@ typename WellTest<Scalar, IndexTraits>::RatioLimitCheckReport
 WellTest<Scalar, IndexTraits>::
 checkRatioEconLimits(const WellEconProductionLimits& econ_production_limits,
                      const SingleWellState<Scalar, IndexTraits>& ws,
+                     const std::unordered_set<int>& excluded_completions,
                      DeferredLogger& deferred_logger) const
 {
     // TODO: not sure how to define the worst-offending completion when more than one
@@ -313,15 +362,15 @@ checkRatioEconLimits(const WellEconProductionLimits& econ_production_limits,
     RatioLimitCheckReport report;
 
     if (econ_production_limits.onMaxWaterCut()) {
-        this->checkMaxWaterCutLimit(econ_production_limits, ws, report);
+        this->checkMaxWaterCutLimit(econ_production_limits, ws, excluded_completions, report);
     }
 
     if (econ_production_limits.onMaxGasOilRatio()) {
-        this->checkMaxGORLimit(econ_production_limits, ws, report);
+        this->checkMaxGORLimit(econ_production_limits, ws, excluded_completions, report);
     }
 
     if (econ_production_limits.onMaxWaterGasRatio()) {
-        this->checkMaxWGRLimit(econ_production_limits, ws, report);
+        this->checkMaxWGRLimit(econ_production_limits, ws, excluded_completions, report);
     }
 
     if (econ_production_limits.onMaxGasLiquidRatio()) {
@@ -430,7 +479,7 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
 
     // checking for ratio related limits, mostly all kinds of ratio.
     RatioLimitCheckReport ratio_report =
-        this->checkRatioEconLimits(econ_production_limits, ws, deferred_logger);
+        this->checkRatioEconLimits(econ_production_limits, ws, {}, deferred_logger);
 
     if (ratio_report.ratio_limit_violated) {
         const auto workover = econ_production_limits.workover();
@@ -439,6 +488,17 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
         // below; only built when a message will actually be logged.
         std::string when;
         std::string reason;
+        auto make_reason = [&unit_system](const RatioLimitCheckReport& report)
+        {
+            const std::string ratio_unit = unit_system.name(report.ratio_measure);
+            const std::string unit_suffix = ratio_unit.empty() ? std::string{}
+                                                               : " " + ratio_unit;
+            return fmt::format(
+                "{} {:.4e}{} exceeds the limit {:.4e}{}",
+                report.ratio_name,
+                unit_system.from_si(report.ratio_measure, report.ratio_value), unit_suffix,
+                unit_system.from_si(report.ratio_measure, report.ratio_limit), unit_suffix);
+        };
         if (write_message_to_opmlog) {
             when = fmt::format(
                 "at time {:.2f} {} (date = {})",
@@ -446,14 +506,7 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
                 unit_system.name(UnitSystem::measure::time),
                 dateString(start_time, simulation_time));
 
-            const std::string ratio_unit = unit_system.name(ratio_report.ratio_measure);
-            const std::string unit_suffix = ratio_unit.empty() ? std::string{}
-                                                               : " " + ratio_unit;
-            reason = fmt::format(
-                "{} {:.4e}{} exceeds the limit {:.4e}{}",
-                ratio_report.ratio_name,
-                unit_system.from_si(ratio_report.ratio_measure, ratio_report.ratio_value), unit_suffix,
-                unit_system.from_si(ratio_report.ratio_measure, ratio_report.ratio_limit), unit_suffix);
+            reason = make_reason(ratio_report);
         }
 
         switch (workover) {
@@ -463,15 +516,55 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
                 // CON  : shut the worst-offending connection/completion only.
                 // +CON : shut the worst-offending connection/completion and all
                 //        connections below it in the wellbore.
+                //
+                // The workover is applied repeatedly at the same time instant:
+                // closing completions changes the well ratio, so it is
+                // re-evaluated from the rates of the remaining completions and
+                // the (new) worst offender is closed until the limit is honored
+                // or the well has no open completions left and is shut.
                 const bool close_connections_below =
                     (workover == WellEconProductionLimits::EconWorkover::CONP);
-                this->closeOffendingCompletion(ratio_report.worst_offending_completion,
-                                               close_connections_below,
-                                               simulation_time,
-                                               write_message_to_opmlog,
-                                               well_test_state,
-                                               when, reason,
-                                               deferred_logger);
+                std::unordered_set<int> closed_this_event;
+                bool well_shut = false;
+                while (ratio_report.ratio_limit_violated) {
+                    well_shut =
+                        this->closeOffendingCompletion(ratio_report.worst_offending_completion,
+                                                       close_connections_below,
+                                                       simulation_time,
+                                                       write_message_to_opmlog,
+                                                       well_test_state,
+                                                       when, reason,
+                                                       closed_this_event,
+                                                       deferred_logger);
+                    if (well_shut) {
+                        break;
+                    }
+                    ratio_report = this->checkRatioEconLimits(econ_production_limits, ws,
+                                                              closed_this_event, deferred_logger);
+                    if (write_message_to_opmlog && ratio_report.ratio_limit_violated) {
+                        reason = make_reason(ratio_report);
+                    }
+                }
+                if (write_message_to_opmlog && !well_shut) {
+                    // Debug output: the well-level ratios of the remaining
+                    // completions after the workover event has finished.
+                    std::string ratios;
+                    for (const auto& checked : ratio_report.checked_ratios) {
+                        const std::string ratio_unit = unit_system.name(checked.measure);
+                        const std::string unit_suffix = ratio_unit.empty() ? std::string{}
+                                                                           : " " + ratio_unit;
+                        ratios += fmt::format(
+                            "{}{} {:.4e}{} (limit {:.4e}{})",
+                            ratios.empty() ? "" : ", ",
+                            checked.name,
+                            unit_system.from_si(checked.measure, checked.value), unit_suffix,
+                            unit_system.from_si(checked.measure, checked.limit), unit_suffix);
+                    }
+                    deferred_logger.debug(
+                        fmt::format("Well {}: CON/+CON workover closed {} completion(s) {}; "
+                                    "the well ratios of the remaining completions: {}",
+                                    well_.name(), closed_this_event.size(), when, ratios));
+                }
                 break;
             }
         case WellEconProductionLimits::EconWorkover::WELL:
@@ -498,7 +591,7 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
 }
 
 template<typename Scalar, typename IndexTraits>
-void WellTest<Scalar, IndexTraits>::
+bool WellTest<Scalar, IndexTraits>::
 closeOffendingCompletion(const int offending_completion,
                          const bool close_connections_below,
                          const double simulation_time,
@@ -506,6 +599,7 @@ closeOffendingCompletion(const int offending_completion,
                          WellTestState& well_test_state,
                          const std::string& when,
                          const std::string& reason,
+                         std::unordered_set<int>& closed_this_event,
                          DeferredLogger& deferred_logger) const
 {
     // complnum is always >= 1; a non-positive value would be a bug.
@@ -513,7 +607,7 @@ closeOffendingCompletion(const int offending_completion,
 
     // Sentinel for "no offending completion"; normally filtered by the caller.
     if (offending_completion == RatioLimitCheckReport::INVALIDCOMPLETION) {
-        return;
+        return false;
     }
 
     // The wellbore ordering of the connections is the one given by COMPORD and
@@ -543,6 +637,7 @@ closeOffendingCompletion(const int offending_completion,
 
     for (const int completion : completions_to_close) {
         well_test_state.close_completion(well_.name(), completion, simulation_time);
+        closed_this_event.insert(completion);
     }
 
     if (write_message_to_opmlog) {
@@ -579,6 +674,8 @@ closeOffendingCompletion(const int offending_completion,
                             sep, well_.name(), when, sep));
         }
     }
+
+    return allCompletionsClosed;
 }
 
 template<typename Scalar, typename IndexTraits>

--- a/opm/simulators/wells/WellTest.hpp
+++ b/opm/simulators/wells/WellTest.hpp
@@ -51,10 +51,11 @@ public:
 
     //! \param during_well_test  true when called from the WTEST re-open loop in
     //!        WellInterface::wellTesting(), which re-solves the well after every
-    //!        completion closure; a CON/+CON workover then applies only one
-    //!        closure per call and defers further closures to the caller's
-    //!        re-converged rates. false for the regular timestep update, which is
-    //!        not re-solved between closures and applies the whole workover here.
+    //!        completion closure; a CON/+CON workover then applies one workover
+    //!        round per call (for +CON this can close multiple completions) and
+    //!        defers further rounds to the caller's re-converged rates. false for
+    //!        the regular timestep update, which is not re-solved between closures
+    //!        and applies the whole workover here.
     void updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
                                      const double simulation_time,
                                      const bool write_message_to_opmlog,
@@ -153,19 +154,13 @@ private:
     //!        several connections/blocks.
     std::string completionDescriptor(int complnum) const;
 
-    //! \brief Apply one round of the CON / +CON (close-connection) workover
-    //!        procedure.
-    //!
-    //! \param when    Human-readable "at time ... (date = ...)" clause shared
-    //!                with the triggering economic-limit message.
-    //! \param reason  Human-readable ratio-violation clause (e.g.
-    //!                "water-gas ratio 1.0353e-06 SM3/SM3 exceeds the limit ...").
-    //! \param[in,out] closed_this_event  Completions closed so far by the
-    //!                ongoing workover event; the completions closed in this
-    //!                round are added to it.
-    //!
-    //! \return Whether the closure left the well without open completions,
-    //!         in which case the well has been shut.
+    //! \brief Apply one round of the CON / +CON (close-connection) workover:
+    //!        close \p offending_completion (and, for +CON when
+    //!        \p close_connections_below is set, every completion below it in the
+    //!        wellbore), adding them to \p closed_this_event. \p when / \p reason
+    //!        are the pre-formatted clauses of the logged closure message.
+    //!        Returns true if this left the well with no open completions, i.e.
+    //!        the well has been shut.
     bool closeOffendingCompletion(int offending_completion,
                                   bool close_connections_below,
                                   double simulation_time,

--- a/opm/simulators/wells/WellTest.hpp
+++ b/opm/simulators/wells/WellTest.hpp
@@ -66,6 +66,11 @@ public:
 private:
     struct RatioLimitCheckReport {
         static constexpr int INVALIDCOMPLETION = std::numeric_limits<int>::max();
+        //! \brief Ratio value used when the denominator phase rate is
+        //!        non-positive while the numerator is positive, i.e. the ratio
+        //!        is effectively infinite. Always violates the limit; messages
+        //!        must not present it as a physical value.
+        static constexpr Scalar INFINITE_RATIO = 1.0e30;
         bool ratio_limit_violated = false;
         int worst_offending_completion = INVALIDCOMPLETION;
         Scalar violation_extent = 0.0;

--- a/opm/simulators/wells/WellTest.hpp
+++ b/opm/simulators/wells/WellTest.hpp
@@ -30,6 +30,7 @@
 #include <ctime>
 #include <limits>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 namespace Opm
@@ -74,26 +75,45 @@ private:
         UnitSystem::measure ratio_measure = UnitSystem::measure::identity;
         Scalar ratio_value = 0.0;
         Scalar ratio_limit = 0.0;
+        //! \brief A well-level ratio evaluated during the check, recorded for
+        //!        every active ratio limit whether violated or not; used for
+        //!        debug output after a CON / +CON workover event.
+        struct CheckedRatio {
+            std::string name{};
+            UnitSystem::measure measure = UnitSystem::measure::identity;
+            Scalar value = 0.0;
+            Scalar limit = 0.0;
+        };
+        std::vector<CheckedRatio> checked_ratios{};
     };
 
     void checkMaxGORLimit(const WellEconProductionLimits& econ_production_limits,
                           const SingleWellState<Scalar, IndexTraits>& ws,
+                          const std::unordered_set<int>& excluded_completions,
                           RatioLimitCheckReport& report) const;
 
     void checkMaxWGRLimit(const WellEconProductionLimits& econ_production_limits,
                           const SingleWellState<Scalar, IndexTraits>& ws,
+                          const std::unordered_set<int>& excluded_completions,
                           RatioLimitCheckReport& report) const;
 
     void checkMaxWaterCutLimit(const WellEconProductionLimits& econ_production_limits,
                                const SingleWellState<Scalar, IndexTraits>& ws,
+                               const std::unordered_set<int>& excluded_completions,
                                RatioLimitCheckReport& report) const;
 
     //! \brief Check whether the well-level ratio exceeds \p max_ratio_limit;
     //!        \p well_ratio_value returns the computed ratio (reported by WECON).
+    //!
+    //! With an empty \p excluded_completions the well rates are taken directly
+    //! from the well state. During a CON / +CON workover event the completions
+    //! closed so far still carry their converged rates, so the well rates are
+    //! instead re-accumulated from the remaining completions.
     template<class RatioFunc>
     bool checkMaxRatioLimitWell(const SingleWellState<Scalar, IndexTraits>& ws,
                                 const Scalar max_ratio_limit,
                                 const RatioFunc& ratioFunc,
+                                const std::unordered_set<int>& excluded_completions,
                                 Scalar& well_ratio_value) const;
 
     template<class RatioFunc>
@@ -101,6 +121,7 @@ private:
                                        const Scalar max_ratio_limit,
                                        const Scalar well_ratio_value,
                                        const RatioFunc& ratioFunc,
+                                       const std::unordered_set<int>& excluded_completions,
                                        const std::string& ratio_name,
                                        const UnitSystem::measure ratio_measure,
                                        RatioLimitCheckReport& report) const;
@@ -109,9 +130,12 @@ private:
                              const std::vector<Scalar>& rates_or_potentials,
                              DeferredLogger& deferred_logger) const;
 
+    //! \brief Check all active ratio limits, ignoring \p excluded_completions
+    //!        (completions already closed by the ongoing workover event).
     RatioLimitCheckReport
     checkRatioEconLimits(const WellEconProductionLimits& econ_production_limits,
                          const SingleWellState<Scalar, IndexTraits>& ws,
+                         const std::unordered_set<int>& excluded_completions,
                          DeferredLogger& deferred_logger) const;
 
     //! \brief Describe a completion as "Completion N - block (i, j, k)" when it
@@ -119,19 +143,27 @@ private:
     //!        several connections/blocks.
     std::string completionDescriptor(int complnum) const;
 
-    //! \brief Apply the CON / +CON (close-connection) workover procedure.
+    //! \brief Apply one round of the CON / +CON (close-connection) workover
+    //!        procedure.
     //!
     //! \param when    Human-readable "at time ... (date = ...)" clause shared
     //!                with the triggering economic-limit message.
     //! \param reason  Human-readable ratio-violation clause (e.g.
     //!                "water-gas ratio 1.0353e-06 SM3/SM3 exceeds the limit ...").
-    void closeOffendingCompletion(int offending_completion,
+    //! \param[in,out] closed_this_event  Completions closed so far by the
+    //!                ongoing workover event; the completions closed in this
+    //!                round are added to it.
+    //!
+    //! \return Whether the closure left the well without open completions,
+    //!         in which case the well has been shut.
+    bool closeOffendingCompletion(int offending_completion,
                                   bool close_connections_below,
                                   double simulation_time,
                                   bool write_message_to_opmlog,
                                   WellTestState& well_test_state,
                                   const std::string& when,
                                   const std::string& reason,
+                                  std::unordered_set<int>& closed_this_event,
                                   DeferredLogger& deferred_logger) const;
 
     //! \brief A line of \p sep_length repetitions of \p sep_char used to frame

--- a/opm/simulators/wells/WellTest.hpp
+++ b/opm/simulators/wells/WellTest.hpp
@@ -24,7 +24,12 @@
 #ifndef OPM_WELL_TEST_HEADER_INCLUDED
 #define OPM_WELL_TEST_HEADER_INCLUDED
 
+#include <opm/input/eclipse/Units/UnitSystem.hpp>
+
+#include <cstddef>
+#include <ctime>
 #include <limits>
+#include <string>
 #include <vector>
 
 namespace Opm
@@ -48,6 +53,8 @@ public:
                                      const bool write_message_to_opmlog,
                                      WellTestState& well_test_state,
                                      bool zero_group_target,
+                                     const UnitSystem& unit_system,
+                                     const std::time_t start_time,
                                      DeferredLogger& deferred_logger) const;
 
     void updateWellTestStatePhysical(const double simulation_time,
@@ -61,6 +68,12 @@ private:
         bool ratio_limit_violated = false;
         int worst_offending_completion = INVALIDCOMPLETION;
         Scalar violation_extent = 0.0;
+        //! \brief Metadata describing the most-violating ratio limit, used to
+        //!        build the human-readable workover message.
+        std::string ratio_name{};
+        UnitSystem::measure ratio_measure = UnitSystem::measure::identity;
+        Scalar ratio_value = 0.0;
+        Scalar ratio_limit = 0.0;
     };
 
     void checkMaxGORLimit(const WellEconProductionLimits& econ_production_limits,
@@ -84,6 +97,8 @@ private:
     void checkMaxRatioLimitCompletions(const SingleWellState<Scalar, IndexTraits>& ws,
                                        const Scalar max_ratio_limit,
                                        const RatioFunc& ratioFunc,
+                                       const std::string& ratio_name,
+                                       const UnitSystem::measure ratio_measure,
                                        RatioLimitCheckReport& report) const;
 
     bool checkRateEconLimits(const WellEconProductionLimits& econ_production_limits,
@@ -95,14 +110,31 @@ private:
                          const SingleWellState<Scalar, IndexTraits>& ws,
                          DeferredLogger& deferred_logger) const;
 
+    //! \brief Describe a completion as "Completion N - block (i, j, k)" when it
+    //!        owns a single connection, or just "Completion N" when it spans
+    //!        several connections/blocks.
+    std::string completionDescriptor(int complnum) const;
+
     //! \brief Apply the CON / +CON (close-connection) workover procedure.
+    //!
+    //! \param when    Human-readable "at time ... (date = ...)" clause shared
+    //!                with the triggering economic-limit message.
+    //! \param reason  Human-readable ratio-violation clause (e.g.
+    //!                "water-gas ratio 1.0353e-06 SM3/SM3 exceeds the limit ...").
     void closeOffendingCompletion(int offending_completion,
                                   bool close_connections_below,
                                   double simulation_time,
                                   bool write_message_to_opmlog,
                                   WellTestState& well_test_state,
+                                  const std::string& when,
+                                  const std::string& reason,
                                   DeferredLogger& deferred_logger) const;
 
+    //! \brief A line of \p sep_length repetitions of \p sep_char used to frame
+    //!        economic-limit workover messages (mirrors GroupEconomicLimitsChecker).
+    std::string message_separator(const char sep_char = '*',
+                                  const std::size_t sep_length = 110) const
+    { return std::string(sep_length, sep_char); }
 
     const WellInterfaceGeneric<Scalar, IndexTraits>& well_; //!< Reference to well interface
 };

--- a/opm/simulators/wells/WellTest.hpp
+++ b/opm/simulators/wells/WellTest.hpp
@@ -88,14 +88,18 @@ private:
                                const SingleWellState<Scalar, IndexTraits>& ws,
                                RatioLimitCheckReport& report) const;
 
+    //! \brief Check whether the well-level ratio exceeds \p max_ratio_limit;
+    //!        \p well_ratio_value returns the computed ratio (reported by WECON).
     template<class RatioFunc>
     bool checkMaxRatioLimitWell(const SingleWellState<Scalar, IndexTraits>& ws,
                                 const Scalar max_ratio_limit,
-                                const RatioFunc& ratioFunc) const;
+                                const RatioFunc& ratioFunc,
+                                Scalar& well_ratio_value) const;
 
     template<class RatioFunc>
     void checkMaxRatioLimitCompletions(const SingleWellState<Scalar, IndexTraits>& ws,
                                        const Scalar max_ratio_limit,
+                                       const Scalar well_ratio_value,
                                        const RatioFunc& ratioFunc,
                                        const std::string& ratio_name,
                                        const UnitSystem::measure ratio_measure,

--- a/opm/simulators/wells/WellTest.hpp
+++ b/opm/simulators/wells/WellTest.hpp
@@ -109,6 +109,16 @@ private:
     //! from the well state. During a CON / +CON workover event the completions
     //! closed so far still carry their converged rates, so the well rates are
     //! instead re-accumulated from the remaining completions.
+    //!
+    //! Note that the two bases are not identical: ws.surface_rates is the
+    //! converged well-level rate, while the re-accumulated rates are sums of
+    //! the perforation rates of the remaining completions, and the two can
+    //! differ slightly (e.g. under cross-flow). Consequently, the ratio used to
+    //! trigger the workover event and the ratios steering the subsequent
+    //! cascade are on slightly different bases. This is considered acceptable
+    //! because the cascade rates are frozen (not re-converged) approximations
+    //! anyway; using the well-state rate for the trigger keeps the behavior of
+    //! a plain (non-cascading) WECON check unchanged.
     template<class RatioFunc>
     bool checkMaxRatioLimitWell(const SingleWellState<Scalar, IndexTraits>& ws,
                                 const Scalar max_ratio_limit,

--- a/opm/simulators/wells/WellTest.hpp
+++ b/opm/simulators/wells/WellTest.hpp
@@ -95,6 +95,14 @@ private:
                          const SingleWellState<Scalar, IndexTraits>& ws,
                          DeferredLogger& deferred_logger) const;
 
+    //! \brief Apply the CON / +CON (close-connection) workover procedure.
+    void closeOffendingCompletion(int offending_completion,
+                                  bool close_connections_below,
+                                  double simulation_time,
+                                  bool write_message_to_opmlog,
+                                  WellTestState& well_test_state,
+                                  DeferredLogger& deferred_logger) const;
+
 
     const WellInterfaceGeneric<Scalar, IndexTraits>& well_; //!< Reference to well interface
 };

--- a/opm/simulators/wells/WellTest.hpp
+++ b/opm/simulators/wells/WellTest.hpp
@@ -49,9 +49,16 @@ public:
     //! \brief Constructor sets reference to well.
     explicit WellTest(const WellInterfaceGeneric<Scalar, IndexTraits>& well) : well_(well) {}
 
+    //! \param during_well_test  true when called from the WTEST re-open loop in
+    //!        WellInterface::wellTesting(), which re-solves the well after every
+    //!        completion closure; a CON/+CON workover then applies only one
+    //!        closure per call and defers further closures to the caller's
+    //!        re-converged rates. false for the regular timestep update, which is
+    //!        not re-solved between closures and applies the whole workover here.
     void updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
                                      const double simulation_time,
                                      const bool write_message_to_opmlog,
+                                     const bool during_well_test,
                                      WellTestState& well_test_state,
                                      bool zero_group_target,
                                      const UnitSystem& unit_system,
@@ -80,32 +87,20 @@ private:
         UnitSystem::measure ratio_measure = UnitSystem::measure::identity;
         Scalar ratio_value = 0.0;
         Scalar ratio_limit = 0.0;
-        //! \brief A well-level ratio evaluated during the check, recorded for
-        //!        every active ratio limit whether violated or not; used for
-        //!        debug output after a CON / +CON workover event.
-        struct CheckedRatio {
-            std::string name{};
-            UnitSystem::measure measure = UnitSystem::measure::identity;
-            Scalar value = 0.0;
-            Scalar limit = 0.0;
-        };
-        std::vector<CheckedRatio> checked_ratios{};
     };
 
-    void checkMaxGORLimit(const WellEconProductionLimits& econ_production_limits,
-                          const SingleWellState<Scalar, IndexTraits>& ws,
-                          const std::unordered_set<int>& excluded_completions,
-                          RatioLimitCheckReport& report) const;
-
-    void checkMaxWGRLimit(const WellEconProductionLimits& econ_production_limits,
-                          const SingleWellState<Scalar, IndexTraits>& ws,
-                          const std::unordered_set<int>& excluded_completions,
-                          RatioLimitCheckReport& report) const;
-
-    void checkMaxWaterCutLimit(const WellEconProductionLimits& econ_production_limits,
-                               const SingleWellState<Scalar, IndexTraits>& ws,
-                               const std::unordered_set<int>& excluded_completions,
-                               RatioLimitCheckReport& report) const;
+    //! \brief Check one active max-ratio limit (water cut, GOR or WGR): if the
+    //!        well-level ratio computed by \p ratioFunc exceeds \p max_ratio_limit,
+    //!        mark the report violated and record the worst-offending completion
+    //!        together with the ratio metadata (\p ratio_name, \p ratio_measure).
+    template<class RatioFunc>
+    void checkMaxRatioLimit(const SingleWellState<Scalar, IndexTraits>& ws,
+                            const Scalar max_ratio_limit,
+                            const RatioFunc& ratioFunc,
+                            const std::unordered_set<int>& excluded_completions,
+                            const std::string& ratio_name,
+                            const UnitSystem::measure ratio_measure,
+                            RatioLimitCheckReport& report) const;
 
     //! \brief Check whether the well-level ratio exceeds \p max_ratio_limit;
     //!        \p well_ratio_value returns the computed ratio (reported by WECON).
@@ -170,12 +165,6 @@ private:
                                   const std::string& reason,
                                   std::unordered_set<int>& closed_this_event,
                                   DeferredLogger& deferred_logger) const;
-
-    //! \brief A line of \p sep_length repetitions of \p sep_char used to frame
-    //!        economic-limit workover messages (mirrors GroupEconomicLimitsChecker).
-    std::string message_separator(const char sep_char = '*',
-                                  const std::size_t sep_length = 110) const
-    { return std::string(sep_length, sep_char); }
 
     const WellInterfaceGeneric<Scalar, IndexTraits>& well_; //!< Reference to well interface
 };


### PR DESCRIPTION
I believe it does the correct thing, especially when coming to the what `below` means in the connection order.  As long as we order the connections based on `COMPORD`, `below` is basically a index order in the connections. 

It is how the PR is implemented. 