### PR TITLE
RelPermDiagnostics: address clang-tidy warnings

### DIFF
--- a/opm/simulators/utils/satfunc/RelpermDiagnostics.cpp
+++ b/opm/simulators/utils/satfunc/RelpermDiagnostics.cpp
@@ -805,13 +805,6 @@ namespace Opm {
         const auto rfunc =
             satfunc::getRawFunctionValues(tables, phases, rtep);
 
-        const TableContainer&  swofTables = tables.getSwofTables();
-        const SwofletTable&  swofletTables = tables.getSwofletTable();
-        const TableContainer&  sgofTables = tables.getSgofTables();
-        const SgofletTable&  sgofletTables = tables.getSgofletTable();
-        const TableContainer& slgofTables = tables.getSlgofTables();
-        const TableContainer&  sof3Tables = tables.getSof3Tables();
-
         // std::cout << "***************\nEnd-Points In all the Tables\n";
         for (std::size_t satnumIdx = 0; satnumIdx < numSatRegions; ++satnumIdx) {
             this->unscaledEpsInfo_[satnumIdx]
@@ -833,43 +826,10 @@ namespace Opm {
 
             // Krow(Sou) == Krog(Sou) for three-phase
             // means Krow(Swco) == Krog(Sgco)
-            double krow_value = 1e20;
-            double krog_value = 1e-20;
             if (fluidSystem_ == FluidSystem::BlackOil) {
-                if (satFamily_ == SaturationFunctionFamily::FamilyI) {
-                    if (!sgofTables.empty()) {
-                        const auto& table = sgofTables.getTable<SgofTable>(satnumIdx);
-                        krog_value = table.evaluate( "KROG" , unscaledEpsInfo_[satnumIdx].Sgl );
-                    } else if (!sgofletTables.empty()) {
-                        krog_value = sgofletTables[satnumIdx].krt2_relperm;
-                    } else {
-                        assert(!slgofTables.empty());
-                        const auto& table = slgofTables.getTable<SlgofTable>(satnumIdx);
-                        krog_value = table.evaluate( "KROG" , unscaledEpsInfo_[satnumIdx].Sgl );
-                    }
-                    if (!swofTables.empty()) {
-                        const auto& table = swofTables.getTable<SwofTable>(satnumIdx);
-                        krow_value = table.evaluate("KROW" , unscaledEpsInfo_[satnumIdx].Swl);
-                    } else {
-                        assert(!swofletTables.empty());
-                        krow_value = swofletTables[satnumIdx].krt2_relperm;
-                    }
-                }
-                if (satFamily_ == SaturationFunctionFamily::FamilyII) {
-                    assert(!sof3Tables.empty());
-                    const auto& table = sof3Tables.getTable<Sof3Table>(satnumIdx);
-                    const double Sou = 1.- unscaledEpsInfo_[satnumIdx].Swl - unscaledEpsInfo_[satnumIdx].Sgl;
-
-                    krow_value = table.evaluate("KROW" , Sou);
-                    krog_value = table.evaluate("KROG" , Sou);
-                }
-                if (krow_value != krog_value) {
-                    OpmLog::warning(fmt::format(
-                        "In saturation table SATNUM = {}, Krow(Somax) should be equal to Krog(Somax).",
-                        satnumIdx + 1
-                    ));
-                }
+                blackoilChecks(eclState, satnumIdx);
             }
+
             // Krw(Sw=0)=Krg(Sg=0)=Krow(So=0)=Krog(So=0)=0.
             // Mobile fluid requirements
             if (((unscaledEpsInfo_[satnumIdx].Sowcr + unscaledEpsInfo_[satnumIdx].Swcr)-1) >= 0) {
@@ -887,6 +847,59 @@ namespace Opm {
                     satnumIdx + 1
                 ));
             }
+        }
+    }
+
+    void RelpermDiagnostics::blackoilChecks(const EclipseState& eclState,
+                                            const std::size_t satnumIdx)
+    {
+        const auto& tables = eclState.getTableManager();
+        const TableContainer&  sgofTables = tables.getSgofTables();
+        const SgofletTable&  sgofletTables = tables.getSgofletTable();
+        const TableContainer& slgofTables = tables.getSlgofTables();
+        const TableContainer&  swofTables = tables.getSwofTables();
+        const SwofletTable&  swofletTables = tables.getSwofletTable();
+        const TableContainer&  sof3Tables = tables.getSof3Tables();
+
+        // Krow(Sou) == Krog(Sou) for three-phase
+        // means Krow(Swco) == Krog(Sgco)
+        double krow_value = 1e20;
+        double krog_value = 1e-20;
+        if (satFamily_ == SaturationFunctionFamily::FamilyI) {
+          if (!sgofTables.empty()) {
+              const auto& table = sgofTables.getTable<SgofTable>(satnumIdx);
+              krog_value = table.evaluate( "KROG" , unscaledEpsInfo_[satnumIdx].Sgl );
+          }
+          else if (!sgofletTables.empty()) {
+              krog_value = sgofletTables[satnumIdx].krt2_relperm;
+          }
+          else {
+              assert(!slgofTables.empty());
+              const auto& table = slgofTables.getTable<SlgofTable>(satnumIdx);
+              krog_value = table.evaluate( "KROG" , unscaledEpsInfo_[satnumIdx].Sgl );
+          }
+          if (!swofTables.empty()) {
+              const auto& table = swofTables.getTable<SwofTable>(satnumIdx);
+              krow_value = table.evaluate("KROW" , unscaledEpsInfo_[satnumIdx].Swl);
+          }
+          else {
+              assert(!swofletTables.empty());
+              krow_value = swofletTables[satnumIdx].krt2_relperm;
+          }
+        }
+        if (satFamily_ == SaturationFunctionFamily::FamilyII) {
+            assert(!sof3Tables.empty());
+            const auto& table = sof3Tables.getTable<Sof3Table>(satnumIdx);
+            const double Sou = 1.- unscaledEpsInfo_[satnumIdx].Swl - unscaledEpsInfo_[satnumIdx].Sgl;
+
+            krow_value = table.evaluate("KROW" , Sou);
+            krog_value = table.evaluate("KROG" , Sou);
+        }
+        if (krow_value != krog_value) {
+            OpmLog::warning(fmt::format(
+                "In saturation table SATNUM = {}, Krow(Somax) should be equal to Krog(Somax).",
+                satnumIdx + 1
+            ));
         }
     }
 

--- a/opm/simulators/utils/satfunc/RelpermDiagnostics.cpp
+++ b/opm/simulators/utils/satfunc/RelpermDiagnostics.cpp
@@ -131,8 +131,14 @@ namespace Opm {
         const bool gasActive   = phases.active(Phase::GAS);
         const bool oilActive   = phases.active(Phase::OIL);
 
+        std::array<bool,3> family{
+            oilActive,
+            true,
+            !gsfTables.empty() && !wsfTables.empty()
+        };
+        auto& [family1, family2, family3] = family;
+
         // Family I test.
-        bool family1 = oilActive;
         if (waterActive) {
             family1 = family1 && (!swofTables.empty() || !swofletTable.empty());
         }
@@ -141,7 +147,6 @@ namespace Opm {
         }
 
         // Family II test.
-        bool family2 = true;
         if (waterActive) {
             family2 = family2 && (!swfnTables.empty() || !sgwfnTables.empty());
         }
@@ -152,43 +157,50 @@ namespace Opm {
             family2 = family2 && (!sgfnTables.empty() || !sgwfnTables.empty());
         }
 
-        bool family3 = !gsfTables.empty() && !wsfTables.empty();
+        analyzeFamily(eclState, family);
+    }
 
+    void RelpermDiagnostics::analyzeFamily(const EclipseState& eclState,
+                                           const std::array<bool,3>& family)
+    {
+        const auto& [family1, family2, family3] = family;
         if (family3) {
+            const auto& phases = eclState.runspec().phases();
             const bool co2store = eclState.runspec().co2Storage();
             const bool h2store = eclState.runspec().h2Storage();
-            if ( !((co2store || h2store) && phases.active(Phase::GAS) && phases.active(Phase::WATER))) {
-                const std::string msg = "Relative permeability input format: Saturation Family III. \n \
-                                         Only valid for CO2STORE or H2STORE cases with GAS and WATER.";
-                OpmLog::info(msg);
+            if (!((co2store || h2store) && phases.active(Phase::GAS) && phases.active(Phase::WATER))) {
+                OpmLog::info(
+                    "Relative permeability input format: Saturation Family III. \n"
+                    "Only valid for CO2STORE or H2STORE cases with GAS and WATER."
+                );
             }
             satFamily_ = SaturationFunctionFamily::FamilyIII;
-            const std::string msg = "Relative permeability input format: Saturation Family III (GSF/WSF).";
-            OpmLog::info(msg);
+            OpmLog::info("Relative permeability input format: Saturation Family III (GSF/WSF).");
             return;
         }
 
         if (family1 && family2) {
-            const std::string msg = "Saturation families should not be mixed.\n Use either SGOF and SWOF or SGFN, SWFN and SOF3";
-            OpmLog::error(msg);
+            OpmLog::error(
+                "Saturation families should not be mixed.\n"
+                "Use either SGOF and SWOF or SGFN, SWFN and SOF3"
+            );
         }
 
         if (!family1 && !family2) {
-            const std::string msg = "Saturations function must be specified using either \n \
-                             family 1, family 2 or family3 keywords \n \
-                             Use either SGOF and SWOF or SGFN, SWFN and SOF3.";
-            OpmLog::error(msg);
+            OpmLog::error(
+                "Saturations function must be specified using either \n"
+                "family 1, family 2 or family3 keywords \n"
+                "Use either SGOF and SWOF or SGFN, SWFN and SOF3."
+            );
         }
 
         if (family1 && !family2) {
             satFamily_ = SaturationFunctionFamily::FamilyI;
-            const std::string msg = "Relative permeability input format: Saturation Family I.";
-            OpmLog::info(msg);
+            OpmLog::info("Relative permeability input format: Saturation Family I.");
         }
         if (!family1 && family2) {
             satFamily_ = SaturationFunctionFamily::FamilyII;
-            const std::string msg = "Relative permeability input format: Saturation Family II.";
-            OpmLog::info(msg);
+            OpmLog::info("Relative permeability input format: Saturation Family II.");
         }
     }
 

--- a/opm/simulators/utils/satfunc/RelpermDiagnostics.cpp
+++ b/opm/simulators/utils/satfunc/RelpermDiagnostics.cpp
@@ -53,6 +53,8 @@
 #include <opm/simulators/flow/AluGridLevelCartesianIndexMapper.hpp>
 #endif // HAVE_DUNE_ALUGRID
 
+#include <fmt/format.h>
+
 namespace Opm {
 
     bool RelpermDiagnostics::phaseCheck_(const EclipseState& es)
@@ -203,29 +205,37 @@ namespace Opm {
         const auto& sw = swofTables.getSwColumn();
         const auto& krw = swofTables.getKrwColumn();
         const auto& krow = swofTables.getKrowColumn();
-        const std::string regionIdx = std::to_string(satnumIdx);
-        //Check sw column.
+
+        // Check sw column.
         if (sw.front() < 0.0 || sw.back() > 1.0) {
-            const std::string msg = "In SWOF table SATNUM = "+ regionIdx + ", saturation should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SWOF table SATNUM = {}, saturation should be in range [0,1].",
+                satnumIdx
+            ));
         }
-        //TODO check endpoint sw.back() == 1. - Sor.
-        //Check krw column.
+        // TODO check endpoint sw.back() == 1. - Sor.
+        // Check krw column.
         if (krw.front() != 0.0) {
-            const std::string msg = "In SWOF table SATNUM = " + regionIdx + ", first value of krw should be 0.";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SWOF table SATNUM = {}, first value of krw should be 0.",
+                satnumIdx
+            ));
         }
         if (krw.front() < 0.0 || krw.back() > 1.0) {
-            const std::string msg = "In SWOF table SATNUM = " + regionIdx + ", krw should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SWOF table SATNUM = {}, krw should be in range [0,1].",
+                satnumIdx
+            ));
         }
 
-        ///Check krow column.
+        // Check krow column.
         if (krow.front() > 1.0 || krow.back() < 0.0) {
-            const std::string msg = "In SWOF table SATNUM = "+ regionIdx + ", krow should be in range [0, 1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SWOF table SATNUM = {}, krow should be in range [0, 1].",
+                satnumIdx
+            ));
         }
-        ///TODO check if run with gas.
+        /// TODO check if run with gas.
     }
 
     template<>
@@ -235,33 +245,43 @@ namespace Opm {
         const auto& sg = sgofTables.getSgColumn();
         const auto& krg = sgofTables.getKrgColumn();
         const auto& krog = sgofTables.getKrogColumn();
-        const std::string regionIdx = std::to_string(satnumIdx);
-        //Check sw column.
+
+        // Check sw column.
         if (sg.front() < 0.0 || sg.back() > 1.0) {
-            const std::string msg = "In SGOF table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SGOF table SATNUM = {}, saturation should be in range [0,1].",
+                satnumIdx
+            ));
         }
         if (sg.front() != 0.0) {
-            const std::string msg = "In SGOF table SATNUM = " + regionIdx + ", first value of sg should be 0.";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SGOF table SATNUM = {}, first value of sg should be 0.",
+                satnumIdx
+            ));
         }
-        //TODO check endpoint sw.back() == 1. - Sor.
-        //Check krw column.
+        // TODO check endpoint sw.back() == 1. - Sor.
+        // Check krw column.
         if (krg.front() != 0.0) {
-            const std::string msg = "In SGOF table SATNUM = " + regionIdx + ", first value of krg should be 0.";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SGOF table SATNUM = {}, first value of krg should be 0.",
+                satnumIdx
+            ));
         }
         if (krg.front() < 0.0 || krg.back() > 1.0) {
-            const std::string msg = "In SGOF table SATNUM = " + regionIdx + ", krg should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SGOF table SATNUM = {}, krg should be in range [0,1].",
+                satnumIdx
+            ));
         }
 
-        //Check krow column.
+        // Check krow column.
         if (krog.front() > 1.0 || krog.back() < 0.0) {
-            const std::string msg = "In SGOF table SATNUM = " + regionIdx + ", krog should be in range [0, 1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SGOF table SATNUM = {}, krog should be in range [0, 1].",
+                satnumIdx
+            ));
         }
-        //TODO check if run with water.
+        // TODO check if run with water.
     }
 
     template<>
@@ -271,30 +291,40 @@ namespace Opm {
         const auto& sl = slgofTables.getSlColumn();
         const auto& krg = slgofTables.getKrgColumn();
         const auto& krog = slgofTables.getKrogColumn();
-        const std::string regionIdx = std::to_string(satnumIdx);
-        //Check sl column.
-        //TODO first value means sl = swco + sor
+
+        // Check sl column.
+        // TODO first value means sl = swco + sor
         if (sl.front() < 0.0 || sl.back() > 1.0) {
-            const std::string msg = "In SLGOF table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SLGOF table SATNUM = {}, saturation should be in range [0,1].",
+                satnumIdx
+            ));
         }
         if (sl.back() != 1.0) {
-            const std::string msg = "In SLGOF table SATNUM = " + regionIdx + ", last value of sl should be 1.";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SLGOF table SATNUM = {}, last value of sl should be 1.",
+                satnumIdx
+            ));
         }
 
         if (krg.front() > 1.0 || krg.back() < 0) {
-            const std::string msg = "In SLGOF table SATNUM = " + regionIdx + ", krg should be in range [0, 1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SLGOF table SATNUM = {}, krg should be in range [0, 1].",
+                satnumIdx
+            ));
         }
         if (krg.back() != 0.0) {
-            const std::string msg = "In SLGOF table SATNUM = " + regionIdx + ", last value of krg hould be 0.";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SLGOF table SATNUM = {}, last value of krg should be 0.",
+                satnumIdx
+            ));
         }
 
         if (krog.front() < 0.0 || krog.back() > 1.0) {
-            const std::string msg = "In SLGOF table SATNUM = " + regionIdx + ", krog should be in range [0, 1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SLGOF table SATNUM = {}, krog should be in range [0, 1].",
+                satnumIdx
+            ));
         }
     }
 
@@ -304,22 +334,28 @@ namespace Opm {
     {
         const auto& sw = swfnTables.getSwColumn();
         const auto& krw = swfnTables.getKrwColumn();
-        const std::string regionIdx = std::to_string(satnumIdx);
-        //Check sw column.
+
+        // Check sw column.
         if (sw.front() < 0.0 || sw.back() > 1.0) {
-            const std::string msg = "In SWFN table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SWFN table SATNUM = {}, saturation should be in range [0,1].",
+                satnumIdx
+            ));
         }
 
-        //Check krw column.
+        // Check krw column.
         if (krw.front() < 0.0 || krw.back() > 1.0) {
-            const std::string msg = "In SWFN table SATNUM = " + regionIdx + ", krw should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SWFN table SATNUM = {}, krw should be in range [0,1].",
+                satnumIdx
+            ));
         }
 
         if (krw.front() != 0.0) {
-            const std::string msg = "In SWFN table SATNUM = " + regionIdx + ", first value of krw should be 0.";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SWFN table SATNUM = {}, first value of krw should be 0.",
+                satnumIdx
+            ));
         }
     }
 
@@ -329,22 +365,28 @@ namespace Opm {
     {
         const auto& sw = wsfTables.getSwColumn();
         const auto& krw = wsfTables.getKrwColumn();
-        const std::string regionIdx = std::to_string(satnumIdx);
-        //Check sw column.
+
+        // Check sw column.
         if (sw.front() < 0.0 || sw.back() > 1.0) {
-            const std::string msg = "In WSF table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In WSF table SATNUM = {}, saturation should be in range [0,1].",
+                satnumIdx
+            ));
         }
 
-        //Check krw column.
+        // Check krw column.
         if (krw.front() < 0.0 || krw.back() > 1.0) {
-            const std::string msg = "In WSF table SATNUM = " + regionIdx + ", krw should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In WSF table SATNUM = {}, krw should be in range [0,1].",
+                satnumIdx
+            ));
         }
 
         if (krw.front() != 0.0) {
-            const std::string msg = "In WSF table SATNUM = " + regionIdx + ", first value of krw should be 0.";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In WSF table SATNUM = {}, first value of krw should be 0.",
+                satnumIdx
+            ));
         }
     }
 
@@ -354,21 +396,27 @@ namespace Opm {
     {
         const auto& sg = sgfnTables.getSgColumn();
         const auto& krg = sgfnTables.getKrgColumn();
-        const std::string regionIdx = std::to_string(satnumIdx);
-        //Check sg column.
+
+        // Check sg column.
         if (sg.front() < 0.0 || sg.back() > 1.0) {
-            const std::string msg = "In SGFN table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SGFN table SATNUM = {}, saturation should be in range [0,1].",
+                satnumIdx
+            ));
         }
 
-        //Check krg column.
+        // Check krg column.
         if (krg.front() < 0.0 || krg.back() > 1.0) {
-            const std::string msg = "In SGFN table SATNUM = " + regionIdx + ", krg should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SGFN table SATNUM = {}, krg should be in range [0,1].",
+                satnumIdx
+            ));
         }
         if (krg.front() != 0.0) {
-            const std::string msg = "In SGFN table SATNUM = " + regionIdx + ", first value of krg should be 0.";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SGFN table SATNUM = {}, first value of krg should be 0.",
+                satnumIdx
+            ));
         }
     }
 
@@ -378,21 +426,27 @@ namespace Opm {
     {
         const auto& sg = gsfTables.getSgColumn();
         const auto& krg = gsfTables.getKrgColumn();
-        const std::string regionIdx = std::to_string(satnumIdx);
-        //Check sg column.
+
+        // Check sg column.
         if (sg.front() < 0.0 || sg.back() > 1.0) {
-            const std::string msg = "In GSF table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In GSF table SATNUM = {}, saturation should be in range [0,1].",
+                satnumIdx
+            ));
         }
 
-        //Check krg column.
+        // Check krg column.
         if (krg.front() < 0.0 || krg.back() > 1.0) {
-            const std::string msg = "In GSF table SATNUM = " + regionIdx + ", krg should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In GSF table SATNUM = {}, krg should be in range [0,1].",
+                satnumIdx
+            ));
         }
         if (krg.front() != 0.0) {
-            const std::string msg = "In GSF table SATNUM = " + regionIdx + ", first value of krg should be 0.";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In GSF table SATNUM = {}, first value of krg should be 0.",
+                satnumIdx
+            ));
         }
     }
 
@@ -403,38 +457,50 @@ namespace Opm {
         const auto& so = sof3Tables.getSoColumn();
         const auto& krow = sof3Tables.getKrowColumn();
         const auto& krog = sof3Tables.getKrogColumn();
-        const std::string regionIdx = std::to_string(satnumIdx);
-        //Check so column.
-        //TODO: The max so = 1 - Swco
+
+        // Check so column.
+        // TODO: The max so = 1 - Swco
         if (so.front() < 0.0 || so.back() > 1.0) {
-            const std::string msg = "In SOF3 table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SOF3 table SATNUM = {}, saturation should be in range [0,1].",
+                satnumIdx
+            ));
         }
 
-        //Check krow column.
+        // Check krow column.
         if (krow.front() < 0.0 || krow.back() > 1.0) {
-            const std::string msg = "In SOF3 table SATNUM = " + regionIdx + ", krow should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SOF3 table SATNUM = {}, krow should be in range [0,1].",
+                satnumIdx
+            ));
         }
         if (krow.front() != 0.0) {
-            const std::string msg = "In SOF3 table SATNUM = " + regionIdx + ", first value of krow should be 0.";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SOF3 table SATNUM = {}, first value of krow should be 0.",
+                satnumIdx
+            ));
         }
 
-        //Check krog column.
+        // Check krog column.
         if (krog.front() < 0.0 || krog.back() > 1.0) {
-            const std::string msg = "In SOF3 table SATNUM = " + regionIdx + ", krog should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SOF3 table SATNUM = {}, krog should be in range [0,1].",
+                satnumIdx
+            ));
         }
 
         if (krog.front() != 0.0) {
-            const std::string msg = "In SOF3 table SATNUM = " + regionIdx + ", first value of krog should be 0.";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SOF3 table SATNUM = {}, first value of krog should be 0.",
+                satnumIdx
+            ));
         }
 
         if (krog.back() != krow.back()) {
-            const std::string msg = "In SOF3 table SATNUM = " + regionIdx + ", max value of krog and krow should be the same.";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SOF3 table SATNUM = {}, max value of krog and krow should be the same.",
+                satnumIdx
+            ));
         }
     }
 
@@ -444,22 +510,28 @@ namespace Opm {
     {
         const auto& so = sof2Tables.getSoColumn();
         const auto& kro = sof2Tables.getKroColumn();
-        const std::string regionIdx = std::to_string(satnumIdx);
-        //Check so column.
-        //TODO: The max so = 1 - Swco
+
+        // Check so column.
+        // TODO: The max so = 1 - Swco
         if (so.front() < 0.0 || so.back() > 1.0) {
-            const std::string msg = "In SOF2 table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SOF2 table SATNUM = {}, saturation should be in range [0,1].",
+                satnumIdx
+            ));
         }
 
-        //Check krow column.
+        // Check krow column.
         if (kro.front() < 0.0 || kro.back() > 1.0) {
-            const std::string msg = "In SOF2 table SATNUM = " + regionIdx + ", krow should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SOF2 table SATNUM = {}, krow should be in range [0,1].",
+                satnumIdx
+            ));
         }
         if (kro.front() != 0.0) {
-            const std::string msg = "In SOF2 table SATNUM = " + regionIdx + ", first value of krow should be 0.";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SOF2 table SATNUM = {}, first value of krow should be 0.",
+                satnumIdx
+            ));
         }
     }
 
@@ -470,32 +542,42 @@ namespace Opm {
         const auto& sg = sgwfnTables.getSgColumn();
         const auto& krg = sgwfnTables.getKrgColumn();
         const auto& krgw = sgwfnTables.getKrgwColumn();
-        const std::string regionIdx = std::to_string(satnumIdx);
-        //Check sg column.
+
+        // Check sg column.
         if (sg.front() < 0.0 || sg.back() > 1.0) {
-            const std::string msg = "In SGWFN table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SGWFN table SATNUM = {}, saturation should be in range [0,1].",
+                satnumIdx
+            ));
         }
 
-        //Check krg column.
+        // Check krg column.
         if (krg.front() < 0.0 || krg.back() > 1.0) {
-            const std::string msg = "In SGWFN table SATNUM = " + regionIdx + ", krg should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SGWFN table SATNUM = {}, krg should be in range [0,1].",
+                satnumIdx
+            ));
         }
         if (krg.front() != 0.0) {
-            const std::string msg = "In SGWFN table SATNUM = " + regionIdx + ", first value of krg should be 0.";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SGWFN table SATNUM = {}, first value of krg should be 0.",
+                satnumIdx
+            ));
         }
 
-        //Check krgw column.
-        //TODO check saturation sw = 1. - sg
+        // Check krgw column.
+        // TODO check saturation sw = 1. - sg
         if (krgw.front() > 1.0 || krgw.back() < 0.0) {
-            const std::string msg = "In SGWFN table SATNUM = " + regionIdx + ", krgw should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SGWFN table SATNUM = {}, krgw should be in range [0,1].",
+                satnumIdx
+            ));
         }
         if (krgw.back() != 0.0) {
-            const std::string msg = "In SGWFN table SATNUM = " + regionIdx + ", last value of krgw should be 0.";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SGWFN table SATNUM = {}, last value of krgw should be 0.",
+                satnumIdx
+            ));
         }
     }
 
@@ -505,17 +587,21 @@ namespace Opm {
     {
         const auto& sw = sgcwmisTables.getWaterSaturationColumn();
         const auto& sgc = sgcwmisTables.getMiscibleResidualGasColumn();
-        const std::string regionIdx = std::to_string(satnumIdx);
-        //Check sw column.
+
+        // Check sw column.
         if (sw.front() < 0.0 || sw.back() > 1.0) {
-            const std::string msg = "In SGCWMIS table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SGCWMIS table SATNUM = {}, saturation should be in range [0,1].",
+                satnumIdx
+            ));
         }
 
-        //Check critical gas column.
+        // Check critical gas column.
         if (sgc.front() < 0.0 || sgc.back() > 1.0) {
-            const std::string msg = "In SGCWMIS table SATNUM = " + regionIdx + ", critical gas saturation should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SGCWMIS table SATNUM = {}, critical gas saturation should be in range [0,1].",
+                satnumIdx
+            ));
         }
     }
 
@@ -525,17 +611,21 @@ namespace Opm {
     {
         const auto& sw = sorwmisTables.getWaterSaturationColumn();
         const auto& sor = sorwmisTables.getMiscibleResidualOilColumn();
-        const std::string regionIdx = std::to_string(satnumIdx);
-        //Check sw column.
+
+        // Check sw column.
         if (sw.front() < 0.0 || sw.back() > 1.0) {
-            const std::string msg = "In SORWMIS table SATNUM = " + regionIdx + ", saturation should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SORWMIS table SATNUM = {}, saturation should be in range [0,1].",
+                satnumIdx
+            ));
         }
 
-        //Check critical oil column.
+        // Check critical oil column.
         if (sor.front() < 0.0 || sor.back() > 1.0) {
-            const std::string msg = "In SORWMIS table SATNUM = " + regionIdx + ", critical oil saturation should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SORWMIS table SATNUM = {}, critical oil saturation should be in range [0,1].",
+                satnumIdx
+            ));
         }
     }
 
@@ -546,23 +636,29 @@ namespace Opm {
         const auto& frac = ssfnTables.getSolventFractionColumn();
         const auto& krgm = ssfnTables.getGasRelPermMultiplierColumn();
         const auto& krsm = ssfnTables.getSolventRelPermMultiplierColumn();
-        const std::string regionIdx = std::to_string(satnumIdx);
-        //Check phase fraction column.
+
+        // Check phase fraction column.
         if (frac.front() < 0.0 || frac.back() > 1.0) {
-            const std::string msg = "In SSFN table SATNUM = " + regionIdx + ", phase fraction should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SSFN table SATNUM = {}, phase fraction should be in range [0,1].",
+                satnumIdx
+            ));
         }
 
-        //Check gas relperm multiplier column.
+        // Check gas relperm multiplier column.
         if (krgm.front() < 0.0 || krgm.back() > 1.0) {
-            const std::string msg = "In SSFN table SATNUM = " + regionIdx + ", gas relative permeability multiplier should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SSFN table SATNUM = {}, gas relative permeability multiplier should be in range [0,1].",
+                satnumIdx
+            ));
         }
 
-        //Check solvent relperm multiplier column.
+        // Check solvent relperm multiplier column.
         if (krsm.front() < 0.0 || krsm.back() > 1.0) {
-            const std::string msg = "In SSFN table SATNUM = " + regionIdx + ", solvent relative permeability multiplier should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In SSFN table SATNUM = {}, solvent relative permeability multiplier should be in range [0,1].",
+                satnumIdx
+            ));
         }
     }
 
@@ -573,17 +669,20 @@ namespace Opm {
         const auto& frac = miscTables.getSolventFractionColumn();
         const auto& misc = miscTables.getMiscibilityColumn();
 
-        const std::string regionIdx = std::to_string(miscnumIdx);
-        //Check phase fraction column.
+        // Check phase fraction column.
         if (frac.front() < 0.0 || frac.back() > 1.0) {
-            const std::string msg = "In MISC table MISCNUM = " + regionIdx + ", phase fraction should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In MISC table MISCNUM = {}, phase fraction should be in range [0,1].",
+                miscnumIdx
+            ));
         }
 
-        //Check miscibility column.
+        // Check miscibility column.
         if (misc.front() < 0.0 || misc.back() > 1.0) {
-            const std::string msg = "In MISC table MISCNUM = " + regionIdx + ", miscibility should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In MISC table MISCNUM = {}, miscibility should be in range [0,1].",
+                miscnumIdx
+            ));
         }
     }
 
@@ -595,33 +694,38 @@ namespace Opm {
         const auto& krgsm = msfnTables.getGasSolventRelpermMultiplierColumn();
         const auto& krom = msfnTables.getOilRelpermMultiplierColumn();
 
-        const std::string regionIdx = std::to_string(satnumIdx);
-        //Check phase fraction column.
+        // Check phase fraction column.
         if (frac.front() < 0.0 || frac.back() > 1.0) {
-            const std::string msg = "In MSFN table SATNUM = " + regionIdx + ", total gas fraction should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In MSFN table SATNUM = {}, total gas fraction should be in range [0,1].",
+                satnumIdx
+            ));
         }
 
-        //Check gas_solvent relperm multiplier column.
+        // Check gas_solvent relperm multiplier column.
         if (krgsm.front() < 0.0 || krgsm.back() > 1.0) {
-            const std::string msg = "In MSFN table SATNUM = " + regionIdx + ", gas+solvent relative permeability multiplier should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In MSFN table SATNUM = {}, gas+solvent relative permeability "
+                "multiplier should be in range [0,1].",
+                satnumIdx
+            ));
         }
 
-        //Check oil relperm multiplier column.
+        // Check oil relperm multiplier column.
         if (krom.front() > 1.0 || krom.back() < 0.0) {
-            const std::string msg = "In MSFN table SATNUM = " + regionIdx + ", oil relative permeability multiplier should be in range [0,1].";
-            OpmLog::error(msg);
+            OpmLog::error(fmt::format(
+                "In MSFN table SATNUM = {}, oil relative permeability "
+                "multiplier should be in range [0,1].",
+                satnumIdx
+            ));
         }
     }
 
     void RelpermDiagnostics::tableCheck_(const EclipseState& eclState)
     {
         const auto numSatRegions = eclState.runspec().tabdims().getNumSatTables();
-        {
-            const std::string msg = "Number of saturation regions: " + std::to_string(numSatRegions) + "\n";
-            OpmLog::info(msg);
-        }
+        OpmLog::info(fmt::format("Number of saturation regions: {}\n", numSatRegions));
+
         const auto& tableManager = eclState.getTableManager();
         const TableContainer& swofTables    = tableManager.getSwofTables();
         const TableContainer& slgofTables   = tableManager.getSlgofTables();
@@ -686,8 +790,7 @@ namespace Opm {
 
         if (tableManager.hasTables("MISC")) {
             const auto numMiscNumIdx = miscTables.size();
-            const std::string msg = "Number of misc regions: " + std::to_string(numMiscNumIdx) + "\n";
-            OpmLog::info(msg);
+            OpmLog::info(fmt::format("Number of misc regions: {}\n", numMiscNumIdx));
             for (std::size_t miscNumIdx = 0; miscNumIdx < numMiscNumIdx; ++miscNumIdx) {
                 checkTable_<MiscTable>(miscTables.getTable<MiscTable>(miscNumIdx), miscNumIdx+1);
             }
@@ -727,25 +830,28 @@ namespace Opm {
 
         // std::cout << "***************\nEnd-Points In all the Tables\n";
         for (std::size_t satnumIdx = 0; satnumIdx < numSatRegions; ++satnumIdx) {
-             this->unscaledEpsInfo_[satnumIdx]
-                 .extractUnscaled(rtep, rfunc, satnumIdx);
+            this->unscaledEpsInfo_[satnumIdx]
+                .extractUnscaled(rtep, rfunc, satnumIdx);
 
-             const std::string regionIdx = std::to_string(satnumIdx + 1);
-             /// Consistency check.
-             if (unscaledEpsInfo_[satnumIdx].Sgu > (1. - unscaledEpsInfo_[satnumIdx].Swl)) {
-                const std::string msg = "In saturation table SATNUM = " + regionIdx + ", Sgmax should not exceed 1-Swco.";
-                OpmLog::warning(msg);
-             }
-             if (unscaledEpsInfo_[satnumIdx].Sgl > (1. - unscaledEpsInfo_[satnumIdx].Swu)) {
-                const std::string msg = "In saturation table SATNUM = " + regionIdx + ", Sgco should not exceed 1-Swmax.";
-                OpmLog::warning(msg);
-             }
+            /// Consistency check.
+            if (unscaledEpsInfo_[satnumIdx].Sgu > (1. - unscaledEpsInfo_[satnumIdx].Swl)) {
+                OpmLog::warning(fmt::format(
+                    "In saturation table SATNUM = {}, Sgmax should not exceed 1-Swco.",
+                    satnumIdx + 1
+                ));
+            }
+            if (unscaledEpsInfo_[satnumIdx].Sgl > (1. - unscaledEpsInfo_[satnumIdx].Swu)) {
+                OpmLog::warning(fmt::format(
+                    "In saturation table SATNUM = {}, Sgco should not exceed 1-Swmax.",
+                    satnumIdx + 1
+                ));
+            }
 
-             // Krow(Sou) == Krog(Sou) for three-phase
-             // means Krow(Swco) == Krog(Sgco)
-             double krow_value = 1e20;
-             double krog_value = 1e-20;
-             if (fluidSystem_ == FluidSystem::BlackOil) {
+            // Krow(Sou) == Krog(Sou) for three-phase
+            // means Krow(Swco) == Krog(Sgco)
+            double krow_value = 1e20;
+            double krog_value = 1e-20;
+            if (fluidSystem_ == FluidSystem::BlackOil) {
                 if (satFamily_ == SaturationFunctionFamily::FamilyI) {
                     if (!sgofTables.empty()) {
                         const auto& table = sgofTables.getTable<SgofTable>(satnumIdx);
@@ -774,19 +880,28 @@ namespace Opm {
                     krog_value = table.evaluate("KROG" , Sou);
                 }
                 if (krow_value != krog_value) {
-                    const std::string msg = "In saturation table SATNUM = " + regionIdx + ", Krow(Somax) should be equal to Krog(Somax).";
-                    OpmLog::warning(msg);
+                    OpmLog::warning(fmt::format(
+                        "In saturation table SATNUM = {}, Krow(Somax) should be equal to Krog(Somax).",
+                        satnumIdx + 1
+                    ));
                 }
             }
             // Krw(Sw=0)=Krg(Sg=0)=Krow(So=0)=Krog(So=0)=0.
             // Mobile fluid requirements
             if (((unscaledEpsInfo_[satnumIdx].Sowcr + unscaledEpsInfo_[satnumIdx].Swcr)-1) >= 0) {
-                const std::string msg = "In saturation table SATNUM = " + regionIdx + ", Sowcr + Swcr should be less than 1.";
-                OpmLog::warning(msg);
+                OpmLog::warning(fmt::format(
+                    "In saturation table SATNUM = {}, Sowcr + Swcr should be less than 1.",
+                    satnumIdx + 1
+                ));
             }
-            if (((unscaledEpsInfo_[satnumIdx].Sogcr + unscaledEpsInfo_[satnumIdx].Sgcr + unscaledEpsInfo_[satnumIdx].Swl) - 1 ) > 0) {
-                const std::string msg = "In saturation table SATNUM = " + regionIdx + ", Sogcr + Sgcr + Swco should be less than 1.";
-                OpmLog::warning(msg);
+            if (((unscaledEpsInfo_[satnumIdx].Sogcr +
+                  unscaledEpsInfo_[satnumIdx].Sgcr +
+                  unscaledEpsInfo_[satnumIdx].Swl) - 1) > 0)
+            {
+                OpmLog::warning(fmt::format(
+                    "In saturation table SATNUM = {}, Sogcr + Sgcr + Swco should be less than 1.",
+                    satnumIdx + 1
+                ));
             }
         }
     }
@@ -831,26 +946,46 @@ namespace Opm {
 
             // SGU <= 1.0 - SWL
             if (scaledEpsInfo_[c].Sgu > (1.0 - scaledEpsInfo_[c].Swl + tolerance)) {
-                const std::string msg = "For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGU exceed 1.0 - SWL";
-                OpmLog::warning(tag, msg);
+                OpmLog::warning(tag,
+                                fmt::format(
+                                    "For scaled endpoints input, cell {} SATNUM = {}, "
+                                    "SGU exceed 1.0 - SWL",
+                                    cellIdx,
+                                    satnumIdx
+                                ));
             }
 
             // SGL <= 1.0 - SWU
             if (scaledEpsInfo_[c].Sgl > (1.0 - scaledEpsInfo_[c].Swu + tolerance)) {
-                const std::string msg = "For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SGL exceed 1.0 - SWU";
-                OpmLog::warning(tag, msg);
+                OpmLog::warning(tag,
+                                fmt::format(
+                                    "For scaled endpoints input, cell {} SATNUM = {}, "
+                                    "SGL exceed 1.0 - SWU",
+                                    cellIdx,
+                                    satnumIdx
+                                ));
             }
 
             if (threepoint && fluidSystem_ == FluidSystem::BlackOil) {
                 // Mobilility check.
                 if ((scaledEpsInfo_[c].Sowcr + scaledEpsInfo_[c].Swcr) >= (1.0 + tolerance)) {
-                    const std::string msg = "For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOWCR + SWCR exceed 1.0";
-                    OpmLog::warning(tag, msg);
+                    OpmLog::warning(tag,
+                                    fmt::format(
+                                        "For scaled endpoints input, cell {} SATNUM = {}, "
+                                        "SOWCR + SWCR exceed 1.0",
+                                        cellIdx,
+                                        satnumIdx
+                                    ));
                 }
 
             if ((scaledEpsInfo_[c].Sogcr + scaledEpsInfo_[c].Sgcr + scaledEpsInfo_[c].Swl) >= (1.0 + tolerance)) {
-                    const std::string msg = "For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOGCR + SGCR + SWL exceed 1.0";
-                    OpmLog::warning(tag, msg);
+                    OpmLog::warning(tag,
+                                    fmt::format(
+                                        "For scaled endpoints input, cell {} SATNUM = {}, "
+                                        "SOGCR + SGCR + SWL exceed 1.0",
+                                        cellIdx,
+                                        satnumIdx
+                                    ));
                 }
             }
         }
@@ -868,7 +1003,7 @@ namespace Opm {
     INSTANCE_DIAGNOSIS(Dune::ALUGrid<3, 3, Dune::cube, Dune::nonconforming, Dune::ALUGridMPIComm>)
 #else
     INSTANCE_DIAGNOSIS(Dune::ALUGrid<3, 3, Dune::cube, Dune::nonconforming, Dune::ALUGridNoComm>)
-#endif //HAVE_MPI
-#endif //HAVE_DUNE_ALUGRID
+#endif // HAVE_MPI
+#endif // HAVE_DUNE_ALUGRID
 
 } //namespace Opm

--- a/opm/simulators/utils/satfunc/RelpermDiagnostics.cpp
+++ b/opm/simulators/utils/satfunc/RelpermDiagnostics.cpp
@@ -194,7 +194,7 @@ namespace Opm {
 
     void RelpermDiagnostics::tableCheck_(const EclipseState& eclState)
     {
-        const int numSatRegions = eclState.runspec().tabdims().getNumSatTables();
+        const auto numSatRegions = eclState.runspec().tabdims().getNumSatTables();
         {
             const std::string msg = "Number of saturation regions: " + std::to_string(numSatRegions) + "\n";
             OpmLog::info(msg);
@@ -216,7 +216,7 @@ namespace Opm {
         const TableContainer& gsfTables     = tableManager.getGsfTables();
         const TableContainer& wsfTables     = tableManager.getWsfTables();
 
-        for (int satnumIdx = 0; satnumIdx < numSatRegions; ++satnumIdx) {
+        for (std::size_t satnumIdx = 0; satnumIdx < numSatRegions; ++satnumIdx) {
             if (tableManager.hasTables("SWOF")) {
                 swofTableCheck_(swofTables.getTable<SwofTable>(satnumIdx), satnumIdx+1);
             }
@@ -262,17 +262,17 @@ namespace Opm {
         }
 
         if (tableManager.hasTables("MISC")) {
-            const int numMiscNumIdx = miscTables.size();
+            const auto numMiscNumIdx = miscTables.size();
             const std::string msg = "Number of misc regions: " + std::to_string(numMiscNumIdx) + "\n";
             OpmLog::info(msg);
-            for (int miscNumIdx = 0; miscNumIdx < numMiscNumIdx; ++miscNumIdx) {
+            for (std::size_t miscNumIdx = 0; miscNumIdx < numMiscNumIdx; ++miscNumIdx) {
                 miscTableCheck_(miscTables.getTable<MiscTable>(miscNumIdx), miscNumIdx+1);
             }
         }
     }
 
-    void RelpermDiagnostics::swofTableCheck_(const SwofTable& swofTables,
-                                             const int satnumIdx)
+    void RelpermDiagnostics::swofTableCheck_(const SwofTable&  swofTables,
+                                             const std::size_t satnumIdx)
     {
         const auto& sw = swofTables.getSwColumn();
         const auto& krw = swofTables.getKrwColumn();
@@ -303,7 +303,7 @@ namespace Opm {
     }
 
     void RelpermDiagnostics::sgofTableCheck_(const SgofTable& sgofTables,
-                                             const int satnumIdx)
+                                             const std::size_t satnumIdx)
     {
         const auto& sg = sgofTables.getSgColumn();
         const auto& krg = sgofTables.getKrgColumn();
@@ -338,7 +338,7 @@ namespace Opm {
     }
 
     void RelpermDiagnostics::slgofTableCheck_(const SlgofTable& slgofTables,
-                                              const int satnumIdx)
+                                              const std::size_t satnumIdx)
     {
         const auto& sl = slgofTables.getSlColumn();
         const auto& krg = slgofTables.getKrgColumn();
@@ -371,7 +371,7 @@ namespace Opm {
     }
 
     void RelpermDiagnostics::swfnTableCheck_(const SwfnTable& swfnTables,
-                                             const int satnumIdx)
+                                             const std::size_t satnumIdx)
     {
         const auto& sw = swfnTables.getSwColumn();
         const auto& krw = swfnTables.getKrwColumn();
@@ -395,7 +395,7 @@ namespace Opm {
     }
 
     void RelpermDiagnostics::wsfTableCheck_(const WsfTable& wsfTables,
-                                            const int satnumIdx)
+                                            const std::size_t satnumIdx)
     {
         const auto& sw = wsfTables.getSwColumn();
         const auto& krw = wsfTables.getKrwColumn();
@@ -419,7 +419,7 @@ namespace Opm {
     }
 
     void RelpermDiagnostics::sgfnTableCheck_(const SgfnTable& sgfnTables,
-                                             const int satnumIdx)
+                                             const std::size_t satnumIdx)
     {
         const auto& sg = sgfnTables.getSgColumn();
         const auto& krg = sgfnTables.getKrgColumn();
@@ -442,7 +442,7 @@ namespace Opm {
     }
 
     void RelpermDiagnostics::gsfTableCheck_(const GsfTable& gsfTables,
-                                            const int satnumIdx)
+                                            const std::size_t satnumIdx)
     {
         const auto& sg = gsfTables.getSgColumn();
         const auto& krg = gsfTables.getKrgColumn();
@@ -465,7 +465,7 @@ namespace Opm {
     }
 
     void RelpermDiagnostics::sof3TableCheck_(const Sof3Table& sof3Tables,
-                                             const int satnumIdx)
+                                             const std::size_t satnumIdx)
     {
         const auto& so = sof3Tables.getSoColumn();
         const auto& krow = sof3Tables.getKrowColumn();
@@ -506,7 +506,7 @@ namespace Opm {
     }
 
     void RelpermDiagnostics::sof2TableCheck_(const Sof2Table& sof2Tables,
-                                             const int satnumIdx)
+                                             const std::size_t satnumIdx)
     {
         const auto& so = sof2Tables.getSoColumn();
         const auto& kro = sof2Tables.getKroColumn();
@@ -530,7 +530,7 @@ namespace Opm {
     }
 
     void RelpermDiagnostics::sgwfnTableCheck_(const SgwfnTable& sgwfnTables,
-                                              const int satnumIdx)
+                                              const std::size_t satnumIdx)
     {
         const auto& sg = sgwfnTables.getSgColumn();
         const auto& krg = sgwfnTables.getKrgColumn();
@@ -565,7 +565,7 @@ namespace Opm {
     }
 
     void RelpermDiagnostics::sgcwmisTableCheck_(const SgcwmisTable& sgcwmisTables,
-                                                const int satnumIdx)
+                                                const std::size_t satnumIdx)
     {
         const auto& sw = sgcwmisTables.getWaterSaturationColumn();
         const auto& sgc = sgcwmisTables.getMiscibleResidualGasColumn();
@@ -584,7 +584,7 @@ namespace Opm {
     }
 
     void RelpermDiagnostics::sorwmisTableCheck_(const SorwmisTable& sorwmisTables,
-                                                const int satnumIdx)
+                                                const std::size_t satnumIdx)
     {
         const auto& sw = sorwmisTables.getWaterSaturationColumn();
         const auto& sor = sorwmisTables.getMiscibleResidualOilColumn();
@@ -603,7 +603,7 @@ namespace Opm {
     }
 
     void RelpermDiagnostics::ssfnTableCheck_(const SsfnTable& ssfnTables,
-                                             const int satnumIdx)
+                                             const std::size_t satnumIdx)
     {
         const auto& frac = ssfnTables.getSolventFractionColumn();
         const auto& krgm = ssfnTables.getGasRelPermMultiplierColumn();
@@ -629,7 +629,7 @@ namespace Opm {
     }
 
     void RelpermDiagnostics::miscTableCheck_(const MiscTable& miscTables,
-                                             const int miscnumIdx)
+                                             const std::size_t miscnumIdx)
     {
         const auto& frac = miscTables.getSolventFractionColumn();
         const auto& misc = miscTables.getMiscibilityColumn();
@@ -649,7 +649,7 @@ namespace Opm {
     }
 
     void RelpermDiagnostics::msfnTableCheck_(const MsfnTable& msfnTables,
-                                             const int satnumIdx)
+                                             const std::size_t satnumIdx)
     {
         const auto& frac = msfnTables.getGasPhaseFractionColumn();
         const auto& krgsm = msfnTables.getGasSolventRelpermMultiplierColumn();
@@ -679,7 +679,7 @@ namespace Opm {
     {
         // get the number of saturation regions and the number of cells in the deck
         const auto& runspec       = eclState.runspec();
-        const int   numSatRegions = runspec.tabdims().getNumSatTables();
+        const auto numSatRegions = runspec.tabdims().getNumSatTables();
 
         if (numSatRegions < 1) {
             return;
@@ -706,7 +706,7 @@ namespace Opm {
         const TableContainer&  sof3Tables = tables.getSof3Tables();
 
         // std::cout << "***************\nEnd-Points In all the Tables\n";
-        for (int satnumIdx = 0; satnumIdx < numSatRegions; ++satnumIdx) {
+        for (std::size_t satnumIdx = 0; satnumIdx < numSatRegions; ++satnumIdx) {
              this->unscaledEpsInfo_[satnumIdx]
                  .extractUnscaled(rtep, rfunc, satnumIdx);
 

--- a/opm/simulators/utils/satfunc/RelpermDiagnostics.cpp
+++ b/opm/simulators/utils/satfunc/RelpermDiagnostics.cpp
@@ -108,10 +108,6 @@ namespace Opm {
         return true;
     }
 
-
-
-
-
     void RelpermDiagnostics::satFamilyCheck_(const EclipseState& eclState)
     {
         const auto& tableManager = eclState.getTableManager();
@@ -131,9 +127,9 @@ namespace Opm {
         const TableContainer& wsfTables = tableManager.getWsfTables();
 
         const auto& phases = eclState.runspec().phases();
-        const bool waterActive   = phases.active( Phase::WATER );
-        const bool gasActive     = phases.active( Phase::GAS );
-        const bool oilActive     = phases.active( Phase::OIL );
+        const bool waterActive = phases.active(Phase::WATER);
+        const bool gasActive   = phases.active(Phase::GAS);
+        const bool oilActive   = phases.active(Phase::OIL);
 
         // Family I test.
         bool family1 = oilActive;
@@ -195,9 +191,6 @@ namespace Opm {
             OpmLog::info(msg);
         }
     }
-
-
-
 
     void RelpermDiagnostics::tableCheck_(const EclipseState& eclState)
     {
@@ -268,7 +261,6 @@ namespace Opm {
             }
         }
 
-
         if (tableManager.hasTables("MISC")) {
             const int numMiscNumIdx = miscTables.size();
             const std::string msg = "Number of misc regions: " + std::to_string(numMiscNumIdx) + "\n";
@@ -277,12 +269,7 @@ namespace Opm {
                 miscTableCheck_(miscTables.getTable<MiscTable>(miscNumIdx), miscNumIdx+1);
             }
         }
-
     }
-
-
-
-
 
     void RelpermDiagnostics::swofTableCheck_(const SwofTable& swofTables,
                                              const int satnumIdx)
@@ -314,10 +301,6 @@ namespace Opm {
         }
         ///TODO check if run with gas.
     }
-
-
-
-
 
     void RelpermDiagnostics::sgofTableCheck_(const SgofTable& sgofTables,
                                              const int satnumIdx)
@@ -387,10 +370,6 @@ namespace Opm {
         }
     }
 
-
-
-
-
     void RelpermDiagnostics::swfnTableCheck_(const SwfnTable& swfnTables,
                                              const int satnumIdx)
     {
@@ -439,8 +418,6 @@ namespace Opm {
         }
     }
 
-
-
     void RelpermDiagnostics::sgfnTableCheck_(const SgfnTable& sgfnTables,
                                              const int satnumIdx)
     {
@@ -464,7 +441,6 @@ namespace Opm {
         }
     }
 
-
     void RelpermDiagnostics::gsfTableCheck_(const GsfTable& gsfTables,
                                             const int satnumIdx)
     {
@@ -487,7 +463,6 @@ namespace Opm {
             OpmLog::error(msg);
         }
     }
-
 
     void RelpermDiagnostics::sof3TableCheck_(const Sof3Table& sof3Tables,
                                              const int satnumIdx)
@@ -530,10 +505,6 @@ namespace Opm {
         }
     }
 
-
-
-
-
     void RelpermDiagnostics::sof2TableCheck_(const Sof2Table& sof2Tables,
                                              const int satnumIdx)
     {
@@ -557,10 +528,6 @@ namespace Opm {
             OpmLog::error(msg);
         }
     }
-
-
-
-
 
     void RelpermDiagnostics::sgwfnTableCheck_(const SgwfnTable& sgwfnTables,
                                               const int satnumIdx)
@@ -597,8 +564,6 @@ namespace Opm {
         }
     }
 
-
-
     void RelpermDiagnostics::sgcwmisTableCheck_(const SgcwmisTable& sgcwmisTables,
                                                 const int satnumIdx)
     {
@@ -618,10 +583,6 @@ namespace Opm {
         }
     }
 
-
-
-
-
     void RelpermDiagnostics::sorwmisTableCheck_(const SorwmisTable& sorwmisTables,
                                                 const int satnumIdx)
     {
@@ -640,9 +601,6 @@ namespace Opm {
             OpmLog::error(msg);
         }
     }
-
-
-
 
     void RelpermDiagnostics::ssfnTableCheck_(const SsfnTable& ssfnTables,
                                              const int satnumIdx)
@@ -670,11 +628,6 @@ namespace Opm {
         }
     }
 
-
-
-
-
-
     void RelpermDiagnostics::miscTableCheck_(const MiscTable& miscTables,
                                              const int miscnumIdx)
     {
@@ -694,10 +647,6 @@ namespace Opm {
             OpmLog::error(msg);
         }
     }
-
-
-
-
 
     void RelpermDiagnostics::msfnTableCheck_(const MsfnTable& msfnTables,
                                              const int satnumIdx)
@@ -725,10 +674,6 @@ namespace Opm {
             OpmLog::error(msg);
         }
     }
-
-
-
-
 
     void RelpermDiagnostics::unscaledEndPointsCheck_(const EclipseState& eclState)
     {
@@ -766,7 +711,7 @@ namespace Opm {
                  .extractUnscaled(rtep, rfunc, satnumIdx);
 
              const std::string regionIdx = std::to_string(satnumIdx + 1);
-             ///Consistency check.
+             /// Consistency check.
              if (unscaledEpsInfo_[satnumIdx].Sgu > (1. - unscaledEpsInfo_[satnumIdx].Swl)) {
                 const std::string msg = "In saturation table SATNUM = " + regionIdx + ", Sgmax should not exceed 1-Swco.";
                 OpmLog::warning(msg);
@@ -776,45 +721,45 @@ namespace Opm {
                 OpmLog::warning(msg);
              }
 
-             //Krow(Sou) == Krog(Sou) for three-phase
+             // Krow(Sou) == Krog(Sou) for three-phase
              // means Krow(Swco) == Krog(Sgco)
              double krow_value = 1e20;
              double krog_value = 1e-20;
              if (fluidSystem_ == FluidSystem::BlackOil) {
                 if (satFamily_ == SaturationFunctionFamily::FamilyI) {
-                     if (!sgofTables.empty()) {
-                         const auto& table = sgofTables.getTable<SgofTable>(satnumIdx);
-                         krog_value = table.evaluate( "KROG" , unscaledEpsInfo_[satnumIdx].Sgl );
-                     } else if (!sgofletTables.empty()) {
-                         krog_value = sgofletTables[satnumIdx].krt2_relperm;
-                     } else {
-                         assert(!slgofTables.empty());
-                         const auto& table = slgofTables.getTable<SlgofTable>(satnumIdx);
-                         krog_value = table.evaluate( "KROG" , unscaledEpsInfo_[satnumIdx].Sgl );
-                     }
-                     if (!swofTables.empty()) {
-                         const auto& table = swofTables.getTable<SwofTable>(satnumIdx);
-                         krow_value = table.evaluate("KROW" , unscaledEpsInfo_[satnumIdx].Swl);
-                     } else {
-                         assert(!swofletTables.empty());
-                         krow_value = swofletTables[satnumIdx].krt2_relperm;
-                     }
-                 }
-                 if (satFamily_ == SaturationFunctionFamily::FamilyII) {
-                     assert(!sof3Tables.empty());
-                     const auto& table = sof3Tables.getTable<Sof3Table>(satnumIdx);
-                     const double Sou = 1.- unscaledEpsInfo_[satnumIdx].Swl - unscaledEpsInfo_[satnumIdx].Sgl;
+                    if (!sgofTables.empty()) {
+                        const auto& table = sgofTables.getTable<SgofTable>(satnumIdx);
+                        krog_value = table.evaluate( "KROG" , unscaledEpsInfo_[satnumIdx].Sgl );
+                    } else if (!sgofletTables.empty()) {
+                        krog_value = sgofletTables[satnumIdx].krt2_relperm;
+                    } else {
+                        assert(!slgofTables.empty());
+                        const auto& table = slgofTables.getTable<SlgofTable>(satnumIdx);
+                        krog_value = table.evaluate( "KROG" , unscaledEpsInfo_[satnumIdx].Sgl );
+                    }
+                    if (!swofTables.empty()) {
+                        const auto& table = swofTables.getTable<SwofTable>(satnumIdx);
+                        krow_value = table.evaluate("KROW" , unscaledEpsInfo_[satnumIdx].Swl);
+                    } else {
+                        assert(!swofletTables.empty());
+                        krow_value = swofletTables[satnumIdx].krt2_relperm;
+                    }
+                }
+                if (satFamily_ == SaturationFunctionFamily::FamilyII) {
+                    assert(!sof3Tables.empty());
+                    const auto& table = sof3Tables.getTable<Sof3Table>(satnumIdx);
+                    const double Sou = 1.- unscaledEpsInfo_[satnumIdx].Swl - unscaledEpsInfo_[satnumIdx].Sgl;
 
-                     krow_value = table.evaluate("KROW" , Sou);
-                     krog_value = table.evaluate("KROG" , Sou);
-                 }
-                 if (krow_value != krog_value) {
-                     const std::string msg = "In saturation table SATNUM = " + regionIdx + ", Krow(Somax) should be equal to Krog(Somax).";
-                     OpmLog::warning(msg);
-                 }
-             }
-             //Krw(Sw=0)=Krg(Sg=0)=Krow(So=0)=Krog(So=0)=0.
-             //Mobile fluid requirements
+                    krow_value = table.evaluate("KROW" , Sou);
+                    krog_value = table.evaluate("KROG" , Sou);
+                }
+                if (krow_value != krog_value) {
+                    const std::string msg = "In saturation table SATNUM = " + regionIdx + ", Krow(Somax) should be equal to Krog(Somax).";
+                    OpmLog::warning(msg);
+                }
+            }
+            // Krw(Sw=0)=Krg(Sg=0)=Krow(So=0)=Krog(So=0)=0.
+            // Mobile fluid requirements
             if (((unscaledEpsInfo_[satnumIdx].Sowcr + unscaledEpsInfo_[satnumIdx].Swcr)-1) >= 0) {
                 const std::string msg = "In saturation table SATNUM = " + regionIdx + ", Sowcr + Swcr should be less than 1.";
                 OpmLog::warning(msg);
@@ -832,8 +777,9 @@ namespace Opm {
     {
         OpmLog::info("\n===============Saturation Functions Diagnostics===============\n");
         bool doDiagnostics = phaseCheck_(eclState);
-        if (!doDiagnostics) // no diagnostics needed for single phase problems
+        if (!doDiagnostics) { // no diagnostics needed for single phase problems
             return;
+        }
         satFamilyCheck_(eclState);
         tableCheck_(eclState);
         unscaledEndPointsCheck_(eclState);
@@ -891,11 +837,12 @@ namespace Opm {
     }
 
 #define INSTANCE_DIAGNOSIS(...) \
-    template void RelpermDiagnostics::diagnosis<Opm::LevelCartesianIndexMapper<__VA_ARGS__>>(const EclipseState&, const Opm::LevelCartesianIndexMapper<__VA_ARGS__>&); \
-    template void RelpermDiagnostics::scaledEndPointsCheck_<Opm::LevelCartesianIndexMapper<__VA_ARGS__>>(const EclipseState&, const Opm::LevelCartesianIndexMapper<__VA_ARGS__>&);
+    template void RelpermDiagnostics::diagnosis<LevelCartesianIndexMapper<__VA_ARGS__>>(const EclipseState&, const LevelCartesianIndexMapper<__VA_ARGS__>&); \
+    template void RelpermDiagnostics::scaledEndPointsCheck_<LevelCartesianIndexMapper<__VA_ARGS__>>(const EclipseState&, const LevelCartesianIndexMapper<__VA_ARGS__>&);
 
     INSTANCE_DIAGNOSIS(Dune::CpGrid)
     INSTANCE_DIAGNOSIS(Dune::PolyhedralGrid<3,3>)
+
 #if HAVE_DUNE_ALUGRID
 #if HAVE_MPI
     INSTANCE_DIAGNOSIS(Dune::ALUGrid<3, 3, Dune::cube, Dune::nonconforming, Dune::ALUGridMPIComm>)
@@ -903,4 +850,5 @@ namespace Opm {
     INSTANCE_DIAGNOSIS(Dune::ALUGrid<3, 3, Dune::cube, Dune::nonconforming, Dune::ALUGridNoComm>)
 #endif //HAVE_MPI
 #endif //HAVE_DUNE_ALUGRID
+
 } //namespace Opm

--- a/opm/simulators/utils/satfunc/RelpermDiagnostics.cpp
+++ b/opm/simulators/utils/satfunc/RelpermDiagnostics.cpp
@@ -64,45 +64,37 @@ namespace Opm {
         bool hasSolvent = phases.active( Phase::SOLVENT );
 
         if (hasWater && !hasGas && !hasOil && !hasSolvent) {
-            const std::string msg = "System:  Single phase Water system. Nothing to check";
-            OpmLog::info(msg);
+            OpmLog::info("System:  Single phase Water system. Nothing to check");
             return false;
         }
 
         if (!hasWater && hasGas && !hasOil && !hasSolvent) {
-            const std::string msg = "System:  Single phase Gas system. Nothing to check";
-            OpmLog::info(msg);
+            OpmLog::info("System:  Single phase Gas system. Nothing to check");
             return false;
         }
 
         if (!hasWater && !hasGas && hasOil && !hasSolvent) {
-            const std::string msg = "System: Single phase Oil system. Nothing to check";
-            OpmLog::info(msg);
+            OpmLog::info("System: Single phase Oil system. Nothing to check");
             return false;
         }
         if (hasWater && hasGas && !hasOil && !hasSolvent) {
-            const std::string msg = "System: Water-Gas system.";
-            OpmLog::info(msg);
+            OpmLog::info("System: Water-Gas system.");
             fluidSystem_ = FluidSystem::WaterGas;
         }
         if (hasWater && hasOil && !hasGas && !hasSolvent) {
-            const std::string msg = "System: Oil-Water system.";
-            OpmLog::info(msg);
+            OpmLog::info("System: Oil-Water system.");
             fluidSystem_ = FluidSystem::OilWater;
         }
         if (hasOil && hasGas && !hasWater && !hasSolvent) {
-            const std::string msg = "System: Oil-Gas system.";
-            OpmLog::info(msg);
+            OpmLog::info("System: Oil-Gas system.");
             fluidSystem_ = FluidSystem::OilGas;
         }
         if (hasOil && hasWater && hasGas && !hasSolvent) {
-            const std::string msg = "System: Black-oil system.";
-            OpmLog::info(msg);
+            OpmLog::info("System: Black-oil system.");
             fluidSystem_ = FluidSystem::BlackOil;
         }
         if (hasSolvent) {
-            const std::string msg = "System: Solvent model.";
-            OpmLog::info(msg);
+            OpmLog::info("System: Solvent model.");
             fluidSystem_ = FluidSystem::Solvent;
         }
         return true;

--- a/opm/simulators/utils/satfunc/RelpermDiagnostics.cpp
+++ b/opm/simulators/utils/satfunc/RelpermDiagnostics.cpp
@@ -204,87 +204,9 @@ namespace Opm {
         }
     }
 
-    void RelpermDiagnostics::tableCheck_(const EclipseState& eclState)
-    {
-        const auto numSatRegions = eclState.runspec().tabdims().getNumSatTables();
-        {
-            const std::string msg = "Number of saturation regions: " + std::to_string(numSatRegions) + "\n";
-            OpmLog::info(msg);
-        }
-        const auto& tableManager = eclState.getTableManager();
-        const TableContainer& swofTables    = tableManager.getSwofTables();
-        const TableContainer& slgofTables   = tableManager.getSlgofTables();
-        const TableContainer& sgofTables    = tableManager.getSgofTables();
-        const TableContainer& swfnTables    = tableManager.getSwfnTables();
-        const TableContainer& sgfnTables    = tableManager.getSgfnTables();
-        const TableContainer& sof3Tables    = tableManager.getSof3Tables();
-        const TableContainer& sof2Tables    = tableManager.getSof2Tables();
-        const TableContainer& sgwfnTables   = tableManager.getSgwfnTables();
-        const TableContainer& sgcwmisTables = tableManager.getSgcwmisTables();
-        const TableContainer& sorwmisTables = tableManager.getSorwmisTables();
-        const TableContainer& ssfnTables    = tableManager.getSsfnTables();
-        const TableContainer& miscTables    = tableManager.getMiscTables();
-        const TableContainer& msfnTables    = tableManager.getMsfnTables();
-        const TableContainer& gsfTables     = tableManager.getGsfTables();
-        const TableContainer& wsfTables     = tableManager.getWsfTables();
-
-        for (std::size_t satnumIdx = 0; satnumIdx < numSatRegions; ++satnumIdx) {
-            if (tableManager.hasTables("SWOF")) {
-                swofTableCheck_(swofTables.getTable<SwofTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("SGOF")) {
-                sgofTableCheck_(sgofTables.getTable<SgofTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("SLGOF")) {
-                slgofTableCheck_(slgofTables.getTable<SlgofTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("SWFN")) {
-                swfnTableCheck_(swfnTables.getTable<SwfnTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("SGFN")) {
-                sgfnTableCheck_(sgfnTables.getTable<SgfnTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("SOF3")) {
-                sof3TableCheck_(sof3Tables.getTable<Sof3Table>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("SOF2")) {
-                sof2TableCheck_(sof2Tables.getTable<Sof2Table>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("SGWFN")) {
-                sgwfnTableCheck_(sgwfnTables.getTable<SgwfnTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("SGCWMIS")) {
-                sgcwmisTableCheck_(sgcwmisTables.getTable<SgcwmisTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("SORWMIS")) {
-                sorwmisTableCheck_(sorwmisTables.getTable<SorwmisTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("SSFN")) {
-                ssfnTableCheck_(ssfnTables.getTable<SsfnTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("MSFN")) {
-                msfnTableCheck_(msfnTables.getTable<MsfnTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("GSF")) {
-                gsfTableCheck_(gsfTables.getTable<GsfTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("WSF")) {
-                wsfTableCheck_(wsfTables.getTable<WsfTable>(satnumIdx), satnumIdx+1);
-            }
-        }
-
-        if (tableManager.hasTables("MISC")) {
-            const auto numMiscNumIdx = miscTables.size();
-            const std::string msg = "Number of misc regions: " + std::to_string(numMiscNumIdx) + "\n";
-            OpmLog::info(msg);
-            for (std::size_t miscNumIdx = 0; miscNumIdx < numMiscNumIdx; ++miscNumIdx) {
-                miscTableCheck_(miscTables.getTable<MiscTable>(miscNumIdx), miscNumIdx+1);
-            }
-        }
-    }
-
-    void RelpermDiagnostics::swofTableCheck_(const SwofTable&  swofTables,
-                                             const std::size_t satnumIdx)
+    template<>
+    void RelpermDiagnostics::checkTable_(const SwofTable& swofTables,
+                                         const std::size_t satnumIdx)
     {
         const auto& sw = swofTables.getSwColumn();
         const auto& krw = swofTables.getKrwColumn();
@@ -314,8 +236,9 @@ namespace Opm {
         ///TODO check if run with gas.
     }
 
-    void RelpermDiagnostics::sgofTableCheck_(const SgofTable& sgofTables,
-                                             const std::size_t satnumIdx)
+    template<>
+    void RelpermDiagnostics::checkTable_<SgofTable>(const SgofTable& sgofTables,
+                                                    const std::size_t satnumIdx)
     {
         const auto& sg = sgofTables.getSgColumn();
         const auto& krg = sgofTables.getKrgColumn();
@@ -349,8 +272,9 @@ namespace Opm {
         //TODO check if run with water.
     }
 
-    void RelpermDiagnostics::slgofTableCheck_(const SlgofTable& slgofTables,
-                                              const std::size_t satnumIdx)
+    template<>
+    void RelpermDiagnostics::checkTable_<SlgofTable>(const SlgofTable& slgofTables,
+                                                     const std::size_t satnumIdx)
     {
         const auto& sl = slgofTables.getSlColumn();
         const auto& krg = slgofTables.getKrgColumn();
@@ -382,8 +306,9 @@ namespace Opm {
         }
     }
 
-    void RelpermDiagnostics::swfnTableCheck_(const SwfnTable& swfnTables,
-                                             const std::size_t satnumIdx)
+    template<>
+    void RelpermDiagnostics::checkTable_<SwfnTable>(const SwfnTable& swfnTables,
+                                                    const std::size_t satnumIdx)
     {
         const auto& sw = swfnTables.getSwColumn();
         const auto& krw = swfnTables.getKrwColumn();
@@ -406,8 +331,9 @@ namespace Opm {
         }
     }
 
-    void RelpermDiagnostics::wsfTableCheck_(const WsfTable& wsfTables,
-                                            const std::size_t satnumIdx)
+    template<>
+    void RelpermDiagnostics::checkTable_<WsfTable>(const WsfTable& wsfTables,
+                                                   const std::size_t satnumIdx)
     {
         const auto& sw = wsfTables.getSwColumn();
         const auto& krw = wsfTables.getKrwColumn();
@@ -430,8 +356,9 @@ namespace Opm {
         }
     }
 
-    void RelpermDiagnostics::sgfnTableCheck_(const SgfnTable& sgfnTables,
-                                             const std::size_t satnumIdx)
+    template<>
+    void RelpermDiagnostics::checkTable_<SgfnTable>(const SgfnTable& sgfnTables,
+                                                    const std::size_t satnumIdx)
     {
         const auto& sg = sgfnTables.getSgColumn();
         const auto& krg = sgfnTables.getKrgColumn();
@@ -453,8 +380,9 @@ namespace Opm {
         }
     }
 
-    void RelpermDiagnostics::gsfTableCheck_(const GsfTable& gsfTables,
-                                            const std::size_t satnumIdx)
+    template<>
+    void RelpermDiagnostics::checkTable_<GsfTable>(const GsfTable& gsfTables,
+                                                   const std::size_t satnumIdx)
     {
         const auto& sg = gsfTables.getSgColumn();
         const auto& krg = gsfTables.getKrgColumn();
@@ -476,8 +404,9 @@ namespace Opm {
         }
     }
 
-    void RelpermDiagnostics::sof3TableCheck_(const Sof3Table& sof3Tables,
-                                             const std::size_t satnumIdx)
+    template<>
+    void RelpermDiagnostics::checkTable_<Sof3Table>(const Sof3Table& sof3Tables,
+                                                    const std::size_t satnumIdx)
     {
         const auto& so = sof3Tables.getSoColumn();
         const auto& krow = sof3Tables.getKrowColumn();
@@ -517,8 +446,9 @@ namespace Opm {
         }
     }
 
-    void RelpermDiagnostics::sof2TableCheck_(const Sof2Table& sof2Tables,
-                                             const std::size_t satnumIdx)
+    template<>
+    void RelpermDiagnostics::checkTable_<Sof2Table>(const Sof2Table& sof2Tables,
+                                                    const std::size_t satnumIdx)
     {
         const auto& so = sof2Tables.getSoColumn();
         const auto& kro = sof2Tables.getKroColumn();
@@ -541,8 +471,9 @@ namespace Opm {
         }
     }
 
-    void RelpermDiagnostics::sgwfnTableCheck_(const SgwfnTable& sgwfnTables,
-                                              const std::size_t satnumIdx)
+    template<>
+    void RelpermDiagnostics::checkTable_<SgwfnTable>(const SgwfnTable& sgwfnTables,
+                                                    const std::size_t satnumIdx)
     {
         const auto& sg = sgwfnTables.getSgColumn();
         const auto& krg = sgwfnTables.getKrgColumn();
@@ -576,8 +507,9 @@ namespace Opm {
         }
     }
 
-    void RelpermDiagnostics::sgcwmisTableCheck_(const SgcwmisTable& sgcwmisTables,
-                                                const std::size_t satnumIdx)
+    template<>
+    void RelpermDiagnostics::checkTable_<SgcwmisTable>(const SgcwmisTable& sgcwmisTables,
+                                                       const std::size_t satnumIdx)
     {
         const auto& sw = sgcwmisTables.getWaterSaturationColumn();
         const auto& sgc = sgcwmisTables.getMiscibleResidualGasColumn();
@@ -595,8 +527,9 @@ namespace Opm {
         }
     }
 
-    void RelpermDiagnostics::sorwmisTableCheck_(const SorwmisTable& sorwmisTables,
-                                                const std::size_t satnumIdx)
+    template<>
+    void RelpermDiagnostics::checkTable_<SorwmisTable>(const SorwmisTable& sorwmisTables,
+                                                       const std::size_t satnumIdx)
     {
         const auto& sw = sorwmisTables.getWaterSaturationColumn();
         const auto& sor = sorwmisTables.getMiscibleResidualOilColumn();
@@ -614,8 +547,9 @@ namespace Opm {
         }
     }
 
-    void RelpermDiagnostics::ssfnTableCheck_(const SsfnTable& ssfnTables,
-                                             const std::size_t satnumIdx)
+    template<>
+    void RelpermDiagnostics::checkTable_<SsfnTable>(const SsfnTable& ssfnTables,
+                                                    const std::size_t satnumIdx)
     {
         const auto& frac = ssfnTables.getSolventFractionColumn();
         const auto& krgm = ssfnTables.getGasRelPermMultiplierColumn();
@@ -640,8 +574,9 @@ namespace Opm {
         }
     }
 
-    void RelpermDiagnostics::miscTableCheck_(const MiscTable& miscTables,
-                                             const std::size_t miscnumIdx)
+    template<>
+    void RelpermDiagnostics::checkTable_<MiscTable>(const MiscTable& miscTables,
+                                                    const std::size_t miscnumIdx)
     {
         const auto& frac = miscTables.getSolventFractionColumn();
         const auto& misc = miscTables.getMiscibilityColumn();
@@ -660,8 +595,9 @@ namespace Opm {
         }
     }
 
-    void RelpermDiagnostics::msfnTableCheck_(const MsfnTable& msfnTables,
-                                             const std::size_t satnumIdx)
+    template<>
+    void RelpermDiagnostics::checkTable_<MsfnTable>(const MsfnTable& msfnTables,
+                                                    const std::size_t satnumIdx)
     {
         const auto& frac = msfnTables.getGasPhaseFractionColumn();
         const auto& krgsm = msfnTables.getGasSolventRelpermMultiplierColumn();
@@ -686,6 +622,86 @@ namespace Opm {
             OpmLog::error(msg);
         }
     }
+
+    void RelpermDiagnostics::tableCheck_(const EclipseState& eclState)
+    {
+        const auto numSatRegions = eclState.runspec().tabdims().getNumSatTables();
+        {
+            const std::string msg = "Number of saturation regions: " + std::to_string(numSatRegions) + "\n";
+            OpmLog::info(msg);
+        }
+        const auto& tableManager = eclState.getTableManager();
+        const TableContainer& swofTables    = tableManager.getSwofTables();
+        const TableContainer& slgofTables   = tableManager.getSlgofTables();
+        const TableContainer& sgofTables    = tableManager.getSgofTables();
+        const TableContainer& swfnTables    = tableManager.getSwfnTables();
+        const TableContainer& sgfnTables    = tableManager.getSgfnTables();
+        const TableContainer& sof3Tables    = tableManager.getSof3Tables();
+        const TableContainer& sof2Tables    = tableManager.getSof2Tables();
+        const TableContainer& sgwfnTables   = tableManager.getSgwfnTables();
+        const TableContainer& sgcwmisTables = tableManager.getSgcwmisTables();
+        const TableContainer& sorwmisTables = tableManager.getSorwmisTables();
+        const TableContainer& ssfnTables    = tableManager.getSsfnTables();
+        const TableContainer& miscTables    = tableManager.getMiscTables();
+        const TableContainer& msfnTables    = tableManager.getMsfnTables();
+        const TableContainer& gsfTables     = tableManager.getGsfTables();
+        const TableContainer& wsfTables     = tableManager.getWsfTables();
+
+        for (std::size_t satnumIdx = 0; satnumIdx < numSatRegions; ++satnumIdx) {
+            if (tableManager.hasTables("SWOF")) {
+                checkTable_<SwofTable>(swofTables.getTable<SwofTable>(satnumIdx), satnumIdx+1);
+            }
+            if (tableManager.hasTables("SGOF")) {
+                checkTable_<SgofTable>(sgofTables.getTable<SgofTable>(satnumIdx), satnumIdx+1);
+            }
+            if (tableManager.hasTables("SLGOF")) {
+                checkTable_<SlgofTable>(slgofTables.getTable<SlgofTable>(satnumIdx), satnumIdx+1);
+            }
+            if (tableManager.hasTables("SWFN")) {
+                checkTable_<SwfnTable>(swfnTables.getTable<SwfnTable>(satnumIdx), satnumIdx+1);
+            }
+            if (tableManager.hasTables("SGFN")) {
+                checkTable_<SgfnTable>(sgfnTables.getTable<SgfnTable>(satnumIdx), satnumIdx+1);
+            }
+            if (tableManager.hasTables("SOF2")) {
+                checkTable_<Sof2Table>(sof2Tables.getTable<Sof2Table>(satnumIdx), satnumIdx+1);
+            }
+            if (tableManager.hasTables("SOF3")) {
+                checkTable_<Sof3Table>(sof3Tables.getTable<Sof3Table>(satnumIdx), satnumIdx+1);
+            }
+            if (tableManager.hasTables("SGWFN")) {
+                checkTable_<SgwfnTable>(sgwfnTables.getTable<SgwfnTable>(satnumIdx), satnumIdx+1);
+            }
+            if (tableManager.hasTables("SGCWMIS")) {
+                checkTable_<SgcwmisTable>(sgcwmisTables.getTable<SgcwmisTable>(satnumIdx), satnumIdx+1);
+            }
+            if (tableManager.hasTables("SORWMIS")) {
+                checkTable_<SorwmisTable>(sorwmisTables.getTable<SorwmisTable>(satnumIdx), satnumIdx+1);
+            }
+            if (tableManager.hasTables("SSFN")) {
+                checkTable_<SsfnTable>(ssfnTables.getTable<SsfnTable>(satnumIdx), satnumIdx+1);
+            }
+            if (tableManager.hasTables("MSFN")) {
+                checkTable_<MsfnTable>(msfnTables.getTable<MsfnTable>(satnumIdx), satnumIdx+1);
+            }
+            if (tableManager.hasTables("GSF")) {
+                checkTable_<GsfTable>(gsfTables.getTable<GsfTable>(satnumIdx), satnumIdx+1);
+            }
+            if (tableManager.hasTables("WSF")) {
+                checkTable_<WsfTable>(wsfTables.getTable<WsfTable>(satnumIdx), satnumIdx+1);
+            }
+        }
+
+        if (tableManager.hasTables("MISC")) {
+            const auto numMiscNumIdx = miscTables.size();
+            const std::string msg = "Number of misc regions: " + std::to_string(numMiscNumIdx) + "\n";
+            OpmLog::info(msg);
+            for (std::size_t miscNumIdx = 0; miscNumIdx < numMiscNumIdx; ++miscNumIdx) {
+                checkTable_<MiscTable>(miscTables.getTable<MiscTable>(miscNumIdx), miscNumIdx+1);
+            }
+        }
+    }
+
 
     void RelpermDiagnostics::unscaledEndPointsCheck_(const EclipseState& eclState)
     {

--- a/opm/simulators/utils/satfunc/RelpermDiagnostics.cpp
+++ b/opm/simulators/utils/satfunc/RelpermDiagnostics.cpp
@@ -53,6 +53,9 @@
 #include <opm/simulators/flow/AluGridLevelCartesianIndexMapper.hpp>
 #endif // HAVE_DUNE_ALUGRID
 
+#include <algorithm>
+#include <functional>
+
 #include <fmt/format.h>
 
 namespace Opm {
@@ -726,69 +729,51 @@ namespace Opm {
         const auto numSatRegions = eclState.runspec().tabdims().getNumSatTables();
         OpmLog::info(fmt::format("Number of saturation regions: {}\n", numSatRegions));
 
+        struct TableEntry
+        {
+            std::string name;
+            const TableContainer& table;
+            std::function<void(const TableContainer&, const std::size_t)> f;
+        };
+
+        auto mkop = [this]<class Type>()
+        {
+            return [this](const TableContainer& table, const std::size_t idx) {
+                this->checkTable_<Type>(table.getTable<Type>(idx), idx + 1);
+            };
+        };
+
         const auto& tableManager = eclState.getTableManager();
-        const TableContainer& swofTables    = tableManager.getSwofTables();
-        const TableContainer& slgofTables   = tableManager.getSlgofTables();
-        const TableContainer& sgofTables    = tableManager.getSgofTables();
-        const TableContainer& swfnTables    = tableManager.getSwfnTables();
-        const TableContainer& sgfnTables    = tableManager.getSgfnTables();
-        const TableContainer& sof3Tables    = tableManager.getSof3Tables();
-        const TableContainer& sof2Tables    = tableManager.getSof2Tables();
-        const TableContainer& sgwfnTables   = tableManager.getSgwfnTables();
-        const TableContainer& sgcwmisTables = tableManager.getSgcwmisTables();
-        const TableContainer& sorwmisTables = tableManager.getSorwmisTables();
-        const TableContainer& ssfnTables    = tableManager.getSsfnTables();
-        const TableContainer& miscTables    = tableManager.getMiscTables();
-        const TableContainer& msfnTables    = tableManager.getMsfnTables();
-        const TableContainer& gsfTables     = tableManager.getGsfTables();
-        const TableContainer& wsfTables     = tableManager.getWsfTables();
+
+        const auto tableChecks = std::array{
+            TableEntry{"GSF", tableManager.getGsfTables(), mkop.operator()<GsfTable>()},
+            TableEntry{"MSFN", tableManager.getMsfnTables(), mkop.operator()<MsfnTable>()},
+            TableEntry{"SGCWMIS", tableManager.getSgcwmisTables(), mkop.operator()<SgcwmisTable>()},
+            TableEntry{"SGFN", tableManager.getSgfnTables(), mkop.operator()<SgfnTable>()},
+            TableEntry{"SGOF", tableManager.getSgofTables(), mkop.operator()<SgofTable>()},
+            TableEntry{"SGWFN", tableManager.getSgwfnTables(), mkop.operator()<SgwfnTable>()},
+            TableEntry{"SLGOF", tableManager.getSlgofTables(), mkop.operator()<SlgofTable>()},
+            TableEntry{"SOF2", tableManager.getSof2Tables(), mkop.operator()<Sof2Table>()},
+            TableEntry{"SOF3", tableManager.getSof3Tables(), mkop.operator()<Sof3Table>()},
+            TableEntry{"SORWMIS", tableManager.getSorwmisTables(), mkop.operator()<SorwmisTable>()},
+            TableEntry{"SSFN", tableManager.getSsfnTables(), mkop.operator()<SsfnTable>()},
+            TableEntry{"SWFN", tableManager.getSwfnTables(), mkop.operator()<SwfnTable>()},
+            TableEntry{"SWOF", tableManager.getSwofTables(), mkop.operator()<SwofTable>()},
+            TableEntry{"WSF", tableManager.getWsfTables(), mkop.operator()<WsfTable>()},
+        };
 
         for (std::size_t satnumIdx = 0; satnumIdx < numSatRegions; ++satnumIdx) {
-            if (tableManager.hasTables("SWOF")) {
-                checkTable_<SwofTable>(swofTables.getTable<SwofTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("SGOF")) {
-                checkTable_<SgofTable>(sgofTables.getTable<SgofTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("SLGOF")) {
-                checkTable_<SlgofTable>(slgofTables.getTable<SlgofTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("SWFN")) {
-                checkTable_<SwfnTable>(swfnTables.getTable<SwfnTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("SGFN")) {
-                checkTable_<SgfnTable>(sgfnTables.getTable<SgfnTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("SOF2")) {
-                checkTable_<Sof2Table>(sof2Tables.getTable<Sof2Table>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("SOF3")) {
-                checkTable_<Sof3Table>(sof3Tables.getTable<Sof3Table>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("SGWFN")) {
-                checkTable_<SgwfnTable>(sgwfnTables.getTable<SgwfnTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("SGCWMIS")) {
-                checkTable_<SgcwmisTable>(sgcwmisTables.getTable<SgcwmisTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("SORWMIS")) {
-                checkTable_<SorwmisTable>(sorwmisTables.getTable<SorwmisTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("SSFN")) {
-                checkTable_<SsfnTable>(ssfnTables.getTable<SsfnTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("MSFN")) {
-                checkTable_<MsfnTable>(msfnTables.getTable<MsfnTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("GSF")) {
-                checkTable_<GsfTable>(gsfTables.getTable<GsfTable>(satnumIdx), satnumIdx+1);
-            }
-            if (tableManager.hasTables("WSF")) {
-                checkTable_<WsfTable>(wsfTables.getTable<WsfTable>(satnumIdx), satnumIdx+1);
-            }
+            std::ranges::for_each(tableChecks,
+                                  [&tableManager, satnumIdx](const auto& input)
+                                  {
+                                      if (tableManager.hasTables(input.name)) {
+                                          input.f(input.table, satnumIdx);
+                                      }
+                                  });
         }
 
         if (tableManager.hasTables("MISC")) {
+            const auto& miscTables = tableManager.getMiscTables();
             const auto numMiscNumIdx = miscTables.size();
             OpmLog::info(fmt::format("Number of misc regions: {}\n", numMiscNumIdx));
             for (std::size_t miscNumIdx = 0; miscNumIdx < numMiscNumIdx; ++miscNumIdx) {
@@ -796,7 +781,6 @@ namespace Opm {
             }
         }
     }
-
 
     void RelpermDiagnostics::unscaledEndPointsCheck_(const EclipseState& eclState)
     {

--- a/opm/simulators/utils/satfunc/RelpermDiagnostics.hpp
+++ b/opm/simulators/utils/satfunc/RelpermDiagnostics.hpp
@@ -20,8 +20,8 @@
 #ifndef OPM_RELPERMDIAGNOSTICS_HEADER_INCLUDED
 #define OPM_RELPERMDIAGNOSTICS_HEADER_INCLUDED
 
+#include <array>
 #include <vector>
-#include <utility>
 
 #include <opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp>
 
@@ -132,6 +132,9 @@ namespace Opm {
                              const std::size_t miscnumIdx);
         void msfnTableCheck_(const MsfnTable& msfnTables,
                              const std::size_t satnumIdx);
+
+        void analyzeFamily(const EclipseState& eclState,
+                           const std::array<bool,3>& family);
     };
 
 } //namespace Opm

--- a/opm/simulators/utils/satfunc/RelpermDiagnostics.hpp
+++ b/opm/simulators/utils/satfunc/RelpermDiagnostics.hpp
@@ -107,6 +107,9 @@ namespace Opm {
 
         void analyzeFamily(const EclipseState& eclState,
                            const std::array<bool,3>& family);
+
+        void blackoilChecks(const EclipseState& eclState,
+                            const std::size_t satnumIdx);
     };
 
 } //namespace Opm

--- a/opm/simulators/utils/satfunc/RelpermDiagnostics.hpp
+++ b/opm/simulators/utils/satfunc/RelpermDiagnostics.hpp
@@ -102,36 +102,36 @@ namespace Opm {
 
         ///For every table, need to deal with case by case.
         void swofTableCheck_(const SwofTable& swofTables,
-                             const int satnumIdx);
+                             const std::size_t satnumIdx);
         void sgofTableCheck_(const SgofTable& sgofTables,
-                             const int satnumIdx);
+                             const std::size_t satnumIdx);
         void slgofTableCheck_(const SlgofTable& slgofTables,
-                              const int satnumIdx);
+                              const std::size_t satnumIdx);
         void swfnTableCheck_(const SwfnTable& swfnTables,
-                             const int satnumIdx);
+                             const std::size_t satnumIdx);
         void sgfnTableCheck_(const SgfnTable& sgfnTables,
-                             const int satnumIdx);
+                             const std::size_t satnumIdx);
         void wsfTableCheck_(const WsfTable& wsfTables,
-                            const int satnumIdx);
+                            const std::size_t satnumIdx);
         void gsfTableCheck_(const GsfTable& gsfTables,
-                            const int satnumIdx);
+                            const std::size_t satnumIdx);
         void sof3TableCheck_(const Sof3Table& sof3Tables,
-                             const int satnumIdx);
+                             const std::size_t satnumIdx);
         void sof2TableCheck_(const Sof2Table& sof2Tables,
-                             const int satnumIdx);
+                             const std::size_t satnumIdx);
         void sgwfnTableCheck_(const SgwfnTable& sgwfnTables,
-                              const int satnumIdx);
+                              const std::size_t satnumIdx);
         ///Tables for solvent model
         void sgcwmisTableCheck_(const SgcwmisTable& sgcwmisTables,
-                                const int satnumIdx);
+                                const std::size_t satnumIdx);
         void sorwmisTableCheck_(const SorwmisTable& sorwmisTables,
-                                const int satnumIdx);
+                                const std::size_t satnumIdx);
         void ssfnTableCheck_(const SsfnTable& ssfnTables,
-                             const int satnumIdx);
+                             const std::size_t satnumIdx);
         void miscTableCheck_(const MiscTable& miscTables,
-                             const int miscnumIdx);
+                             const std::size_t miscnumIdx);
         void msfnTableCheck_(const MsfnTable& msfnTables,
-                             const int satnumIdx);
+                             const std::size_t satnumIdx);
     };
 
 } //namespace Opm

--- a/opm/simulators/utils/satfunc/RelpermDiagnostics.hpp
+++ b/opm/simulators/utils/satfunc/RelpermDiagnostics.hpp
@@ -101,37 +101,9 @@ namespace Opm {
                                    const LevelCartesianIndexMapper& levelCartesianIndexMapper);
 
         ///For every table, need to deal with case by case.
-        void swofTableCheck_(const SwofTable& swofTables,
-                             const std::size_t satnumIdx);
-        void sgofTableCheck_(const SgofTable& sgofTables,
-                             const std::size_t satnumIdx);
-        void slgofTableCheck_(const SlgofTable& slgofTables,
-                              const std::size_t satnumIdx);
-        void swfnTableCheck_(const SwfnTable& swfnTables,
-                             const std::size_t satnumIdx);
-        void sgfnTableCheck_(const SgfnTable& sgfnTables,
-                             const std::size_t satnumIdx);
-        void wsfTableCheck_(const WsfTable& wsfTables,
-                            const std::size_t satnumIdx);
-        void gsfTableCheck_(const GsfTable& gsfTables,
-                            const std::size_t satnumIdx);
-        void sof3TableCheck_(const Sof3Table& sof3Tables,
-                             const std::size_t satnumIdx);
-        void sof2TableCheck_(const Sof2Table& sof2Tables,
-                             const std::size_t satnumIdx);
-        void sgwfnTableCheck_(const SgwfnTable& sgwfnTables,
-                              const std::size_t satnumIdx);
-        ///Tables for solvent model
-        void sgcwmisTableCheck_(const SgcwmisTable& sgcwmisTables,
-                                const std::size_t satnumIdx);
-        void sorwmisTableCheck_(const SorwmisTable& sorwmisTables,
-                                const std::size_t satnumIdx);
-        void ssfnTableCheck_(const SsfnTable& ssfnTables,
-                             const std::size_t satnumIdx);
-        void miscTableCheck_(const MiscTable& miscTables,
-                             const std::size_t miscnumIdx);
-        void msfnTableCheck_(const MsfnTable& msfnTables,
-                             const std::size_t satnumIdx);
+        template<class TableType>
+        void checkTable_(const TableType& tables,
+                         const std::size_t satnumIdx);
 
         void analyzeFamily(const EclipseState& eclState,
                            const std::array<bool,3>& family);


### PR DESCRIPTION
Various cleanups and splitting of code.