### PR TITLE
Fix interiorSize calculation when the indexSet is empty

### DIFF
--- a/opm/simulators/linalg/ParallelOverlappingILU0_impl.hpp
+++ b/opm/simulators/linalg/ParallelOverlappingILU0_impl.hpp
@@ -200,9 +200,11 @@ size_t set_interiorSize( [[maybe_unused]] size_t N, size_t interiorSize, [[maybe
 template<>
 size_t set_interiorSize(size_t N, size_t interiorSize, const Dune::OwnerOverlapCopyCommunication<int,int>& comm)
 {
-    if (interiorSize<N)
+    if (interiorSize<=N)
         return interiorSize;
     auto indexSet = comm.indexSet();
+    if (indexSet.size() == 0)
+        return 0;
 
     size_t new_is = 0;
     for (auto idx = indexSet.begin(); idx!=indexSet.end(); ++idx)

--- a/opm/simulators/linalg/WellOperators.hpp
+++ b/opm/simulators/linalg/WellOperators.hpp
@@ -470,6 +470,8 @@ private:
     size_t setInteriorSize(const communication_type& comm) const
     {
         auto indexSet = comm.indexSet();
+        if (indexSet.size() == 0)
+            return 0;
 
         size_t is = 0;
         // Loop over index set
@@ -484,7 +486,7 @@ private:
                 }
             }
         }
-        return is + 1; //size is plus 1 since we start at 0
+        return is + 1; //size is plus 1 since we start at 0, except when indexSet is empty
     }
     const std::shared_ptr<const matrix_type> A_ ;
     const communication_type&  comm_;


### PR DESCRIPTION
The calculation for the interiorSize iterates over indexSet finds the biggest index and returns that number incremented by one. The variable storing the biggest index is initialized to zero, so when indexSet was empty the calculation wrongly returned 1. This PR corrects this edge case and returns 0 when the indexSet is empty. (Initializing the storing variable to -1 would work if only its type was signed.)

It is very rare to have empty indexSet. Nevertheless, we came upon such model and wrong interiorSize caused a segmentation fault.

Addition by @blattms for the manual:
This situation can only arise if the model has regions that are not connected to the rest of the reservoir and by chance only the cells of that region are part of one partition created by the partitioner.