### PR TITLE
PrimaryVariables: make indices unsigned

### DIFF
--- a/opm/models/blackoil/blackoilbioeffectsmodules.hh
+++ b/opm/models/blackoil/blackoilbioeffectsmodules.hh
@@ -533,7 +533,7 @@ class BlackOilBioeffectsIntensiveQuantities<TypeTag, true>
     static constexpr unsigned microbialConcentrationIdx = Indices::microbialConcentrationIdx;
     static constexpr unsigned oxygenConcentrationIdx = Indices::oxygenConcentrationIdx;
     static constexpr unsigned ureaConcentrationIdx = Indices::ureaConcentrationIdx;
-    static constexpr int biofilmVolumeFractionIdx = Indices::biofilmVolumeFractionIdx;
+    static constexpr unsigned biofilmVolumeFractionIdx = Indices::biofilmVolumeFractionIdx;
     static constexpr int calciteVolumeFractionIdx = Indices::calciteVolumeFractionIdx;
     static constexpr bool enableMICP = Indices::enableMICP;
 

--- a/opm/models/blackoil/blackoilbioeffectsmodules.hh
+++ b/opm/models/blackoil/blackoilbioeffectsmodules.hh
@@ -530,7 +530,7 @@ class BlackOilBioeffectsIntensiveQuantities<TypeTag, true>
 
     using BioeffectsModule = BlackOilBioeffectsModule<TypeTag, true>;
 
-    static constexpr int microbialConcentrationIdx = Indices::microbialConcentrationIdx;
+    static constexpr unsigned microbialConcentrationIdx = Indices::microbialConcentrationIdx;
     static constexpr int oxygenConcentrationIdx = Indices::oxygenConcentrationIdx;
     static constexpr int ureaConcentrationIdx = Indices::ureaConcentrationIdx;
     static constexpr int biofilmVolumeFractionIdx = Indices::biofilmVolumeFractionIdx;

--- a/opm/models/blackoil/blackoilbioeffectsmodules.hh
+++ b/opm/models/blackoil/blackoilbioeffectsmodules.hh
@@ -532,7 +532,7 @@ class BlackOilBioeffectsIntensiveQuantities<TypeTag, true>
 
     static constexpr unsigned microbialConcentrationIdx = Indices::microbialConcentrationIdx;
     static constexpr unsigned oxygenConcentrationIdx = Indices::oxygenConcentrationIdx;
-    static constexpr int ureaConcentrationIdx = Indices::ureaConcentrationIdx;
+    static constexpr unsigned ureaConcentrationIdx = Indices::ureaConcentrationIdx;
     static constexpr int biofilmVolumeFractionIdx = Indices::biofilmVolumeFractionIdx;
     static constexpr int calciteVolumeFractionIdx = Indices::calciteVolumeFractionIdx;
     static constexpr bool enableMICP = Indices::enableMICP;

--- a/opm/models/blackoil/blackoilbioeffectsmodules.hh
+++ b/opm/models/blackoil/blackoilbioeffectsmodules.hh
@@ -534,7 +534,7 @@ class BlackOilBioeffectsIntensiveQuantities<TypeTag, true>
     static constexpr unsigned oxygenConcentrationIdx = Indices::oxygenConcentrationIdx;
     static constexpr unsigned ureaConcentrationIdx = Indices::ureaConcentrationIdx;
     static constexpr unsigned biofilmVolumeFractionIdx = Indices::biofilmVolumeFractionIdx;
-    static constexpr int calciteVolumeFractionIdx = Indices::calciteVolumeFractionIdx;
+    static constexpr unsigned calciteVolumeFractionIdx = Indices::calciteVolumeFractionIdx;
     static constexpr bool enableMICP = Indices::enableMICP;
 
 public:

--- a/opm/models/blackoil/blackoilbioeffectsmodules.hh
+++ b/opm/models/blackoil/blackoilbioeffectsmodules.hh
@@ -531,7 +531,7 @@ class BlackOilBioeffectsIntensiveQuantities<TypeTag, true>
     using BioeffectsModule = BlackOilBioeffectsModule<TypeTag, true>;
 
     static constexpr unsigned microbialConcentrationIdx = Indices::microbialConcentrationIdx;
-    static constexpr int oxygenConcentrationIdx = Indices::oxygenConcentrationIdx;
+    static constexpr unsigned oxygenConcentrationIdx = Indices::oxygenConcentrationIdx;
     static constexpr int ureaConcentrationIdx = Indices::ureaConcentrationIdx;
     static constexpr int biofilmVolumeFractionIdx = Indices::biofilmVolumeFractionIdx;
     static constexpr int calciteVolumeFractionIdx = Indices::calciteVolumeFractionIdx;

--- a/opm/models/blackoil/blackoilbrinemodules.hh
+++ b/opm/models/blackoil/blackoilbrinemodules.hh
@@ -367,7 +367,7 @@ class BlackOilBrineIntensiveQuantities<TypeTag, /*enableBrineV=*/true>
     using BrineModule = BlackOilBrineModule<TypeTag, true>;
 
     enum { numPhases = getPropValue<TypeTag, Properties::NumPhases>() };
-    static constexpr int saltConcentrationIdx = Indices::saltConcentrationIdx;
+    static constexpr unsigned saltConcentrationIdx = Indices::saltConcentrationIdx;
     static constexpr int waterPhaseIdx = FluidSystem::waterPhaseIdx;
     static constexpr int gasPhaseIdx = FluidSystem::gasPhaseIdx;
     static constexpr int oilPhaseIdx = FluidSystem::oilPhaseIdx;

--- a/opm/models/blackoil/blackoilenergymodules.hh
+++ b/opm/models/blackoil/blackoilenergymodules.hh
@@ -332,7 +332,7 @@ class BlackOilEnergyIntensiveQuantities<TypeTag, EnergyModules::FullyImplicitThe
     using Problem = GetPropType<TypeTag, Properties::Problem>;
 
     enum { numPhases = getPropValue<TypeTag, Properties::NumPhases>() };
-    static constexpr int temperatureIdx = Indices::temperatureIdx;
+    static constexpr unsigned temperatureIdx = Indices::temperatureIdx;
 
 public:
     /*!

--- a/opm/models/blackoil/blackoilextbomodules.hh
+++ b/opm/models/blackoil/blackoilextbomodules.hh
@@ -379,7 +379,7 @@ class BlackOilExtboIntensiveQuantities<TypeTag, /*enableExtboV=*/true>
 
     using ExtboModule = BlackOilExtboModule<TypeTag, true>;
 
-    static constexpr int zFractionIdx = Indices::zFractionIdx;
+    static constexpr unsigned zFractionIdx = Indices::zFractionIdx;
     static constexpr int oilPhaseIdx = FluidSystem::oilPhaseIdx;
     static constexpr int gasPhaseIdx = FluidSystem::gasPhaseIdx;
 

--- a/opm/models/blackoil/blackoilfoammodules.hh
+++ b/opm/models/blackoil/blackoilfoammodules.hh
@@ -377,7 +377,7 @@ class BlackOilFoamIntensiveQuantities<TypeTag, /*enableFoam=*/true>
 
     static constexpr bool enableSolvent = getPropValue<TypeTag, Properties::EnableSolvent>();
 
-    static constexpr int foamConcentrationIdx = Indices::foamConcentrationIdx;
+    static constexpr unsigned foamConcentrationIdx = Indices::foamConcentrationIdx;
     static constexpr unsigned waterPhaseIdx = FluidSystem::waterPhaseIdx;
     static constexpr unsigned oilPhaseIdx = FluidSystem::oilPhaseIdx;
     static constexpr int gasPhaseIdx = FluidSystem::gasPhaseIdx;

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -50,6 +50,7 @@
 #include <array>
 #include <cassert>
 #include <cstring>
+#include <limits>
 #include <stdexcept>
 #include <utility>
 
@@ -230,8 +231,8 @@ public:
         Evaluation Sw = 0.0;
         if constexpr (waterEnabled) {
             if (priVars.primaryVarsMeaningWater() == PrimaryVariables::WaterMeaning::Sw) {
-                assert(Indices::waterSwitchIdx >= 0);
-                if constexpr (Indices::waterSwitchIdx >= 0) {
+                assert(Indices::waterSwitchIdx != std::numeric_limits<unsigned>::max());
+                if constexpr (Indices::waterSwitchIdx != std::numeric_limits<unsigned>::max()) {
                     Sw = priVars.makeEvaluation(Indices::waterSwitchIdx, timeIdx);
                 }
             }

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -115,9 +115,10 @@ class BlackOilIntensiveQuantities
     enum { waterPhaseIdx = FluidSystem::waterPhaseIdx };
     enum { oilPhaseIdx = FluidSystem::oilPhaseIdx };
     enum { gasPhaseIdx = FluidSystem::gasPhaseIdx };
-    enum { compositionSwitchIdx = Indices::compositionSwitchIdx };
+    static constexpr unsigned compositionSwitchIdx = Indices::compositionSwitchIdx;
 
-    static constexpr bool compositionSwitchEnabled = Indices::compositionSwitchIdx >= 0;
+    static constexpr bool compositionSwitchEnabled =
+        Indices::compositionSwitchIdx != std::numeric_limits<unsigned>::max();
     static constexpr bool waterEnabled = Indices::waterEnabled;
     static constexpr bool gasEnabled = Indices::gasEnabled;
     static constexpr bool oilEnabled = Indices::oilEnabled;
@@ -247,7 +248,7 @@ public:
         Evaluation Sg = 0.0;
         if constexpr (gasEnabled) {
             if (priVars.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Sg) {
-                assert(Indices::compositionSwitchIdx >= 0);
+                assert(Indices::compositionSwitchIdx != std::numeric_limits<unsigned>::max());
                 if constexpr (compositionSwitchEnabled) {
                     Sg = priVars.makeEvaluation(Indices::compositionSwitchIdx, timeIdx);
                 }

--- a/opm/models/blackoil/blackoillocalresidual.hh
+++ b/opm/models/blackoil/blackoillocalresidual.hh
@@ -37,6 +37,7 @@
 #include <opm/models/discretization/common/fvbaseproperties.hh>
 
 #include <cassert>
+#include <limits>
 
 namespace Opm {
 
@@ -69,12 +70,13 @@ class BlackOilLocalResidual : public GetPropType<TypeTag, Properties::DiscLocalR
     enum { gasCompIdx = FluidSystem::gasCompIdx };
     enum { oilCompIdx = FluidSystem::oilCompIdx };
     enum { waterCompIdx = FluidSystem::waterCompIdx };
-    enum { compositionSwitchIdx = Indices::compositionSwitchIdx };
+    static constexpr unsigned compositionSwitchIdx = Indices::compositionSwitchIdx;
 
     static constexpr bool waterEnabled = Indices::waterEnabled;
     static constexpr bool gasEnabled = Indices::gasEnabled;
     static constexpr bool oilEnabled = Indices::oilEnabled;
-    static constexpr bool compositionSwitchEnabled = (compositionSwitchIdx >= 0);
+    static constexpr bool compositionSwitchEnabled =
+        compositionSwitchIdx != std::numeric_limits<unsigned>::max();
 
     static constexpr bool blackoilConserveSurfaceVolume = 
         getPropValue<TypeTag, Properties::BlackoilConserveSurfaceVolume>();

--- a/opm/models/blackoil/blackoillocalresidualtpfa.hh
+++ b/opm/models/blackoil/blackoillocalresidualtpfa.hh
@@ -48,6 +48,7 @@
 
 #include <array>
 #include <cassert>
+#include <limits>
 #include <stdexcept>
 #include <string>
 
@@ -89,12 +90,13 @@ class BlackOilLocalResidualTPFA : public GetPropType<TypeTag, Properties::DiscLo
     enum { gasCompIdx = FluidSystem::gasCompIdx };
     enum { oilCompIdx = FluidSystem::oilCompIdx };
     enum { waterCompIdx = FluidSystem::waterCompIdx };
-    enum { compositionSwitchIdx = Indices::compositionSwitchIdx };
+    static constexpr unsigned compositionSwitchIdx = Indices::compositionSwitchIdx;
 
     static constexpr bool waterEnabled = Indices::waterEnabled;
     static constexpr bool gasEnabled = Indices::gasEnabled;
     static constexpr bool oilEnabled = Indices::oilEnabled;
-    static constexpr bool compositionSwitchEnabled = compositionSwitchIdx >= 0;
+    static constexpr bool compositionSwitchEnabled =
+        compositionSwitchIdx != std::numeric_limits<unsigned>::max();
 
     static constexpr bool blackoilConserveSurfaceVolume
         = getPropValue<TypeTag, Properties::BlackoilConserveSurfaceVolume>();

--- a/opm/models/blackoil/blackoilmodel.hh
+++ b/opm/models/blackoil/blackoilmodel.hh
@@ -56,6 +56,7 @@
 
 #include <cassert>
 #include <istream>
+#include <limits>
 #include <memory>
 #include <ostream>
 #include <sstream>
@@ -423,7 +424,7 @@ public:
      */
     std::string primaryVarName(int pvIdx) const
     {
-        if (pvIdx == Indices::waterSwitchIdx) {
+        if (pvIdx == static_cast<int>(Indices::waterSwitchIdx)) {
             return "water_switching";
         }
         else if (pvIdx == Indices::pressureSwitchIdx) {
@@ -510,7 +511,7 @@ public:
         }
 
         // saturations are always in the range [0, 1]!
-        if (int(Indices::waterSwitchIdx) == int(pvIdx)) {
+        if (Indices::waterSwitchIdx == pvIdx) {
             return 1.0;
         }
 

--- a/opm/models/blackoil/blackoilmodel.hh
+++ b/opm/models/blackoil/blackoilmodel.hh
@@ -423,15 +423,15 @@ public:
     /*!
      * \copydoc FvBaseDiscretization::primaryVarName
      */
-    std::string primaryVarName(int pvIdx) const
+    std::string primaryVarName(unsigned pvIdx) const
     {
-        if (pvIdx == static_cast<int>(Indices::waterSwitchIdx)) {
+        if (pvIdx == Indices::waterSwitchIdx) {
             return "water_switching";
         }
-        else if (pvIdx == static_cast<int>(Indices::pressureSwitchIdx)) {
+        else if (pvIdx == Indices::pressureSwitchIdx) {
             return "pressure_switching";
         }
-        else if (pvIdx == static_cast<int>(Indices::compositionSwitchIdx)) {
+        else if (pvIdx == Indices::compositionSwitchIdx) {
             return "composition_switching";
         }
 

--- a/opm/models/blackoil/blackoilmodel.hh
+++ b/opm/models/blackoil/blackoilmodel.hh
@@ -351,7 +351,8 @@ private:
     enum { numComponents = FluidSystem::numComponents };
     enum { numEq = getPropValue<TypeTag, Properties::NumEq>() };
 
-    static constexpr bool compositionSwitchEnabled = Indices::compositionSwitchIdx >= 0;
+    static constexpr bool compositionSwitchEnabled =
+        Indices::compositionSwitchIdx != std::numeric_limits<unsigned>::max();
     static constexpr bool enableBioeffects = getPropValue<TypeTag, Properties::EnableBioeffects>();
     static constexpr bool enableDiffusion = getPropValue<TypeTag, Properties::EnableDiffusion>();
     static constexpr bool enableDispersion = getPropValue<TypeTag, Properties::EnableDispersion>();
@@ -430,7 +431,7 @@ public:
         else if (pvIdx == static_cast<int>(Indices::pressureSwitchIdx)) {
             return "pressure_switching";
         }
-        else if (static_cast<int>(pvIdx) == Indices::compositionSwitchIdx) {
+        else if (pvIdx == static_cast<int>(Indices::compositionSwitchIdx)) {
             return "composition_switching";
         }
 
@@ -550,7 +551,7 @@ public:
         }
 
         // if the primary variable is either the gas saturation, Rs or Rv
-        assert(int(Indices::compositionSwitchIdx) == int(pvIdx));
+        assert(Indices::compositionSwitchIdx == pvIdx);
 
         switch (this->solution(0)[globalDofIdx].primaryVarsMeaningGas()) {
         case PrimaryVariables::GasMeaning::Sg: return 1.0; // gas saturation

--- a/opm/models/blackoil/blackoilmodel.hh
+++ b/opm/models/blackoil/blackoilmodel.hh
@@ -427,7 +427,7 @@ public:
         if (pvIdx == static_cast<int>(Indices::waterSwitchIdx)) {
             return "water_switching";
         }
-        else if (pvIdx == Indices::pressureSwitchIdx) {
+        else if (pvIdx == static_cast<int>(Indices::pressureSwitchIdx)) {
             return "pressure_switching";
         }
         else if (static_cast<int>(pvIdx) == Indices::compositionSwitchIdx) {

--- a/opm/models/blackoil/blackoilnewtonmethod.hpp
+++ b/opm/models/blackoil/blackoilnewtonmethod.hpp
@@ -267,7 +267,7 @@ protected:
             satAlpha = bparams_.dsMax_ / maxSatDelta;
         }
 
-        for (int pvIdx = 0; pvIdx < int(numEq); ++pvIdx) {
+        for (unsigned pvIdx = 0; pvIdx < numEq; ++pvIdx) {
             // calculate the update of the current primary variable. For the black-oil
             // model we limit the pressure delta relative to the pressure's current
             // absolute value (Default: 30%) and saturation deltas to an absolute change
@@ -283,7 +283,7 @@ protected:
                 }
             }
             // water saturation delta
-            else if (pvIdx == static_cast<int>(Indices::waterSwitchIdx))
+            else if (pvIdx == Indices::waterSwitchIdx)
                 if (currentValue.primaryVarsMeaningWater() == PrimaryVariables::WaterMeaning::Sw) {
                     delta *= satAlpha;
                 }
@@ -293,7 +293,7 @@ protected:
                         delta = currentValue[ Indices::waterSwitchIdx];
                     }
                 }
-            else if (pvIdx == static_cast<int>(Indices::compositionSwitchIdx)) {
+            else if (pvIdx == Indices::compositionSwitchIdx) {
                 // the switching primary variable for composition is tricky because the
                 // "reasonable" value ranges it exhibits vary widely depending on its
                 // interpretation since it can represent Sg, Rs or Rv. For now, we only
@@ -309,7 +309,7 @@ protected:
                     }
                 }
             }
-            else if (enableSolvent && pvIdx == static_cast<int>(Indices::solventSaturationIdx)) {
+            else if (enableSolvent && pvIdx == Indices::solventSaturationIdx) {
                 // solvent saturation updates are also subject to the Appleyard chop
                 if (currentValue.primaryVarsMeaningSolvent() == PrimaryVariables::SolventMeaning::Ss) {
                     delta *= satAlpha;
@@ -321,12 +321,12 @@ protected:
                     }
                 }
             }
-            else if (enableExtbo && pvIdx == static_cast<int>(Indices::zFractionIdx)) {
+            else if (enableExtbo && pvIdx == Indices::zFractionIdx) {
                 // z fraction updates are also subject to the Appleyard chop
                 const auto& curr = currentValue[Indices::zFractionIdx]; // or currentValue[pvIdx] given the block condition
                 delta = std::clamp(delta, curr - Scalar{1.0}, curr);
             }
-            else if (enablePolymerWeight && pvIdx == static_cast<int>(Indices::polymerMoleWeightIdx)) {
+            else if (enablePolymerWeight && pvIdx == Indices::polymerMoleWeightIdx) {
                 const double sign = delta >= 0. ? 1. : -1.;
                 // maximum change of polymer molecular weight, the unit is MDa.
                 // applying this limit to stabilize the simulation. The value itself is still experimental.
@@ -334,11 +334,11 @@ protected:
                 delta = sign * std::min(std::abs(delta), maxMolarWeightChange);
                 delta *= satAlpha;
             }
-            else if (enableFullyImplicitThermal && pvIdx == static_cast<int>(Indices::temperatureIdx)) {
+            else if (enableFullyImplicitThermal && pvIdx == Indices::temperatureIdx) {
                 const double sign = delta >= 0. ? 1. : -1.;
                 delta = sign * std::min(std::abs(delta), bparams_.maxTempChange_);
             }
-            else if (enableBrine && pvIdx == static_cast<int>(Indices::saltConcentrationIdx) &&
+            else if (enableBrine && pvIdx == Indices::saltConcentrationIdx &&
                      enableSaltPrecipitation &&
                      currentValue.primaryVarsMeaningBrine() == PrimaryVariables::BrineMeaning::Sp)
             {
@@ -351,23 +351,23 @@ protected:
             nextValue[pvIdx] = currentValue[pvIdx] - delta;
 
             // keep the solvent saturation between 0 and 1
-            if (enableSolvent && pvIdx == static_cast<int>(Indices::solventSaturationIdx)) {
+            if (enableSolvent && pvIdx == Indices::solventSaturationIdx) {
                 if (currentValue.primaryVarsMeaningSolvent() == PrimaryVariables::SolventMeaning::Ss) {
                     nextValue[pvIdx] = std::min(std::max(nextValue[pvIdx], Scalar{0.0}), Scalar{1.0});
                 }
             }
 
             // keep the z fraction between 0 and 1
-            if (enableExtbo && pvIdx == static_cast<int>(Indices::zFractionIdx)) {
+            if (enableExtbo && pvIdx == Indices::zFractionIdx) {
                 nextValue[pvIdx] = std::min(std::max(nextValue[pvIdx], Scalar{0.0}), Scalar{1.0});
             }
 
             // keep the polymer concentration above 0
-            if (enablePolymer && pvIdx == static_cast<int>(Indices::polymerConcentrationIdx)) {
+            if (enablePolymer && pvIdx == Indices::polymerConcentrationIdx) {
                 nextValue[pvIdx] = std::max(nextValue[pvIdx], Scalar{0.0});
             }
 
-            if (enablePolymerWeight && pvIdx == static_cast<int>(Indices::polymerMoleWeightIdx)) {
+            if (enablePolymerWeight && pvIdx == Indices::polymerMoleWeightIdx) {
                 nextValue[pvIdx] = std::max(nextValue[pvIdx], Scalar{0.0});
                 const double polymerConcentration = nextValue[Indices::polymerConcentrationIdx];
                 if (polymerConcentration < 1.e-10) {
@@ -376,11 +376,11 @@ protected:
             }
 
             // keep the foam concentration above 0
-            if (enableFoam && pvIdx == static_cast<int>(Indices::foamConcentrationIdx)) {
+            if (enableFoam && pvIdx == Indices::foamConcentrationIdx) {
                 nextValue[pvIdx] = std::max(nextValue[pvIdx], Scalar{0.0});
             }
 
-            if (enableBrine && pvIdx == static_cast<int>(Indices::saltConcentrationIdx)) {
+            if (enableBrine && pvIdx == Indices::saltConcentrationIdx) {
                // keep the salt concentration above 0
                 if (!enableSaltPrecipitation ||
                     currentValue.primaryVarsMeaningBrine() == PrimaryVariables::BrineMeaning::Cs)
@@ -396,7 +396,7 @@ protected:
             }
 
             // keep the temperature within given values
-            if (enableFullyImplicitThermal && pvIdx == static_cast<int>(Indices::temperatureIdx)) {
+            if (enableFullyImplicitThermal && pvIdx == Indices::temperatureIdx) {
                 nextValue[pvIdx] = std::clamp(nextValue[pvIdx], bparams_.tempMin_, bparams_.tempMax_);
             }
 
@@ -410,22 +410,22 @@ protected:
             // evaluated at 1/(iniPoro - calcite)). The value 1e-8 is taken from the salt precipitation
             // clapping above.
             if constexpr (enableBioeffects) {
-                if (pvIdx == static_cast<int>(Indices::microbialConcentrationIdx)) {
+                if (pvIdx == Indices::microbialConcentrationIdx) {
                     nextValue[pvIdx] = std::max(nextValue[pvIdx], Scalar{0.0});
                 }
-                if (pvIdx == static_cast<int>(Indices::biofilmVolumeFractionIdx)) {
+                if (pvIdx == Indices::biofilmVolumeFractionIdx) {
                     nextValue[pvIdx] = std::clamp(nextValue[pvIdx],
                                                   Scalar{0.0},
                                                   this->problem().referencePorosity(globalDofIdx, 0) - 1e-8);
                 }
                 if constexpr (enableMICP) {
-                    if (pvIdx == static_cast<int>(Indices::oxygenConcentrationIdx)) {
+                    if (pvIdx == Indices::oxygenConcentrationIdx) {
                         nextValue[pvIdx] = std::max(nextValue[pvIdx], Scalar{0.0});
                     }
-                    if (pvIdx == static_cast<int>(Indices::ureaConcentrationIdx)) {
+                    if (pvIdx == Indices::ureaConcentrationIdx) {
                         nextValue[pvIdx] = std::max(nextValue[pvIdx], Scalar{0.0});
                     }
-                    if (pvIdx == static_cast<int>(Indices::calciteVolumeFractionIdx)) {
+                    if (pvIdx == Indices::calciteVolumeFractionIdx) {
                         nextValue[pvIdx] = std::clamp(nextValue[pvIdx], Scalar{0.0},
                                                                         this->problem().referencePorosity(globalDofIdx, 0) - 1e-8);
                     }

--- a/opm/models/blackoil/blackoilnewtonmethod.hpp
+++ b/opm/models/blackoil/blackoilnewtonmethod.hpp
@@ -217,7 +217,8 @@ protected:
         static constexpr bool enablePolymerWeight =
             Indices::polymerMoleWeightIdx != std::numeric_limits<unsigned>::max();
         static constexpr bool enableFullyImplicitThermal = Indices::temperatureIdx >= 0;
-        static constexpr bool enableFoam = Indices::foamConcentrationIdx >= 0;
+        static constexpr bool enableFoam =
+            Indices::foamConcentrationIdx != std::numeric_limits<unsigned>::max();
         static constexpr bool enableBrine = Indices::saltConcentrationIdx >= 0;
         static constexpr bool enableMICP = Indices::enableMICP;
 
@@ -373,7 +374,7 @@ protected:
             }
 
             // keep the foam concentration above 0
-            if (enableFoam && pvIdx == Indices::foamConcentrationIdx) {
+            if (enableFoam && pvIdx == static_cast<int>(Indices::foamConcentrationIdx)) {
                 nextValue[pvIdx] = std::max(nextValue[pvIdx], Scalar{0.0});
             }
 

--- a/opm/models/blackoil/blackoilnewtonmethod.hpp
+++ b/opm/models/blackoil/blackoilnewtonmethod.hpp
@@ -219,7 +219,8 @@ protected:
         static constexpr bool enableFullyImplicitThermal = Indices::temperatureIdx >= 0;
         static constexpr bool enableFoam =
             Indices::foamConcentrationIdx != std::numeric_limits<unsigned>::max();
-        static constexpr bool enableBrine = Indices::saltConcentrationIdx >= 0;
+        static constexpr bool enableBrine =
+            Indices::saltConcentrationIdx != std::numeric_limits<unsigned>::max();
         static constexpr bool enableMICP = Indices::enableMICP;
 
         currentValue.checkDefined();
@@ -336,7 +337,7 @@ protected:
                 const double sign = delta >= 0. ? 1. : -1.;
                 delta = sign * std::min(std::abs(delta), bparams_.maxTempChange_);
             }
-            else if (enableBrine && pvIdx == Indices::saltConcentrationIdx &&
+            else if (enableBrine && pvIdx == static_cast<int>(Indices::saltConcentrationIdx) &&
                      enableSaltPrecipitation &&
                      currentValue.primaryVarsMeaningBrine() == PrimaryVariables::BrineMeaning::Sp)
             {
@@ -378,7 +379,7 @@ protected:
                 nextValue[pvIdx] = std::max(nextValue[pvIdx], Scalar{0.0});
             }
 
-            if (enableBrine && pvIdx == Indices::saltConcentrationIdx) {
+            if (enableBrine && pvIdx == static_cast<int>(Indices::saltConcentrationIdx)) {
                // keep the salt concentration above 0
                 if (!enableSaltPrecipitation ||
                     currentValue.primaryVarsMeaningBrine() == PrimaryVariables::BrineMeaning::Cs)

--- a/opm/models/blackoil/blackoilnewtonmethod.hpp
+++ b/opm/models/blackoil/blackoilnewtonmethod.hpp
@@ -416,7 +416,7 @@ protected:
                                                   this->problem().referencePorosity(globalDofIdx, 0) - 1e-8);
                 }
                 if constexpr (enableMICP) {
-                    if (pvIdx == Indices::oxygenConcentrationIdx) {
+                    if (pvIdx == static_cast<int>(Indices::oxygenConcentrationIdx)) {
                         nextValue[pvIdx] = std::max(nextValue[pvIdx], Scalar{0.0});
                     }
                     if (pvIdx == Indices::ureaConcentrationIdx) {

--- a/opm/models/blackoil/blackoilnewtonmethod.hpp
+++ b/opm/models/blackoil/blackoilnewtonmethod.hpp
@@ -419,7 +419,7 @@ protected:
                     if (pvIdx == static_cast<int>(Indices::oxygenConcentrationIdx)) {
                         nextValue[pvIdx] = std::max(nextValue[pvIdx], Scalar{0.0});
                     }
-                    if (pvIdx == Indices::ureaConcentrationIdx) {
+                    if (pvIdx == static_cast<int>(Indices::ureaConcentrationIdx)) {
                         nextValue[pvIdx] = std::max(nextValue[pvIdx], Scalar{0.0});
                     }
                     if (pvIdx == Indices::calciteVolumeFractionIdx) {

--- a/opm/models/blackoil/blackoilnewtonmethod.hpp
+++ b/opm/models/blackoil/blackoilnewtonmethod.hpp
@@ -228,8 +228,10 @@ protected:
 
         if (currentValue.primaryVarsMeaningWater() == PrimaryVariables::WaterMeaning::Sw)
         {
-            deltaSw = update[Indices::waterSwitchIdx];
-            deltaSo -= deltaSw;
+            if constexpr (Indices::waterSwitchIdx != std::numeric_limits<unsigned>::max()) {
+                deltaSw = update[Indices::waterSwitchIdx];
+                deltaSo -= deltaSw;
+            }
         }
         if (currentValue.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Sg)
         {
@@ -269,7 +271,7 @@ protected:
                 }
             }
             // water saturation delta
-            else if (pvIdx == Indices::waterSwitchIdx)
+            else if (pvIdx == static_cast<int>(Indices::waterSwitchIdx))
                 if (currentValue.primaryVarsMeaningWater() == PrimaryVariables::WaterMeaning::Sw) {
                     delta *= satAlpha;
                 }

--- a/opm/models/blackoil/blackoilnewtonmethod.hpp
+++ b/opm/models/blackoil/blackoilnewtonmethod.hpp
@@ -214,7 +214,8 @@ protected:
             Indices::zFractionIdx != std::numeric_limits<unsigned>::max();
         static constexpr bool enablePolymer =
             Indices::polymerConcentrationIdx != std::numeric_limits<unsigned>::max();
-        static constexpr bool enablePolymerWeight = Indices::polymerMoleWeightIdx >= 0;
+        static constexpr bool enablePolymerWeight =
+            Indices::polymerMoleWeightIdx != std::numeric_limits<unsigned>::max();
         static constexpr bool enableFullyImplicitThermal = Indices::temperatureIdx >= 0;
         static constexpr bool enableFoam = Indices::foamConcentrationIdx >= 0;
         static constexpr bool enableBrine = Indices::saltConcentrationIdx >= 0;
@@ -322,7 +323,7 @@ protected:
                 const auto& curr = currentValue[Indices::zFractionIdx]; // or currentValue[pvIdx] given the block condition
                 delta = std::clamp(delta, curr - Scalar{1.0}, curr);
             }
-            else if (enablePolymerWeight && pvIdx == Indices::polymerMoleWeightIdx) {
+            else if (enablePolymerWeight && pvIdx == static_cast<int>(Indices::polymerMoleWeightIdx)) {
                 const double sign = delta >= 0. ? 1. : -1.;
                 // maximum change of polymer molecular weight, the unit is MDa.
                 // applying this limit to stabilize the simulation. The value itself is still experimental.
@@ -363,7 +364,7 @@ protected:
                 nextValue[pvIdx] = std::max(nextValue[pvIdx], Scalar{0.0});
             }
 
-            if (enablePolymerWeight && pvIdx == Indices::polymerMoleWeightIdx) {
+            if (enablePolymerWeight && pvIdx == static_cast<int>(Indices::polymerMoleWeightIdx)) {
                 nextValue[pvIdx] = std::max(nextValue[pvIdx], Scalar{0.0});
                 const double polymerConcentration = nextValue[Indices::polymerConcentrationIdx];
                 if (polymerConcentration < 1.e-10) {

--- a/opm/models/blackoil/blackoilnewtonmethod.hpp
+++ b/opm/models/blackoil/blackoilnewtonmethod.hpp
@@ -216,7 +216,8 @@ protected:
             Indices::polymerConcentrationIdx != std::numeric_limits<unsigned>::max();
         static constexpr bool enablePolymerWeight =
             Indices::polymerMoleWeightIdx != std::numeric_limits<unsigned>::max();
-        static constexpr bool enableFullyImplicitThermal = Indices::temperatureIdx >= 0;
+        static constexpr bool enableFullyImplicitThermal =
+            Indices::temperatureIdx != std::numeric_limits<unsigned>::max();
         static constexpr bool enableFoam =
             Indices::foamConcentrationIdx != std::numeric_limits<unsigned>::max();
         static constexpr bool enableBrine =
@@ -333,7 +334,7 @@ protected:
                 delta = sign * std::min(std::abs(delta), maxMolarWeightChange);
                 delta *= satAlpha;
             }
-            else if (enableFullyImplicitThermal && pvIdx == Indices::temperatureIdx) {
+            else if (enableFullyImplicitThermal && pvIdx == static_cast<int>(Indices::temperatureIdx)) {
                 const double sign = delta >= 0. ? 1. : -1.;
                 delta = sign * std::min(std::abs(delta), bparams_.maxTempChange_);
             }
@@ -395,7 +396,7 @@ protected:
             }
 
             // keep the temperature within given values
-            if (enableFullyImplicitThermal && pvIdx == Indices::temperatureIdx) {
+            if (enableFullyImplicitThermal && pvIdx == static_cast<int>(Indices::temperatureIdx)) {
                 nextValue[pvIdx] = std::clamp(nextValue[pvIdx], bparams_.tempMin_, bparams_.tempMax_);
             }
 

--- a/opm/models/blackoil/blackoilnewtonmethod.hpp
+++ b/opm/models/blackoil/blackoilnewtonmethod.hpp
@@ -410,7 +410,7 @@ protected:
                 if (pvIdx == static_cast<int>(Indices::microbialConcentrationIdx)) {
                     nextValue[pvIdx] = std::max(nextValue[pvIdx], Scalar{0.0});
                 }
-                if (pvIdx == Indices::biofilmVolumeFractionIdx) {
+                if (pvIdx == static_cast<int>(Indices::biofilmVolumeFractionIdx)) {
                     nextValue[pvIdx] = std::clamp(nextValue[pvIdx],
                                                   Scalar{0.0},
                                                   this->problem().referencePorosity(globalDofIdx, 0) - 1e-8);

--- a/opm/models/blackoil/blackoilnewtonmethod.hpp
+++ b/opm/models/blackoil/blackoilnewtonmethod.hpp
@@ -407,7 +407,7 @@ protected:
             // evaluated at 1/(iniPoro - calcite)). The value 1e-8 is taken from the salt precipitation
             // clapping above.
             if constexpr (enableBioeffects) {
-                if (pvIdx == Indices::microbialConcentrationIdx) {
+                if (pvIdx == static_cast<int>(Indices::microbialConcentrationIdx)) {
                     nextValue[pvIdx] = std::max(nextValue[pvIdx], Scalar{0.0});
                 }
                 if (pvIdx == Indices::biofilmVolumeFractionIdx) {

--- a/opm/models/blackoil/blackoilnewtonmethod.hpp
+++ b/opm/models/blackoil/blackoilnewtonmethod.hpp
@@ -235,8 +235,10 @@ protected:
         }
         if (currentValue.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Sg)
         {
-            deltaSg = update[Indices::compositionSwitchIdx];
-            deltaSo -= deltaSg;
+            if constexpr (Indices::compositionSwitchIdx != std::numeric_limits<unsigned>::max()) {
+                deltaSg = update[Indices::compositionSwitchIdx];
+                deltaSo -= deltaSg;
+            }
         }
         if (currentValue.primaryVarsMeaningSolvent() == PrimaryVariables::SolventMeaning::Ss) {
             deltaSs = update[Indices::solventSaturationIdx];
@@ -281,7 +283,7 @@ protected:
                         delta = currentValue[ Indices::waterSwitchIdx];
                     }
                 }
-            else if (pvIdx == Indices::compositionSwitchIdx) {
+            else if (pvIdx == static_cast<int>(Indices::compositionSwitchIdx)) {
                 // the switching primary variable for composition is tricky because the
                 // "reasonable" value ranges it exhibits vary widely depending on its
                 // interpretation since it can represent Sg, Rs or Rv. For now, we only

--- a/opm/models/blackoil/blackoilnewtonmethod.hpp
+++ b/opm/models/blackoil/blackoilnewtonmethod.hpp
@@ -422,7 +422,7 @@ protected:
                     if (pvIdx == static_cast<int>(Indices::ureaConcentrationIdx)) {
                         nextValue[pvIdx] = std::max(nextValue[pvIdx], Scalar{0.0});
                     }
-                    if (pvIdx == Indices::calciteVolumeFractionIdx) {
+                    if (pvIdx == static_cast<int>(Indices::calciteVolumeFractionIdx)) {
                         nextValue[pvIdx] = std::clamp(nextValue[pvIdx], Scalar{0.0},
                                                                         this->problem().referencePorosity(globalDofIdx, 0) - 1e-8);
                     }

--- a/opm/models/blackoil/blackoilnewtonmethod.hpp
+++ b/opm/models/blackoil/blackoilnewtonmethod.hpp
@@ -212,7 +212,8 @@ protected:
             Indices::solventSaturationIdx != std::numeric_limits<unsigned>::max();
         static constexpr bool enableExtbo =
             Indices::zFractionIdx != std::numeric_limits<unsigned>::max();
-        static constexpr bool enablePolymer = Indices::polymerConcentrationIdx >= 0;
+        static constexpr bool enablePolymer =
+            Indices::polymerConcentrationIdx != std::numeric_limits<unsigned>::max();
         static constexpr bool enablePolymerWeight = Indices::polymerMoleWeightIdx >= 0;
         static constexpr bool enableFullyImplicitThermal = Indices::temperatureIdx >= 0;
         static constexpr bool enableFoam = Indices::foamConcentrationIdx >= 0;
@@ -358,7 +359,7 @@ protected:
             }
 
             // keep the polymer concentration above 0
-            if (enablePolymer && pvIdx == Indices::polymerConcentrationIdx) {
+            if (enablePolymer && pvIdx == static_cast<int>(Indices::polymerConcentrationIdx)) {
                 nextValue[pvIdx] = std::max(nextValue[pvIdx], Scalar{0.0});
             }
 

--- a/opm/models/blackoil/blackoilnewtonmethod.hpp
+++ b/opm/models/blackoil/blackoilnewtonmethod.hpp
@@ -42,6 +42,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <vector>
 
 namespace Opm::Properties {
@@ -209,7 +210,8 @@ protected:
     {
         static constexpr bool enableSolvent =
             Indices::solventSaturationIdx != std::numeric_limits<unsigned>::max();
-        static constexpr bool enableExtbo = Indices::zFractionIdx >= 0;
+        static constexpr bool enableExtbo =
+            Indices::zFractionIdx != std::numeric_limits<unsigned>::max();
         static constexpr bool enablePolymer = Indices::polymerConcentrationIdx >= 0;
         static constexpr bool enablePolymerWeight = Indices::polymerMoleWeightIdx >= 0;
         static constexpr bool enableFullyImplicitThermal = Indices::temperatureIdx >= 0;
@@ -314,7 +316,7 @@ protected:
                     }
                 }
             }
-            else if (enableExtbo && pvIdx == Indices::zFractionIdx) {
+            else if (enableExtbo && pvIdx == static_cast<int>(Indices::zFractionIdx)) {
                 // z fraction updates are also subject to the Appleyard chop
                 const auto& curr = currentValue[Indices::zFractionIdx]; // or currentValue[pvIdx] given the block condition
                 delta = std::clamp(delta, curr - Scalar{1.0}, curr);
@@ -351,7 +353,7 @@ protected:
             }
 
             // keep the z fraction between 0 and 1
-            if (enableExtbo && pvIdx == Indices::zFractionIdx) {
+            if (enableExtbo && pvIdx == static_cast<int>(Indices::zFractionIdx)) {
                 nextValue[pvIdx] = std::min(std::max(nextValue[pvIdx], Scalar{0.0}), Scalar{1.0});
             }
 

--- a/opm/models/blackoil/blackoilnewtonmethod.hpp
+++ b/opm/models/blackoil/blackoilnewtonmethod.hpp
@@ -207,7 +207,8 @@ protected:
                                  const EqVector& update,
                                  const EqVector& currentResidual)
     {
-        static constexpr bool enableSolvent = Indices::solventSaturationIdx >= 0;
+        static constexpr bool enableSolvent =
+            Indices::solventSaturationIdx != std::numeric_limits<unsigned>::max();
         static constexpr bool enableExtbo = Indices::zFractionIdx >= 0;
         static constexpr bool enablePolymer = Indices::polymerConcentrationIdx >= 0;
         static constexpr bool enablePolymerWeight = Indices::polymerMoleWeightIdx >= 0;
@@ -241,8 +242,10 @@ protected:
             }
         }
         if (currentValue.primaryVarsMeaningSolvent() == PrimaryVariables::SolventMeaning::Ss) {
-            deltaSs = update[Indices::solventSaturationIdx];
-            deltaSo -= deltaSs;
+            if constexpr (Indices::solventSaturationIdx != std::numeric_limits<unsigned>::max()) {
+                deltaSs = update[Indices::solventSaturationIdx];
+                deltaSo -= deltaSs;
+            }
         }
 
         // maximum saturation delta
@@ -299,7 +302,7 @@ protected:
                     }
                 }
             }
-            else if (enableSolvent && pvIdx == Indices::solventSaturationIdx) {
+            else if (enableSolvent && pvIdx == static_cast<int>(Indices::solventSaturationIdx)) {
                 // solvent saturation updates are also subject to the Appleyard chop
                 if (currentValue.primaryVarsMeaningSolvent() == PrimaryVariables::SolventMeaning::Ss) {
                     delta *= satAlpha;
@@ -341,7 +344,7 @@ protected:
             nextValue[pvIdx] = currentValue[pvIdx] - delta;
 
             // keep the solvent saturation between 0 and 1
-            if (enableSolvent && pvIdx == Indices::solventSaturationIdx) {
+            if (enableSolvent && pvIdx == static_cast<int>(Indices::solventSaturationIdx)) {
                 if (currentValue.primaryVarsMeaningSolvent() == PrimaryVariables::SolventMeaning::Ss) {
                     nextValue[pvIdx] = std::min(std::max(nextValue[pvIdx], Scalar{0.0}), Scalar{1.0});
                 }

--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -139,8 +139,9 @@ struct BlackOilOnePhaseIndices
     static constexpr unsigned compositionSwitchIdx = std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the first solvent
-    static constexpr int solventSaturationIdx =
-        enableSolvent ? PVOffset + numPhases : -1000;
+    static constexpr unsigned solventSaturationIdx =
+        enableSolvent ? PVOffset + numPhases
+                      : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the first extbo component
     static constexpr int zFractionIdx =

--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -164,8 +164,9 @@ struct BlackOilOnePhaseIndices
                    : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the second MICP component
-    static constexpr int oxygenConcentrationIdx =
-        numMICPs > 1 ? microbialConcentrationIdx + 1 : -1000;
+    static constexpr unsigned oxygenConcentrationIdx =
+        numMICPs > 1 ? microbialConcentrationIdx + 1
+                     : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the third MICP component
     static constexpr int ureaConcentrationIdx =

--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -136,7 +136,7 @@ struct BlackOilOnePhaseIndices
      *
      * \note For one-phase models this is disabled.
      */
-    static constexpr int compositionSwitchIdx = -10000;
+    static constexpr unsigned compositionSwitchIdx = std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the first solvent
     static constexpr int solventSaturationIdx =

--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -29,6 +29,7 @@
 #define EWOMS_BLACK_OIL_ONE_PHASE_INDICES_HH
 
 #include <cassert>
+#include <limits>
 
 #include <opm/common/utility/ConstexprAssert.hpp>
 
@@ -119,7 +120,7 @@ struct BlackOilOnePhaseIndices
      *
      * \note For one-phase models this is disabled.
      */
-    static constexpr int waterSwitchIdx  = -10000;
+    static constexpr unsigned waterSwitchIdx = std::numeric_limits<unsigned>::max();
 
     /*!
      * \brief Index of the switching variable which determines the pressure

--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -149,8 +149,9 @@ struct BlackOilOnePhaseIndices
                     : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the first polymer
-    static constexpr int polymerConcentrationIdx =
-        enablePolymer ? PVOffset + numPhases + numSolvents : -1000;
+    static constexpr unsigned polymerConcentrationIdx =
+        enablePolymer ? PVOffset + numPhases + numSolvents
+                      : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the second polymer primary variable (molecular weight)
     static constexpr int polymerMoleWeightIdx =

--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -194,8 +194,10 @@ struct BlackOilOnePhaseIndices
                     : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for temperature
-    static constexpr int temperatureIdx  =
-        (enableFullyImplicitThermal) ? PVOffset + numPhases + numSolvents + numExtbos + numPolymers + numMICPs + numFoam + numBrine : - 1000;
+    static constexpr unsigned temperatureIdx  =
+        enableFullyImplicitThermal ? PVOffset + numPhases + numSolvents + numExtbos +
+                                     numPolymers + numMICPs + numFoam + numBrine
+                                   : std::numeric_limits<unsigned>::max();
 
     //////////////////////
     // Equation indices

--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -144,8 +144,9 @@ struct BlackOilOnePhaseIndices
                       : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the first extbo component
-    static constexpr int zFractionIdx =
-        enableExtbo ? PVOffset + numPhases + numSolvents : -1000;
+    static constexpr unsigned zFractionIdx =
+        enableExtbo ? PVOffset + numPhases + numSolvents
+                    : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the first polymer
     static constexpr int polymerConcentrationIdx =

--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -159,8 +159,9 @@ struct BlackOilOnePhaseIndices
                         : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the first MICP component
-    static constexpr int microbialConcentrationIdx =
-        enableMICP ? PVOffset + numPhases + numSolvents : -1000;
+    static constexpr unsigned microbialConcentrationIdx =
+        enableMICP ? PVOffset + numPhases + numSolvents
+                   : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the second MICP component
     static constexpr int oxygenConcentrationIdx =

--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -154,8 +154,9 @@ struct BlackOilOnePhaseIndices
                       : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the second polymer primary variable (molecular weight)
-    static constexpr int polymerMoleWeightIdx =
-        numPolymers > 1 ? polymerConcentrationIdx + 1 : -1000;
+    static constexpr unsigned polymerMoleWeightIdx =
+        numPolymers > 1 ? polymerConcentrationIdx + 1
+                        : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the first MICP component
     static constexpr int microbialConcentrationIdx =

--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -174,8 +174,9 @@ struct BlackOilOnePhaseIndices
                      : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the fourth MICP component
-    static constexpr int biofilmVolumeFractionIdx =
-        numMICPs > 3 ? ureaConcentrationIdx + 1 : -1000;
+    static constexpr unsigned biofilmVolumeFractionIdx =
+        numMICPs > 3 ? ureaConcentrationIdx + 1
+                     : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the fifth MICP component
     static constexpr int calciteVolumeFractionIdx =

--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -169,8 +169,9 @@ struct BlackOilOnePhaseIndices
                      : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the third MICP component
-    static constexpr int ureaConcentrationIdx =
-        numMICPs > 2 ? oxygenConcentrationIdx + 1 : -1000;
+    static constexpr unsigned ureaConcentrationIdx =
+        numMICPs > 2 ? oxygenConcentrationIdx + 1
+                     : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the fourth MICP component
     static constexpr int biofilmVolumeFractionIdx =

--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -128,7 +128,7 @@ struct BlackOilOnePhaseIndices
      * Depending on the phases present, this variable is either interpreted as the
      * pressure of the oil phase, gas phase (if no oil) or water phase (if only water)
      */
-     static constexpr int pressureSwitchIdx  = PVOffset + 0;
+    static constexpr unsigned pressureSwitchIdx = PVOffset + 0;
 
     /*!
      * \brief Index of the switching variable which determines the composition of the

--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -179,8 +179,9 @@ struct BlackOilOnePhaseIndices
                      : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the fifth MICP component
-    static constexpr int calciteVolumeFractionIdx =
-        numMICPs > 4 ? biofilmVolumeFractionIdx + 1 : -1000;
+    static constexpr unsigned calciteVolumeFractionIdx =
+        numMICPs > 4 ? biofilmVolumeFractionIdx + 1
+                     : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the foam
     static constexpr int foamConcentrationIdx =

--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -189,8 +189,9 @@ struct BlackOilOnePhaseIndices
                    : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the salt
-    static constexpr int saltConcentrationIdx =
-        enableBrine ? PVOffset + numPhases + numSolvents + numExtbos + numPolymers + numMICPs + numFoam : -1000;
+    static constexpr unsigned saltConcentrationIdx =
+        enableBrine ? PVOffset + numPhases + numSolvents + numExtbos + numPolymers + numMICPs + numFoam
+                    : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for temperature
     static constexpr int temperatureIdx  =

--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -184,8 +184,9 @@ struct BlackOilOnePhaseIndices
                      : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the foam
-    static constexpr int foamConcentrationIdx =
-        enableFoam ? PVOffset + numPhases + numSolvents + numPolymers + numMICPs : -1000;
+    static constexpr unsigned foamConcentrationIdx =
+        enableFoam ? PVOffset + numPhases + numSolvents + numPolymers + numMICPs
+                   : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the salt
     static constexpr int saltConcentrationIdx =

--- a/opm/models/blackoil/blackoilpolymermodules.hh
+++ b/opm/models/blackoil/blackoilpolymermodules.hh
@@ -568,7 +568,7 @@ class BlackOilPolymerIntensiveQuantities<TypeTag, /*enablePolymerV=*/true>
     static constexpr unsigned polymerConcentrationIdx = Indices::polymerConcentrationIdx;
     static constexpr int waterPhaseIdx = FluidSystem::waterPhaseIdx;
     static constexpr bool enablePolymerMolarWeight = getPropValue<TypeTag, Properties::EnablePolymerMW>();
-    static constexpr int polymerMoleWeightIdx = Indices::polymerMoleWeightIdx;
+    static constexpr unsigned polymerMoleWeightIdx = Indices::polymerMoleWeightIdx;
 
 public:
     /*!

--- a/opm/models/blackoil/blackoilpolymermodules.hh
+++ b/opm/models/blackoil/blackoilpolymermodules.hh
@@ -565,7 +565,7 @@ class BlackOilPolymerIntensiveQuantities<TypeTag, /*enablePolymerV=*/true>
 
     using PolymerModule = BlackOilPolymerModule<TypeTag, true>;
 
-    static constexpr int polymerConcentrationIdx = Indices::polymerConcentrationIdx;
+    static constexpr unsigned polymerConcentrationIdx = Indices::polymerConcentrationIdx;
     static constexpr int waterPhaseIdx = FluidSystem::waterPhaseIdx;
     static constexpr bool enablePolymerMolarWeight = getPropValue<TypeTag, Properties::EnablePolymerMW>();
     static constexpr int polymerMoleWeightIdx = Indices::polymerMoleWeightIdx;

--- a/opm/models/blackoil/blackoilprimaryvariables.hh
+++ b/opm/models/blackoil/blackoilprimaryvariables.hh
@@ -83,7 +83,7 @@ class BlackOilPrimaryVariables : public FvBasePrimaryVariables<TypeTag, VectorTy
 
     // primary variable indices
     static constexpr unsigned waterSwitchIdx = Indices::waterSwitchIdx;
-    enum { pressureSwitchIdx = Indices::pressureSwitchIdx };
+    static constexpr unsigned pressureSwitchIdx = Indices::pressureSwitchIdx;
     enum { compositionSwitchIdx = Indices::compositionSwitchIdx };
     enum { saltConcentrationIdx  = Indices::saltConcentrationIdx };
     enum { solventSaturationIdx  = Indices::solventSaturationIdx };

--- a/opm/models/blackoil/blackoilprimaryvariables.hh
+++ b/opm/models/blackoil/blackoilprimaryvariables.hh
@@ -82,7 +82,7 @@ class BlackOilPrimaryVariables : public FvBasePrimaryVariables<TypeTag, VectorTy
     enum { numEq = getPropValue<TypeTag, Properties::NumEq>() };
 
     // primary variable indices
-    enum { waterSwitchIdx = Indices::waterSwitchIdx };
+    static constexpr unsigned waterSwitchIdx = Indices::waterSwitchIdx;
     enum { pressureSwitchIdx = Indices::pressureSwitchIdx };
     enum { compositionSwitchIdx = Indices::compositionSwitchIdx };
     enum { saltConcentrationIdx  = Indices::saltConcentrationIdx };

--- a/opm/models/blackoil/blackoilprimaryvariables.hh
+++ b/opm/models/blackoil/blackoilprimaryvariables.hh
@@ -44,6 +44,7 @@
 #include <array>
 #include <cassert>
 #include <cstddef>
+#include <limits>
 #include <stdexcept>
 #include <type_traits>
 
@@ -84,11 +85,12 @@ class BlackOilPrimaryVariables : public FvBasePrimaryVariables<TypeTag, VectorTy
     // primary variable indices
     static constexpr unsigned waterSwitchIdx = Indices::waterSwitchIdx;
     static constexpr unsigned pressureSwitchIdx = Indices::pressureSwitchIdx;
-    enum { compositionSwitchIdx = Indices::compositionSwitchIdx };
+    static constexpr unsigned compositionSwitchIdx = Indices::compositionSwitchIdx;
     enum { saltConcentrationIdx  = Indices::saltConcentrationIdx };
     enum { solventSaturationIdx  = Indices::solventSaturationIdx };
 
-    static constexpr bool compositionSwitchEnabled = Indices::compositionSwitchIdx >= 0;
+    static constexpr bool compositionSwitchEnabled =
+        Indices::compositionSwitchIdx != std::numeric_limits<unsigned>::max();
     static constexpr bool waterEnabled = Indices::waterEnabled;
     static constexpr bool gasEnabled = Indices::gasEnabled;
     static constexpr bool oilEnabled = Indices::oilEnabled;

--- a/opm/models/blackoil/blackoilprimaryvariables.hh
+++ b/opm/models/blackoil/blackoilprimaryvariables.hh
@@ -86,7 +86,7 @@ class BlackOilPrimaryVariables : public FvBasePrimaryVariables<TypeTag, VectorTy
     static constexpr unsigned waterSwitchIdx = Indices::waterSwitchIdx;
     static constexpr unsigned pressureSwitchIdx = Indices::pressureSwitchIdx;
     static constexpr unsigned compositionSwitchIdx = Indices::compositionSwitchIdx;
-    enum { saltConcentrationIdx  = Indices::saltConcentrationIdx };
+    static constexpr unsigned saltConcentrationIdx  = Indices::saltConcentrationIdx;
     static constexpr unsigned solventSaturationIdx  = Indices::solventSaturationIdx;
 
     static constexpr bool compositionSwitchEnabled =

--- a/opm/models/blackoil/blackoilprimaryvariables.hh
+++ b/opm/models/blackoil/blackoilprimaryvariables.hh
@@ -87,7 +87,7 @@ class BlackOilPrimaryVariables : public FvBasePrimaryVariables<TypeTag, VectorTy
     static constexpr unsigned pressureSwitchIdx = Indices::pressureSwitchIdx;
     static constexpr unsigned compositionSwitchIdx = Indices::compositionSwitchIdx;
     enum { saltConcentrationIdx  = Indices::saltConcentrationIdx };
-    enum { solventSaturationIdx  = Indices::solventSaturationIdx };
+    static constexpr unsigned solventSaturationIdx  = Indices::solventSaturationIdx;
 
     static constexpr bool compositionSwitchEnabled =
         Indices::compositionSwitchIdx != std::numeric_limits<unsigned>::max();

--- a/opm/models/blackoil/blackoilsolventmodules.hh
+++ b/opm/models/blackoil/blackoilsolventmodules.hh
@@ -545,7 +545,7 @@ class BlackOilSolventIntensiveQuantities<TypeTag, /*enableSolventV=*/true>
     using SolventModule = BlackOilSolventModule<TypeTag, true>;
 
     enum { numPhases = getPropValue<TypeTag, Properties::NumPhases>() };
-    static constexpr int solventSaturationIdx = Indices::solventSaturationIdx;
+    static constexpr unsigned solventSaturationIdx = Indices::solventSaturationIdx;
     static constexpr int oilPhaseIdx = FluidSystem::oilPhaseIdx;
     static constexpr int gasPhaseIdx = FluidSystem::gasPhaseIdx;
     static constexpr int waterPhaseIdx = FluidSystem::waterPhaseIdx;

--- a/opm/models/blackoil/blackoiltwophaseindices.hh
+++ b/opm/models/blackoil/blackoiltwophaseindices.hh
@@ -177,7 +177,7 @@ struct BlackOilTwoPhaseIndices
     //! MICP only available for one phase indices
     static constexpr unsigned oxygenConcentrationIdx = std::numeric_limits<unsigned>::max();
     static constexpr unsigned ureaConcentrationIdx = std::numeric_limits<unsigned>::max();
-    static constexpr int calciteVolumeFractionIdx = -1000;
+    static constexpr unsigned calciteVolumeFractionIdx = std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the foam
     static constexpr int foamConcentrationIdx =

--- a/opm/models/blackoil/blackoiltwophaseindices.hh
+++ b/opm/models/blackoil/blackoiltwophaseindices.hh
@@ -130,7 +130,9 @@ struct BlackOilTwoPhaseIndices
      * Depending on the phases present, this variable is either interpreted as the
      * pressure of the oil phase, gas phase (if no oil) or water phase (if only water)
      */
-    static constexpr int pressureSwitchIdx  = waterEnabled ? PVOffset + 1 : PVOffset + 0;
+    static constexpr unsigned pressureSwitchIdx =
+        waterEnabled ? PVOffset + 1
+                     : PVOffset + 0;
 
     /*!
      * \brief Index of the switching variable which determines the composition of the

--- a/opm/models/blackoil/blackoiltwophaseindices.hh
+++ b/opm/models/blackoil/blackoiltwophaseindices.hh
@@ -170,8 +170,9 @@ struct BlackOilTwoPhaseIndices
                       : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the biofilm component
-    static constexpr int biofilmVolumeFractionIdx =
-        enableBiofilm ? PVOffset + numPhases + numSolvents + 1 : -1000;
+    static constexpr unsigned biofilmVolumeFractionIdx =
+        enableBiofilm ? PVOffset + numPhases + numSolvents + 1
+                      : std::numeric_limits<unsigned>::max();
 
     //! MICP only available for one phase indices
     static constexpr unsigned oxygenConcentrationIdx = std::numeric_limits<unsigned>::max();

--- a/opm/models/blackoil/blackoiltwophaseindices.hh
+++ b/opm/models/blackoil/blackoiltwophaseindices.hh
@@ -185,8 +185,9 @@ struct BlackOilTwoPhaseIndices
                    : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the salt
-    static constexpr int saltConcentrationIdx =
-        enableBrine ? PVOffset + numPhases + numSolvents + numPolymers + numBioComp + numFoam : -1000;
+    static constexpr unsigned saltConcentrationIdx =
+        enableBrine ? PVOffset + numPhases + numSolvents + numPolymers + numBioComp + numFoam
+                    : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for temperature
     static constexpr int temperatureIdx  =

--- a/opm/models/blackoil/blackoiltwophaseindices.hh
+++ b/opm/models/blackoil/blackoiltwophaseindices.hh
@@ -174,7 +174,7 @@ struct BlackOilTwoPhaseIndices
         enableBiofilm ? PVOffset + numPhases + numSolvents + 1 : -1000;
 
     //! MICP only available for one phase indices
-    static constexpr int oxygenConcentrationIdx = -1000;
+    static constexpr unsigned oxygenConcentrationIdx = std::numeric_limits<unsigned>::max();
     static constexpr int ureaConcentrationIdx = -1000;
     static constexpr int calciteVolumeFractionIdx = -1000;
 

--- a/opm/models/blackoil/blackoiltwophaseindices.hh
+++ b/opm/models/blackoil/blackoiltwophaseindices.hh
@@ -150,8 +150,9 @@ struct BlackOilTwoPhaseIndices
                       : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the first extbo component
-    static constexpr int zFractionIdx =
-        enableExtbo ? PVOffset + numPhases + numSolvents : -1000;
+    static constexpr unsigned zFractionIdx =
+        enableExtbo ? PVOffset + numPhases + numSolvents
+                    : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the first polymer
     static constexpr int polymerConcentrationIdx =

--- a/opm/models/blackoil/blackoiltwophaseindices.hh
+++ b/opm/models/blackoil/blackoiltwophaseindices.hh
@@ -180,8 +180,9 @@ struct BlackOilTwoPhaseIndices
     static constexpr unsigned calciteVolumeFractionIdx = std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the foam
-    static constexpr int foamConcentrationIdx =
-        enableFoam ? PVOffset + numPhases + numSolvents + numPolymers + numBioComp : -1000;
+    static constexpr unsigned foamConcentrationIdx =
+        enableFoam ? PVOffset + numPhases + numSolvents + numPolymers + numBioComp
+                   : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the salt
     static constexpr int saltConcentrationIdx =

--- a/opm/models/blackoil/blackoiltwophaseindices.hh
+++ b/opm/models/blackoil/blackoiltwophaseindices.hh
@@ -175,7 +175,7 @@ struct BlackOilTwoPhaseIndices
 
     //! MICP only available for one phase indices
     static constexpr unsigned oxygenConcentrationIdx = std::numeric_limits<unsigned>::max();
-    static constexpr int ureaConcentrationIdx = -1000;
+    static constexpr unsigned ureaConcentrationIdx = std::numeric_limits<unsigned>::max();
     static constexpr int calciteVolumeFractionIdx = -1000;
 
     //! Index of the primary variable for the foam

--- a/opm/models/blackoil/blackoiltwophaseindices.hh
+++ b/opm/models/blackoil/blackoiltwophaseindices.hh
@@ -165,8 +165,9 @@ struct BlackOilTwoPhaseIndices
                         : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the first microbial component
-    static constexpr int microbialConcentrationIdx =
-        enableBiofilm ? PVOffset + numPhases + numSolvents : -1000;
+    static constexpr unsigned microbialConcentrationIdx =
+        enableBiofilm ? PVOffset + numPhases + numSolvents
+                      : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the biofilm component
     static constexpr int biofilmVolumeFractionIdx =

--- a/opm/models/blackoil/blackoiltwophaseindices.hh
+++ b/opm/models/blackoil/blackoiltwophaseindices.hh
@@ -140,7 +140,9 @@ struct BlackOilTwoPhaseIndices
      *
      * \note For two-phase water oil and water gas models this is disabled.
      */
-    static constexpr int compositionSwitchIdx = (gasEnabled && oilEnabled) ? PVOffset + 1 : -10000;
+    static constexpr unsigned compositionSwitchIdx =
+        gasEnabled && oilEnabled ? PVOffset + 1
+                                 : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the first solvent
     static constexpr int solventSaturationIdx =

--- a/opm/models/blackoil/blackoiltwophaseindices.hh
+++ b/opm/models/blackoil/blackoiltwophaseindices.hh
@@ -31,6 +31,7 @@
 #include <opm/common/utility/ConstexprAssert.hpp>
 
 #include <cassert>
+#include <limits>
 
 namespace Opm {
 
@@ -119,7 +120,9 @@ struct BlackOilTwoPhaseIndices
      *
      * \note For two-phase gas-oil models this is disabled.
      */
-    static constexpr int waterSwitchIdx  = waterEnabled ? PVOffset + 0 : -10000;
+    static constexpr unsigned waterSwitchIdx  =
+        waterEnabled ? PVOffset + 0
+                     : std::numeric_limits<unsigned>::max();
 
     /*!
      * \brief Index of the switching variable which determines the pressure

--- a/opm/models/blackoil/blackoiltwophaseindices.hh
+++ b/opm/models/blackoil/blackoiltwophaseindices.hh
@@ -190,8 +190,10 @@ struct BlackOilTwoPhaseIndices
                     : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for temperature
-    static constexpr int temperatureIdx  =
-        (enableFullyImplicitThermal) ? PVOffset + numPhases + numSolvents + numExtbos + numPolymers + numBioComp + numFoam + numBrine : - 1000;
+    static constexpr unsigned temperatureIdx  =
+        enableFullyImplicitThermal ? PVOffset + numPhases + numSolvents + numExtbos +
+                                     numPolymers + numBioComp + numFoam + numBrine
+                                   : std::numeric_limits<unsigned>::max();
 
     //////////////////////
     // Equation indices

--- a/opm/models/blackoil/blackoiltwophaseindices.hh
+++ b/opm/models/blackoil/blackoiltwophaseindices.hh
@@ -155,8 +155,9 @@ struct BlackOilTwoPhaseIndices
                     : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the first polymer
-    static constexpr int polymerConcentrationIdx =
-        enablePolymer ? PVOffset + numPhases + numSolvents : -1000;
+    static constexpr unsigned polymerConcentrationIdx =
+        enablePolymer ? PVOffset + numPhases + numSolvents
+                      : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the second polymer primary variable (molecular weight)
     static constexpr int polymerMoleWeightIdx =

--- a/opm/models/blackoil/blackoiltwophaseindices.hh
+++ b/opm/models/blackoil/blackoiltwophaseindices.hh
@@ -160,8 +160,9 @@ struct BlackOilTwoPhaseIndices
                       : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the second polymer primary variable (molecular weight)
-    static constexpr int polymerMoleWeightIdx =
-        numPolymers > 1 ? polymerConcentrationIdx + 1 : -1000;
+    static constexpr unsigned polymerMoleWeightIdx =
+        numPolymers > 1 ? polymerConcentrationIdx + 1
+                        : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the first microbial component
     static constexpr int microbialConcentrationIdx =

--- a/opm/models/blackoil/blackoiltwophaseindices.hh
+++ b/opm/models/blackoil/blackoiltwophaseindices.hh
@@ -145,8 +145,9 @@ struct BlackOilTwoPhaseIndices
                                  : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the first solvent
-    static constexpr int solventSaturationIdx =
-        enableSolvent ? PVOffset + numPhases : -1000;
+    static constexpr unsigned solventSaturationIdx =
+        enableSolvent ? PVOffset + numPhases
+                      : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the first extbo component
     static constexpr int zFractionIdx =

--- a/opm/models/blackoil/blackoilvariableandequationindices.hh
+++ b/opm/models/blackoil/blackoilvariableandequationindices.hh
@@ -144,8 +144,9 @@ struct BlackOilVariableAndEquationIndices
                       : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the second polymer primary variable (molecular weight)
-    static constexpr int polymerMoleWeightIdx =
-        numPolymers > 1 ? polymerConcentrationIdx + 1 : -1000;
+    static constexpr unsigned polymerMoleWeightIdx =
+        numPolymers > 1 ? polymerConcentrationIdx + 1
+                        : std::numeric_limits<unsigned>::max();
 
     //! No bioeffects for three phase indices
     static constexpr int microbialConcentrationIdx = -1000;

--- a/opm/models/blackoil/blackoilvariableandequationindices.hh
+++ b/opm/models/blackoil/blackoilvariableandequationindices.hh
@@ -134,8 +134,9 @@ struct BlackOilVariableAndEquationIndices
                       : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the first extbo component
-    static constexpr int zFractionIdx =
-        enableExtbo ? PVOffset + numPhases + numSolvents : -1000;
+    static constexpr unsigned zFractionIdx =
+        enableExtbo ? PVOffset + numPhases + numSolvents
+                    : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the first polymer
     static constexpr int polymerConcentrationIdx =

--- a/opm/models/blackoil/blackoilvariableandequationindices.hh
+++ b/opm/models/blackoil/blackoilvariableandequationindices.hh
@@ -151,7 +151,7 @@ struct BlackOilVariableAndEquationIndices
     //! No bioeffects for three phase indices
     static constexpr unsigned microbialConcentrationIdx = std::numeric_limits<unsigned>::max();
     static constexpr unsigned oxygenConcentrationIdx = std::numeric_limits<unsigned>::max();
-    static constexpr int ureaConcentrationIdx = -1000;
+    static constexpr unsigned ureaConcentrationIdx = std::numeric_limits<unsigned>::max();
     static constexpr int biofilmVolumeFractionIdx = -1000;
     static constexpr int calciteVolumeFractionIdx = -1000;
 

--- a/opm/models/blackoil/blackoilvariableandequationindices.hh
+++ b/opm/models/blackoil/blackoilvariableandequationindices.hh
@@ -116,7 +116,7 @@ struct BlackOilVariableAndEquationIndices
      * Depending on the phases present, this variable is either interpreted as the
      * pressure of the oil phase, gas phase (if no oil) or water phase (if only water)
      */
-    static constexpr int pressureSwitchIdx = PVOffset + 1;
+    static constexpr unsigned pressureSwitchIdx = PVOffset + 1;
 
     /*!
      * \brief Index of the switching variable which determines the composition of the

--- a/opm/models/blackoil/blackoilvariableandequationindices.hh
+++ b/opm/models/blackoil/blackoilvariableandequationindices.hh
@@ -166,8 +166,10 @@ struct BlackOilVariableAndEquationIndices
                     : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for temperature
-    static constexpr int temperatureIdx  =
-        enableFullyImplicitThermal ? PVOffset + numPhases + numSolvents + numExtbos + numPolymers + numFoam + numBrine : - 1000;
+    static constexpr unsigned temperatureIdx  =
+        enableFullyImplicitThermal ? PVOffset + numPhases + numSolvents +
+                                     numExtbos + numPolymers + numFoam + numBrine
+                                   : std::numeric_limits<unsigned>::max();
 
 
     ////////

--- a/opm/models/blackoil/blackoilvariableandequationindices.hh
+++ b/opm/models/blackoil/blackoilvariableandequationindices.hh
@@ -149,7 +149,7 @@ struct BlackOilVariableAndEquationIndices
                         : std::numeric_limits<unsigned>::max();
 
     //! No bioeffects for three phase indices
-    static constexpr int microbialConcentrationIdx = -1000;
+    static constexpr unsigned microbialConcentrationIdx = std::numeric_limits<unsigned>::max();
     static constexpr int oxygenConcentrationIdx = -1000;
     static constexpr int ureaConcentrationIdx = -1000;
     static constexpr int biofilmVolumeFractionIdx = -1000;

--- a/opm/models/blackoil/blackoilvariableandequationindices.hh
+++ b/opm/models/blackoil/blackoilvariableandequationindices.hh
@@ -150,7 +150,7 @@ struct BlackOilVariableAndEquationIndices
 
     //! No bioeffects for three phase indices
     static constexpr unsigned microbialConcentrationIdx = std::numeric_limits<unsigned>::max();
-    static constexpr int oxygenConcentrationIdx = -1000;
+    static constexpr unsigned oxygenConcentrationIdx = std::numeric_limits<unsigned>::max();
     static constexpr int ureaConcentrationIdx = -1000;
     static constexpr int biofilmVolumeFractionIdx = -1000;
     static constexpr int calciteVolumeFractionIdx = -1000;

--- a/opm/models/blackoil/blackoilvariableandequationindices.hh
+++ b/opm/models/blackoil/blackoilvariableandequationindices.hh
@@ -161,8 +161,9 @@ struct BlackOilVariableAndEquationIndices
                    : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the brine
-    static constexpr int saltConcentrationIdx =
-        enableBrine ? PVOffset + numPhases + numSolvents + numExtbos + numPolymers + numFoam : -1000;
+    static constexpr unsigned saltConcentrationIdx =
+        enableBrine ? PVOffset + numPhases + numSolvents + numExtbos + numPolymers + numFoam
+                    : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for temperature
     static constexpr int temperatureIdx  =

--- a/opm/models/blackoil/blackoilvariableandequationindices.hh
+++ b/opm/models/blackoil/blackoilvariableandequationindices.hh
@@ -153,7 +153,7 @@ struct BlackOilVariableAndEquationIndices
     static constexpr unsigned oxygenConcentrationIdx = std::numeric_limits<unsigned>::max();
     static constexpr unsigned ureaConcentrationIdx = std::numeric_limits<unsigned>::max();
     static constexpr unsigned biofilmVolumeFractionIdx = std::numeric_limits<unsigned>::max();
-    static constexpr int calciteVolumeFractionIdx = -1000;
+    static constexpr unsigned calciteVolumeFractionIdx = std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the foam
     static constexpr int foamConcentrationIdx =

--- a/opm/models/blackoil/blackoilvariableandequationindices.hh
+++ b/opm/models/blackoil/blackoilvariableandequationindices.hh
@@ -152,7 +152,7 @@ struct BlackOilVariableAndEquationIndices
     static constexpr unsigned microbialConcentrationIdx = std::numeric_limits<unsigned>::max();
     static constexpr unsigned oxygenConcentrationIdx = std::numeric_limits<unsigned>::max();
     static constexpr unsigned ureaConcentrationIdx = std::numeric_limits<unsigned>::max();
-    static constexpr int biofilmVolumeFractionIdx = -1000;
+    static constexpr unsigned biofilmVolumeFractionIdx = std::numeric_limits<unsigned>::max();
     static constexpr int calciteVolumeFractionIdx = -1000;
 
     //! Index of the primary variable for the foam

--- a/opm/models/blackoil/blackoilvariableandequationindices.hh
+++ b/opm/models/blackoil/blackoilvariableandequationindices.hh
@@ -129,8 +129,9 @@ struct BlackOilVariableAndEquationIndices
     static constexpr unsigned compositionSwitchIdx = PVOffset + 2;
 
     //! Index of the primary variable for the first solvent
-    static constexpr int solventSaturationIdx =
-        enableSolvent ? PVOffset + numPhases : -1000;
+    static constexpr unsigned solventSaturationIdx =
+        enableSolvent ? PVOffset + numPhases
+                      : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the first extbo component
     static constexpr int zFractionIdx =

--- a/opm/models/blackoil/blackoilvariableandequationindices.hh
+++ b/opm/models/blackoil/blackoilvariableandequationindices.hh
@@ -156,8 +156,9 @@ struct BlackOilVariableAndEquationIndices
     static constexpr unsigned calciteVolumeFractionIdx = std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the foam
-    static constexpr int foamConcentrationIdx =
-        enableFoam ? PVOffset + numPhases + numSolvents + numExtbos + numPolymers : -1000;
+    static constexpr unsigned foamConcentrationIdx =
+        enableFoam ? PVOffset + numPhases + numSolvents + numExtbos + numPolymers
+                   : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the brine
     static constexpr int saltConcentrationIdx =

--- a/opm/models/blackoil/blackoilvariableandequationindices.hh
+++ b/opm/models/blackoil/blackoilvariableandequationindices.hh
@@ -126,7 +126,7 @@ struct BlackOilVariableAndEquationIndices
      * saturation of the gas phase, as the mole fraction of the gas component in the oil
      * phase or as the mole fraction of the oil component in the gas phase.
      */
-    static constexpr int compositionSwitchIdx = PVOffset + 2;
+    static constexpr unsigned compositionSwitchIdx = PVOffset + 2;
 
     //! Index of the primary variable for the first solvent
     static constexpr int solventSaturationIdx =

--- a/opm/models/blackoil/blackoilvariableandequationindices.hh
+++ b/opm/models/blackoil/blackoilvariableandequationindices.hh
@@ -28,6 +28,8 @@
 #ifndef OPM_BLACK_OIL_VARIABLE_AND_EQUATION_INDICES_HH
 #define OPM_BLACK_OIL_VARIABLE_AND_EQUATION_INDICES_HH
 
+#include <limits>
+
 namespace Opm {
 
 /*!
@@ -106,7 +108,7 @@ struct BlackOilVariableAndEquationIndices
      * Depending on the phases present, this variable is either interpreted as
      * water saturation or vapporized water in gas phase
      */
-    static constexpr int waterSwitchIdx = PVOffset + 0;
+    static constexpr unsigned waterSwitchIdx = PVOffset + 0;
 
     /*!
      * \brief Index of the switching variable which determines the pressure

--- a/opm/models/blackoil/blackoilvariableandequationindices.hh
+++ b/opm/models/blackoil/blackoilvariableandequationindices.hh
@@ -139,8 +139,9 @@ struct BlackOilVariableAndEquationIndices
                     : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the first polymer
-    static constexpr int polymerConcentrationIdx =
-        enablePolymer ? PVOffset + numPhases + numSolvents : -1000;
+    static constexpr unsigned polymerConcentrationIdx =
+        enablePolymer ? PVOffset + numPhases + numSolvents
+                      : std::numeric_limits<unsigned>::max();
 
     //! Index of the primary variable for the second polymer primary variable (molecular weight)
     static constexpr int polymerMoleWeightIdx =

--- a/opm/models/common/energymodule.hh
+++ b/opm/models/common/energymodule.hh
@@ -40,6 +40,7 @@
 
 #include <cassert>
 #include <cmath>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -236,7 +237,7 @@ class EnergyModule<TypeTag, /*enableEnergy=*/true>
     enum { numEq = getPropValue<TypeTag, Properties::NumEq>() };
     enum { numPhases = FluidSystem::numPhases };
     enum { energyEqIdx = Indices::energyEqIdx };
-    enum { temperatureIdx = Indices::temperatureIdx };
+    static constexpr unsigned temperatureIdx = Indices::temperatureIdx;
 
     using Toolbox = Opm::MathToolbox<Evaluation>;
 
@@ -500,7 +501,7 @@ template <unsigned PVOffset>
 struct EnergyIndices<PVOffset, /*enableEnergy=*/false>
 {
     //! The index of the primary variable representing temperature
-    enum { temperatureIdx = -1000 };
+    static constexpr unsigned temperatureIdx = std::numeric_limits<unsigned>::max();
 
     //! The index of the equation representing the conservation of energy
     enum { energyEqIdx = -1000 };
@@ -516,7 +517,7 @@ template <unsigned PVOffset>
 struct EnergyIndices<PVOffset, /*enableEnergy=*/true>
 {
     //! The index of the primary variable representing temperature
-    enum { temperatureIdx = PVOffset };
+    static constexpr unsigned temperatureIdx = PVOffset;
 
     //! The index of the equation representing the conservation of energy
     enum { energyEqIdx = PVOffset };
@@ -608,7 +609,7 @@ class EnergyIntensiveQuantities<TypeTag, /*enableEnergy=*/true>
     using Indices = GetPropType<TypeTag, Properties::Indices>;
 
     enum { numPhases = FluidSystem::numPhases };
-    enum { temperatureIdx = Indices::temperatureIdx };
+    static constexpr unsigned temperatureIdx = Indices::temperatureIdx;
 
     using Toolbox = Opm::MathToolbox<Evaluation>;
 

--- a/opm/simulators/flow/EquilInitializer.hpp
+++ b/opm/simulators/flow/EquilInitializer.hpp
@@ -39,6 +39,7 @@
 
 #include <opm/simulators/flow/equil/InitStateEquil.hpp>
 
+#include <limits>
 #include <vector>
 
 namespace Opm {
@@ -74,12 +75,14 @@ class EquilInitializer
     enum { waterCompIdx = FluidSystem::waterCompIdx };
 
     enum { dimWorld = GridView::dimensionworld };
-    enum { enableDissolution = Indices::compositionSwitchIdx >= 0 };
+    static constexpr bool enableDissolution =
+        Indices::compositionSwitchIdx != std::numeric_limits<unsigned>::max();
     static constexpr bool enableBrine = getPropValue<TypeTag, Properties::EnableBrine>();
     enum { enableVapwat = getPropValue<TypeTag, Properties::EnableVapwat>() };
     enum { enableSaltPrecipitation = getPropValue<TypeTag, Properties::EnableSaltPrecipitation>() };
     enum { enableDisgasInWater = getPropValue<TypeTag, Properties::EnableDisgasInWater>() };
-    enum { enableDissolvedGas = Indices::compositionSwitchIdx >= 0 };
+    static constexpr bool enableDissolvedGas =
+        Indices::compositionSwitchIdx != std::numeric_limits<unsigned>::max();
     static constexpr bool enableSolvent = getPropValue<TypeTag, Properties::EnableSolvent>();
     static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
 

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -138,7 +138,8 @@ private:
     using typename FlowProblemType::MaterialLaw;
     using typename FlowProblemType::DimMatrix;
 
-    enum { enableDissolvedGas = Indices::compositionSwitchIdx >= 0 };
+    static constexpr bool enableDissolvedGas =
+        Indices::compositionSwitchIdx != std::numeric_limits<unsigned>::max();
     enum { enableVapwat = getPropValue<TypeTag, Properties::EnableVapwat>() };
     enum { enableDisgasInWater = getPropValue<TypeTag, Properties::EnableDisgasInWater>() };
     enum { enableGeochemistry = getPropValue<TypeTag, Properties::EnableGeochemistry>() };

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -1000,7 +1000,7 @@ public:
             values[Indices::biofilmVolumeFractionIdx]= this->bioeffects_.biofilmVolumeFraction[globalDofIdx];
             if constexpr (enableMICP) {
                 values[Indices::oxygenConcentrationIdx] = this->bioeffects_.oxygenConcentration[globalDofIdx];
-                values[Indices::ureaConcentrationIdx]= this->bioeffects_.ureaConcentration[globalDofIdx];
+                values[Indices::ureaConcentrationIdx] = this->bioeffects_.ureaConcentration[globalDofIdx];
                 values[Indices::calciteVolumeFractionIdx]= this->bioeffects_.calciteVolumeFraction[globalDofIdx];
             }
         }

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -999,7 +999,7 @@ public:
             values[Indices::microbialConcentrationIdx] = this->bioeffects_.microbialConcentration[globalDofIdx];
             values[Indices::biofilmVolumeFractionIdx]= this->bioeffects_.biofilmVolumeFraction[globalDofIdx];
             if constexpr (enableMICP) {
-                values[Indices::oxygenConcentrationIdx]= this->bioeffects_.oxygenConcentration[globalDofIdx];
+                values[Indices::oxygenConcentrationIdx] = this->bioeffects_.oxygenConcentration[globalDofIdx];
                 values[Indices::ureaConcentrationIdx]= this->bioeffects_.ureaConcentration[globalDofIdx];
                 values[Indices::calciteVolumeFractionIdx]= this->bioeffects_.calciteVolumeFraction[globalDofIdx];
             }

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -997,7 +997,7 @@ public:
 
         if constexpr (enableBioeffects) {
             values[Indices::microbialConcentrationIdx] = this->bioeffects_.microbialConcentration[globalDofIdx];
-            values[Indices::biofilmVolumeFractionIdx]= this->bioeffects_.biofilmVolumeFraction[globalDofIdx];
+            values[Indices::biofilmVolumeFractionIdx] = this->bioeffects_.biofilmVolumeFraction[globalDofIdx];
             if constexpr (enableMICP) {
                 values[Indices::oxygenConcentrationIdx] = this->bioeffects_.oxygenConcentration[globalDofIdx];
                 values[Indices::ureaConcentrationIdx] = this->bioeffects_.ureaConcentration[globalDofIdx];

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -1001,7 +1001,7 @@ public:
             if constexpr (enableMICP) {
                 values[Indices::oxygenConcentrationIdx] = this->bioeffects_.oxygenConcentration[globalDofIdx];
                 values[Indices::ureaConcentrationIdx] = this->bioeffects_.ureaConcentration[globalDofIdx];
-                values[Indices::calciteVolumeFractionIdx]= this->bioeffects_.calciteVolumeFraction[globalDofIdx];
+                values[Indices::calciteVolumeFractionIdx] = this->bioeffects_.calciteVolumeFraction[globalDofIdx];
             }
         }
 

--- a/opm/simulators/flow/HybridNewton.hpp
+++ b/opm/simulators/flow/HybridNewton.hpp
@@ -29,6 +29,7 @@
 
 #include <opm/ml/ml_model.hpp>
 
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -71,7 +72,8 @@ protected:
     enum { oilPhaseIdx = FluidSystem::oilPhaseIdx };
     enum { waterPhaseIdx = FluidSystem::waterPhaseIdx };
 
-    static constexpr bool compositionSwitchEnabled = Indices::compositionSwitchIdx >= 0;
+    static constexpr bool compositionSwitchEnabled =
+        Indices::compositionSwitchIdx != std::numeric_limits<unsigned>::max();
 
 public:
     explicit BlackOilHybridNewton(Simulator& simulator)

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
@@ -96,7 +96,7 @@ public:
     static constexpr unsigned polymerMoleWeightIdx = Indices::polymerMoleWeightIdx;
     static constexpr int temperatureIdx = Indices::temperatureIdx;
     static constexpr unsigned foamConcentrationIdx = Indices::foamConcentrationIdx;
-    static constexpr int saltConcentrationIdx = Indices::saltConcentrationIdx;
+    static constexpr unsigned saltConcentrationIdx = Indices::saltConcentrationIdx;
     static constexpr unsigned microbialConcentrationIdx = Indices::microbialConcentrationIdx;
     static constexpr unsigned oxygenConcentrationIdx = Indices::oxygenConcentrationIdx;
     static constexpr unsigned ureaConcentrationIdx = Indices::ureaConcentrationIdx;

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
@@ -92,7 +92,7 @@ public:
     static constexpr int contiCalciteEqIdx = Indices::contiCalciteEqIdx;
     static constexpr unsigned solventSaturationIdx = Indices::solventSaturationIdx;
     static constexpr unsigned zFractionIdx = Indices::zFractionIdx;
-    static constexpr int polymerConcentrationIdx = Indices::polymerConcentrationIdx;
+    static constexpr unsigned polymerConcentrationIdx = Indices::polymerConcentrationIdx;
     static constexpr int polymerMoleWeightIdx = Indices::polymerMoleWeightIdx;
     static constexpr int temperatureIdx = Indices::temperatureIdx;
     static constexpr int foamConcentrationIdx = Indices::foamConcentrationIdx;

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
@@ -98,7 +98,7 @@ public:
     static constexpr int foamConcentrationIdx = Indices::foamConcentrationIdx;
     static constexpr int saltConcentrationIdx = Indices::saltConcentrationIdx;
     static constexpr unsigned microbialConcentrationIdx = Indices::microbialConcentrationIdx;
-    static constexpr int oxygenConcentrationIdx = Indices::oxygenConcentrationIdx;
+    static constexpr unsigned oxygenConcentrationIdx = Indices::oxygenConcentrationIdx;
     static constexpr int ureaConcentrationIdx = Indices::ureaConcentrationIdx;
     static constexpr int biofilmVolumeFractionIdx = Indices::biofilmVolumeFractionIdx;
     static constexpr int calciteVolumeFractionIdx = Indices::calciteVolumeFractionIdx;

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
@@ -101,7 +101,7 @@ public:
     static constexpr unsigned oxygenConcentrationIdx = Indices::oxygenConcentrationIdx;
     static constexpr unsigned ureaConcentrationIdx = Indices::ureaConcentrationIdx;
     static constexpr unsigned biofilmVolumeFractionIdx = Indices::biofilmVolumeFractionIdx;
-    static constexpr int calciteVolumeFractionIdx = Indices::calciteVolumeFractionIdx;
+    static constexpr unsigned calciteVolumeFractionIdx = Indices::calciteVolumeFractionIdx;
 
     using VectorBlockType = Dune::FieldVector<Scalar, numEq>;
     using MatrixBlockType = typename SparseMatrixAdapter::MatrixBlock;

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
@@ -94,7 +94,7 @@ public:
     static constexpr unsigned zFractionIdx = Indices::zFractionIdx;
     static constexpr unsigned polymerConcentrationIdx = Indices::polymerConcentrationIdx;
     static constexpr unsigned polymerMoleWeightIdx = Indices::polymerMoleWeightIdx;
-    static constexpr int temperatureIdx = Indices::temperatureIdx;
+    static constexpr unsigned temperatureIdx = Indices::temperatureIdx;
     static constexpr unsigned foamConcentrationIdx = Indices::foamConcentrationIdx;
     static constexpr unsigned saltConcentrationIdx = Indices::saltConcentrationIdx;
     static constexpr unsigned microbialConcentrationIdx = Indices::microbialConcentrationIdx;

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
@@ -95,7 +95,7 @@ public:
     static constexpr unsigned polymerConcentrationIdx = Indices::polymerConcentrationIdx;
     static constexpr unsigned polymerMoleWeightIdx = Indices::polymerMoleWeightIdx;
     static constexpr int temperatureIdx = Indices::temperatureIdx;
-    static constexpr int foamConcentrationIdx = Indices::foamConcentrationIdx;
+    static constexpr unsigned foamConcentrationIdx = Indices::foamConcentrationIdx;
     static constexpr int saltConcentrationIdx = Indices::saltConcentrationIdx;
     static constexpr unsigned microbialConcentrationIdx = Indices::microbialConcentrationIdx;
     static constexpr unsigned oxygenConcentrationIdx = Indices::oxygenConcentrationIdx;

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
@@ -93,7 +93,7 @@ public:
     static constexpr unsigned solventSaturationIdx = Indices::solventSaturationIdx;
     static constexpr unsigned zFractionIdx = Indices::zFractionIdx;
     static constexpr unsigned polymerConcentrationIdx = Indices::polymerConcentrationIdx;
-    static constexpr int polymerMoleWeightIdx = Indices::polymerMoleWeightIdx;
+    static constexpr unsigned polymerMoleWeightIdx = Indices::polymerMoleWeightIdx;
     static constexpr int temperatureIdx = Indices::temperatureIdx;
     static constexpr int foamConcentrationIdx = Indices::foamConcentrationIdx;
     static constexpr int saltConcentrationIdx = Indices::saltConcentrationIdx;

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
@@ -90,7 +90,7 @@ public:
     static constexpr int contiUreaEqIdx = Indices::contiUreaEqIdx;
     static constexpr int contiBiofilmEqIdx = Indices::contiBiofilmEqIdx;
     static constexpr int contiCalciteEqIdx = Indices::contiCalciteEqIdx;
-    static constexpr int solventSaturationIdx = Indices::solventSaturationIdx;
+    static constexpr unsigned solventSaturationIdx = Indices::solventSaturationIdx;
     static constexpr int zFractionIdx = Indices::zFractionIdx;
     static constexpr int polymerConcentrationIdx = Indices::polymerConcentrationIdx;
     static constexpr int polymerMoleWeightIdx = Indices::polymerMoleWeightIdx;

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
@@ -100,7 +100,7 @@ public:
     static constexpr unsigned microbialConcentrationIdx = Indices::microbialConcentrationIdx;
     static constexpr unsigned oxygenConcentrationIdx = Indices::oxygenConcentrationIdx;
     static constexpr unsigned ureaConcentrationIdx = Indices::ureaConcentrationIdx;
-    static constexpr int biofilmVolumeFractionIdx = Indices::biofilmVolumeFractionIdx;
+    static constexpr unsigned biofilmVolumeFractionIdx = Indices::biofilmVolumeFractionIdx;
     static constexpr int calciteVolumeFractionIdx = Indices::calciteVolumeFractionIdx;
 
     using VectorBlockType = Dune::FieldVector<Scalar, numEq>;

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
@@ -99,7 +99,7 @@ public:
     static constexpr int saltConcentrationIdx = Indices::saltConcentrationIdx;
     static constexpr unsigned microbialConcentrationIdx = Indices::microbialConcentrationIdx;
     static constexpr unsigned oxygenConcentrationIdx = Indices::oxygenConcentrationIdx;
-    static constexpr int ureaConcentrationIdx = Indices::ureaConcentrationIdx;
+    static constexpr unsigned ureaConcentrationIdx = Indices::ureaConcentrationIdx;
     static constexpr int biofilmVolumeFractionIdx = Indices::biofilmVolumeFractionIdx;
     static constexpr int calciteVolumeFractionIdx = Indices::calciteVolumeFractionIdx;
 

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
@@ -91,7 +91,7 @@ public:
     static constexpr int contiBiofilmEqIdx = Indices::contiBiofilmEqIdx;
     static constexpr int contiCalciteEqIdx = Indices::contiCalciteEqIdx;
     static constexpr unsigned solventSaturationIdx = Indices::solventSaturationIdx;
-    static constexpr int zFractionIdx = Indices::zFractionIdx;
+    static constexpr unsigned zFractionIdx = Indices::zFractionIdx;
     static constexpr int polymerConcentrationIdx = Indices::polymerConcentrationIdx;
     static constexpr int polymerMoleWeightIdx = Indices::polymerMoleWeightIdx;
     static constexpr int temperatureIdx = Indices::temperatureIdx;

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
@@ -97,7 +97,7 @@ public:
     static constexpr int temperatureIdx = Indices::temperatureIdx;
     static constexpr int foamConcentrationIdx = Indices::foamConcentrationIdx;
     static constexpr int saltConcentrationIdx = Indices::saltConcentrationIdx;
-    static constexpr int microbialConcentrationIdx = Indices::microbialConcentrationIdx;
+    static constexpr unsigned microbialConcentrationIdx = Indices::microbialConcentrationIdx;
     static constexpr int oxygenConcentrationIdx = Indices::oxygenConcentrationIdx;
     static constexpr int ureaConcentrationIdx = Indices::ureaConcentrationIdx;
     static constexpr int biofilmVolumeFractionIdx = Indices::biofilmVolumeFractionIdx;

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
@@ -608,7 +608,8 @@ typename NonlinearSystemBlackOilReservoir<TypeTag>::MaxSolutionUpdateData
 NonlinearSystemBlackOilReservoir<TypeTag>::
 getMaxSolutionUpdate(const std::vector<unsigned>& ixCells)
 {
-    static constexpr bool enableSolvent = Indices::solventSaturationIdx >= 0;
+    static constexpr bool enableSolvent =
+        Indices::solventSaturationIdx != std::numeric_limits<unsigned>::max();
     static constexpr bool enableBrine = Indices::saltConcentrationIdx >= 0;
 
     // Init output
@@ -628,7 +629,7 @@ getMaxSolutionUpdate(const std::vector<unsigned>& ixCells)
                        && value.primaryVarsMeaningWater() == PrimaryVariables::WaterMeaning::Sw)
                       || (pvIdx == static_cast<int>(Indices::compositionSwitchIdx)
                           && value.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Sg)
-                      || (enableSolvent && pvIdx == Indices::solventSaturationIdx
+                      || (enableSolvent && pvIdx == static_cast<int>(Indices::solventSaturationIdx)
                           && value.primaryVarsMeaningSolvent() == PrimaryVariables::SolventMeaning::Ss)
                       || (enableBrine && enableSaltPrecipitation && pvIdx == Indices::saltConcentrationIdx
                           && value.primaryVarsMeaningBrine() == PrimaryVariables::BrineMeaning::Sp) ) {

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
@@ -610,7 +610,8 @@ getMaxSolutionUpdate(const std::vector<unsigned>& ixCells)
 {
     static constexpr bool enableSolvent =
         Indices::solventSaturationIdx != std::numeric_limits<unsigned>::max();
-    static constexpr bool enableBrine = Indices::saltConcentrationIdx >= 0;
+    static constexpr bool enableBrine =
+        Indices::saltConcentrationIdx != std::numeric_limits<unsigned>::max();
 
     // Init output
     Scalar dPMax = 0.0;
@@ -631,7 +632,7 @@ getMaxSolutionUpdate(const std::vector<unsigned>& ixCells)
                           && value.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Sg)
                       || (enableSolvent && pvIdx == static_cast<int>(Indices::solventSaturationIdx)
                           && value.primaryVarsMeaningSolvent() == PrimaryVariables::SolventMeaning::Ss)
-                      || (enableBrine && enableSaltPrecipitation && pvIdx == Indices::saltConcentrationIdx
+                      || (enableBrine && enableSaltPrecipitation && pvIdx == static_cast<int>(Indices::saltConcentrationIdx)
                           && value.primaryVarsMeaningBrine() == PrimaryVariables::BrineMeaning::Sp) ) {
                 dSMax = std::max(dSMax, std::abs(value[pvIdx]));
             }

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
@@ -624,7 +624,7 @@ getMaxSolutionUpdate(const std::vector<unsigned>& ixCells)
             if (pvIdx == Indices::pressureSwitchIdx) {
                 dPMax = std::max(dPMax, std::abs(value[pvIdx]));
             }
-            else if ( (pvIdx == Indices::waterSwitchIdx
+            else if ((pvIdx == int(Indices::waterSwitchIdx)
                        && value.primaryVarsMeaningWater() == PrimaryVariables::WaterMeaning::Sw)
                       || (pvIdx == Indices::compositionSwitchIdx
                           && value.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Sg)

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
@@ -622,25 +622,25 @@ getMaxSolutionUpdate(const std::vector<unsigned>& ixCells)
     // Loop over solution update, get the correct variables and calculate max.
     for (const auto& ix : ixCells) {
         const auto& value = solUpd_[ix];
-        for (int pvIdx = 0; pvIdx < static_cast<int>(value.size()); ++pvIdx) {
+        for (unsigned pvIdx = 0; pvIdx < value.size(); ++pvIdx) {
             if (pvIdx == Indices::pressureSwitchIdx) {
                 dPMax = std::max(dPMax, std::abs(value[pvIdx]));
             }
-            else if ((pvIdx == int(Indices::waterSwitchIdx)
+            else if ((pvIdx == Indices::waterSwitchIdx
                        && value.primaryVarsMeaningWater() == PrimaryVariables::WaterMeaning::Sw)
-                      || (pvIdx == static_cast<int>(Indices::compositionSwitchIdx)
+                      || (pvIdx == Indices::compositionSwitchIdx
                           && value.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Sg)
-                      || (enableSolvent && pvIdx == static_cast<int>(Indices::solventSaturationIdx)
+                      || (enableSolvent && pvIdx == Indices::solventSaturationIdx
                           && value.primaryVarsMeaningSolvent() == PrimaryVariables::SolventMeaning::Ss)
-                      || (enableBrine && enableSaltPrecipitation && pvIdx == static_cast<int>(Indices::saltConcentrationIdx)
+                      || (enableBrine && enableSaltPrecipitation && pvIdx == Indices::saltConcentrationIdx
                           && value.primaryVarsMeaningBrine() == PrimaryVariables::BrineMeaning::Sp) ) {
                 dSMax = std::max(dSMax, std::abs(value[pvIdx]));
             }
-            else if (pvIdx == static_cast<int>(Indices::compositionSwitchIdx)
+            else if (pvIdx == Indices::compositionSwitchIdx
                      && value.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Rs) {
                 dRsMax = std::max(dRsMax, std::abs(value[pvIdx]));
             }
-            else if (pvIdx == static_cast<int>(Indices::compositionSwitchIdx)
+            else if (pvIdx == Indices::compositionSwitchIdx
                      && value.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Rv) {
                 dRvMax = std::max(dRvMax, std::abs(value[pvIdx]));
             }

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
@@ -410,7 +410,7 @@ relativeChange() const
             FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx) &&
             priVarsNew.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Sg)
         {
-            assert(Indices::compositionSwitchIdx >= 0);
+            assert(Indices::compositionSwitchIdx != std::numeric_limits<unsigned>::max());
             saturationsNew[FluidSystem::gasPhaseIdx] = priVarsNew[Indices::compositionSwitchIdx];
             oilSaturationNew -= saturationsNew[FluidSystem::gasPhaseIdx];
         }
@@ -441,7 +441,7 @@ relativeChange() const
 
             if (priVarsOld.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Sg)
             {
-                assert(Indices::compositionSwitchIdx >= 0 );
+                assert(Indices::compositionSwitchIdx != std::numeric_limits<unsigned>::max());
                 saturationsOld[FluidSystem::gasPhaseIdx] =
                     priVarsOld[Indices::compositionSwitchIdx];
                 oilSaturationOld -= saturationsOld[FluidSystem::gasPhaseIdx];
@@ -626,7 +626,7 @@ getMaxSolutionUpdate(const std::vector<unsigned>& ixCells)
             }
             else if ((pvIdx == int(Indices::waterSwitchIdx)
                        && value.primaryVarsMeaningWater() == PrimaryVariables::WaterMeaning::Sw)
-                      || (pvIdx == Indices::compositionSwitchIdx
+                      || (pvIdx == static_cast<int>(Indices::compositionSwitchIdx)
                           && value.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Sg)
                       || (enableSolvent && pvIdx == Indices::solventSaturationIdx
                           && value.primaryVarsMeaningSolvent() == PrimaryVariables::SolventMeaning::Ss)
@@ -634,11 +634,11 @@ getMaxSolutionUpdate(const std::vector<unsigned>& ixCells)
                           && value.primaryVarsMeaningBrine() == PrimaryVariables::BrineMeaning::Sp) ) {
                 dSMax = std::max(dSMax, std::abs(value[pvIdx]));
             }
-            else if (pvIdx == Indices::compositionSwitchIdx
+            else if (pvIdx == static_cast<int>(Indices::compositionSwitchIdx)
                      && value.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Rs) {
                 dRsMax = std::max(dRsMax, std::abs(value[pvIdx]));
             }
-            else if (pvIdx == Indices::compositionSwitchIdx
+            else if (pvIdx == static_cast<int>(Indices::compositionSwitchIdx)
                      && value.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Rv) {
                 dRvMax = std::max(dRvMax, std::abs(value[pvIdx]));
             }

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -62,6 +62,7 @@
 #include <cassert>
 #include <cstddef>
 #include <functional>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -128,7 +129,8 @@ class OutputBlackOilModule : public GenericOutputBlackoilModule<GetPropType<Type
     enum { enableMICP = Indices::enableMICP };
     enum { enableVapwat = getPropValue<TypeTag, Properties::EnableVapwat>() };
     enum { enableDisgasInWater = getPropValue<TypeTag, Properties::EnableDisgasInWater>() };
-    enum { enableDissolvedGas = Indices::compositionSwitchIdx >= 0 };
+    static constexpr bool enableDissolvedGas =
+        Indices::compositionSwitchIdx != std::numeric_limits<unsigned>::max();
 
     template<class VectorType>
     static Scalar value_or_zero(int idx, const VectorType& v)

--- a/opm/simulators/flow/TemperatureModel.hpp
+++ b/opm/simulators/flow/TemperatureModel.hpp
@@ -42,10 +42,13 @@
 #include <opm/simulators/linalg/istlsparsematrixadapter.hh>
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cmath>
 #include <cstddef>
+#include <memory>
 #include <limits>
+#include <set>
 #include <vector>
 
 namespace Opm::Properties {

--- a/opm/simulators/flow/TemperatureModel.hpp
+++ b/opm/simulators/flow/TemperatureModel.hpp
@@ -45,7 +45,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstddef>
-#include <string>
+#include <limits>
 #include <vector>
 
 namespace Opm::Properties {
@@ -78,7 +78,8 @@ class BlackOilEnergyIntensiveQuantitiesTemp
     enum { enableSaltPrecipitation = getPropValue<TypeTag, Properties::EnableSaltPrecipitation>() };
     static constexpr bool enableSolvent = getPropValue<TypeTag, Properties::EnableSolvent>();
     enum { numPhases = getPropValue<TypeTag, Properties::NumPhases>() };
-    static constexpr bool compositionSwitchEnabled = Indices::compositionSwitchIdx >= 0;
+    static constexpr bool compositionSwitchEnabled =
+        Indices::compositionSwitchIdx != std::numeric_limits<unsigned>::max();
 
     public:
     using EvaluationTemp = DenseAd::Evaluation<Scalar, 1>;

--- a/opm/simulators/flow/TemperatureModel.hpp
+++ b/opm/simulators/flow/TemperatureModel.hpp
@@ -226,7 +226,7 @@ class TemperatureModel : public GenericTemperatureModel<GetPropType<TypeTag, Pro
     enum { waterPhaseIdx = FluidSystem::waterPhaseIdx };
     enum { oilPhaseIdx = FluidSystem::oilPhaseIdx };
     enum { gasPhaseIdx = FluidSystem::gasPhaseIdx };
-    static constexpr int temperatureIdx = 0;
+    static constexpr unsigned temperatureIdx = 0;
 
 public:
     explicit TemperatureModel(Simulator& simulator)

--- a/opm/simulators/utils/ComponentName.cpp
+++ b/opm/simulators/utils/ComponentName.cpp
@@ -31,6 +31,7 @@
 #include <opm/models/blackoil/blackoiltwophaseindices.hh>
 
 #include <cassert>
+#include <limits>
 
 namespace Opm {
 
@@ -60,7 +61,7 @@ ComponentName<FluidSystem,Indices>::ComponentName()
         names_[Indices::polymerConcentrationIdx] = "Polymer";
     }
 
-    if constexpr (Indices::polymerMoleWeightIdx >= 0) {
+    if constexpr (Indices::polymerMoleWeightIdx != std::numeric_limits<unsigned>::max()) {
         assert(Indices::enablePolymer);
         names_[Indices::polymerMoleWeightIdx] = "MolecularWeightP";
     }

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -62,6 +62,7 @@ namespace Opm {
 
 #include <opm/material/densead/Evaluation.hpp>
 
+#include <limits>
 #include <vector>
 
 namespace Opm
@@ -131,7 +132,7 @@ public:
                                           FluidSystem,
                                           energyModuleType != EnergyModules::NoTemperature,
                                           energyModuleType == EnergyModules::FullyImplicitThermal,
-                                          Indices::compositionSwitchIdx >= 0,
+                                          Indices::compositionSwitchIdx != std::numeric_limits<unsigned>::max(),
                                           has_watVapor,
                                           has_brine,
                                           has_saltPrecip,


### PR DESCRIPTION
nvcc creates a lot of noise when you call operator[] with an int index, since operator[] is implemented for an unsigned index.

We can either cast everywhere, or we can make indices unsigned once and for all. Here I have implemented the latter, using numeric_limits<unsigned>::max() as sentintel instead of the -1000 previous used.