### PR TITLE
worst_offending_completion can only be positive

### DIFF
--- a/opm/simulators/wells/WellTest.cpp
+++ b/opm/simulators/wells/WellTest.cpp
@@ -29,6 +29,8 @@
 
 #include <opm/material/fluidsystems/BlackOilDefaultFluidSystemIndices.hpp>
 
+#include <fmt/format.h>
+
 #include <opm/simulators/utils/DeferredLogger.hpp>
 #include <opm/simulators/wells/ParallelWellInfo.hpp>
 #include <opm/simulators/wells/SingleWellState.hpp>
@@ -392,18 +394,12 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
         case WellEconProductionLimits::EconWorkover::CON:
             {
                 const int worst_offending_completion = ratio_report.worst_offending_completion;
+                assert(worst_offending_completion > 0);
 
                 well_test_state.close_completion(well_.name(), worst_offending_completion, simulation_time);
                 if (write_message_to_opmlog) {
-                    if (worst_offending_completion < 0) {
-                        const std::string msg = std::string("Connection ") + std::to_string(- worst_offending_completion)
-                                + std::string(" for well ") + well_.name() + std::string(" will be closed due to economic limit");
-                        deferred_logger.info(msg);
-                    } else {
-                        const std::string msg = std::string("Completion ") + std::to_string(worst_offending_completion)
-                                + std::string(" for well ") + well_.name() + std::string(" will be closed due to economic limit");
-                        deferred_logger.info(msg);
-                    }
+                    deferred_logger.info(fmt::format("Completion {} for well {} will be closed due to economic limit",
+                                                      worst_offending_completion, well_.name()));
                 }
 
                 bool allCompletionsClosed = true;


### PR DESCRIPTION
The current implementation is assuming all the connection has a Completion number even when COMPLUMP is not specified. And there is no possibility to have a negative `worst_offending_completion`. So removing the branch to simplify the logic and remove the implication that negative completion means to use Connection. 