### PR TITLE
gpuistl: allocate cusparseSpMV external buffer on all CUDA versions

### DIFF
--- a/opm/simulators/linalg/gpuistl/GpuSparseMatrixGeneric.cpp
+++ b/opm/simulators/linalg/gpuistl/GpuSparseMatrixGeneric.cpp
@@ -170,9 +170,11 @@ GpuSparseMatrixGeneric<T>::preprocessSpMV()
                                                    &bufferSize));
 
     if (bufferSize > 0) {
-#if CUDA_VERSION >= 12040
+        // cusparseSpMV() always needs a valid external buffer (since CUDA 11.0),
+        // so allocate it for every supported CUDA version, not only >= 12.4.
         m_buffer.resize(bufferSize);
-        // Preprocess SpMV operation to optimize for this sparsity pattern (requires CUDA 12.4+)
+#if CUDA_VERSION >= 12040
+        // Preprocess SpMV operation to optimize for this sparsity pattern (requires CUDA 12.4+).
         // TODO: Does the value of the alpha and beta matter in this preprocessing?
         OPM_CUSPARSE_SAFE_CALL(cusparseSpMV_preprocess(m_cusparseHandle.get(),
                                                     CUSPARSE_OPERATION_NON_TRANSPOSE,


### PR DESCRIPTION
# GpuSparseMatrixGeneric: cusparseSpMV fails with NULL externalBuffer on CUDA 12.0–12.3 (buffer allocation incorrectly gated behind `CUDA_VERSION >= 12040`)

## Summary

In `GpuSparseMatrixGeneric<T>::preprocessSpMV()`, the cuSPARSE generic-SpMV external
work buffer (`m_buffer`) is **allocated only when `CUDA_VERSION >= 12040`**, but the
buffer pointer `m_buffer.data()` is later passed to `cusparseSpMV()` **unconditionally**
in `spMV()`. When OPM is built against a CUDA toolkit in the range 12.0–12.3, the buffer
is therefore never allocated, `m_buffer.data()` returns `nullptr`, and the first
`cusparseSpMV()` call aborts with:

```
** On entry to cusparseSpMV() parameter number 10 (externalBuffer) had an illegal value: NULL pointer
```

`cusparseSpMV()` requires a valid `externalBuffer` whenever `cusparseSpMV_bufferSize()`
returns `bufferSize > 0` — independent of the CUDA version. Only the
**`cusparseSpMV_preprocess()`** optimization is new in CUDA 12.4 and legitimately needs
the version guard. The bug is that the buffer **allocation** was placed inside the same
`#if CUDA_VERSION >= 12040` block as the preprocess call, when it should be performed for
every supported CUDA version.

## Environment

- OPM `master` @ `6c91565f1` (also present in release 2026.04).
- CUDA Runtime 12.2 / driver 12.2 (conda `cuda-toolkit` 12.2).
- GPU: NVIDIA Tesla V100 (sm_70). **Not GPU-model specific** — see "Affected scope".
- Built with `gpuistl` (GPU ISTL) enabled, full-GPU CPR linear solver.

## Where the bug lives (master)

`opm/simulators/linalg/gpuistl/GpuSparseMatrixGeneric.cpp`, `preprocessSpMV()`:

```cpp
172     if (bufferSize > 0) {
173 #if CUDA_VERSION >= 12040
174         m_buffer.resize(bufferSize);                 // <-- only allocated on CUDA >= 12.4
175         // Preprocess SpMV operation ... (requires CUDA 12.4+)
177         OPM_CUSPARSE_SAFE_CALL(cusparseSpMV_preprocess( ... m_buffer.data()));
187 #endif
188     }
```

Same file, `spMV()` (the buffer is consumed unconditionally):

```cpp
280     OPM_CUSPARSE_SAFE_CALL(cusparseSpMV(m_cusparseHandle.get(),
281                                         CUSPARSE_OPERATION_NON_TRANSPOSE,
                                            ...
289                                         m_buffer.data()));   // <-- nullptr on CUDA < 12.4
```

`m_buffer` is a `GpuBuffer<std::byte>` (`GpuSparseMatrixGeneric.hpp:316`). A
default-constructed `GpuBuffer` has `m_dataOnDevice = nullptr` and `size() == 0`
(`GpuBuffer.hpp:67, 387`), so `data()` returns `nullptr` until `resize()` is called.

## Why CUDA 12.x is affected even though `GpuSparseMatrixWrapper` selects the legacy API

`GpuSparseMatrixWrapper` picks the legacy `GpuSparseMatrix<T>` for
`CUDA_VERSION < 13000` (`GpuSparseMatrixWrapper.hpp:73-79`). However, the legacy
`GpuSparseMatrix<T>` does **not** implement block size 1 itself — it delegates every
block-size-1 matrix to an internally owned `GpuSparseMatrixGeneric<T>`:

- construction: `GpuSparseMatrix.cpp:60-64` (`if (blockSize == 1) m_genericMatrixForBlockSize1 = make_unique<GpuSparseMatrixGeneric<T>>(...)`)
- SpMV: `GpuSparseMatrix.cpp:324-328` (`usmv` forwards to `m_genericMatrixForBlockSize1->usmv(...)`), likewise `mv`/`umv`.

The CPR pressure (coarse) level matrix is exactly such a block-size-1 matrix
(`GpuPressureTransferPolicy::createCoarseLevelSystem`, block size 1, same sparsity
pattern, `GpuPressureTransferPolicy.hpp:77-78`). So on CUDA 12.2 the coarse-level
`usmv` lands in `GpuSparseMatrixGeneric::spMV` with an unallocated buffer.

## Minimal reproduction

Run any GPU CPR case with a CUDA 12.0–12.3 toolkit, e.g. full-GPU CPR with a
block-size-1 coarse level:

```
flow CASE.DATA \
     --linear-solver=cpr_gpu.json \   # two-level CPR, GPU coarse operator
     --matrix-add-well-contributions=true
```

It fails at the very first linear solve (step 0). A pure unit reproduction also exists in
the current test suite — `RandomSparsityMatrixGeneric<1>` in
`tests/gpuistl/test_GpuSparseMatrix.cu` constructs a `GpuSparseMatrixGeneric<double>`
with block size 1 and calls `usmv`/`mv`; that test case fails on CUDA 12.0–12.3 for the
same reason (see `bugA_test.md`).

## Exact error / backtrace (from our run, CUDA 12.2, V100)

```
** On entry to cusparseSpMV() parameter number 10 (externalBuffer) had an illegal value: NULL pointer

Error: [.../gpuistl/detail/cusparse_safe_call.hpp:118] cuSparse expression did not execute correctly. Expression was:
    cusparseSpMV(m_cusparseHandle.get(), CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha,
                 *m_matrixDescriptor, *vecX, &beta, *vecY, getDataType(),
                 CUSPARSE_SPMV_ALG_DEFAULT, m_buffer.data())
in function spMV, in .../gpuistl/GpuSparseMatrixGeneric.cpp, at line 280

#2  Opm::gpuistl::GpuSparseMatrixGeneric<double>::spMV(...)
#3  Opm::gpuistl::GpuSparseMatrix<double>::usmv(...)
#4  Dune::LoopSolver<GpuVector<double>>::apply(...)
#5  Dune::OwningTwoLevelPreconditioner< ... GpuPressureTransferPolicy ... >::apply(...)
#6  Dune::BiCGSTABSolver<GpuVector<double>>::apply(...)
#7  Opm::gpuistl::ISTLSolverGPUISTL<...>::solve(...)
```

## Root cause

The `cusparseSpMV` external buffer allocation (`m_buffer.resize(bufferSize)`) was placed
inside the `#if CUDA_VERSION >= 12040` guard together with the (correctly guarded)
`cusparseSpMV_preprocess()` call. The buffer is a hard requirement of `cusparseSpMV()`
on all supported CUDA versions, so it must be allocated whenever `bufferSize > 0`,
independent of the CUDA version.

## Affected scope

- Any OPM build with `gpuistl` enabled against a **CUDA 12.0–12.3** toolkit
  (`12000 <= CUDA_VERSION < 12040`).
- Triggered by any use of `GpuSparseMatrixGeneric<T>::spMV`/`mv`/`umv`/`usmv`, which in
  practice means **any block-size-1 GPU sparse matrix** (legacy `GpuSparseMatrix<T>`
  delegates block size 1 to it). The most common trigger is the **GPU CPR coarse
  (pressure) level**.
- Not reproduced on CUDA >= 12.4 (buffer allocated) and not on CUDA >= 13.0 path either.
- **HIP/ROCm is affected by the same root cause**: under `USE_HIP`, `CUDA_VERSION` is
  undefined so the guard is false and `m_buffer` is likewise never allocated; the fix
  (allocate whenever `bufferSize > 0`) corrects HIP as well rather than regressing it
  (`GpuBuffer::resize` is a plain hipMalloc/hipMemcpy with no version guard).
- **Not** specific to V100 / sm_70 or to any GPU model: it is a compile-time
  CUDA-version guard placement issue. The faulty pointer is a host-side
  null pointer passed to a CUDA API; it is identical on every NVIDIA GPU.

## Proposed fix

Move `m_buffer.resize(bufferSize)` **out of** the `#if CUDA_VERSION >= 12040` block so the
buffer is always allocated when `bufferSize > 0`, and keep only the
`cusparseSpMV_preprocess()` call (which genuinely requires CUDA 12.4) inside the guard.
See `bugA_patch.diff`. This restores the original intent of `preprocessSpMV()` (allocate
once at construction) and keeps `spMV()` unchanged.
