### PR TITLE
TPSA fix gas-water dissolution simulator

### DIFF
--- a/flow/flow_gaswater_dissolution_tpsa.cpp
+++ b/flow/flow_gaswater_dissolution_tpsa.cpp
@@ -20,7 +20,12 @@
 */
 #include "config.h"
 
+#include <flow/flow_gaswater_dissolution_tpsa.hpp>
+
+#include <opm/material/thermal/EnergyModuleType.hpp>
+
 #include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+#include <opm/models/blackoil/blackoilenergymodules.hh>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/blackoil/blackoiltwophaseindices.hh>
 
@@ -64,6 +69,10 @@ struct EnableDisgasInWater<TypeTag, TTag::FlowGasWaterDissolutionProblemTPSA>
 template<class TypeTag>
 struct EnableVapwat<TypeTag, TTag::FlowGasWaterDissolutionProblemTPSA>
 { static constexpr bool value = true; };
+
+template<class TypeTag>
+struct EnergyModuleType<TypeTag, TTag::FlowGasWaterDissolutionProblemTPSA>
+{ static constexpr EnergyModules value = EnergyModules::ConstantTemperature; };
 
 //! The indices required by the model
 template<class TypeTag>


### PR DESCRIPTION
Fixes a bug where gas-water dissolution with TPSA simulator had no temperature module activated.