### PR TITLE
ISTLSolverGpuBridge: add using statement, mark method override

### DIFF
--- a/opm/simulators/linalg/ISTLSolverGpuBridge.hpp
+++ b/opm/simulators/linalg/ISTLSolverGpuBridge.hpp
@@ -184,7 +184,8 @@ public:
                                                                             linsolver);
     }
 
-    void prepare(const Matrix& M, Vector& b)
+    using ISTLSolver<TypeTag>::prepare;
+    void prepare(const Matrix& M, Vector& b) override
     {
         OPM_TIMEBLOCK(prepare);
         [[maybe_unused]] const bool firstcall = (this->matrix_ == nullptr);


### PR DESCRIPTION
Quell nvcc warning while building flow_gpu_thermal_gaswater
```
warning #611-D: overloaded virtual function "Opm::AbstractISTLSolver<SparseMatrixAdapter, Vector>::prepare [with SparseMatrixAdapter=Opm::Linear::IstlSparseMatrixAdapter<Opm::MatrixBlock<double, 3, 3>, std::allocator<Opm::MatrixBlock<double, 3, 3>>>, Vector=Dune::BlockVector<Dune::FieldVector<double, 3>, std::allocator<Dune::FieldVector<double, 3>>>]" is only partially overridden in class "Opm::ISTLSolverGpuBridge<Opm::Properties::TTag::FlowGasWaterEnergyProblemGPU>"
```