### PR TITLE
Output pv at reservoir conditions not reference for FRPV and RRPV

### DIFF
--- a/opm/simulators/flow/FIPContainer.cpp
+++ b/opm/simulators/flow/FIPContainer.cpp
@@ -527,9 +527,16 @@ template<class FluidSystem>
 void
 FIPContainer<FluidSystem>::
 assignPoreVolume(const unsigned globalDofIdx,
-                 const Scalar   value)
+                 const Scalar   poreVolume,
+                 const Scalar   dynamicPoreVolume)
 {
-    this->fip_[Inplace::Phase::PoreVolume][globalDofIdx] = value;
+    if (this->has(Inplace::Phase::PoreVolume)) {
+        this->fip_[Inplace::Phase::PoreVolume][globalDofIdx] = poreVolume;
+    }
+
+    if (this->has(Inplace::Phase::DynamicPoreVolume)) {
+        this->fip_[Inplace::Phase::DynamicPoreVolume][globalDofIdx] = dynamicPoreVolume;
+    }
 }
 
 template<class T> using FS = BlackOilFluidSystem<T, BlackOilDefaultFluidSystemIndices>;

--- a/opm/simulators/flow/FIPContainer.hpp
+++ b/opm/simulators/flow/FIPContainer.hpp
@@ -121,7 +121,8 @@ public:
                                   const Scalar   oilInPlaceGas);
 
     void assignPoreVolume(const unsigned globalDofIdx,
-                          const Scalar   value);
+                          const Scalar   poreVolume,
+                          const Scalar   dynamicPoreVolume);
 
     void assignVolumesSurface(const unsigned globalDofIdx,
                               const std::array<Scalar, numPhases>& fip);

--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -636,17 +636,18 @@ doAllocBuffers(const unsigned bufferSize,
         this->summaryConfig_.hasKeyword("FPR") ||
         this->summaryConfig_.hasKeyword("FPRP");
 
-    const auto needPoreVolume = needAvgPress    ||
-        this->summaryConfig_.hasKeyword("FHPV") ||
-        this->summaryConfig_.match("RHPV*");
+    const auto needPoreVolume = needAvgPress     ||
+        this->summaryConfig_.hasKeyword("FRPV")  ||
+        this->summaryConfig_.match("RRPV*") ||
+        this->summaryConfig_.hasKeyword("FHPV")  ||
+        this->summaryConfig_.match("RHPV*") ;
 
     if (needPoreVolume) {
         this->fipC_.add(Inplace::Phase::PoreVolume);
-        this->dynamicPoreVolume_.resize(bufferSize, 0.0);
+        this->fipC_.add(Inplace::Phase::DynamicPoreVolume);
         this->hydrocarbonPoreVolume_.resize(bufferSize, 0.0);
     }
     else {
-        this->dynamicPoreVolume_.clear();
         this->hydrocarbonPoreVolume_.clear();
     }
 
@@ -1037,9 +1038,6 @@ makeRegionSum(Inplace& inplace,
 
     update_inplace(Inplace::Phase::PressureHydroCarbonPV,
                    this->pressureTimesHydrocarbonVolume_);
-
-    update_inplace(Inplace::Phase::DynamicPoreVolume,
-                   this->dynamicPoreVolume_);
 
     for (const auto& phase : Inplace::phases()) {
         update_inplace(phase, this->fipC_.get(phase));

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -433,7 +433,6 @@ protected:
     ScalarBuffer hydrocarbonPoreVolume_;
     ScalarBuffer pressureTimesPoreVolume_;
     ScalarBuffer pressureTimesHydrocarbonVolume_;
-    ScalarBuffer dynamicPoreVolume_;
     ScalarBuffer rPorV_;
     ScalarBuffer fluidPressure_;
     ScalarBuffer temperature_;

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -954,11 +954,10 @@ private:
         const double pv = totVolume * intQuants.porosity().value();
         const auto hydrocarbon = this->hydroCarbonFraction(fs);
 
+        this->fipC_.assignPoreVolume(globalDofIdx,
+                                totVolume * intQuants.referencePorosity(),
+                                pv);
         if (! this->hydrocarbonPoreVolume_.empty()) {
-            this->fipC_.assignPoreVolume(globalDofIdx,
-                                         totVolume * intQuants.referencePorosity());
-
-            this->dynamicPoreVolume_[globalDofIdx] = pv;
             this->hydrocarbonPoreVolume_[globalDofIdx] = pv * hydrocarbon;
         }
 

--- a/tests/test_LogOutputHelper.cpp
+++ b/tests/test_LogOutputHelper.cpp
@@ -461,6 +461,11 @@ BOOST_FIXTURE_TEST_CASE(FipResv, LogNoteFixture)
     current.add(Opm::Inplace::Phase::GasResVolume, 4.0);
     current.add("FIPNUM", Opm::Inplace::Phase::DynamicPoreVolume, 1, 11.0 + offset);
 
+    // Keep region-level reservoir volumes stable regardless of phase list order.
+    current.add("FIPNUM", Opm::Inplace::Phase::OilResVolume, 1, 27.0);
+    current.add("FIPNUM", Opm::Inplace::Phase::WaterResVolume, 1, 26.0);
+    current.add("FIPNUM", Opm::Inplace::Phase::GasResVolume, 1, 28.0);
+
     Opm::LogOutputHelper<double> helper(eclState, schedule, st, "dummy version");
     helper.fipResv(current, "FIPNUM");
 


### PR DESCRIPTION
The current FRPV and RRPV outputs PV at the reference condition. (not very interesting as they are constant anyway). 