### PR TITLE
Read parameters from user's configuration file if present.

### DIFF
--- a/opm/models/utils/start.hh
+++ b/opm/models/utils/start.hh
@@ -43,6 +43,7 @@
 #include <dune/fem/misc/mpimanager.hh>
 #endif
 
+#include <cstdlib>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -149,6 +150,17 @@ static inline int setupParameters_(int argc,
                 Parameters::printUsage(argv[0], std::cerr, oss.str());
             }
             return /*status=*/1;
+        }
+    }
+
+    {
+        const char* home = std::getenv("HOME");
+        if (home != nullptr) {
+            const std::string userRcFilename = std::string(home) + "/.config/OpmFlow/user_parameters.param";
+            const bool readFromUserRc = Parameters::parseParameterFile(userRcFilename, /*overwrite=*/false);
+            if (readFromUserRc && myRank == 0) {
+                std::cerr << "Read parameters from " << userRcFilename << ".\n";
+            }
         }
     }
 


### PR DESCRIPTION
Allows to put command line parameters you would like to use all the time in a configuration file in your home directory, `$(HOME)/.config/OpmFlow/user_parameters.param` Parameters from that file will not override any given on the command line or via the --parameter-file option.

The syntax used is the same as for files passed using the ParameterFile option, i.e.
```
ThreadsPerProcess=1
```
instead of the command line version `--threads-per-process=1`.