### PR TITLE
Mark all overridden methods with override.

### DIFF
--- a/opm/simulators/linalg/ISTLSolverGpuBridge.hpp
+++ b/opm/simulators/linalg/ISTLSolverGpuBridge.hpp
@@ -217,22 +217,22 @@ public:
     }
 
 
-    void setResidual(Vector& /* b */)
+    void setResidual(Vector& /* b */) override
     {
         // rhs_ = &b; // Must be handled in prepare() instead.
     }
 
-    void getResidual(Vector& b) const
+    void getResidual(Vector& b) const override
     {
         b = *(this->rhs_);
     }
 
-    void setMatrix(const SparseMatrixAdapter& /* M */)
+    void setMatrix(const SparseMatrixAdapter& /* M */) override
     {
         // matrix_ = &M.istlMatrix(); // Must be handled in prepare() instead.
     }
 
-    bool solve(Vector& x)
+    bool solve(Vector& x) override
     {
         if (!gpuBridge_) {
             return ParentType::solve(x);


### PR DESCRIPTION
With only `prepare()` marked `override`, clang gives warnings.