### PR TITLE
Fix MPI abort when END truncates master schedule

### DIFF
--- a/opm/simulators/flow/SimulatorFullyImplicit.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicit.hpp
@@ -327,6 +327,21 @@ protected:
 
     const WellModel& wellModel_() const { return simulator_.problem().wellModel(); }
 
+#ifdef RESERVOIR_COUPLING_ENABLED
+    /** \brief Reservoir-coupling slave: tear down the current report step
+     *         after the master has ended the coupled run.
+     *
+     * Called from \ref runStep when the slave received the terminate signal
+     * from the master and disconnected its intercommunicator during the
+     * adaptive time stepping. The terminate step ran zero substeps, so the
+     * simulator state is unchanged from the previous (fully-coupled) report
+     * step and there is no new state to write; \ref finalize will flush all
+     * output. Logs the stop and balances the beginReportStep() issued
+     * earlier in \ref runStep; the caller then stops the run loop.
+     */
+    void handleSlaveTerminated_();
+#endif
+
     /// Surrounding eWoms simulator; observed, not owned.
     Simulator& simulator_;
 

--- a/opm/simulators/flow/SimulatorFullyImplicit_impl.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicit_impl.hpp
@@ -511,10 +511,17 @@ handleSlaveTerminated_()
         OpmLog::info("Reservoir coupling: master simulation has ended; "
                      "stopping slave simulation gracefully.");
     }
-    // The terminate step ran zero substeps, so the simulator state is unchanged from the
-    // previous (fully-coupled) report step and there is no new state to write; finalize()
-    // will flush all output. Balance the beginReportStep() issued earlier in runStep().
+    // The slave stops as soon as it is terminated, so no further substeps run for this report
+    // step. Per-substep SUMMARY output for any substeps already completed in this report step
+    // was written by the adaptive substep loop; the report-step-level restart write is
+    // intentionally skipped because a terminated report step is partial - the last completed
+    // report step is the clean restart point. finalize() flushes the remaining output.
+    // Balance the beginReportStep() issued earlier in runStep().
     this->solver_->model().endReportStep();
+    // Account for this report step's solver time and leave the timer stopped: runStep()'s own
+    // solverTimer_->stop()/accumulation below is bypassed by the early return on termination.
+    this->solverTimer_->stop();
+    this->report_.success.solver_time += this->solverTimer_->secsSinceStart();
 }
 #endif
 

--- a/opm/simulators/flow/SimulatorFullyImplicit_impl.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicit_impl.hpp
@@ -436,6 +436,18 @@ runStep(SimulatorTimer& timer)
             events.hasEvent(ScheduleEvents::WELL_STATUS_CHANGE);
         auto stepReport = adaptiveTimeStepping_->step(timer, *solver_, event, tuningUpdater);
         report_ += stepReport;
+#ifdef RESERVOIR_COUPLING_ENABLED
+        // If the master ended its schedule first (e.g. an END keyword truncates the master
+        // SCHEDULE), the slave received the terminate signal and disconnected its
+        // intercommunicator inside step() above. The coupled run is over for this slave:
+        // finish the current report step cleanly and stop the run loop instead of advancing
+        // to another report step, which would issue an MPI_Recv on the now-disconnected
+        // communicator and abort the job.
+        if (this->reservoirCouplingSlave_ && this->reservoirCouplingSlave_->terminated()) {
+            this->handleSlaveTerminated_();
+            return false;   // breaks the while(!timer.done()) loop in run()
+        }
+#endif
     } else {
         // solve for complete report step
         auto stepReport = solver_->step(timer, nullptr);
@@ -488,6 +500,23 @@ runStep(SimulatorTimer& timer)
 
     return true;
 }
+
+#ifdef RESERVOIR_COUPLING_ENABLED
+template<class TypeTag>
+void
+SimulatorFullyImplicit<TypeTag>::
+handleSlaveTerminated_()
+{
+    if (terminalOutput_) {
+        OpmLog::info("Reservoir coupling: master simulation has ended; "
+                     "stopping slave simulation gracefully.");
+    }
+    // The terminate step ran zero substeps, so the simulator state is unchanged from the
+    // previous (fully-coupled) report step and there is no new state to write; finalize()
+    // will flush all output. Balance the beginReportStep() issued earlier in runStep().
+    this->solver_->model().endReportStep();
+}
+#endif
 
 template<class TypeTag>
 SimulatorReport

--- a/opm/simulators/flow/rescoup/ReservoirCouplingMaster.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingMaster.cpp
@@ -404,13 +404,25 @@ void
 ReservoirCouplingMaster<Scalar>::
 sendDontTerminateSignalToSlaves()
 {
-    // Send "don't terminate" signal (value=0) to all spawned slaves.
+    // Send "don't terminate" signal (value=0) to the activated slaves.
     // This is called at the start of each iteration in the master's substep loop.
-    // We send to all spawned slaves, not just activated ones, because even non-activated
-    // slaves are running and waiting at the terminate signal receive point.
+    // We send only to activated slaves: only an activated slave runs the coupled substep
+    // loop and is blocked at the terminate-signal receive point. A slave that has not yet
+    // activated does not consume this channel, so sending to it would queue stale signals
+    // that the slave later reads out of step when it does activate (e.g. a slave whose
+    // activation date coincides with the master's last report step when the master schedule
+    // is truncated by an END keyword). The final terminate signal is still sent to all
+    // started slaves in sendTerminateAndDisconnect().
     if (this->comm_.rank() == 0) {
         int terminate_signal = 0;
+        // maybeReceiveActivationHandshakeFromSlaves() has resized the activation-status
+        // vector before the substep loop that calls us, and the slaves are spawned only
+        // once, so the vector covers all started slaves here.
+        assert(this->slave_activation_status_.size() == this->numSlavesStarted());
         for (std::size_t i = 0; i < this->numSlavesStarted(); i++) {
+            if (!this->slaveIsActivated(i)) {
+                continue;
+            }
             // NOTE: See comment about error handling at the top of this file.
             MPI_Send(
                 &terminate_signal,

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
@@ -196,6 +196,12 @@ private:
         /// \ref SubStepIteration covers the whole report step.
         SimulatorReport runStepOriginal_();
 #ifdef RESERVOIR_COUPLING_ENABLED
+        /// Reservoir-coupling slave: throw if the slave has already been
+        /// terminated by the master. A terminated slave has disconnected its
+        /// intercommunicator, so running another coupled substep loop would
+        /// issue an MPI_Recv on a null communicator and abort the job.
+        void checkIfSlaveIsTerminated_();
+
         // Reservoir coupling master: pick the sync-step length for the next outer-loop
         // iteration of `runStepReservoirCouplingMaster_()`, including the chop
         // against slave-report boundaries.  See the helper's own comment for

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -581,6 +581,24 @@ suggestedNextTimestep_() const
 
 
 #ifdef RESERVOIR_COUPLING_ENABLED
+// Throw if the slave has already been terminated by the master. A terminated slave has
+// disconnected its intercommunicator, so running another coupled substep loop would issue
+// an MPI_Recv on a null communicator and abort the job. The run loop in
+// SimulatorFullyImplicit::runStep() stops before this can happen, so this guards
+// against future regressions of that logic.
+template <class TypeTag>
+template <class Solver>
+void
+AdaptiveTimeStepping<TypeTag>::SubStepper<Solver>::
+checkIfSlaveIsTerminated_()
+{
+    if (reservoirCouplingSlave_().terminated()) {
+        OPM_THROW(ReservoirCouplingError,
+                  "Internal error: attempt to run a coupled substep loop after the slave "
+                  "has been terminated by the master process");
+    }
+}
+
 // Pick the master's sync-step length for the next outer-loop iteration of
 // `runStepReservoirCouplingMaster_()`.  Includes the chop against slave-
 // report dates and emits the user-visible log line.  See the block comment
@@ -779,6 +797,7 @@ SimulatorReport
 AdaptiveTimeStepping<TypeTag>::SubStepper<Solver>::
 runStepReservoirCouplingSlave_()
 {
+    checkIfSlaveIsTerminated_();
     int iteration = 0;
     const double original_time_step = this->simulator_timer_.currentStepLength();
     double current_time{this->simulator_timer_.simulationTimeElapsed()};


### PR DESCRIPTION
An `END` keyword in the middle of the master deck's `SCHEDULE` section truncates the master schedule, so the master can finish before its slaves do. This case was not handled by the master/slave shutdown protocol: depending on the slave's state, the run either aborted with a fatal MPI error or hung. This PR makes all processes shut down cleanly with exit status 0, with each slave finalizing its output up to the last coupled report step.

#### The problem

The shutdown protocol failed in two ways when the master finished first:

- **Abort:** a slave that received the terminate signal disconnected its intercommunicator but kept its run loop going, since its own schedule still has report steps left. The next report step re-entered the coupled substep loop and called `MPI_Recv()` on the now-null communicator, aborting the whole job with `MPI_ERR_COMM` ("invalid communicator") under `MPI_ERRORS_ARE_FATAL`.
- **Hang:** the master sent the per-substep "don't terminate" signal to **all started slaves**, including ones not yet activated. A non-activated slave does not consume that channel, so the signals queued up. A slave whose activation date coincides with the master's final report date then read a stale "don't terminate" instead of the terminate signal, advanced into the coupled substep loop, and blocked forever in `receiveNextTimeStepFromMaster()` — while the master blocked in `MPI_Comm_disconnect()` for that slave.

#### The fix

- **Stop the slave's run loop gracefully** when it is terminated by the master: the new helper `SimulatorFullyImplicit::handleSlaveTerminated_()` logs the stop and balances the earlier `beginReportStep()`, and `runStep()` then returns `false` to exit the main simulation loop. The slave finalizes its output up to the last coupled report step instead of simulating past the coupled horizon.
- **Send the per-substep "don't terminate" signal only to activated slaves** in `sendDontTerminateSignalToSlaves()`. The final terminate signal is still sent to all started slaves, so a slave activating after the master has finished now reads it as its first message and stops cleanly.
- **Guard the coupled substep loop** with the new helper `SubStepper::checkIfSlaveIsTerminated_()`, which throws `ReservoirCouplingError` if the loop is ever entered after termination, so a future regression gives a clear error message instead of the cryptic MPI abort.

#### How to reproduce

Add an `END` keyword in the middle of the `SCHEDULE` section of the master deck in a coupled run, e.g. between two `DATES` blocks, so that the master schedule ends while the slave schedules continue. Before this PR the run aborts with `MPI_ERR_COMM` (or hangs if a slave activates at the master's final report date); after this PR the master sends the terminate signal to all slaves, disconnects all intercommunicators, and every process exits cleanly.

#### Notes

- Verified manually with a two-slave coupled case where one slave is active during the master's run (previously the abort) and the other activates exactly at the master's final report date (previously the hang); both now stop gracefully and the master exits normally.
- No automated test case is included yet; happy to add one if the reviewers think it is needed.
