### PR TITLE
Parallel(FileMerger|Restart): address clang-tidy warnings

### DIFF
--- a/opm/simulators/utils/ParallelFileMerger.cpp
+++ b/opm/simulators/utils/ParallelFileMerger.cpp
@@ -84,7 +84,7 @@ void ParallelFileMerger::operator()(const fs::path& file)
 
 void ParallelFileMerger::appendFile(std::ofstream& of, const fs::path& file, const std::string& rank)
 {
-    if (fs::file_size(file)) {
+    if (fs::file_size(file) > 0) {
         std::cerr << "WARNING: There has been logging to file "
                       << file.string() <<" by process "
                       << rank << std::endl;

--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -44,7 +44,7 @@ RestartValue loadParallelRestart(const EclipseIO* eclIO,
 #if HAVE_MPI
     RestartValue restartValues{};
 
-    if (eclIO)
+    if (eclIO != nullptr)
     {
         assert(comm.rank() == 0);
         restartValues = eclIO->loadRestart(actionState, summaryState, solutionKeys, extraKeys);
@@ -66,7 +66,7 @@ data::Solution loadParallelRestartSolution(const EclipseIO* eclIO,
 #if HAVE_MPI
     data::Solution sol{};
 
-    if (eclIO)
+    if (eclIO != nullptr)
     {
         assert(comm.rank() == 0);
         sol = eclIO->loadRestartSolution(solutionKeys, step);


### PR DESCRIPTION
And the final mop-up for the utils directory.