### PR TITLE
Reduce rank-local control flags before collectives

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1301,7 +1301,11 @@ namespace Opm {
         // alq_updated (per-rank gas-lift) and the cross-rescoup signal can differ
         // between ranks, so reduce here; otherwise ranks run a different number of
         // sub-iterations and the per-iteration collectives (e.g. the allgather in
-        // getGroupFipnumAndPvtreg) deadlock under MPI.
+        // getGroupFipnumAndPvtreg) deadlock under MPI. In a standard (non-coupled) MPI
+        // run these inputs are already identical on every rank, so this reduction is a
+        // no-op there; it is needed for reservoir coupling, where a slave group's
+        // control mode is imposed per-rank from the master target and can resolve
+        // differently across the slave's ranks.
         {
             int more = more_network_update ? 1 : 0;
             more = this->grid().comm().max(more);
@@ -1574,7 +1578,10 @@ namespace Opm {
             // rank-local values. If they differ across ranks the Newton loop runs a
             // different number of iterations per rank, and the per-iteration collectives
             // (e.g. the allgather in getGroupFipnumAndPvtreg) deadlock under MPI. Reduce
-            // each across ranks (OR) so the convergence decision is global.
+            // each across ranks (OR) so the convergence decision is global. In a standard
+            // (non-coupled) MPI run these flags are already identical on every rank, so
+            // this is a no-op there; it is needed for reservoir coupling, where a slave
+            // group's per-rank master-imposed control mode can make them diverge.
             const bool well_group_targets_violated =
                 comm.max(static_cast<int>(this->lastReport().well_group_control_changed)) > 0;
             report.setWellGroupTargetsViolated(well_group_targets_violated);
@@ -1640,6 +1647,10 @@ namespace Opm {
             // disagree on whether a control changed they run a different number of
             // iterations and those collectives deadlock. Reduce here, mirroring the
             // comm.sum() reductions applied to the well-to-group and individual flags below.
+            // In a standard (non-coupled) MPI run the group state behind this flag is
+            // communicated and identical on every rank, so this is a no-op there; it is
+            // needed for reservoir coupling, where a slave group's per-rank master-imposed
+            // control mode can make the flag diverge.
             changed_well_group = comm.sum(static_cast<int>(changed_well_group)) > 0;
 
             // Check wells' group constraints and communicate.
@@ -1759,6 +1770,10 @@ namespace Opm {
         // makes some ranks run it while others skip it, desyncing the collective stream and
         // deadlocking under MPI. Reduce so all ranks agree before the call -- a group-control
         // change is a global event, and updateAndCommunicate() is what reconciles the state.
+        // In a standard (non-coupled) MPI run the group state behind these flags is
+        // communicated and identical on every rank, so this is a no-op there. It is needed
+        // for reservoir coupling, where a slave group's control mode is imposed per-rank
+        // from the master target and can resolve differently across the slave's ranks.
         changed_hc = this->comm_.max(static_cast<int>(changed_hc)) > 0;
         if (changed_hc) {
             changed = true;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1297,6 +1297,16 @@ namespace Opm {
             more_network_update = more_network_update || more_cross_rescoup_update;
         }
 
+        // The network sub-iteration loop condition must be identical on all ranks.
+        // alq_updated (per-rank gas-lift) and the cross-rescoup signal can differ
+        // between ranks, so reduce here; otherwise ranks run a different number of
+        // sub-iterations and the per-iteration collectives (e.g. the allgather in
+        // getGroupFipnumAndPvtreg) deadlock under MPI.
+        {
+            int more = more_network_update ? 1 : 0;
+            more = this->grid().comm().max(more);
+            more_network_update = (more != 0);
+        }
         return {well_group_control_changed, more_network_update, network_imbalance};
     }
 
@@ -1559,9 +1569,18 @@ namespace Opm {
         ConvergenceReport report = gatherConvergenceReport(local_report, comm);
 
         if (checkWellGroupControlsAndNetwork) {
-            // the well_group_control_changed info is already communicated
-            report.setWellGroupTargetsViolated(this->lastReport().well_group_control_changed);
-            report.setNetworkNotYetBalancedForceAnotherNewtonIteration(network_needs_more_balancing_force_another_newton_iteration_);
+            // converged() depends on both flags below. gatherConvergenceReport() above
+            // does NOT cover them (they are set here, after the gather), so they carry
+            // rank-local values. If they differ across ranks the Newton loop runs a
+            // different number of iterations per rank, and the per-iteration collectives
+            // (e.g. the allgather in getGroupFipnumAndPvtreg) deadlock under MPI. Reduce
+            // each across ranks (OR) so the convergence decision is global.
+            const bool well_group_targets_violated =
+                comm.max(static_cast<int>(this->lastReport().well_group_control_changed)) > 0;
+            report.setWellGroupTargetsViolated(well_group_targets_violated);
+            const bool force_another_newton =
+                comm.max(static_cast<int>(network_needs_more_balancing_force_another_newton_iteration_)) > 0;
+            report.setNetworkNotYetBalancedForceAnotherNewtonIteration(force_another_newton);
         }
 
         if (this->terminal_output_) {
@@ -1615,6 +1634,13 @@ namespace Opm {
         const std::size_t max_iter = param_.well_group_constraints_max_iterations_;
         while(!changed_well_group && iter < max_iter) {
             changed_well_group = updateGroupControls(fieldGroup, deferred_logger, episodeIdx);
+            // The loop condition must be identical on all ranks: updateGroupControls()
+            // returns a rank-local OR of group-control changes, and each iteration calls
+            // collectives (e.g. the allgather in getGroupFipnumAndPvtreg). If the ranks
+            // disagree on whether a control changed they run a different number of
+            // iterations and those collectives deadlock. Reduce here, mirroring the
+            // comm.sum() reductions applied to the well-to-group and individual flags below.
+            changed_well_group = comm.sum(static_cast<int>(changed_well_group)) > 0;
 
             // Check wells' group constraints and communicate.
             bool changed_well_to_group = false;
@@ -1725,8 +1751,15 @@ namespace Opm {
         // restrict the number of group switches but only after nupcol iterations.
         const int nupcol = this->schedule()[reportStepIdx].nupcol();
         const bool update_group_switching_log = !iterCtx.withinNupcol(nupcol);
-        const bool changed_hc = this->checkGroupHigherConstraints(
+        bool changed_hc = this->checkGroupHigherConstraints(
             group, deferred_logger, reportStepIdx, update_group_switching_log);
+        // updateAndCommunicate() runs collectives (group-data communication and a
+        // parallel try/catch). checkGroupHigherConstraints() and updateGroupIndividualControl()
+        // both return rank-local change decisions, so gating the collective on them directly
+        // makes some ranks run it while others skip it, desyncing the collective stream and
+        // deadlocking under MPI. Reduce so all ranks agree before the call -- a group-control
+        // change is a global event, and updateAndCommunicate() is what reconciles the state.
+        changed_hc = this->comm_.max(static_cast<int>(changed_hc)) > 0;
         if (changed_hc) {
             changed = true;
             updateAndCommunicate(reportStepIdx);
@@ -1745,6 +1778,7 @@ namespace Opm {
                                              this->wellState(),
                                              deferred_logger);
 
+        changed_individual = this->comm_.max(static_cast<int>(changed_individual)) > 0;
         if (changed_individual) {
             changed = true;
             updateAndCommunicate(reportStepIdx);


### PR DESCRIPTION
Several rank-local boolean decisions in the parallel well/group control and convergence code gate or bound collective operations, but were used without first being reduced across ranks. When ranks disagree on such a flag they run a **different number of control/network/Newton iterations**, and the per-iteration collectives (e.g. the `allgather` in `getGroupFipnumAndPvtreg`, or `updateAndCommunicate`) **deadlock under MPI**. This was observed on multi-rank reservoir coupling runs; single-rank runs are unaffected. Each flag is now reduced across ranks before it is used, so the loop/branch conditions are identical on every rank.

#### Changes

- **`updateWellControlsAndNetworkIteration`**: `max()` the network sub-iteration continuation flag (`more_network_update`) before returning it, so all ranks run the same number of network sub-iterations.
- **`updateWellControls`**: `sum()` the group-control-changed flag returned by `updateGroupControls()` before using it as the outer-loop condition (mirroring the existing reductions already applied to the well-to-group and individual flags in the same loop).
- **`updateGroupControls`**: `max()` the **higher-constraint** (`changed_hc`) and **individual-control** (`changed_individual`) change flags before each `updateAndCommunicate()` call — that call runs collectives, so gating it on a rank-local flag desyncs the collective stream.
- **`getWellConvergence`**: `max()` the **well-group-targets-violated** and **network-not-yet-balanced** flags before they enter the convergence decision. These are set *after* `gatherConvergenceReport()` (so they were not otherwise communicated) yet `converged()` depends on them.

#### Notes

- These are general multi-rank robustness fixes (the reductions are no-ops on a single rank), independent of any specific feature — they prevent deadlocks where ranks would otherwise iterate a different number of times.
