### PR TITLE
Extra timings

### DIFF
--- a/flowexperimental/comp/EmptyModel.hpp
+++ b/flowexperimental/comp/EmptyModel.hpp
@@ -75,6 +75,7 @@ public:
     void endIteration()const{};
     void endTimeStep(){};
     void endEpisode(){};
+    int numTracers() const { return 0; }
     void applyInitial() override {}
     auto aquiferData() const {
         return data::Aquifers{};

--- a/opm/simulators/flow/Banners.cpp
+++ b/opm/simulators/flow/Banners.cpp
@@ -116,7 +116,8 @@ void printFlowTrailer(int nprocs,
                       int nthreads,
                       const double total_setup_time,
                       const double deck_read_time,
-                      const SimulatorReport& report)
+                      const SimulatorReport& report,
+                      const bool performance_details)
 {
     std::ostringstream ss;
     ss << "\n\n================    End of simulation     ===============\n\n";
@@ -124,7 +125,7 @@ void printFlowTrailer(int nprocs,
     ss << fmt::format("Threads per MPI process: {:9}\n", nthreads);
     ss << fmt::format("Setup time:                 {:9.2f} s\n", total_setup_time);
     ss << fmt::format("  Deck input:               {:9.2f} s\n", deck_read_time);
-    report.reportFullyImplicit(ss);
+    report.reportFullyImplicit(ss, performance_details);
     OpmLog::info(ss.str());
 }
 

--- a/opm/simulators/flow/Banners.cpp
+++ b/opm/simulators/flow/Banners.cpp
@@ -121,7 +121,8 @@ void printFlowTrailer(int nprocs,
                       const double total_setup_time,
                       const double deck_read_time,
                       const SimulatorReport& report,
-                      const std::string_view extra_summary)
+                      const std::string_view extra_summary,
+                      const bool performance_details)
 {
     std::ostringstream ss;
     ss << "\n\n================    End of simulation     ===============\n\n";
@@ -129,7 +130,7 @@ void printFlowTrailer(int nprocs,
     ss << fmt::format("Threads per MPI process: {:9}\n", nthreads);
     ss << fmt::format("Setup time:                 {:9.2f} s\n", total_setup_time);
     ss << fmt::format("  Deck input:               {:9.2f} s\n", deck_read_time);
-    report.reportFullyImplicit(ss);
+    report.reportFullyImplicit(ss, performance_details);
     if (!extra_summary.empty()) {
         if (extra_summary.front() != '\n') {
             ss << '\n';

--- a/opm/simulators/flow/Banners.hpp
+++ b/opm/simulators/flow/Banners.hpp
@@ -44,7 +44,8 @@ void printFlowTrailer(int nprocs,
                       int nthreads,
                       const double total_setup_time,
                       const double deck_read_time,
-                      const SimulatorReport& report);
+                      const SimulatorReport& report,
+                      const bool performance_details = false);
 
 } // namespace Opm
 

--- a/opm/simulators/flow/Banners.hpp
+++ b/opm/simulators/flow/Banners.hpp
@@ -46,7 +46,8 @@ void printFlowTrailer(int nprocs,
                       const double total_setup_time,
                       const double deck_read_time,
                       const SimulatorReport& report,
-                      std::string_view extra_summary);
+                      std::string_view extra_summary,
+                      const bool performance_details = false);
 
 } // namespace Opm
 

--- a/opm/simulators/flow/ConvergenceOutputConfiguration.cpp
+++ b/opm/simulators/flow/ConvergenceOutputConfiguration.cpp
@@ -57,7 +57,7 @@ namespace {
                 fmt::format("Unsupported convergence output "
                             "option value{}: {}\n"
                             "Supported values are \"none\", "
-                            "\"steps\", and \"iterations\"",
+                            "\"steps\", \"iterations\", and \"performance\"",
                             pl, fmt::join(unsupp.begin(), u, ", "))
             };
         }
@@ -65,7 +65,7 @@ namespace {
         throw std::invalid_argument {
             fmt::format("Option {}:\n - Unsupported value{}: {}\n"
                         " - Supported values are \"none\", "
-                        "\"steps\", and \"iterations\"",
+                        "\"steps\", \"iterations\", and \"performance\"",
                         optionName, pl,
                         fmt::join(unsupp.begin(), u, ", "))
         };
@@ -79,11 +79,13 @@ namespace {
         auto opt = std::vector<Option>{};
 
         const auto values = std::unordered_map<std::string, Option> {
-            { "none"      , Option::None       },
-            { "step"      , Option::Steps      }, // Alias for 'steps' (plural)
-            { "steps"     , Option::Steps      },
-            { "iteration" , Option::Iterations }, // Alias for 'iterations' (plural)
-            { "iterations", Option::Iterations },
+            { "none"       , Option::None        },
+            { "step"       , Option::Steps       }, // Alias for 'steps' (plural)
+            { "steps"      , Option::Steps       },
+            { "iteration"  , Option::Iterations  }, // Alias for 'iterations' (plural)
+            { "iterations" , Option::Iterations  },
+            { "perf"       , Option::Performance }, // Alias for 'performance'
+            { "performance", Option::Performance },
         };
 
         auto unsupp = std::vector<std::string>{};

--- a/opm/simulators/flow/ConvergenceOutputConfiguration.hpp
+++ b/opm/simulators/flow/ConvergenceOutputConfiguration.hpp
@@ -39,6 +39,9 @@ namespace Opm {
 ///   * "iterations" -- Want additional convergence output pertaining to each
 ///                     non-linar ieration in each timestep.
 ///
+///   * "performance" -- Want additional performance details in the summary
+///                      at the end of the simulation.
+///
 /// Option value "none" overrides all other options.  In other words, if the
 /// user requests "none", then there will be no additional convergence
 /// output, even if there are other options in the option string.
@@ -54,6 +57,7 @@ public:
         None = 0,
         Steps = 1 << 1,
         Iterations = 1 << 2,
+        Performance = 1 << 3,
     };
 
     /// Constructor

--- a/opm/simulators/flow/EclGenericWriter.hpp
+++ b/opm/simulators/flow/EclGenericWriter.hpp
@@ -114,6 +114,14 @@ public:
 
     void extractOutputTransAndNNC(const std::function<unsigned int(unsigned int)>& map);
 
+    /// \brief Wait for any pending output tasklet to finish and return the
+    /// accumulated time used by the actual (possibly asynchronous) writes.
+    double finalizeAsyncWriteTime()
+    {
+        taskletRunner_->barrier();
+        return asyncWriteTime_;
+    }
+
 protected:
     const TransmissibilityType& globalTrans() const;
     unsigned int gridEquilIdxToGridIdx(unsigned int elemIndex) const;
@@ -163,6 +171,9 @@ protected:
     const EclipseState& eclState_;
     std::unique_ptr<EclipseIO> eclIO_;
     std::unique_ptr<TaskletRunner> taskletRunner_;
+    // time used by the actual output writes; written by the output thread,
+    // only read after a barrier on the tasklet runner
+    double asyncWriteTime_ = 0.0;
     Scalar restartTimeStepSize_;
     const TransmissibilityType* globalTrans_ = nullptr;
     const Dune::CartesianIndexMapper<Grid>& cartMapper_;

--- a/opm/simulators/flow/EclGenericWriter_impl.hpp
+++ b/opm/simulators/flow/EclGenericWriter_impl.hpp
@@ -65,6 +65,7 @@
 #include <cmath>
 #include <functional>
 #include <map>
+#include <chrono>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -153,6 +154,9 @@ struct EclWriteTasklet : public Opm::TaskletInterface
     bool writeDoublePrecision_;
     /// \brief True if there was an EXIT keyword in ACTIONX causing a simulation end
     bool forcedSimulationFinished_;
+    /// \brief Accumulates the time used by the actual write. Written by the
+    /// output thread; only to be read after a barrier on the tasklet runner.
+    double* writeTime_;
 
     explicit EclWriteTasklet(const Opm::Action::State& actionState,
                              const Opm::WellTestState& wtestState,
@@ -165,7 +169,8 @@ struct EclWriteTasklet : public Opm::TaskletInterface
                              double secondsElapsed,
                              std::vector<Opm::RestartValue> restartValue,
                              bool writeDoublePrecision,
-                             bool forcedSimulationFinished)
+                             bool forcedSimulationFinished,
+                             double* writeTime)
         : actionState_(actionState)
         , wtestState_(wtestState)
         , summaryState_(summaryState)
@@ -178,10 +183,22 @@ struct EclWriteTasklet : public Opm::TaskletInterface
         , restartValue_(std::move(restartValue))
         , writeDoublePrecision_(writeDoublePrecision)
         , forcedSimulationFinished_(forcedSimulationFinished)
+        , writeTime_(writeTime)
     {}
 
     // callback to eclIO serial writeTimeStep method
     void run() override
+    {
+        const auto start = std::chrono::steady_clock::now();
+        this->writeTimeStep_();
+        const auto end = std::chrono::steady_clock::now();
+        if (this->writeTime_ != nullptr) {
+            *this->writeTime_ += std::chrono::duration<double>(end - start).count();
+        }
+    }
+
+private:
+    void writeTimeStep_()
     {
         if (this->restartValue_.size() == 1) {
             this->eclIO_.writeTimeStep(this->actionState_,
@@ -1010,7 +1027,7 @@ doWriteOutput(const int                          reportStepNum,
         isParallel ? this->collectOnIORank_.globalWellTestState() : std::move(localWTestState),
         summaryState, udqState, *this->eclIO_,
         reportStepNum, timeStepNum, isSubStep, curTime, std::move(restartValues), doublePrecision,
-        isForcedFinalOutput);
+        isForcedFinalOutput, &this->asyncWriteTime_);
 
     // finally, start a new output writing job
     this->taskletRunner_->dispatch(std::move(eclWriteTasklet));

--- a/opm/simulators/flow/FlowMain.hpp
+++ b/opm/simulators/flow/FlowMain.hpp
@@ -29,6 +29,7 @@
 #include <opm/models/utils/start.hh>
 
 #include <opm/simulators/flow/Banners.hpp>
+#include <opm/simulators/flow/ConvergenceOutputConfiguration.hpp>
 #include <opm/simulators/flow/FlowUtils.hpp>
 #include <opm/simulators/flow/NlddReporting.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicit.hpp>
@@ -430,7 +431,13 @@ namespace Opm {
                 = omp_get_max_threads();
 #endif
 
-            printFlowTrailer(mpi_size_, threads, total_setup_time_, deck_read_time_, report);
+            const auto extraConvOutput = ConvergenceOutputConfiguration {
+                Parameters::Get<Parameters::OutputExtraConvergenceInfo>(),
+                R"(OutputExtraConvergenceInfo (--output-extra-convergence-info))"
+            };
+
+            printFlowTrailer(mpi_size_, threads, total_setup_time_, deck_read_time_, report,
+                             extraConvOutput.want(ConvergenceOutputConfiguration::Option::Performance));
 
             detail::handleExtraConvergenceOutput(report,
                                                  Parameters::Get<Parameters::OutputExtraConvergenceInfo>(),

--- a/opm/simulators/flow/FlowMain.hpp
+++ b/opm/simulators/flow/FlowMain.hpp
@@ -29,6 +29,7 @@
 #include <opm/models/utils/start.hh>
 
 #include <opm/simulators/flow/Banners.hpp>
+#include <opm/simulators/flow/ConvergenceOutputConfiguration.hpp>
 #include <opm/simulators/flow/FlowUtils.hpp>
 #include <opm/simulators/flow/NlddReporting.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicit.hpp>
@@ -435,8 +436,14 @@ namespace Opm {
                 = omp_get_max_threads();
 #endif
 
+            const auto extraConvOutput = ConvergenceOutputConfiguration {
+                Parameters::Get<Parameters::OutputExtraConvergenceInfo>(),
+                R"(OutputExtraConvergenceInfo (--output-extra-convergence-info))"
+            };
+
             printFlowTrailer(mpi_size_, threads, total_setup_time_, deck_read_time_, report,
-                             simulator_->model().simulator().problem().extraTrailerSummary());
+                             simulator_->model().simulator().problem().extraTrailerSummary(),
+                             extraConvOutput.want(ConvergenceOutputConfiguration::Option::Performance));
 
             detail::handleExtraConvergenceOutput(report,
                                                  Parameters::Get<Parameters::OutputExtraConvergenceInfo>(),

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -33,6 +33,7 @@
 #include <dune/common/version.hh>
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
+#include <dune/common/timer.hh>
 
 #include <opm/common/utility/TimeService.hpp>
 
@@ -463,7 +464,16 @@ public:
 
         this->wellModel_.endTimeStep();
         this->aquiferModel_.endTimeStep();
-        this->tracerModel_.endTimeStep();
+        {
+            // keep track of the time used for solving the tracers, so it
+            // can be reported separately in the performance summary
+            Dune::Timer tracerTimer;
+            tracerTimer.start();
+            this->tracerModel_.endTimeStep();
+            if (this->tracerModel_.numTracers() > 0) {
+                tracer_solve_time_ += tracerTimer.stop();
+            }
+        }
 
         // Compute flux for output
         this->model().linearizer().updateFlowsInfo();
@@ -485,7 +495,13 @@ public:
 
         // Drift compensation needs to be updated before calling the temperature equation
         if constexpr(energyModuleType == EnergyModules::SequentialImplicitThermal) {
+            // keep track of the time used for the sequential implicit
+            // temperature solve, so it can be reported separately in the
+            // performance summary
+            Dune::Timer temperatureTimer;
+            temperatureTimer.start();
             this->temperatureModel_.endTimeStep(wellModel_.wellState());
+            temperature_solve_time_ += temperatureTimer.stop();
         }
     }
 
@@ -685,6 +701,24 @@ public:
 
     TracerModel& tracerModel()
     { return tracerModel_; }
+
+    /// Return the time used for solving the tracer equations since the last
+    /// call to this function, and reset the counter.
+    double popTracerSolveTime()
+    {
+        const double t = tracer_solve_time_;
+        tracer_solve_time_ = 0.0;
+        return t;
+    }
+
+    /// Return the time used for the sequential implicit temperature solve
+    /// since the last call to this function, and reset the counter.
+    double popTemperatureSolveTime()
+    {
+        const double t = temperature_solve_time_;
+        temperature_solve_time_ = 0.0;
+        return t;
+    }
 
     TemperatureModel& temperatureModel() // need for restart
     { return temperatureModel_; }
@@ -1837,6 +1871,8 @@ protected:
     PffGridVector<GridView, Stencil, PffDofData_, DofMapper> pffDofData_;
     TracerModel tracerModel_;
     TemperatureModel temperatureModel_;
+    double tracer_solve_time_ = 0.0;
+    double temperature_solve_time_ = 0.0;
 
     template<class T>
     struct BCData

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -33,6 +33,7 @@
 #include <dune/common/version.hh>
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
+#include <dune/common/timer.hh>
 
 #include <opm/common/utility/TimeService.hpp>
 
@@ -468,7 +469,16 @@ public:
 
         this->wellModel_.endTimeStep();
         this->aquiferModel_.endTimeStep();
-        this->tracerModel_.endTimeStep();
+        {
+            // keep track of the time used for solving the tracers, so it
+            // can be reported separately in the performance summary
+            Dune::Timer tracerTimer;
+            tracerTimer.start();
+            this->tracerModel_.endTimeStep();
+            if (this->tracerModel_.numTracers() > 0) {
+                tracer_solve_time_ += tracerTimer.stop();
+            }
+        }
 
         // Compute flux for output
         this->model().linearizer().updateFlowsInfo();
@@ -490,7 +500,13 @@ public:
 
         // Drift compensation needs to be updated before calling the temperature equation
         if constexpr(energyModuleType == EnergyModules::SequentialImplicitThermal) {
+            // keep track of the time used for the sequential implicit
+            // temperature solve, so it can be reported separately in the
+            // performance summary
+            Dune::Timer temperatureTimer;
+            temperatureTimer.start();
             this->temperatureModel_.endTimeStep(wellModel_.wellState());
+            temperature_solve_time_ += temperatureTimer.stop();
         }
     }
 
@@ -690,6 +706,24 @@ public:
 
     TracerModel& tracerModel()
     { return tracerModel_; }
+
+    /// Return the time used for solving the tracer equations since the last
+    /// call to this function, and reset the counter.
+    double popTracerSolveTime()
+    {
+        const double t = tracer_solve_time_;
+        tracer_solve_time_ = 0.0;
+        return t;
+    }
+
+    /// Return the time used for the sequential implicit temperature solve
+    /// since the last call to this function, and reset the counter.
+    double popTemperatureSolveTime()
+    {
+        const double t = temperature_solve_time_;
+        temperature_solve_time_ = 0.0;
+        return t;
+    }
 
     TemperatureModel& temperatureModel() // need for restart
     { return temperatureModel_; }
@@ -1841,6 +1875,8 @@ protected:
     PffGridVector<GridView, Stencil, PffDofData_, DofMapper> pffDofData_;
     TracerModel tracerModel_;
     TemperatureModel temperatureModel_;
+    double tracer_solve_time_ = 0.0;
+    double temperature_solve_time_ = 0.0;
 
     template<class T>
     struct BCData

--- a/opm/simulators/flow/NonlinearSystem.hpp
+++ b/opm/simulators/flow/NonlinearSystem.hpp
@@ -171,6 +171,9 @@ protected:
     std::vector<std::vector<Scalar>> residual_norms_history_;
     Scalar current_relaxation_;
     GlobalEqVector dx_old_;
+    // time used for the property (intensive quantities) evaluation in the
+    // last call to updateSolution()
+    double props_update_time_ = 0.0;
 };
 
 } // namespace Opm

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
@@ -312,6 +312,9 @@ private:
     Scalar drMaxRel() const { return this->param_.dr_max_rel_; }
     Scalar maxResidualAllowed() const { return this->param_.max_residual_allowed_; }
     double linear_solve_setup_time_;
+    double linear_solve_apply_time_ = 0.0;
+    double precond_setup_time_ = 0.0;
+    double precond_apply_time_ = 0.0;
     std::vector<bool> wasSwitched_;
 };
 

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
@@ -192,7 +192,11 @@ initialLinearization(SimulatorReportSingle& report,
                               ));
         }
     }
-    report.update_time += perfTimer.stop();
+    // This block contains the convergence checks (reservoir and wells),
+    // keep track of the time separately from the rest of update_time.
+    const double convergence_check_time = perfTimer.stop();
+    report.update_time += convergence_check_time;
+    report.convergence_check_time += convergence_check_time;
     this->residual_norms_history_.push_back(residual_norms);
 }
 
@@ -256,6 +260,9 @@ nonlinearIterationNewton(const SimulatorTimerInterface& timer,
         BVector x(nc);
 
         linear_solve_setup_time_ = 0.0;
+        linear_solve_apply_time_ = 0.0;
+        precond_setup_time_ = 0.0;
+        precond_apply_time_ = 0.0;
         try {
             this->wellModel().linearize(this->simulator().model().linearizer().jacobian(),
                                         this->simulator().model().linearizer().residual());
@@ -263,11 +270,17 @@ nonlinearIterationNewton(const SimulatorTimerInterface& timer,
             solveJacobianSystem(x);
 
             report.linear_solve_setup_time += linear_solve_setup_time_;
+            report.linear_solve_apply_time += linear_solve_apply_time_;
+            report.precond_setup_time += precond_setup_time_;
+            report.precond_apply_time += precond_apply_time_;
             report.linear_solve_time += perfTimer.stop();
             report.total_linear_iterations += linearIterationsLastSolve();
         }
         catch (...) {
             report.linear_solve_setup_time += linear_solve_setup_time_;
+            report.linear_solve_apply_time += linear_solve_apply_time_;
+            report.precond_setup_time += precond_setup_time_;
+            report.precond_apply_time += precond_apply_time_;
             report.linear_solve_time += perfTimer.stop();
             report.total_linear_iterations += linearIterationsLastSolve();
 
@@ -300,6 +313,7 @@ nonlinearIterationNewton(const SimulatorTimerInterface& timer,
 
         this->updateSolution(x);
         report.update_time += perfTimer.stop();
+        report.props_time += this->props_update_time_;
     }
 
     return report;
@@ -433,6 +447,10 @@ solveJacobianSystem(BVector& x)
         // Use timing on rank 0 to determine fastest, must be consistent across ranks.
         this->grid_.comm().broadcast(&fastest_solver, 1, 0);
         this->linear_solve_setup_time_ = setupTimes[fastest_solver];
+        this->linear_solve_apply_time_ = times[fastest_solver];
+        // Note: aggregated over all solvers tried in the speed test.
+        this->precond_setup_time_ = linSolver.popPreconditionerUpdateTime();
+        this->precond_apply_time_ = linSolver.popPreconditionerApplyTime();
         x = x_trial[fastest_solver];
         linSolver.setActiveSolver(fastest_solver);
     }
@@ -443,12 +461,17 @@ solveJacobianSystem(BVector& x)
         perfTimer.start();
         linSolver.prepare(jacobian, residual);
         this->linear_solve_setup_time_ = perfTimer.stop();
+        this->precond_setup_time_ = linSolver.popPreconditionerUpdateTime();
         linSolver.setResidual(residual);
         // actually, the error needs to be calculated after setResidual in order to
         // account for parallelization properly. since the residual of ECFV
         // discretizations does not need to be synchronized across processes to be
         // consistent, this is not relevant for OPM-flow...
+        perfTimer.reset();
+        perfTimer.start();
         linSolver.solve(x);
+        linear_solve_apply_time_ = perfTimer.stop();
+        precond_apply_time_ = linSolver.popPreconditionerApplyTime();
     }
 }
 

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
@@ -197,7 +197,11 @@ initialLinearization(SimulatorReportSingle& report,
                               ));
         }
     }
-    report.update_time += perfTimer.stop();
+    // This block contains the convergence checks (reservoir and wells),
+    // keep track of the time separately from the rest of update_time.
+    const double convergence_check_time = perfTimer.stop();
+    report.update_time += convergence_check_time;
+    report.convergence_check_time += convergence_check_time;
     this->residual_norms_history_.push_back(residual_norms);
 }
 
@@ -261,6 +265,9 @@ nonlinearIterationNewton(const SimulatorTimerInterface& timer,
         BVector x(nc);
 
         linear_solve_setup_time_ = 0.0;
+        linear_solve_apply_time_ = 0.0;
+        precond_setup_time_ = 0.0;
+        precond_apply_time_ = 0.0;
         try {
             this->wellModel().linearize(this->simulator().model().linearizer().jacobian(),
                                         this->simulator().model().linearizer().residual());
@@ -268,11 +275,17 @@ nonlinearIterationNewton(const SimulatorTimerInterface& timer,
             solveJacobianSystem(x);
 
             report.linear_solve_setup_time += linear_solve_setup_time_;
+            report.linear_solve_apply_time += linear_solve_apply_time_;
+            report.precond_setup_time += precond_setup_time_;
+            report.precond_apply_time += precond_apply_time_;
             report.linear_solve_time += perfTimer.stop();
             report.total_linear_iterations += linearIterationsLastSolve();
         }
         catch (...) {
             report.linear_solve_setup_time += linear_solve_setup_time_;
+            report.linear_solve_apply_time += linear_solve_apply_time_;
+            report.precond_setup_time += precond_setup_time_;
+            report.precond_apply_time += precond_apply_time_;
             report.linear_solve_time += perfTimer.stop();
             report.total_linear_iterations += linearIterationsLastSolve();
 
@@ -318,6 +331,7 @@ nonlinearIterationNewton(const SimulatorTimerInterface& timer,
 
         this->updateSolution(x);
         report.update_time += perfTimer.stop();
+        report.props_time += this->props_update_time_;
     }
 
     return report;
@@ -451,6 +465,10 @@ solveJacobianSystem(BVector& x)
         // Use timing on rank 0 to determine fastest, must be consistent across ranks.
         this->grid_.comm().broadcast(&fastest_solver, 1, 0);
         this->linear_solve_setup_time_ = setupTimes[fastest_solver];
+        this->linear_solve_apply_time_ = times[fastest_solver];
+        // Note: aggregated over all solvers tried in the speed test.
+        this->precond_setup_time_ = linSolver.popPreconditionerUpdateTime();
+        this->precond_apply_time_ = linSolver.popPreconditionerApplyTime();
         x = x_trial[fastest_solver];
         linSolver.setActiveSolver(fastest_solver);
     }
@@ -461,12 +479,17 @@ solveJacobianSystem(BVector& x)
         perfTimer.start();
         linSolver.prepare(jacobian, residual);
         this->linear_solve_setup_time_ = perfTimer.stop();
+        this->precond_setup_time_ = linSolver.popPreconditionerUpdateTime();
         linSolver.setResidual(residual);
         // actually, the error needs to be calculated after setResidual in order to
         // account for parallelization properly. since the residual of ECFV
         // discretizations does not need to be synchronized across processes to be
         // consistent, this is not relevant for OPM-flow...
+        perfTimer.reset();
+        perfTimer.start();
         linSolver.solve(x);
+        linear_solve_apply_time_ = perfTimer.stop();
+        precond_apply_time_ = linSolver.popPreconditionerApplyTime();
     }
 }
 

--- a/opm/simulators/flow/NonlinearSystem_impl.hpp
+++ b/opm/simulators/flow/NonlinearSystem_impl.hpp
@@ -81,7 +81,10 @@ updateSolution(const GlobalEqVector& dx)
 
     {
         OPM_TIMEBLOCK(invalidateAndUpdateIntensiveQuantities);
+        Dune::Timer propsTimer;
+        propsTimer.start();
         simulator_.model().invalidateAndUpdateIntensiveQuantities(/*timeIdx=*/0);
+        props_update_time_ = propsTimer.stop();
     }
 
     if (shouldStore) {

--- a/opm/simulators/flow/SimulatorFullyImplicit.cpp
+++ b/opm/simulators/flow/SimulatorFullyImplicit.cpp
@@ -40,7 +40,9 @@ void registerSimulatorParameters()
          "\"none\" gives no extra output and "
          "overrides all other options, "
          "\"steps\" generates an INFOSTEP file, "
-         "\"iterations\" generates an INFOITER file. "
+         "\"iterations\" generates an INFOITER file, "
+         "\"performance\" adds detailed timings to the "
+         "performance summary at the end of the simulation. "
          "Combine options with commas, e.g., "
          "\"steps,iterations\" for multiple outputs.");
     Parameters::Register<Parameters::SaveStep>

--- a/opm/simulators/flow/SimulatorFullyImplicit_impl.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicit_impl.hpp
@@ -562,6 +562,10 @@ finalize()
         Dune::Timer finalOutputTimer;
         finalOutputTimer.start();
 
+        // collect the time used by the actual (possibly asynchronous)
+        // output writes before the writer is destroyed below
+        report_.success.output_disk_write_time +=
+            simulator_.problem().eclWriter().finalizeAsyncWriteTime();
         simulator_.problem().finalizeOutput();
         report_.success.output_write_time += finalOutputTimer.stop();
     }

--- a/opm/simulators/flow/SimulatorFullyImplicit_impl.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicit_impl.hpp
@@ -543,6 +543,10 @@ finalize()
         Dune::Timer finalOutputTimer;
         finalOutputTimer.start();
 
+        // collect the time used by the actual (possibly asynchronous)
+        // output writes before the writer is destroyed below
+        report_.success.output_disk_write_time +=
+            simulator_.problem().eclWriter().finalizeAsyncWriteTime();
         simulator_.problem().finalizeOutput();
         report_.success.output_write_time += finalOutputTimer.stop();
     }

--- a/opm/simulators/linalg/AbstractISTLSolver.hpp
+++ b/opm/simulators/linalg/AbstractISTLSolver.hpp
@@ -178,6 +178,24 @@ public:
      */
     virtual int getSolveCount() const = 0;
 
+    /**
+     * \brief Return the time used by preconditioner applications since the
+     * last call to this function, and reset the counter.
+     *
+     * \note The default implementation returns 0 (no timing available).
+     */
+    virtual double popPreconditionerApplyTime()
+    { return 0.0; }
+
+    /**
+     * \brief Return the time used by preconditioner updates since the last
+     * call to this function, and reset the counter.
+     *
+     * \note The default implementation returns 0 (no timing available).
+     */
+    virtual double popPreconditionerUpdateTime()
+    { return 0.0; }
+
 protected:
 
     /**

--- a/opm/simulators/linalg/FlexibleSolver_impl.hpp
+++ b/opm/simulators/linalg/FlexibleSolver_impl.hpp
@@ -154,14 +154,19 @@ namespace Dune
         const std::string solver_type = prm.get<std::string>("solver", "bicgstab");
         auto child = prm.get_child_optional("preconditioner");
         if (solver_type == "umfpack") {
+            // Deliberately not wrapped in TimedPreconditioner: apply() locates
+            // this type with a dynamic_cast to trigger a refactorisation, and
+            // that cast does not see through the decorator.
             preconditioner_ = std::make_shared<Dune::DirectSolverUpdatePreconditioner<VectorType, VectorType>>(
                 linearoperator_for_solver_->category());
         } else {
-            preconditioner_ = Opm::PreconditionerFactory<Operator, Comm>::create(op,
-                                                                                 child ? *child : Opm::PropertyTree(),
-                                                                                 weightsCalculator,
-                                                                                 comm,
-                                                                                 pressureIndex);
+            // wrap the preconditioner in a timing decorator for the performance summary
+            preconditioner_ = std::make_shared<TimedPreconditioner<VectorType, VectorType>>(
+                Opm::PreconditionerFactory<Operator, Comm>::create(op,
+                                                                   child ? *child : Opm::PropertyTree(),
+                                                                   weightsCalculator,
+                                                                   comm,
+                                                                   pressureIndex));
         }
         scalarproduct_ = Dune::createScalarProduct<VectorType, Comm>(comm, op.category());
     }
@@ -180,13 +185,18 @@ namespace Dune
         const std::string solver_type = prm.get<std::string>("solver", "bicgstab");
         auto child = prm.get_child_optional("preconditioner");
         if (solver_type == "umfpack") {
+            // Deliberately not wrapped in TimedPreconditioner: apply() locates
+            // this type with a dynamic_cast to trigger a refactorisation, and
+            // that cast does not see through the decorator.
             preconditioner_ = std::make_shared<Dune::DirectSolverUpdatePreconditioner<VectorType, VectorType>>(
                 linearoperator_for_solver_->category());
         } else {
-            preconditioner_ = Opm::PreconditionerFactory<Operator, Dune::Amg::SequentialInformation>::create(op,
-                                                                                                              child ? *child : Opm::PropertyTree(),
-                                                                                                              weightsCalculator,
-                                                                                                              pressureIndex);
+            // wrap the preconditioner in a timing decorator for the performance summary
+            preconditioner_ = std::make_shared<TimedPreconditioner<VectorType, VectorType>>(
+                Opm::PreconditionerFactory<Operator, Dune::Amg::SequentialInformation>::create(op,
+                                                                   child ? *child : Opm::PropertyTree(),
+                                                                   weightsCalculator,
+                                                                   pressureIndex));
         }
         scalarproduct_ = std::make_shared<Dune::SeqScalarProduct<VectorType>>();
     }

--- a/opm/simulators/linalg/ISTLSolver.hpp
+++ b/opm/simulators/linalg/ISTLSolver.hpp
@@ -22,6 +22,8 @@
 #ifndef OPM_ISTLSOLVER_HEADER_INCLUDED
 #define OPM_ISTLSOLVER_HEADER_INCLUDED
 
+#include <dune/common/timer.hh>
+
 #include <dune/istl/owneroverlapcopy.hh>
 #include <dune/istl/solver.hh>
 
@@ -415,6 +417,25 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
             solveCount_ = 0;
         }
 
+        double popPreconditionerApplyTime() override
+        {
+            auto* timed = timedPreconditioner_();
+            return timed ? timed->popApplyTime() : 0.0;
+        }
+
+        double popPreconditionerUpdateTime() override
+        {
+            // include the time used for (re)creating the solver, which is
+            // dominated by the construction of the preconditioner
+            double t = solver_create_time_;
+            solver_create_time_ = 0.0;
+            auto* timed = timedPreconditioner_();
+            if (timed) {
+                t += timed->popUpdateTime();
+            }
+            return t;
+        }
+
         bool solve(Vector& x) override
         {
             OPM_TIMEBLOCK(istlSolverSolve);
@@ -486,6 +507,17 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
 #endif
         }
 
+        //! \brief Access the timing decorator around the active preconditioner,
+        //! or nullptr if not available.
+        Dune::TimedPreconditioner<Vector, Vector>* timedPreconditioner_()
+        {
+            if (flexibleSolver_.empty() || !flexibleSolver_[activeSolverNum_].pre_) {
+                return nullptr;
+            }
+            return dynamic_cast<Dune::TimedPreconditioner<Vector, Vector>*>(
+                flexibleSolver_[activeSolverNum_].pre_);
+        }
+
         void prepareFlexibleSolver()
         {
             OPM_TIMEBLOCK(flexibleSolverPrepare);
@@ -503,6 +535,8 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
                 }
                 std::function<Vector()> weightCalculator = this->getWeightsCalculator(prm_[activeSolverNum_], getMatrix(), pressureIndex);
                 OPM_TIMEBLOCK(flexibleSolverCreate);
+                Dune::Timer createTimer;
+                createTimer.start();
                 flexibleSolver_[activeSolverNum_].create(getMatrix(),
                                                          isParallel(),
                                                          prm_[activeSolverNum_],
@@ -510,6 +544,7 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
                                                          weightCalculator,
                                                          forceSerial_,
                                                          comm_.get());
+                solver_create_time_ += createTimer.stop();
             }
             else
             {
@@ -656,6 +691,9 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
         const Simulator& simulator_;
         mutable int iterations_;
         mutable int solveCount_;
+        // time used for (re)creating the linear solver, dominated by the
+        // construction of the preconditioner
+        double solver_create_time_ = 0.0;
         std::any parallelInformation_;
 
         // non-const to be able to scale the linear system

--- a/opm/simulators/linalg/ISTLSolver.hpp
+++ b/opm/simulators/linalg/ISTLSolver.hpp
@@ -22,6 +22,8 @@
 #ifndef OPM_ISTLSOLVER_HEADER_INCLUDED
 #define OPM_ISTLSOLVER_HEADER_INCLUDED
 
+#include <dune/common/timer.hh>
+
 #include <dune/istl/owneroverlapcopy.hh>
 #include <dune/istl/solver.hh>
 
@@ -425,6 +427,25 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
             solveCount_ = 0;
         }
 
+        double popPreconditionerApplyTime() override
+        {
+            auto* timed = timedPreconditioner_();
+            return timed ? timed->popApplyTime() : 0.0;
+        }
+
+        double popPreconditionerUpdateTime() override
+        {
+            // include the time used for (re)creating the solver, which is
+            // dominated by the construction of the preconditioner
+            double t = solver_create_time_;
+            solver_create_time_ = 0.0;
+            auto* timed = timedPreconditioner_();
+            if (timed) {
+                t += timed->popUpdateTime();
+            }
+            return t;
+        }
+
         bool solve(Vector& x) override
         {
             OPM_TIMEBLOCK(istlSolverSolve);
@@ -496,6 +517,17 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
 #endif
         }
 
+        //! \brief Access the timing decorator around the active preconditioner,
+        //! or nullptr if not available.
+        Dune::TimedPreconditioner<Vector, Vector>* timedPreconditioner_()
+        {
+            if (flexibleSolver_.empty() || !flexibleSolver_[activeSolverNum_].pre_) {
+                return nullptr;
+            }
+            return dynamic_cast<Dune::TimedPreconditioner<Vector, Vector>*>(
+                flexibleSolver_[activeSolverNum_].pre_);
+        }
+
         void prepareFlexibleSolver()
         {
             OPM_TIMEBLOCK(flexibleSolverPrepare);
@@ -513,6 +545,8 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
                 }
                 std::function<Vector()> weightCalculator = this->getWeightsCalculator(prm_[activeSolverNum_], getMatrix(), pressureIndex);
                 OPM_TIMEBLOCK(flexibleSolverCreate);
+                Dune::Timer createTimer;
+                createTimer.start();
                 flexibleSolver_[activeSolverNum_].create(getMatrix(),
                                                          isParallel(),
                                                          prm_[activeSolverNum_],
@@ -521,6 +555,7 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
                                                          forceSerial_,
                                                          comm_.get());
                 numWellEquations_ = this->numWellEquations();
+                solver_create_time_ += createTimer.stop();
             }
             else
             {
@@ -689,6 +724,9 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
         const Simulator& simulator_;
         mutable int iterations_;
         mutable int solveCount_;
+        // time used for (re)creating the linear solver, dominated by the
+        // construction of the preconditioner
+        double solver_create_time_ = 0.0;
         std::any parallelInformation_;
 
         // non-const to be able to scale the linear system

--- a/opm/simulators/linalg/ISTLSolverRuntimeOptionProxy.hpp
+++ b/opm/simulators/linalg/ISTLSolverRuntimeOptionProxy.hpp
@@ -147,6 +147,16 @@ public:
         return istlSolver_->getSolveCount();
     }
 
+    double popPreconditionerApplyTime() override
+    {
+        return istlSolver_->popPreconditionerApplyTime();
+    }
+
+    double popPreconditionerUpdateTime() override
+    {
+        return istlSolver_->popPreconditionerUpdateTime();
+    }
+
 private:
     std::unique_ptr<AbstractISTLSolver<SparseMatrixAdapter, Vector>> istlSolver_;
 

--- a/opm/simulators/linalg/PreconditionerWithUpdate.hpp
+++ b/opm/simulators/linalg/PreconditionerWithUpdate.hpp
@@ -21,6 +21,7 @@
 #define OPM_PRECONDITIONERWITHUPDATE_HEADER_INCLUDED
 
 #include <dune/istl/preconditioner.hh>
+#include <chrono>
 #include <memory>
 #include <tuple>
 #include <utility>
@@ -143,6 +144,79 @@ public:
 private:
     SolverCategory::Category category_;
     bool needs_rebuild_;
+};
+
+/// Decorator measuring the time spent in apply() and update() of the wrapped
+/// preconditioner, for reporting in the performance summary.
+///
+/// \note Deliberately not applied to DirectSolverUpdatePreconditioner:
+///   FlexibleSolver::apply() uses dynamic_cast to find that type and trigger a
+///   refactorisation, and the cast does not see through this decorator.
+template <class X, class Y>
+class TimedPreconditioner : public PreconditionerWithUpdate<X, Y>
+{
+public:
+    explicit TimedPreconditioner(std::shared_ptr<PreconditionerWithUpdate<X, Y>> precond)
+        : precond_(std::move(precond))
+    {
+    }
+
+    virtual void pre(X& x, Y& b) override
+    {
+        precond_->pre(x, b);
+    }
+
+    virtual void apply(X& v, const Y& d) override
+    {
+        const auto start = std::chrono::steady_clock::now();
+        precond_->apply(v, d);
+        apply_time_ += std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+    }
+
+    virtual void post(X& x) override
+    {
+        precond_->post(x);
+    }
+
+    virtual SolverCategory::Category category() const override
+    {
+        return precond_->category();
+    }
+
+    virtual void update() override
+    {
+        const auto start = std::chrono::steady_clock::now();
+        precond_->update();
+        update_time_ += std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+    }
+
+    virtual bool hasPerfectUpdate() const override
+    {
+        return precond_->hasPerfectUpdate();
+    }
+
+    /// Return the time used in apply() since the last call to this
+    /// function, and reset the counter.
+    double popApplyTime()
+    {
+        const double t = apply_time_;
+        apply_time_ = 0.0;
+        return t;
+    }
+
+    /// Return the time used in update() since the last call to this
+    /// function, and reset the counter.
+    double popUpdateTime()
+    {
+        const double t = update_time_;
+        update_time_ = 0.0;
+        return t;
+    }
+
+private:
+    std::shared_ptr<PreconditionerWithUpdate<X, Y>> precond_;
+    double apply_time_ = 0.0;
+    double update_time_ = 0.0;
 };
 
 /// @brief Interface class ensuring make function is overriden

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -950,7 +950,14 @@ run()
             full_report += substep_report;
             problem.setSimulationReport(full_report);
             problem.endTimeStep();
-            substep_report.pre_post_time += perfTimer.stop();
+            // The post-step part (endTimeStep) is dominated by the extra
+            // evaluations related to output (summary evaluation, actions)
+            // and the tracer solve, keep track of them separately.
+            const double post_step_time = perfTimer.stop();
+            const double tracer_solve_time = problem.popTracerSolveTime();
+            substep_report.pre_post_time += post_step_time;
+            substep_report.tracer_solve_time += tracer_solve_time;
+            substep_report.output_eval_time += post_step_time - tracer_solve_time;
 
             report += substep_report;
 

--- a/opm/simulators/timestepping/SimulatorReport.cpp
+++ b/opm/simulators/timestepping/SimulatorReport.cpp
@@ -38,7 +38,8 @@ namespace Opm
                                      true, false, false, 19, 20.0, 21.0,
                                      22, 23, 24, 25, 26, 27, 28, 29,
                                      30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0,
-                                     38.0, 39.0, 40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46, 47};
+                                     38.0, 39.0, 40.0, 41.0, 42.0, 43.0, 44.0, 45.0,
+                                     46.0, 47.0, 48.0, 49, 50};
     }
 
     bool SimulatorReportSingle::operator==(const SimulatorReportSingle& rhs) const
@@ -91,6 +92,9 @@ namespace Opm
                this->well_control_network_time == rhs.well_control_network_time &&
                this->gaslift_time == rhs.gaslift_time &&
                this->well_facility_time == rhs.well_facility_time &&
+               this->group_control_time == rhs.group_control_time &&
+               this->network_balance_time == rhs.network_balance_time &&
+               this->control_well_solve_time == rhs.control_well_solve_time &&
                this->total_well_potential_iterations == rhs.total_well_potential_iterations &&
                this->total_network_iterations == rhs.total_network_iterations;
     }
@@ -123,6 +127,9 @@ namespace Opm
         well_control_network_time += sr.well_control_network_time;
         gaslift_time += sr.gaslift_time;
         well_facility_time += sr.well_facility_time;
+        group_control_time += sr.group_control_time;
+        network_balance_time += sr.network_balance_time;
+        control_well_solve_time += sr.control_well_solve_time;
         output_write_time += sr.output_write_time;
         total_time += sr.total_time;
         total_well_iterations += sr.total_well_iterations;
@@ -199,6 +206,22 @@ namespace Opm
                                 100*failureReport->assemble_time_well/noZero(t));
             }
             os << std::endl;
+
+            // part of the well assembly used for the facility calculations
+            // (further details in the Facility calculations section below)
+            t = well_facility_time + (failureReport ? failureReport->well_facility_time : 0.0);
+            if (performance_details && t > 0.0) {
+                os << fmt::format("      Facility calculations:  {:7.2f} s", t);
+                os << std::endl;
+
+                t = well_control_network_time + (failureReport ? failureReport->well_control_network_time : 0.0);
+                os << fmt::format("        Control/network:      {:7.2f} s", t);
+                os << std::endl;
+
+                t = well_solve_time + (failureReport ? failureReport->well_solve_time : 0.0);
+                os << fmt::format("        Well solves:          {:7.2f} s", t);
+                os << std::endl;
+            }
 
             t = linear_solve_time + (failureReport ? failureReport->linear_solve_time : 0.0);
             os << fmt::format("  Linear solve time:        {:9.2f} s", t);
@@ -361,11 +384,25 @@ namespace Opm
             os << fmt::format("  Control/network:            {:7.2f} s", t);
             os << std::endl;
 
+            t = group_control_time + (failureReport ? failureReport->group_control_time : 0.0);
+            os << fmt::format("    Group/control updates:    {:7.2f} s", t);
+            os << std::endl;
+
+            t = network_balance_time + (failureReport ? failureReport->network_balance_time : 0.0);
+            if (t > 0.0) {
+                os << fmt::format("    Network balance:          {:7.2f} s", t);
+                os << std::endl;
+            }
+
             t = gaslift_time + (failureReport ? failureReport->gaslift_time : 0.0);
             if (t > 0.0) {
                 os << fmt::format("    Gas lift optimize:        {:7.2f} s", t);
                 os << std::endl;
             }
+
+            t = control_well_solve_time + (failureReport ? failureReport->control_well_solve_time : 0.0);
+            os << fmt::format("    Well solves (control):    {:7.2f} s", t);
+            os << std::endl;
 
             t = well_solve_time + (failureReport ? failureReport->well_solve_time : 0.0);
             os << fmt::format("  Well solves:                {:7.2f} s", t);

--- a/opm/simulators/timestepping/SimulatorReport.cpp
+++ b/opm/simulators/timestepping/SimulatorReport.cpp
@@ -36,7 +36,9 @@ namespace Opm
                                      7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
                                      13, 14, 15, 16, 17, 18,
                                      true, false, false, 19, 20.0, 21.0,
-                                     22, 23, 24, 25, 26, 27, 28, 29};
+                                     22, 23, 24, 25, 26, 27, 28, 29,
+                                     30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0,
+                                     38.0, 39.0, 40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46, 47};
     }
 
     bool SimulatorReportSingle::operator==(const SimulatorReportSingle& rhs) const
@@ -72,7 +74,25 @@ namespace Opm
                this->converged_domains == rhs.converged_domains &&
                this->unconverged_domains == rhs.unconverged_domains &&
                this->accepted_unconverged_domains == rhs.accepted_unconverged_domains &&
-               this->skipped_domains == rhs.skipped_domains;
+               this->skipped_domains == rhs.skipped_domains &&
+               this->props_time == rhs.props_time &&
+               this->convergence_check_time == rhs.convergence_check_time &&
+               this->output_eval_time == rhs.output_eval_time &&
+               this->tracer_solve_time == rhs.tracer_solve_time &&
+               this->temperature_solve_time == rhs.temperature_solve_time &&
+               this->output_disk_write_time == rhs.output_disk_write_time &&
+               this->linear_solve_apply_time == rhs.linear_solve_apply_time &&
+               this->precond_setup_time == rhs.precond_setup_time &&
+               this->precond_apply_time == rhs.precond_apply_time &&
+               this->well_solve_time == rhs.well_solve_time &&
+               this->well_potential_solve_time == rhs.well_potential_solve_time &&
+               this->well_solve_assemble_time == rhs.well_solve_assemble_time &&
+               this->well_solve_linear_solve_time == rhs.well_solve_linear_solve_time &&
+               this->well_control_network_time == rhs.well_control_network_time &&
+               this->gaslift_time == rhs.gaslift_time &&
+               this->well_facility_time == rhs.well_facility_time &&
+               this->total_well_potential_iterations == rhs.total_well_potential_iterations &&
+               this->total_network_iterations == rhs.total_network_iterations;
     }
 
     void SimulatorReportSingle::operator+=(const SimulatorReportSingle& sr)
@@ -87,9 +107,27 @@ namespace Opm
         pre_post_time += sr.pre_post_time;
         assemble_time_well += sr.assemble_time_well;
         update_time += sr.update_time;
+        props_time += sr.props_time;
+        convergence_check_time += sr.convergence_check_time;
+        output_eval_time += sr.output_eval_time;
+        tracer_solve_time += sr.tracer_solve_time;
+        temperature_solve_time += sr.temperature_solve_time;
+        output_disk_write_time += sr.output_disk_write_time;
+        linear_solve_apply_time += sr.linear_solve_apply_time;
+        precond_setup_time += sr.precond_setup_time;
+        precond_apply_time += sr.precond_apply_time;
+        well_solve_time += sr.well_solve_time;
+        well_potential_solve_time += sr.well_potential_solve_time;
+        well_solve_assemble_time += sr.well_solve_assemble_time;
+        well_solve_linear_solve_time += sr.well_solve_linear_solve_time;
+        well_control_network_time += sr.well_control_network_time;
+        gaslift_time += sr.gaslift_time;
+        well_facility_time += sr.well_facility_time;
         output_write_time += sr.output_write_time;
         total_time += sr.total_time;
         total_well_iterations += sr.total_well_iterations;
+        total_well_potential_iterations += sr.total_well_potential_iterations;
+        total_network_iterations += sr.total_network_iterations;
         total_linearizations += sr.total_linearizations;
         total_newton_iterations += sr.total_newton_iterations;
         total_linear_iterations += sr.total_linear_iterations;
@@ -130,7 +168,9 @@ namespace Opm
         return val;
     };
 
-    void SimulatorReportSingle::reportFullyImplicit(std::ostream& os, const SimulatorReportSingle* failureReport) const
+    void SimulatorReportSingle::reportFullyImplicit(std::ostream& os,
+                                                    const SimulatorReportSingle* failureReport,
+                                                    bool performance_details) const
     {
         // Disabling this output as it is redundant with the solver_time, now
         // output as "Simulation time". Usually very small difference between them.
@@ -160,6 +200,35 @@ namespace Opm
             }
             os << std::endl;
 
+            // The facility calculations cover the time step preparation of
+            // the wells and the control/network updates. The indented items
+            // below are parts of their parent, but do not necessarily add
+            // up to it (e.g. well solves also happen during the
+            // control/network updates).
+            t = well_facility_time + (failureReport ? failureReport->well_facility_time : 0.0);
+            if (performance_details && t > 0.0) {
+                os << fmt::format("      Facility calculations:  {:7.2f} s", t);
+                os << std::endl;
+            }
+
+            t = well_control_network_time + (failureReport ? failureReport->well_control_network_time : 0.0);
+            if (performance_details && t > 0.0) {
+                os << fmt::format("        Control/network:      {:7.2f} s", t);
+                os << std::endl;
+            }
+
+            t = gaslift_time + (failureReport ? failureReport->gaslift_time : 0.0);
+            if (performance_details && t > 0.0) {
+                os << fmt::format("          Gas lift optimize:  {:7.2f} s", t);
+                os << std::endl;
+            }
+
+            t = well_solve_time + (failureReport ? failureReport->well_solve_time : 0.0);
+            if (performance_details && t > 0.0) {
+                os << fmt::format("        Well solves:          {:7.2f} s", t);
+                os << std::endl;
+            }
+
             t = linear_solve_time + (failureReport ? failureReport->linear_solve_time : 0.0);
             os << fmt::format("  Linear solve time:        {:9.2f} s", t);
             if (failureReport) {
@@ -177,6 +246,29 @@ namespace Opm
                                 100*failureReport->linear_solve_setup_time/noZero(t));
             }
             os << std::endl;
+
+            t = precond_setup_time + (failureReport ? failureReport->precond_setup_time : 0.0);
+            if (performance_details && t > 0.0) {
+                os << fmt::format("      Precond setup:          {:7.2f} s", t);
+                os << std::endl;
+            }
+
+            if (performance_details) {
+                t = linear_solve_apply_time + (failureReport ? failureReport->linear_solve_apply_time : 0.0);
+                os << fmt::format("    Linear apply:             {:7.2f} s", t);
+                if (failureReport) {
+                  os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                                    failureReport->linear_solve_apply_time,
+                                    100*failureReport->linear_solve_apply_time/noZero(t));
+                }
+                os << std::endl;
+            }
+
+            t = precond_apply_time + (failureReport ? failureReport->precond_apply_time : 0.0);
+            if (performance_details && t > 0.0) {
+                os << fmt::format("      Precond apply:          {:7.2f} s", t);
+                os << std::endl;
+            }
 
             if (local_solve_time > 0.0) {
                 t = local_solve_time + (failureReport ? failureReport->local_solve_time : 0.0);
@@ -197,6 +289,29 @@ namespace Opm
                                 100*failureReport->update_time/noZero(t));
             }
             os << std::endl;
+
+            if (performance_details) {
+                t = props_time + (failureReport ? failureReport->props_time : 0.0);
+                os << fmt::format("    Properties evaluation:    {:7.2f} s", t);
+                if (failureReport) {
+                  os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                                    failureReport->props_time,
+                                    100*failureReport->props_time/noZero(t));
+                }
+                os << std::endl;
+            }
+
+            if (performance_details) {
+                t = convergence_check_time + (failureReport ? failureReport->convergence_check_time : 0.0);
+                os << fmt::format("    Convergence checks:       {:7.2f} s", t);
+                if (failureReport) {
+                  os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                                    failureReport->convergence_check_time,
+                                    100*failureReport->convergence_check_time/noZero(t));
+                }
+                os << std::endl;
+            }
+
             t = pre_post_time + (failureReport ? failureReport->pre_post_time : 0.0);
             os << fmt::format("  Pre/post step:              {:7.2f} s", t);
             if (failureReport) {
@@ -206,9 +321,75 @@ namespace Opm
             }
             os << std::endl;
 
+            if (performance_details) {
+                t = output_eval_time + (failureReport ? failureReport->output_eval_time : 0.0);
+                os << fmt::format("    Output evaluation:        {:7.2f} s", t);
+                if (failureReport) {
+                  os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                                    failureReport->output_eval_time,
+                                    100*failureReport->output_eval_time/noZero(t));
+                }
+                os << std::endl;
+            }
+
+            t = tracer_solve_time + (failureReport ? failureReport->tracer_solve_time : 0.0);
+            if (performance_details && t > 0.0) {
+                os << fmt::format("    Tracer solve:             {:7.2f} s", t);
+                if (failureReport) {
+                  os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                                    failureReport->tracer_solve_time,
+                                    100*failureReport->tracer_solve_time/noZero(t));
+                }
+                os << std::endl;
+            }
+
+            t = temperature_solve_time + (failureReport ? failureReport->temperature_solve_time : 0.0);
+            if (performance_details && t > 0.0) {
+                os << fmt::format("    Temperature solve:        {:7.2f} s", t);
+                if (failureReport) {
+                  os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                                    failureReport->temperature_solve_time,
+                                    100*failureReport->temperature_solve_time/noZero(t));
+                }
+                os << std::endl;
+            }
+
             os << fmt::format("  Output write time:          {:7.2f} s",
                               output_write_time + (failureReport ? failureReport->output_write_time : 0.0));
             os << std::endl;
+
+            t = output_disk_write_time + (failureReport ? failureReport->output_disk_write_time : 0.0);
+            if (performance_details && t > 0.0) {
+                os << fmt::format("    Actual disk write:        {:7.2f} s", t);
+                os << std::endl;
+            }
+
+            const double total_well_solve_time =
+                well_solve_time + well_potential_solve_time +
+                (failureReport ? failureReport->well_solve_time +
+                                 failureReport->well_potential_solve_time : 0.0);
+            if (performance_details && total_well_solve_time > 0.0) {
+                os << fmt::format("  Well solve time:            {:7.2f} s", total_well_solve_time);
+                if (failureReport) {
+                  os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                                    failureReport->well_solve_time + failureReport->well_potential_solve_time,
+                                    100*(failureReport->well_solve_time + failureReport->well_potential_solve_time)
+                                       /noZero(total_well_solve_time));
+                }
+                os << std::endl;
+
+                t = well_solve_assemble_time + (failureReport ? failureReport->well_solve_assemble_time : 0.0);
+                os << fmt::format("    Assembly:                 {:7.2f} s", t);
+                os << std::endl;
+
+                t = well_solve_linear_solve_time + (failureReport ? failureReport->well_solve_linear_solve_time : 0.0);
+                os << fmt::format("    Linear solve:             {:7.2f} s", t);
+                os << std::endl;
+
+                t = well_potential_solve_time + (failureReport ? failureReport->well_potential_solve_time : 0.0);
+                os << fmt::format("    Potential solves:         {:7.2f} s", t);
+                os << std::endl;
+            }
         }
 
         int n = total_linearizations + (failureReport ? failureReport->total_linearizations : 0);
@@ -237,6 +418,39 @@ namespace Opm
                             100.0*failureReport->total_linear_iterations/noZero(n));
         }
         os << std::endl;
+
+        n = total_well_iterations + (failureReport ? failureReport->total_well_iterations : 0);
+        unsigned int np = total_well_potential_iterations +
+            (failureReport ? failureReport->total_well_potential_iterations : 0);
+        if (performance_details && (n > 0 || np > 0)) {
+            os << fmt::format("Overall Well Iterations:   {:7}", n);
+            if (failureReport) {
+              os << fmt::format("      (Wasted: {:5}; {:2.1f}%)",
+                                failureReport->total_well_iterations,
+                                100.0*failureReport->total_well_iterations/noZero(n));
+            }
+            os << std::endl;
+
+            os << fmt::format("Well Potential Iterations: {:7}", np);
+            if (failureReport) {
+              os << fmt::format("      (Wasted: {:5}; {:2.1f}%)",
+                                failureReport->total_well_potential_iterations,
+                                100.0*failureReport->total_well_potential_iterations/noZero(np));
+            }
+            os << std::endl;
+        }
+
+        unsigned int nn = total_network_iterations +
+            (failureReport ? failureReport->total_network_iterations : 0);
+        if (performance_details && nn > 0) {
+            os << fmt::format("Network Balance Iterations:{:7}", nn);
+            if (failureReport) {
+              os << fmt::format("      (Wasted: {:5}; {:2.1f}%)",
+                                failureReport->total_network_iterations,
+                                100.0*failureReport->total_network_iterations/noZero(nn));
+            }
+            os << std::endl;
+        }
     }
 
 
@@ -379,10 +593,10 @@ namespace Opm
         stepreports.insert(stepreports.end(), sr.stepreports.begin(), sr.stepreports.end());
     }
 
-    void SimulatorReport::reportFullyImplicit(std::ostream& os) const
+    void SimulatorReport::reportFullyImplicit(std::ostream& os, bool performance_details) const
     {
         os << fmt::format("Number of timesteps:     {:9}\n", stepreports.size());
-        success.reportFullyImplicit(os, &failure);
+        success.reportFullyImplicit(os, &failure, performance_details);
     }
 
     void SimulatorReport::reportNLDD(std::ostream& os) const

--- a/opm/simulators/timestepping/SimulatorReport.cpp
+++ b/opm/simulators/timestepping/SimulatorReport.cpp
@@ -200,35 +200,6 @@ namespace Opm
             }
             os << std::endl;
 
-            // The facility calculations cover the time step preparation of
-            // the wells and the control/network updates. The indented items
-            // below are parts of their parent, but do not necessarily add
-            // up to it (e.g. well solves also happen during the
-            // control/network updates).
-            t = well_facility_time + (failureReport ? failureReport->well_facility_time : 0.0);
-            if (performance_details && t > 0.0) {
-                os << fmt::format("      Facility calculations:  {:7.2f} s", t);
-                os << std::endl;
-            }
-
-            t = well_control_network_time + (failureReport ? failureReport->well_control_network_time : 0.0);
-            if (performance_details && t > 0.0) {
-                os << fmt::format("        Control/network:      {:7.2f} s", t);
-                os << std::endl;
-            }
-
-            t = gaslift_time + (failureReport ? failureReport->gaslift_time : 0.0);
-            if (performance_details && t > 0.0) {
-                os << fmt::format("          Gas lift optimize:  {:7.2f} s", t);
-                os << std::endl;
-            }
-
-            t = well_solve_time + (failureReport ? failureReport->well_solve_time : 0.0);
-            if (performance_details && t > 0.0) {
-                os << fmt::format("        Well solves:          {:7.2f} s", t);
-                os << std::endl;
-            }
-
             t = linear_solve_time + (failureReport ? failureReport->linear_solve_time : 0.0);
             os << fmt::format("  Linear solve time:        {:9.2f} s", t);
             if (failureReport) {
@@ -364,32 +335,53 @@ namespace Opm
                 os << std::endl;
             }
 
-            const double total_well_solve_time =
-                well_solve_time + well_potential_solve_time +
-                (failureReport ? failureReport->well_solve_time +
-                                 failureReport->well_potential_solve_time : 0.0);
-            if (performance_details && total_well_solve_time > 0.0) {
-                os << fmt::format("  Well solve time:            {:7.2f} s", total_well_solve_time);
-                if (failureReport) {
-                  os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
-                                    failureReport->well_solve_time + failureReport->well_potential_solve_time,
-                                    100*(failureReport->well_solve_time + failureReport->well_potential_solve_time)
-                                       /noZero(total_well_solve_time));
-                }
-                os << std::endl;
+        }
 
-                t = well_solve_assemble_time + (failureReport ? failureReport->well_solve_assemble_time : 0.0);
-                os << fmt::format("    Assembly:                 {:7.2f} s", t);
-                os << std::endl;
+        // Summary of all time used in the wells/facility. This cuts across
+        // the simulation phases above: the control/network updates and the
+        // normal well solves happen during the assembly, while the well
+        // potential solves are part of the pre/post step (output
+        // evaluation). The indented items are parts of their parent, but do
+        // not necessarily add up to it.
+        const double total_facility_time =
+            well_facility_time + well_potential_solve_time +
+            (failureReport ? failureReport->well_facility_time +
+                             failureReport->well_potential_solve_time : 0.0);
+        if (performance_details && total_facility_time > 0.0) {
+            os << fmt::format("Facility calculations:      {:9.2f} s", total_facility_time);
+            if (failureReport) {
+              os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                                failureReport->well_facility_time + failureReport->well_potential_solve_time,
+                                100*(failureReport->well_facility_time + failureReport->well_potential_solve_time)
+                                   /noZero(total_facility_time));
+            }
+            os << std::endl;
 
-                t = well_solve_linear_solve_time + (failureReport ? failureReport->well_solve_linear_solve_time : 0.0);
-                os << fmt::format("    Linear solve:             {:7.2f} s", t);
-                os << std::endl;
+            double t = well_control_network_time + (failureReport ? failureReport->well_control_network_time : 0.0);
+            os << fmt::format("  Control/network:            {:7.2f} s", t);
+            os << std::endl;
 
-                t = well_potential_solve_time + (failureReport ? failureReport->well_potential_solve_time : 0.0);
-                os << fmt::format("    Potential solves:         {:7.2f} s", t);
+            t = gaslift_time + (failureReport ? failureReport->gaslift_time : 0.0);
+            if (t > 0.0) {
+                os << fmt::format("    Gas lift optimize:        {:7.2f} s", t);
                 os << std::endl;
             }
+
+            t = well_solve_time + (failureReport ? failureReport->well_solve_time : 0.0);
+            os << fmt::format("  Well solves:                {:7.2f} s", t);
+            os << std::endl;
+
+            t = well_solve_assemble_time + (failureReport ? failureReport->well_solve_assemble_time : 0.0);
+            os << fmt::format("    Assembly:                 {:7.2f} s", t);
+            os << std::endl;
+
+            t = well_solve_linear_solve_time + (failureReport ? failureReport->well_solve_linear_solve_time : 0.0);
+            os << fmt::format("    Linear solve:             {:7.2f} s", t);
+            os << std::endl;
+
+            t = well_potential_solve_time + (failureReport ? failureReport->well_potential_solve_time : 0.0);
+            os << fmt::format("  Potential solves:           {:7.2f} s", t);
+            os << std::endl;
         }
 
         int n = total_linearizations + (failureReport ? failureReport->total_linearizations : 0);

--- a/opm/simulators/timestepping/SimulatorReport.cpp
+++ b/opm/simulators/timestepping/SimulatorReport.cpp
@@ -36,7 +36,9 @@ namespace Opm
                                      7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
                                      13, 14, 15, 16, 17, 18, 19,
                                      true, false, false, 20, 21.0, 22.0,
-                                     23, 24, 25, 26, 27, 28, 29, 30};
+                                     23, 24, 25, 26, 27, 28, 29, 30,
+                                     31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0, 38.0, 39.0, 40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0, 47.0, 48.0, 49.0,
+                                     50, 51};
     }
 
     bool SimulatorReportSingle::operator==(const SimulatorReportSingle& rhs) const
@@ -73,7 +75,28 @@ namespace Opm
                this->converged_domains == rhs.converged_domains &&
                this->unconverged_domains == rhs.unconverged_domains &&
                this->accepted_unconverged_domains == rhs.accepted_unconverged_domains &&
-               this->skipped_domains == rhs.skipped_domains;
+               this->skipped_domains == rhs.skipped_domains &&
+               this->props_time == rhs.props_time &&
+               this->convergence_check_time == rhs.convergence_check_time &&
+               this->output_eval_time == rhs.output_eval_time &&
+               this->tracer_solve_time == rhs.tracer_solve_time &&
+               this->temperature_solve_time == rhs.temperature_solve_time &&
+               this->output_disk_write_time == rhs.output_disk_write_time &&
+               this->linear_solve_apply_time == rhs.linear_solve_apply_time &&
+               this->precond_setup_time == rhs.precond_setup_time &&
+               this->precond_apply_time == rhs.precond_apply_time &&
+               this->well_solve_time == rhs.well_solve_time &&
+               this->well_potential_solve_time == rhs.well_potential_solve_time &&
+               this->well_solve_assemble_time == rhs.well_solve_assemble_time &&
+               this->well_solve_linear_solve_time == rhs.well_solve_linear_solve_time &&
+               this->well_control_network_time == rhs.well_control_network_time &&
+               this->gaslift_time == rhs.gaslift_time &&
+               this->well_facility_time == rhs.well_facility_time &&
+               this->group_control_time == rhs.group_control_time &&
+               this->network_balance_time == rhs.network_balance_time &&
+               this->control_well_solve_time == rhs.control_well_solve_time &&
+               this->total_well_potential_iterations == rhs.total_well_potential_iterations &&
+               this->total_network_iterations == rhs.total_network_iterations;
     }
 
     void SimulatorReportSingle::operator+=(const SimulatorReportSingle& sr)
@@ -88,9 +111,30 @@ namespace Opm
         pre_post_time += sr.pre_post_time;
         assemble_time_well += sr.assemble_time_well;
         update_time += sr.update_time;
+        props_time += sr.props_time;
+        convergence_check_time += sr.convergence_check_time;
+        output_eval_time += sr.output_eval_time;
+        tracer_solve_time += sr.tracer_solve_time;
+        temperature_solve_time += sr.temperature_solve_time;
+        output_disk_write_time += sr.output_disk_write_time;
+        linear_solve_apply_time += sr.linear_solve_apply_time;
+        precond_setup_time += sr.precond_setup_time;
+        precond_apply_time += sr.precond_apply_time;
+        well_solve_time += sr.well_solve_time;
+        well_potential_solve_time += sr.well_potential_solve_time;
+        well_solve_assemble_time += sr.well_solve_assemble_time;
+        well_solve_linear_solve_time += sr.well_solve_linear_solve_time;
+        well_control_network_time += sr.well_control_network_time;
+        gaslift_time += sr.gaslift_time;
+        well_facility_time += sr.well_facility_time;
+        group_control_time += sr.group_control_time;
+        network_balance_time += sr.network_balance_time;
+        control_well_solve_time += sr.control_well_solve_time;
         output_write_time += sr.output_write_time;
         total_time += sr.total_time;
         total_well_iterations += sr.total_well_iterations;
+        total_well_potential_iterations += sr.total_well_potential_iterations;
+        total_network_iterations += sr.total_network_iterations;
         total_linearizations += sr.total_linearizations;
         total_newton_iterations += sr.total_newton_iterations;
         relaxed_cnv_acceptances += sr.relaxed_cnv_acceptances;
@@ -132,7 +176,9 @@ namespace Opm
         return val;
     };
 
-    void SimulatorReportSingle::reportFullyImplicit(std::ostream& os, const SimulatorReportSingle* failureReport) const
+    void SimulatorReportSingle::reportFullyImplicit(std::ostream& os,
+                                                    const SimulatorReportSingle* failureReport,
+                                                    bool performance_details) const
     {
         // Disabling this output as it is redundant with the solver_time, now
         // output as "Simulation time". Usually very small difference between them.
@@ -162,6 +208,22 @@ namespace Opm
             }
             os << std::endl;
 
+            // part of the well assembly used for the facility calculations
+            // (further details in the Facility calculations section below)
+            t = well_facility_time + (failureReport ? failureReport->well_facility_time : 0.0);
+            if (performance_details && t > 0.0) {
+                os << fmt::format("      Facility calculations:  {:7.2f} s", t);
+                os << std::endl;
+
+                t = well_control_network_time + (failureReport ? failureReport->well_control_network_time : 0.0);
+                os << fmt::format("        Control/network:      {:7.2f} s", t);
+                os << std::endl;
+
+                t = well_solve_time + (failureReport ? failureReport->well_solve_time : 0.0);
+                os << fmt::format("        Well solves:          {:7.2f} s", t);
+                os << std::endl;
+            }
+
             t = linear_solve_time + (failureReport ? failureReport->linear_solve_time : 0.0);
             os << fmt::format("  Linear solve time:        {:9.2f} s", t);
             if (failureReport) {
@@ -179,6 +241,29 @@ namespace Opm
                                 100*failureReport->linear_solve_setup_time/noZero(t));
             }
             os << std::endl;
+
+            t = precond_setup_time + (failureReport ? failureReport->precond_setup_time : 0.0);
+            if (performance_details && t > 0.0) {
+                os << fmt::format("      Precond setup:          {:7.2f} s", t);
+                os << std::endl;
+            }
+
+            if (performance_details) {
+                t = linear_solve_apply_time + (failureReport ? failureReport->linear_solve_apply_time : 0.0);
+                os << fmt::format("    Linear apply:             {:7.2f} s", t);
+                if (failureReport) {
+                  os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                                    failureReport->linear_solve_apply_time,
+                                    100*failureReport->linear_solve_apply_time/noZero(t));
+                }
+                os << std::endl;
+            }
+
+            t = precond_apply_time + (failureReport ? failureReport->precond_apply_time : 0.0);
+            if (performance_details && t > 0.0) {
+                os << fmt::format("      Precond apply:          {:7.2f} s", t);
+                os << std::endl;
+            }
 
             if (local_solve_time > 0.0) {
                 t = local_solve_time + (failureReport ? failureReport->local_solve_time : 0.0);
@@ -199,6 +284,29 @@ namespace Opm
                                 100*failureReport->update_time/noZero(t));
             }
             os << std::endl;
+
+            if (performance_details) {
+                t = props_time + (failureReport ? failureReport->props_time : 0.0);
+                os << fmt::format("    Properties evaluation:    {:7.2f} s", t);
+                if (failureReport) {
+                  os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                                    failureReport->props_time,
+                                    100*failureReport->props_time/noZero(t));
+                }
+                os << std::endl;
+            }
+
+            if (performance_details) {
+                t = convergence_check_time + (failureReport ? failureReport->convergence_check_time : 0.0);
+                os << fmt::format("    Convergence checks:       {:7.2f} s", t);
+                if (failureReport) {
+                  os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                                    failureReport->convergence_check_time,
+                                    100*failureReport->convergence_check_time/noZero(t));
+                }
+                os << std::endl;
+            }
+
             t = pre_post_time + (failureReport ? failureReport->pre_post_time : 0.0);
             os << fmt::format("  Pre/post step:              {:7.2f} s", t);
             if (failureReport) {
@@ -208,8 +316,109 @@ namespace Opm
             }
             os << std::endl;
 
+            if (performance_details) {
+                t = output_eval_time + (failureReport ? failureReport->output_eval_time : 0.0);
+                os << fmt::format("    Output evaluation:        {:7.2f} s", t);
+                if (failureReport) {
+                  os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                                    failureReport->output_eval_time,
+                                    100*failureReport->output_eval_time/noZero(t));
+                }
+                os << std::endl;
+            }
+
+            t = tracer_solve_time + (failureReport ? failureReport->tracer_solve_time : 0.0);
+            if (performance_details && t > 0.0) {
+                os << fmt::format("    Tracer solve:             {:7.2f} s", t);
+                if (failureReport) {
+                  os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                                    failureReport->tracer_solve_time,
+                                    100*failureReport->tracer_solve_time/noZero(t));
+                }
+                os << std::endl;
+            }
+
+            t = temperature_solve_time + (failureReport ? failureReport->temperature_solve_time : 0.0);
+            if (performance_details && t > 0.0) {
+                os << fmt::format("    Temperature solve:        {:7.2f} s", t);
+                if (failureReport) {
+                  os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                                    failureReport->temperature_solve_time,
+                                    100*failureReport->temperature_solve_time/noZero(t));
+                }
+                os << std::endl;
+            }
+
             os << fmt::format("  Output write time:          {:7.2f} s",
                               output_write_time + (failureReport ? failureReport->output_write_time : 0.0));
+            os << std::endl;
+
+            t = output_disk_write_time + (failureReport ? failureReport->output_disk_write_time : 0.0);
+            if (performance_details && t > 0.0) {
+                os << fmt::format("    Actual disk write:        {:7.2f} s", t);
+                os << std::endl;
+            }
+
+        }
+
+        // Summary of all time used in the wells/facility. This cuts across
+        // the simulation phases above: the control/network updates and the
+        // normal well solves happen during the assembly, while the well
+        // potential solves are part of the pre/post step (output
+        // evaluation). The indented items are parts of their parent, but do
+        // not necessarily add up to it.
+        const double total_facility_time =
+            well_facility_time + well_potential_solve_time +
+            (failureReport ? failureReport->well_facility_time +
+                             failureReport->well_potential_solve_time : 0.0);
+        if (performance_details && total_facility_time > 0.0) {
+            os << fmt::format("Facility calculations:      {:9.2f} s", total_facility_time);
+            if (failureReport) {
+              os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                                failureReport->well_facility_time + failureReport->well_potential_solve_time,
+                                100*(failureReport->well_facility_time + failureReport->well_potential_solve_time)
+                                   /noZero(total_facility_time));
+            }
+            os << std::endl;
+
+            double t = well_control_network_time + (failureReport ? failureReport->well_control_network_time : 0.0);
+            os << fmt::format("  Control/network:            {:7.2f} s", t);
+            os << std::endl;
+
+            t = group_control_time + (failureReport ? failureReport->group_control_time : 0.0);
+            os << fmt::format("    Group/control updates:    {:7.2f} s", t);
+            os << std::endl;
+
+            t = network_balance_time + (failureReport ? failureReport->network_balance_time : 0.0);
+            if (t > 0.0) {
+                os << fmt::format("    Network balance:          {:7.2f} s", t);
+                os << std::endl;
+            }
+
+            t = gaslift_time + (failureReport ? failureReport->gaslift_time : 0.0);
+            if (t > 0.0) {
+                os << fmt::format("    Gas lift optimize:        {:7.2f} s", t);
+                os << std::endl;
+            }
+
+            t = control_well_solve_time + (failureReport ? failureReport->control_well_solve_time : 0.0);
+            os << fmt::format("    Well solves (control):    {:7.2f} s", t);
+            os << std::endl;
+
+            t = well_solve_time + (failureReport ? failureReport->well_solve_time : 0.0);
+            os << fmt::format("  Well solves:                {:7.2f} s", t);
+            os << std::endl;
+
+            t = well_solve_assemble_time + (failureReport ? failureReport->well_solve_assemble_time : 0.0);
+            os << fmt::format("    Assembly:                 {:7.2f} s", t);
+            os << std::endl;
+
+            t = well_solve_linear_solve_time + (failureReport ? failureReport->well_solve_linear_solve_time : 0.0);
+            os << fmt::format("    Linear solve:             {:7.2f} s", t);
+            os << std::endl;
+
+            t = well_potential_solve_time + (failureReport ? failureReport->well_potential_solve_time : 0.0);
+            os << fmt::format("  Potential solves:           {:7.2f} s", t);
             os << std::endl;
         }
 
@@ -245,6 +454,39 @@ namespace Opm
         if (relaxed_cnv_acceptances > 0) {
             os << fmt::format("Relaxed CNV acceptances:   {:7}", relaxed_cnv_acceptances)
                << std::endl;
+        }
+
+        n = total_well_iterations + (failureReport ? failureReport->total_well_iterations : 0);
+        unsigned int np = total_well_potential_iterations +
+            (failureReport ? failureReport->total_well_potential_iterations : 0);
+        if (performance_details && (n > 0 || np > 0)) {
+            os << fmt::format("Overall Well Iterations:   {:7}", n);
+            if (failureReport) {
+              os << fmt::format("      (Wasted: {:5}; {:2.1f}%)",
+                                failureReport->total_well_iterations,
+                                100.0*failureReport->total_well_iterations/noZero(n));
+            }
+            os << std::endl;
+
+            os << fmt::format("Well Potential Iterations: {:7}", np);
+            if (failureReport) {
+              os << fmt::format("      (Wasted: {:5}; {:2.1f}%)",
+                                failureReport->total_well_potential_iterations,
+                                100.0*failureReport->total_well_potential_iterations/noZero(np));
+            }
+            os << std::endl;
+        }
+
+        unsigned int nn = total_network_iterations +
+            (failureReport ? failureReport->total_network_iterations : 0);
+        if (performance_details && nn > 0) {
+            os << fmt::format("Network Balance Iterations:{:7}", nn);
+            if (failureReport) {
+              os << fmt::format("      (Wasted: {:5}; {:2.1f}%)",
+                                failureReport->total_network_iterations,
+                                100.0*failureReport->total_network_iterations/noZero(nn));
+            }
+            os << std::endl;
         }
     }
 
@@ -388,10 +630,10 @@ namespace Opm
         stepreports.insert(stepreports.end(), sr.stepreports.begin(), sr.stepreports.end());
     }
 
-    void SimulatorReport::reportFullyImplicit(std::ostream& os) const
+    void SimulatorReport::reportFullyImplicit(std::ostream& os, bool performance_details) const
     {
         os << fmt::format("Number of timesteps:     {:9}\n", stepreports.size());
-        success.reportFullyImplicit(os, &failure);
+        success.reportFullyImplicit(os, &failure, performance_details);
     }
 
     void SimulatorReport::reportNLDD(std::ostream& os) const

--- a/opm/simulators/timestepping/SimulatorReport.hpp
+++ b/opm/simulators/timestepping/SimulatorReport.hpp
@@ -111,6 +111,15 @@ namespace Opm
         /// i.e. the time step preparation of the wells (including the
         /// standalone well solves) and the control/network updates.
         double well_facility_time = 0.0;
+        /// Part of well_control_network_time used for updating and
+        /// communicating the group data, checking the well controls and
+        /// updating the guide rates.
+        double group_control_time = 0.0;
+        /// Part of well_control_network_time used for balancing the network.
+        double network_balance_time = 0.0;
+        /// Part of well_control_network_time used for the well solves
+        /// triggered by control changes (prepareWellsBeforeAssembling).
+        double control_well_solve_time = 0.0;
         unsigned int total_well_potential_iterations = 0;
         unsigned int total_network_iterations = 0;
 
@@ -178,6 +187,9 @@ namespace Opm
             serializer(well_control_network_time);
             serializer(gaslift_time);
             serializer(well_facility_time);
+            serializer(group_control_time);
+            serializer(network_balance_time);
+            serializer(control_well_solve_time);
             serializer(total_well_potential_iterations);
             serializer(total_network_iterations);
         }

--- a/opm/simulators/timestepping/SimulatorReport.hpp
+++ b/opm/simulators/timestepping/SimulatorReport.hpp
@@ -70,6 +70,50 @@ namespace Opm
         int accepted_unconverged_domains = 0;
         int skipped_domains = 0;
 
+        /// Part of update_time used for evaluating properties
+        /// (intensive quantities) after a solution update.
+        double props_time = 0.0;
+        /// Part of update_time used for the convergence checks
+        /// (reservoir and wells).
+        double convergence_check_time = 0.0;
+        /// Part of pre_post_time used for the extra evaluations related
+        /// to output (endTimeStep: summary evaluation, actions etc.).
+        double output_eval_time = 0.0;
+        /// Part of pre_post_time used for solving the tracer equations.
+        double tracer_solve_time = 0.0;
+        /// Part of pre_post_time used for the sequential implicit
+        /// temperature solve.
+        double temperature_solve_time = 0.0;
+        /// Time used by the actual (possibly asynchronous) output writes.
+        double output_disk_write_time = 0.0;
+        /// Part of linear_solve_time spent in the actual solver apply.
+        double linear_solve_apply_time = 0.0;
+        /// Part of linear_solve_setup_time used for creating and updating
+        /// the preconditioner.
+        double precond_setup_time = 0.0;
+        /// Part of linear_solve_apply_time used for applying the
+        /// preconditioner.
+        double precond_apply_time = 0.0;
+        /// Statistics for the separate (standalone) well solves, i.e. the
+        /// local solves of the well equations done outside the global
+        /// linearizations (prepareTimeStep, well testing) and the well
+        /// potential calculations.
+        double well_solve_time = 0.0;
+        double well_potential_solve_time = 0.0;
+        double well_solve_assemble_time = 0.0;
+        double well_solve_linear_solve_time = 0.0;
+        /// Part of assemble_time_well used for updating well controls,
+        /// group targets and balancing the network.
+        double well_control_network_time = 0.0;
+        /// Part of well_control_network_time used for gas lift optimization.
+        double gaslift_time = 0.0;
+        /// Part of assemble_time_well used for the facility calculations,
+        /// i.e. the time step preparation of the wells (including the
+        /// standalone well solves) and the control/network updates.
+        double well_facility_time = 0.0;
+        unsigned int total_well_potential_iterations = 0;
+        unsigned int total_network_iterations = 0;
+
         static SimulatorReportSingle serializationTestObject();
 
         bool operator==(const SimulatorReportSingle&) const;
@@ -78,7 +122,10 @@ namespace Opm
         /// Print a report suitable for a single simulation step.
         void reportStep(std::ostream& os) const;
         /// Print a report suitable for the end of a fully implicit case, leaving out the pressure/transport time.
-        void reportFullyImplicit(std::ostream& os, const SimulatorReportSingle* failedReport = nullptr) const;
+        /// With performance_details, additional detailed timings are included.
+        void reportFullyImplicit(std::ostream& os,
+                                 const SimulatorReportSingle* failedReport = nullptr,
+                                 bool performance_details = false) const;
         void reportNLDD(std::ostream& os, const SimulatorReportSingle* failedReport = nullptr) const;
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -115,6 +162,24 @@ namespace Opm
             serializer(unconverged_domains);
             serializer(accepted_unconverged_domains);
             serializer(skipped_domains);
+            serializer(props_time);
+            serializer(convergence_check_time);
+            serializer(output_eval_time);
+            serializer(tracer_solve_time);
+            serializer(temperature_solve_time);
+            serializer(output_disk_write_time);
+            serializer(linear_solve_apply_time);
+            serializer(precond_setup_time);
+            serializer(precond_apply_time);
+            serializer(well_solve_time);
+            serializer(well_potential_solve_time);
+            serializer(well_solve_assemble_time);
+            serializer(well_solve_linear_solve_time);
+            serializer(well_control_network_time);
+            serializer(gaslift_time);
+            serializer(well_facility_time);
+            serializer(total_well_potential_iterations);
+            serializer(total_network_iterations);
         }
     };
 
@@ -129,7 +194,7 @@ namespace Opm
         bool operator==(const SimulatorReport&) const;
         void operator+=(const SimulatorReportSingle& sr);
         void operator+=(const SimulatorReport& sr);
-        void reportFullyImplicit(std::ostream& os) const;
+        void reportFullyImplicit(std::ostream& os, bool performance_details = false) const;
         void reportNLDD(std::ostream& os) const;
         void fullReports(std::ostream& os) const;
 

--- a/opm/simulators/timestepping/SimulatorReport.hpp
+++ b/opm/simulators/timestepping/SimulatorReport.hpp
@@ -72,6 +72,59 @@ namespace Opm
         int accepted_unconverged_domains = 0;
         int skipped_domains = 0;
 
+        /// Part of update_time used for evaluating properties
+        /// (intensive quantities) after a solution update.
+        double props_time = 0.0;
+        /// Part of update_time used for the convergence checks
+        /// (reservoir and wells).
+        double convergence_check_time = 0.0;
+        /// Part of pre_post_time used for the extra evaluations related
+        /// to output (endTimeStep: summary evaluation, actions etc.).
+        double output_eval_time = 0.0;
+        /// Part of pre_post_time used for solving the tracer equations.
+        double tracer_solve_time = 0.0;
+        /// Part of pre_post_time used for the sequential implicit
+        /// temperature solve.
+        double temperature_solve_time = 0.0;
+        /// Time used by the actual (possibly asynchronous) output writes.
+        double output_disk_write_time = 0.0;
+        /// Part of linear_solve_time spent in the actual solver apply.
+        double linear_solve_apply_time = 0.0;
+        /// Part of linear_solve_setup_time used for creating and updating
+        /// the preconditioner.
+        double precond_setup_time = 0.0;
+        /// Part of linear_solve_apply_time used for applying the
+        /// preconditioner.
+        double precond_apply_time = 0.0;
+        /// Statistics for the separate (standalone) well solves, i.e. the
+        /// local solves of the well equations done outside the global
+        /// linearizations (prepareTimeStep, well testing) and the well
+        /// potential calculations.
+        double well_solve_time = 0.0;
+        double well_potential_solve_time = 0.0;
+        double well_solve_assemble_time = 0.0;
+        double well_solve_linear_solve_time = 0.0;
+        /// Part of assemble_time_well used for updating well controls,
+        /// group targets and balancing the network.
+        double well_control_network_time = 0.0;
+        /// Part of well_control_network_time used for gas lift optimization.
+        double gaslift_time = 0.0;
+        /// Part of assemble_time_well used for the facility calculations,
+        /// i.e. the time step preparation of the wells (including the
+        /// standalone well solves) and the control/network updates.
+        double well_facility_time = 0.0;
+        /// Part of well_control_network_time used for updating and
+        /// communicating the group data, checking the well controls and
+        /// updating the guide rates.
+        double group_control_time = 0.0;
+        /// Part of well_control_network_time used for balancing the network.
+        double network_balance_time = 0.0;
+        /// Part of well_control_network_time used for the well solves
+        /// triggered by control changes (prepareWellsBeforeAssembling).
+        double control_well_solve_time = 0.0;
+        unsigned int total_well_potential_iterations = 0;
+        unsigned int total_network_iterations = 0;
+
         static SimulatorReportSingle serializationTestObject();
 
         bool operator==(const SimulatorReportSingle&) const;
@@ -80,7 +133,10 @@ namespace Opm
         /// Print a report suitable for a single simulation step.
         void reportStep(std::ostream& os) const;
         /// Print a report suitable for the end of a fully implicit case, leaving out the pressure/transport time.
-        void reportFullyImplicit(std::ostream& os, const SimulatorReportSingle* failedReport = nullptr) const;
+        /// With performance_details, additional detailed timings are included.
+        void reportFullyImplicit(std::ostream& os,
+                                 const SimulatorReportSingle* failedReport = nullptr,
+                                 bool performance_details = false) const;
         void reportNLDD(std::ostream& os, const SimulatorReportSingle* failedReport = nullptr) const;
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -118,6 +174,27 @@ namespace Opm
             serializer(unconverged_domains);
             serializer(accepted_unconverged_domains);
             serializer(skipped_domains);
+            serializer(props_time);
+            serializer(convergence_check_time);
+            serializer(output_eval_time);
+            serializer(tracer_solve_time);
+            serializer(temperature_solve_time);
+            serializer(output_disk_write_time);
+            serializer(linear_solve_apply_time);
+            serializer(precond_setup_time);
+            serializer(precond_apply_time);
+            serializer(well_solve_time);
+            serializer(well_potential_solve_time);
+            serializer(well_solve_assemble_time);
+            serializer(well_solve_linear_solve_time);
+            serializer(well_control_network_time);
+            serializer(gaslift_time);
+            serializer(well_facility_time);
+            serializer(group_control_time);
+            serializer(network_balance_time);
+            serializer(control_well_solve_time);
+            serializer(total_well_potential_iterations);
+            serializer(total_network_iterations);
         }
     };
 
@@ -132,7 +209,7 @@ namespace Opm
         bool operator==(const SimulatorReport&) const;
         void operator+=(const SimulatorReportSingle& sr);
         void operator+=(const SimulatorReport& sr);
-        void reportFullyImplicit(std::ostream& os) const;
+        void reportFullyImplicit(std::ostream& os, bool performance_details = false) const;
         void reportNLDD(std::ostream& os) const;
         void fullReports(std::ostream& os) const;
 

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -615,6 +615,10 @@ template<class Scalar> class WellContributions;
             // and in the well equations.
             void assemble(const double dt);
 
+            // collect the statistics for the standalone well solves gathered
+            // since the last call into last_report_ and reset them.
+            void collectWellSolveStats();
+
             // well controls and network pressures affect each other and are solved in an iterative manner.
             // the function handles one iteration of updating well controls and network pressures.
             // it is possible to decouple the update of well controls and network pressures further.

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -573,6 +573,10 @@ template<class Scalar> class WellContributions;
             // and in the well equations.
             void assemble(const double dt);
 
+            // collect the statistics for the standalone well solves gathered
+            // since the last call into last_report_ and reset them.
+            void collectWellSolveStats();
+
             // well controls and network pressures affect each other and are solved in an iterative manner.
             // the function handles one iteration of updating well controls and network pressures.
             // it is possible to decouple the update of well controls and network pressures further.

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1314,16 +1314,26 @@ namespace Opm {
             this->rescoupHelper_.receiveMasterGroupNodePressuresFromMaster();
         }
 #endif
+        Dune::Timer groupTimer;
+        groupTimer.start();
         this->updateAndCommunicateGroupData(reportStepIdx, /*update_wellgrouptarget*/ true);
         // We need to call updateWellControls before we update the network as
         // network updates are only done on thp controlled wells.
         // Note that well controls are allowed to change during updateNetwork
         // and in prepareWellsBeforeAssembling during well solves.
         bool well_group_control_changed = updateWellControls(local_deferredLogger);
+        last_report_.group_control_time += groupTimer.stop();
+
+        Dune::Timer networkBalanceTimer;
+        networkBalanceTimer.start();
         const auto [more_inner_network_update, network_imbalance] =
                 this->network_.update(mandatory_network_balance,
                                       local_deferredLogger,
                                       relax_network_tolerance);
+        // only account for the time when a network is active
+        if (this->schedule()[reportStepIdx].network().active()) {
+            last_report_.network_balance_time += networkBalanceTimer.stop();
+        }
 #ifdef RESERVOIR_COUPLING_ENABLED
         if (this->isReservoirCouplingMaster()) {
             this->rescoupHelper_.maybeExchangeNetworkOuterIterationWithSlaves(more_inner_network_update);
@@ -1352,7 +1362,12 @@ namespace Opm {
                     last_report_.gaslift_time += gliftTimer.stop();
                 }
             }
+            // the well solves triggered by control changes are part of the
+            // control/network update, keep track of the time separately
+            Dune::Timer prepareWellsTimer;
+            prepareWellsTimer.start();
             prepareWellsBeforeAssembling(dt);
+            last_report_.control_well_solve_time += prepareWellsTimer.stop();
         }
         OPM_END_PARALLEL_TRY_CATCH_LOG(local_deferredLogger,
                                        "updateWellControlsAndNetworkIteration() failed: ",
@@ -1362,12 +1377,15 @@ namespace Opm {
         if (alq_updated || BlackoilWellModelGuideRates(*this).
                               guideRateUpdateIsNeeded(reportStepIdx)) {
             const double simulationTime = simulator_.time();
+            Dune::Timer guideRateTimer;
+            guideRateTimer.start();
             // NOTE: For reservoir coupling: Slave group potentials are only communicated
             //    at the start of the time step, see beginTimeStep(). Here, we assume those
             //    potentials remain unchanged during the time step when updating guide rates below.
             this->guide_rate_handler_.updateGuideRates(
                 reportStepIdx, simulationTime, this->wellState(), this->groupState()
             );
+            last_report_.group_control_time += guideRateTimer.stop();
         }
         // we need to re-iterate the network when the well group controls changed or gaslift/alq is changed or
         // the inner iterations are did not converge

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1158,6 +1158,8 @@ namespace Opm {
         // Timestep initialization: should run once at the start of each timestep.
         if (iterCtx.needsTimestepInit() && this->wellsActive()) {
             OPM_TIMEBLOCK(firstIterationAssemble);
+            Dune::Timer prepareTimer;
+            prepareTimer.start();
             // try-catch is needed here as updateWellControls
             // contains global communication and has either to
             // be reached by all processes or all need to abort
@@ -1170,12 +1172,20 @@ namespace Opm {
             OPM_END_PARALLEL_TRY_CATCH_LOG(local_deferredLogger,
                                            "assemble() failed during well initialization: ",
                                            this->terminal_output_, grid().comm());
+            last_report_.well_facility_time += prepareTimer.stop();
         }
 
+        Dune::Timer networkTimer;
+        networkTimer.start();
         const bool well_group_control_changed = updateWellControlsAndNetwork(
                             /*mandatory_network_balance=*/false,
                             dt,
                             local_deferredLogger);
+        // the control/network update is part of the facility calculations,
+        // together with the time step preparation of the wells above
+        const double network_time = networkTimer.stop();
+        last_report_.well_control_network_time += network_time;
+        last_report_.well_facility_time += network_time;
 
         // even when there is no wells active, the network nodal pressure still need to be updated through updateWellControlsAndNetwork()
         // but there is no need to assemble the well equations
@@ -1187,10 +1197,35 @@ namespace Opm {
         // Pre-compute cell rates to we don't have to do this for every cell during linearization...
         updateCellRates();
 
+        // collect the statistics for the standalone well solves done since
+        // the last assembly (prepareTimeStep, well testing and well
+        // potential calculations)
+        collectWellSolveStats();
+
         // if group or well control changes we don't consider the
         // case converged
         last_report_.well_group_control_changed = well_group_control_changed;
         last_report_.assemble_time_well += perfTimer.stop();
+    }
+
+
+
+
+    template<typename TypeTag>
+    void
+    BlackoilWellModel<TypeTag>::
+    collectWellSolveStats()
+    {
+        for (const auto& well : well_container_) {
+            const auto& stats = well->solveStats();
+            last_report_.well_solve_time += stats.solve_time;
+            last_report_.well_potential_solve_time += stats.potential_solve_time;
+            last_report_.well_solve_assemble_time += stats.assemble_time;
+            last_report_.well_solve_linear_solve_time += stats.linear_solve_time;
+            last_report_.total_well_iterations += stats.iterations;
+            last_report_.total_well_potential_iterations += stats.potential_iterations;
+            well->resetSolveStats();
+        }
     }
 
 
@@ -1252,6 +1287,10 @@ namespace Opm {
         if (this->isRescoupMasterCoupledNetworkIteration_()) {
             this->sendSlaveNetworkLoopTerminationSignal_();
         }
+        // only count the balancing iterations when a network is active
+        if (this->schedule()[simulator_.episodeIndex()].network().active()) {
+            last_report_.total_network_iterations += network_update_iteration;
+        }
         return well_group_control_changed;
     }
 
@@ -1299,6 +1338,8 @@ namespace Opm {
                 // the network balancing
                 const bool updatePotentials = (this->network_.shouldBalance(reportStepIdx) ||
                                                mandatory_network_balance);
+                Dune::Timer gliftTimer;
+                gliftTimer.start();
                 alq_updated = gaslift_.maybeDoGasLiftOptimize(simulator_,
                                                           well_container_,
                                                           this->network_.nodePressures(),
@@ -1306,6 +1347,10 @@ namespace Opm {
                                                           this->wellState(),
                                                           this->groupState(),
                                                           local_deferredLogger);
+                // only account for the time when gas lift optimization is in use
+                if (this->schedule().glo(reportStepIdx).active()) {
+                    last_report_.gaslift_time += gliftTimer.stop();
+                }
             }
             prepareWellsBeforeAssembling(dt);
         }

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1181,6 +1181,8 @@ namespace Opm {
         // Timestep initialization: should run once at the start of each timestep.
         if (iterCtx.needsTimestepInit() && this->wellsActive()) {
             OPM_TIMEBLOCK(firstIterationAssemble);
+            Dune::Timer prepareTimer;
+            prepareTimer.start();
             // try-catch is needed here as updateWellControls
             // contains global communication and has either to
             // be reached by all processes or all need to abort
@@ -1193,12 +1195,20 @@ namespace Opm {
             OPM_END_PARALLEL_TRY_CATCH_LOG(local_deferredLogger,
                                            "assemble() failed during well initialization: ",
                                            this->terminal_output_, grid().comm());
+            last_report_.well_facility_time += prepareTimer.stop();
         }
 
+        Dune::Timer networkTimer;
+        networkTimer.start();
         const bool well_group_control_changed = updateWellControlsAndNetwork(
                             /*mandatory_network_balance=*/false,
                             dt,
                             local_deferredLogger);
+        // the control/network update is part of the facility calculations,
+        // together with the time step preparation of the wells above
+        const double network_time = networkTimer.stop();
+        last_report_.well_control_network_time += network_time;
+        last_report_.well_facility_time += network_time;
 
         // even when there is no wells active, the network nodal pressure still need to be updated through updateWellControlsAndNetwork()
         // but there is no need to assemble the well equations
@@ -1210,10 +1220,35 @@ namespace Opm {
         // Pre-compute cell rates to we don't have to do this for every cell during linearization...
         updateCellRates();
 
+        // collect the statistics for the standalone well solves done since
+        // the last assembly (prepareTimeStep, well testing and well
+        // potential calculations)
+        collectWellSolveStats();
+
         // if group or well control changes we don't consider the
         // case converged
         last_report_.well_group_control_changed = well_group_control_changed;
         last_report_.assemble_time_well += perfTimer.stop();
+    }
+
+
+
+
+    template<typename TypeTag>
+    void
+    BlackoilWellModel<TypeTag>::
+    collectWellSolveStats()
+    {
+        for (const auto& well : well_container_) {
+            const auto& stats = well->solveStats();
+            last_report_.well_solve_time += stats.solve_time;
+            last_report_.well_potential_solve_time += stats.potential_solve_time;
+            last_report_.well_solve_assemble_time += stats.assemble_time;
+            last_report_.well_solve_linear_solve_time += stats.linear_solve_time;
+            last_report_.total_well_iterations += stats.iterations;
+            last_report_.total_well_potential_iterations += stats.potential_iterations;
+            well->resetSolveStats();
+        }
     }
 
 
@@ -1275,6 +1310,10 @@ namespace Opm {
         if (this->isRescoupMasterCoupledNetworkIteration_()) {
             this->sendSlaveNetworkLoopTerminationSignal_();
         }
+        // only count the balancing iterations when a network is active
+        if (this->schedule()[simulator_.episodeIndex()].network().active()) {
+            last_report_.total_network_iterations += network_update_iteration;
+        }
         return well_group_control_changed;
     }
 
@@ -1298,16 +1337,26 @@ namespace Opm {
             this->rescoupHelper_.receiveMasterGroupNodePressuresFromMaster();
         }
 #endif
+        Dune::Timer groupTimer;
+        groupTimer.start();
         this->updateAndCommunicateGroupData(reportStepIdx, /*update_wellgrouptarget*/ true);
         // We need to call updateWellControls before we update the network as
         // network updates are only done on thp controlled wells.
         // Note that well controls are allowed to change during updateNetwork
         // and in prepareWellsBeforeAssembling during well solves.
         bool well_group_control_changed = updateWellControls(local_deferredLogger);
+        last_report_.group_control_time += groupTimer.stop();
+
+        Dune::Timer networkBalanceTimer;
+        networkBalanceTimer.start();
         const auto [more_inner_network_update, network_imbalance] =
                 this->network_.update(mandatory_network_balance,
                                       local_deferredLogger,
                                       relax_network_tolerance);
+        // only account for the time when a network is active
+        if (this->schedule()[reportStepIdx].network().active()) {
+            last_report_.network_balance_time += networkBalanceTimer.stop();
+        }
 #ifdef RESERVOIR_COUPLING_ENABLED
         if (this->isReservoirCouplingMaster()) {
             this->rescoupHelper_.maybeExchangeNetworkOuterIterationWithSlaves(more_inner_network_update);
@@ -1322,6 +1371,8 @@ namespace Opm {
                 // the network balancing
                 const bool updatePotentials = (this->network_.shouldBalance(reportStepIdx) ||
                                                mandatory_network_balance);
+                Dune::Timer gliftTimer;
+                gliftTimer.start();
                 alq_updated = gaslift_.maybeDoGasLiftOptimize(simulator_,
                                                           well_container_,
                                                           this->network_.nodePressures(),
@@ -1329,8 +1380,17 @@ namespace Opm {
                                                           this->wellState(),
                                                           this->groupState(),
                                                           local_deferredLogger);
+                // only account for the time when gas lift optimization is in use
+                if (this->schedule().glo(reportStepIdx).active()) {
+                    last_report_.gaslift_time += gliftTimer.stop();
+                }
             }
+            // the well solves triggered by control changes are part of the
+            // control/network update, keep track of the time separately
+            Dune::Timer prepareWellsTimer;
+            prepareWellsTimer.start();
             prepareWellsBeforeAssembling(dt);
+            last_report_.control_well_solve_time += prepareWellsTimer.stop();
         }
         OPM_END_PARALLEL_TRY_CATCH_LOG(local_deferredLogger,
                                        "updateWellControlsAndNetworkIteration() failed: ",
@@ -1340,12 +1400,15 @@ namespace Opm {
         if (alq_updated || BlackoilWellModelGuideRates(*this).
                               guideRateUpdateIsNeeded(reportStepIdx)) {
             const double simulationTime = simulator_.time();
+            Dune::Timer guideRateTimer;
+            guideRateTimer.start();
             // NOTE: For reservoir coupling: Slave group potentials are only communicated
             //    at the start of the time step, see beginTimeStep(). Here, we assume those
             //    potentials remain unchanged during the time step when updating guide rates below.
             this->guide_rate_handler_.updateGuideRates(
                 reportStepIdx, simulationTime, this->wellState(), this->groupState()
             );
+            last_report_.group_control_time += guideRateTimer.stop();
         }
         // we need to re-iterate the network when the well group controls changed or gaslift/alq is changed or
         // the inner iterations are did not converge

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -309,6 +309,10 @@ namespace Opm
             return;
         }
 
+        // attribute the well solves done below (also those done by well
+        // copies) to the well potential calculations in the solve statistics
+        const auto potential_scope = this->potentialCalculationScope();
+
         debug_cost_counter_ = 0;
         bool converged_implicit = false;
         if (this->param_.local_well_solver_control_switching_) {
@@ -622,7 +626,11 @@ namespace Opm
         // We assemble the well equations, then we check the convergence,
         // which is why we do not put the assembleWellEq here.
         try{
-            const BVectorWell dx_well = this->linSys_.solve();
+            BVectorWell dx_well;
+            {
+                const auto linear_solve_timer = this->solveLinearSolveTimer();
+                dx_well = this->linSys_.solve();
+            }
             updateWellState(simulator, dx_well, groupStateHelper, well_state);
         }
         catch(const NumericalProblem& exp) {
@@ -1557,6 +1565,7 @@ namespace Opm
         std::vector<std::vector<Scalar> > residual_history;
         std::vector<Scalar> measure_history;
         int it = 0;
+        const auto solve_scope = this->solveScope(it);
         // relaxation factor
         Scalar relaxation_factor = 1.;
         bool converged = false;
@@ -1616,7 +1625,10 @@ namespace Opm
 
             BVectorWell dx_well;
             try{
-                dx_well = this->linSys_.solve();
+                {
+                    const auto linear_solve_timer = this->solveLinearSolveTimer();
+                    dx_well = this->linSys_.solve();
+                }
                 updateWellState(simulator, dx_well, groupStateHelper, well_state, relaxation_factor);
                 if constexpr (has_energy) {
                     // segment fluid state is only consumed by the energy equation
@@ -1695,6 +1707,7 @@ namespace Opm
         std::vector<std::vector<Scalar> > residual_history;
         std::vector<Scalar> measure_history;
         int it = 0;
+        const auto solve_scope = this->solveScope(it);
         // relaxation factor
         Scalar relaxation_factor = 1.;
         bool converged = false;
@@ -1809,7 +1822,11 @@ namespace Opm
                 }
             }
             try{
-                const BVectorWell dx_well = this->linSys_.solve();
+                BVectorWell dx_well;
+                {
+                    const auto linear_solve_timer = this->solveLinearSolveTimer();
+                    dx_well = this->linSys_.solve();
+                }
                 updateWellState(simulator, dx_well, groupStateHelper, well_state, relaxation_factor);
                 if constexpr (has_energy) {
                     // segment fluid state is only consumed by the energy equation
@@ -1869,6 +1886,8 @@ namespace Opm
                                    const bool solving_with_zero_rate)
     {
         if (!this->isOperableAndSolvable() && !this->wellIsStopped()) return;
+
+        const auto assemble_timer = this->solveAssembleTimer();
 
         auto& deferred_logger = groupStateHelper.deferredLogger();
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -351,6 +351,8 @@ namespace Opm
         // for example, the matrices B C does not need to update if only_wells
         if (!this->isOperableAndSolvable() && !this->wellIsStopped()) return;
 
+        const auto assemble_timer = this->solveAssembleTimer();
+
         // clear all entries
         this->linSys_.clear();
 
@@ -1429,7 +1431,10 @@ namespace Opm
         // which is why we do not put the assembleWellEq here.
         BVectorWell dx_well(1);
         dx_well[0].resize(this->primary_variables_.numWellEq());
-        this->linSys_.solve( dx_well);
+        {
+            const auto linear_solve_timer = this->solveLinearSolveTimer();
+            this->linSys_.solve( dx_well);
+        }
 
         updateWellState(simulator, dx_well, groupStateHelper, well_state);
     }
@@ -1809,6 +1814,10 @@ namespace Opm
         if (!compute_potential) {
             return;
         }
+
+        // attribute the well solves done below (also those done by well
+        // copies) to the well potential calculations in the solve statistics
+        const auto potential_scope = this->potentialCalculationScope();
 
         bool converged_implicit = false;
         // for newly opened wells we dont compute the potentials implicit
@@ -2404,6 +2413,7 @@ namespace Opm
 
         const int max_iter = this->param_.max_inner_iter_wells_;
         int it = 0;
+        const auto solve_scope = this->solveScope(it);
         bool converged;
         bool relax_convergence = false;
         this->regularize_ = false;
@@ -2471,6 +2481,7 @@ namespace Opm
 
         const int max_iter = this->param_.max_inner_iter_wells_;
         int it = 0;
+        const auto solve_scope = this->solveScope(it);
         bool converged = false;
         bool relax_convergence = false;
         this->regularize_ = false;

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -24,12 +24,15 @@
 #ifndef OPM_WELLINTERFACE_GENERIC_HEADER_INCLUDED
 #define OPM_WELLINTERFACE_GENERIC_HEADER_INCLUDED
 
+#include <dune/common/timer.hh>
+
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/simulators/flow/BlackoilModelParameters.hpp>
 #include <opm/simulators/wells/RuntimePerforation.hpp>
 
 #include <ctime>
 #include <map>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -243,7 +246,107 @@ public:
 
     void addPerforations(const std::vector<RuntimePerforation>& perfs);
 
+    /// Statistics for the separate (standalone) well solves, i.e. the local
+    /// nonlinear solves of the single well equations done outside the global
+    /// linearizations (prepareTimeStep, well testing) and during the well
+    /// potential calculations.
+    struct WellSolveStats
+    {
+        double solve_time{0.0};            //!< time used by normal well solves
+        double potential_solve_time{0.0};  //!< time used by well potential solves
+        double assemble_time{0.0};         //!< assembly time in the well solves
+        double linear_solve_time{0.0};     //!< linear solve time in the well solves
+        unsigned int iterations{0};            //!< well iterations in normal solves
+        unsigned int potential_iterations{0};  //!< well iterations in potential solves
+    };
+
+    const WellSolveStats& solveStats() const { return *solve_stats_; }
+    void resetSolveStats() const { *solve_stats_ = WellSolveStats{}; }
+
 protected:
+    /// RAII helper marking a standalone well solve. Accumulates the elapsed
+    /// time and the number of well iterations into the solve statistics on
+    /// scope exit, attributing them to the well potential calculations if
+    /// such a calculation is in progress.
+    class WellSolveScope
+    {
+    public:
+        WellSolveScope(const WellInterfaceGeneric& well, const int& iterations)
+            : well_(well), iterations_(iterations)
+        {
+            well_.in_well_solve_ = true;
+            timer_.start();
+        }
+        ~WellSolveScope()
+        {
+            well_.in_well_solve_ = false;
+            auto& stats = *well_.solve_stats_;
+            if (well_.computing_well_potentials_) {
+                stats.potential_solve_time += timer_.stop();
+                stats.potential_iterations += iterations_;
+            } else {
+                stats.solve_time += timer_.stop();
+                stats.iterations += iterations_;
+            }
+        }
+    private:
+        const WellInterfaceGeneric& well_;
+        const int& iterations_;
+        Dune::Timer timer_{};
+    };
+
+    /// RAII helper accumulating the elapsed time into the given part of the
+    /// solve statistics, but only when inside a standalone well solve.
+    class SolvePartTimer
+    {
+    public:
+        SolvePartTimer(const WellInterfaceGeneric& well, double& target)
+            : well_(well), target_(target)
+        {
+            timer_.start();
+        }
+        ~SolvePartTimer()
+        {
+            if (well_.in_well_solve_) {
+                target_ += timer_.stop();
+            }
+        }
+    private:
+        const WellInterfaceGeneric& well_;
+        double& target_;
+        Dune::Timer timer_{};
+    };
+
+    /// RAII helper marking that a well potential calculation is in progress.
+    class PotentialCalculationScope
+    {
+    public:
+        explicit PotentialCalculationScope(const WellInterfaceGeneric& well)
+            : well_(well), previous_(well.computing_well_potentials_)
+        {
+            well_.computing_well_potentials_ = true;
+        }
+        ~PotentialCalculationScope()
+        {
+            well_.computing_well_potentials_ = previous_;
+        }
+    private:
+        const WellInterfaceGeneric& well_;
+        bool previous_;
+    };
+
+    WellSolveScope solveScope(const int& iterations) const
+    { return WellSolveScope(*this, iterations); }
+
+    SolvePartTimer solveAssembleTimer() const
+    { return SolvePartTimer(*this, solve_stats_->assemble_time); }
+
+    SolvePartTimer solveLinearSolveTimer() const
+    { return SolvePartTimer(*this, solve_stats_->linear_solve_time); }
+
+    PotentialCalculationScope potentialCalculationScope() const
+    { return PotentialCalculationScope(*this); }
+
     bool getAllowCrossFlow() const;
 
     Scalar wmicrobes_() const;
@@ -441,6 +544,14 @@ protected:
     std::vector<std::string> well_control_log_;
 
     bool changed_to_open_this_step_ = true;
+
+    // statistics for standalone well solves; shared so that well copies used
+    // during e.g. potential calculations contribute to the same statistics
+    std::shared_ptr<WellSolveStats> solve_stats_ = std::make_shared<WellSolveStats>();
+    // true while a well potential calculation is in progress
+    mutable bool computing_well_potentials_ = false;
+    // true while a standalone well solve is in progress
+    mutable bool in_well_solve_ = false;
 };
 
 }

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -24,12 +24,15 @@
 #ifndef OPM_WELLINTERFACE_GENERIC_HEADER_INCLUDED
 #define OPM_WELLINTERFACE_GENERIC_HEADER_INCLUDED
 
+#include <dune/common/timer.hh>
+
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/simulators/flow/BlackoilModelParameters.hpp>
 #include <opm/simulators/wells/RuntimePerforation.hpp>
 
 #include <ctime>
 #include <map>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -226,7 +229,107 @@ public:
 
     void addPerforations(const std::vector<RuntimePerforation>& perfs);
 
+    /// Statistics for the separate (standalone) well solves, i.e. the local
+    /// nonlinear solves of the single well equations done outside the global
+    /// linearizations (prepareTimeStep, well testing) and during the well
+    /// potential calculations.
+    struct WellSolveStats
+    {
+        double solve_time{0.0};            //!< time used by normal well solves
+        double potential_solve_time{0.0};  //!< time used by well potential solves
+        double assemble_time{0.0};         //!< assembly time in the well solves
+        double linear_solve_time{0.0};     //!< linear solve time in the well solves
+        unsigned int iterations{0};            //!< well iterations in normal solves
+        unsigned int potential_iterations{0};  //!< well iterations in potential solves
+    };
+
+    const WellSolveStats& solveStats() const { return *solve_stats_; }
+    void resetSolveStats() const { *solve_stats_ = WellSolveStats{}; }
+
 protected:
+    /// RAII helper marking a standalone well solve. Accumulates the elapsed
+    /// time and the number of well iterations into the solve statistics on
+    /// scope exit, attributing them to the well potential calculations if
+    /// such a calculation is in progress.
+    class WellSolveScope
+    {
+    public:
+        WellSolveScope(const WellInterfaceGeneric& well, const int& iterations)
+            : well_(well), iterations_(iterations)
+        {
+            well_.in_well_solve_ = true;
+            timer_.start();
+        }
+        ~WellSolveScope()
+        {
+            well_.in_well_solve_ = false;
+            auto& stats = *well_.solve_stats_;
+            if (well_.computing_well_potentials_) {
+                stats.potential_solve_time += timer_.stop();
+                stats.potential_iterations += iterations_;
+            } else {
+                stats.solve_time += timer_.stop();
+                stats.iterations += iterations_;
+            }
+        }
+    private:
+        const WellInterfaceGeneric& well_;
+        const int& iterations_;
+        Dune::Timer timer_{};
+    };
+
+    /// RAII helper accumulating the elapsed time into the given part of the
+    /// solve statistics, but only when inside a standalone well solve.
+    class SolvePartTimer
+    {
+    public:
+        SolvePartTimer(const WellInterfaceGeneric& well, double& target)
+            : well_(well), target_(target)
+        {
+            timer_.start();
+        }
+        ~SolvePartTimer()
+        {
+            if (well_.in_well_solve_) {
+                target_ += timer_.stop();
+            }
+        }
+    private:
+        const WellInterfaceGeneric& well_;
+        double& target_;
+        Dune::Timer timer_{};
+    };
+
+    /// RAII helper marking that a well potential calculation is in progress.
+    class PotentialCalculationScope
+    {
+    public:
+        explicit PotentialCalculationScope(const WellInterfaceGeneric& well)
+            : well_(well), previous_(well.computing_well_potentials_)
+        {
+            well_.computing_well_potentials_ = true;
+        }
+        ~PotentialCalculationScope()
+        {
+            well_.computing_well_potentials_ = previous_;
+        }
+    private:
+        const WellInterfaceGeneric& well_;
+        bool previous_;
+    };
+
+    WellSolveScope solveScope(const int& iterations) const
+    { return WellSolveScope(*this, iterations); }
+
+    SolvePartTimer solveAssembleTimer() const
+    { return SolvePartTimer(*this, solve_stats_->assemble_time); }
+
+    SolvePartTimer solveLinearSolveTimer() const
+    { return SolvePartTimer(*this, solve_stats_->linear_solve_time); }
+
+    PotentialCalculationScope potentialCalculationScope() const
+    { return PotentialCalculationScope(*this); }
+
     bool getAllowCrossFlow() const;
 
     Scalar wmicrobes_() const;
@@ -424,6 +527,14 @@ protected:
     std::vector<std::string> well_control_log_;
 
     bool changed_to_open_this_step_ = true;
+
+    // statistics for standalone well solves; shared so that well copies used
+    // during e.g. potential calculations contribute to the same statistics
+    std::shared_ptr<WellSolveStats> solve_stats_ = std::make_shared<WellSolveStats>();
+    // true while a well potential calculation is in progress
+    mutable bool computing_well_potentials_ = false;
+    // true while a standalone well solve is in progress
+    mutable bool in_well_solve_ = false;
 };
 
 }

--- a/tests/test_convergenceoutputconfiguration.cpp
+++ b/tests/test_convergenceoutputconfiguration.cpp
@@ -84,6 +84,44 @@ BOOST_AUTO_TEST_CASE(Iterations_Alias)
                         "option value must activate Steps option");
 }
 
+BOOST_AUTO_TEST_CASE(Performance)
+{
+    const auto config = Opm::ConvergenceOutputConfiguration{"performance"};
+    BOOST_CHECK_MESSAGE(config.any(),
+                        "Configuration object with supported "
+                        "option value must activate option");
+    BOOST_CHECK_MESSAGE(config.want(Opm::ConvergenceOutputConfiguration::Option::Performance),
+                        "Configuration object with \"performance\" "
+                        "option value must activate Performance option");
+}
+
+BOOST_AUTO_TEST_CASE(Performance_Alias)
+{
+    const auto config = Opm::ConvergenceOutputConfiguration{"perf"};
+    BOOST_CHECK_MESSAGE(config.any(),
+                        "Configuration object with supported "
+                        "option value must activate option");
+    BOOST_CHECK_MESSAGE(config.want(Opm::ConvergenceOutputConfiguration::Option::Performance),
+                        "Configuration object with \"perf\" "
+                        "option value must activate Performance option");
+}
+
+BOOST_AUTO_TEST_CASE(Performance_Combination)
+{
+    const auto both = Opm::ConvergenceOutputConfiguration{"iterations,performance"};
+    BOOST_CHECK_MESSAGE(both.want(Opm::ConvergenceOutputConfiguration::Option::Iterations),
+                        "Combined option must activate Iterations");
+    BOOST_CHECK_MESSAGE(both.want(Opm::ConvergenceOutputConfiguration::Option::Performance),
+                        "Combined option must activate Performance");
+}
+
+BOOST_AUTO_TEST_CASE(Performance_None_Overrides)
+{
+    const auto config = Opm::ConvergenceOutputConfiguration{"performance,none"};
+    BOOST_CHECK_MESSAGE(!config.any(),
+                        "\"none\" must override the performance option");
+}
+
 BOOST_AUTO_TEST_CASE(Combinations)
 {
     const auto steps_iter = Opm::ConvergenceOutputConfiguration{"steps,iterations"};


### PR DESCRIPTION
Add simple timings for highlighting wells solves. Should be useful when investigating changes in this logic. It is hidden behind --output-extra-convergence-info=performance
