### PR TITLE
using lastCompletionCloseTime() when trying to open completions

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -931,7 +931,8 @@ namespace Opm {
                         }
 
                         // ... but not one closed during the current timestep
-                        const bool closed_this_step = (well_test_state.lastTestTime(well_name) == simulator_.time());
+                        const bool closed_this_step =
+                            (well_test_state.lastCompletionCloseTime(well_name, complnum) == simulator_.time());
                         if (closed_this_step) {
                             continue;
                         }


### PR DESCRIPTION
the original code will trigger map::at failure. 

it is to fix a bug introduced in https://github.com/OPM/opm-simulators/pull/7165