### PR TITLE
TPSA warn against using aquifers

### DIFF
--- a/opm/simulators/flow/FacePropertiesTPSA_impl.hpp
+++ b/opm/simulators/flow/FacePropertiesTPSA_impl.hpp
@@ -217,7 +217,8 @@ update()
                 if (inside.faceIdx == -1) {
                     const auto id = details::isIdTPSA(inside.elemIdx, outside.elemIdx);
                     weightsAvgMap.insert_or_assign(id, 0.0);
-                    distanceMap.insert_or_assign(id, 0.0);
+                    weightsProdMap.insert_or_assign(id, 0.0);
+                    distanceMap.insert_or_assign(id, 1.0);
                     faceNormalMap.insert_or_assign(id, DimVector{0.0, 0.0, 0.0});
 
                     continue;

--- a/opm/simulators/flow/FlowProblemTPSA.hpp
+++ b/opm/simulators/flow/FlowProblemTPSA.hpp
@@ -121,6 +121,12 @@ public:
                 OpmLog::error(msg);
                 throw std::runtime_error(msg);
             }
+
+            // Warn against using aquifers with TPSA
+            if (simulator.vanguard().eclState().aquifer().active()) {
+                OpmLog::warning("TPSA geomechanics does not handle numerical or analytical "
+                                "aquifers, hence results may be inaccurate!");
+            }
         }
         else {
             // Sanity check


### PR DESCRIPTION
Warn against using aquifers with TPSA, since we currently do not handle aquifers in the TPSA calculations. In addition, I fixed a bug leading to simulation errors if explicit NNCs, like aquifers, are present. 