### PR TITLE
Implement AQANTRC tracer influx for analytical aquifers.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -477,6 +477,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/models/test_tasklets_failure.cpp
   tests/test_ALQState.cpp
   tests/test_aquifergridutils.cpp
+  tests/test_aqantrc_flow_keyword.cpp
   tests/test_blackoil_amg.cpp
   tests/test_blackoilprimaryvariables.cpp
   tests/test_convergenceoutputconfiguration.cpp

--- a/opm/simulators/aquifers/AquiferAnalytical.hpp
+++ b/opm/simulators/aquifers/AquiferAnalytical.hpp
@@ -163,6 +163,18 @@ public:
                                    this->simulator_.vanguard().grid().comm());
     }
 
+    // Tracer assembly only: scalar readout after the flow step. Never call
+    // calculateInflowRate() here (mutates Carter–Tracy state after endTimeStep).
+    Scalar cachedConnectionInfluxRate(unsigned cellIdx) const override
+    {
+        const int idx = this->cellToConnectionIdx_[cellIdx];
+        if (idx < 0) {
+            return Scalar{0};
+        }
+
+        return getValue(this->Qai_[idx]);
+    }
+
     void addToSource(RateVector& rates,
                      const unsigned cellIdx,
                      const unsigned timeIdx) override
@@ -179,6 +191,8 @@ public:
         this->updateCellPressure(this->pressure_current_, idx, intQuants);
         this->calculateInflowRate(idx, this->simulator_);
 
+        // Qai_[idx] is Evaluation: must not pass through getValue() or Newton loses
+        // pressure derivatives and the aquifer source becomes explicit.
         rates[BlackoilIndices::conti0EqIdx + compIdx_()]
             += this->Qai_[idx] / model.dofTotalVolume(cellIdx);
 
@@ -196,7 +210,7 @@ public:
                 fs.setEnthalpy(this->phaseIdx_(), h);
             }
             rates[BlackoilIndices::contiEnergyEqIdx]
-            += this->Qai_[idx] *fs.enthalpy(this->phaseIdx_()) * FluidSystem::referenceDensity( this->phaseIdx_(), intQuants.pvtRegionIndex()) / model.dofTotalVolume(cellIdx);
+            += this->Qai_[idx] * fs.enthalpy(this->phaseIdx_()) * FluidSystem::referenceDensity(this->phaseIdx_(), intQuants.pvtRegionIndex()) / model.dofTotalVolume(cellIdx);
 
         }
     }

--- a/opm/simulators/aquifers/AquiferInterface.hpp
+++ b/opm/simulators/aquifers/AquiferInterface.hpp
@@ -76,6 +76,13 @@ public:
                              const unsigned cellIdx,
                              const unsigned timeIdx) = 0;
 
+    /// Scalar influx from the last flow Newton iteration (decoupled tracer solve only).
+    /// Do not use this in addToSource: Qai_ must stay as Evaluation for the Jacobian.
+    virtual Scalar cachedConnectionInfluxRate(unsigned cellIdx) const
+    {
+        return Scalar{0};
+    }
+
     int aquiferID() const { return this->aquiferID_; }
 
 protected:

--- a/opm/simulators/aquifers/AquiferInterface.hpp
+++ b/opm/simulators/aquifers/AquiferInterface.hpp
@@ -78,7 +78,7 @@ public:
 
     /// Scalar influx from the last flow Newton iteration (decoupled tracer solve only).
     /// Do not use this in addToSource: Qai_ must stay as Evaluation for the Jacobian.
-    virtual Scalar cachedConnectionInfluxRate(unsigned cellIdx) const
+    virtual Scalar cachedConnectionInfluxRate([[maybe_unused]] unsigned cellIdx) const
     {
         return Scalar{0};
     }

--- a/opm/simulators/aquifers/BlackoilAquiferModel.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel.hpp
@@ -50,6 +50,7 @@ class BlackoilAquiferModel
 {
     using Simulator = GetPropType<TypeTag, Properties::Simulator>;
     using RateVector = GetPropType<TypeTag, Properties::RateVector>;
+    using Scalar = GetPropType<TypeTag, Properties::Scalar>;
 
 
 public:
@@ -65,6 +66,7 @@ public:
     template <class Context>
     void addToSource(RateVector& rates, const Context& context, unsigned spaceIdx, unsigned timeIdx) const;
     void addToSource(RateVector& rates, unsigned globalSpaceIdx, unsigned timeIdx) const;
+    Scalar cachedConnectionInfluxRate(unsigned globalSpaceIdx) const;
     void endIteration();
     void endTimeStep();
     void endEpisode();
@@ -83,7 +85,6 @@ public:
 protected:
     // ---------      Types      ---------
     using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;
-    using Scalar = GetPropType<TypeTag, Properties::Scalar>;
 
     Simulator& simulator_;
 

--- a/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
@@ -126,6 +126,17 @@ BlackoilAquiferModel<TypeTag>::addToSource(RateVector& rates,
 }
 
 template <typename TypeTag>
+typename BlackoilAquiferModel<TypeTag>::Scalar
+BlackoilAquiferModel<TypeTag>::cachedConnectionInfluxRate(unsigned globalSpaceIdx) const
+{
+    Scalar rate{0};
+    for (const auto& aquifer : this->aquifers) {
+        rate += aquifer->cachedConnectionInfluxRate(globalSpaceIdx);
+    }
+    return rate;
+}
+
+template <typename TypeTag>
 void
 BlackoilAquiferModel<TypeTag>::endIteration()
 {}

--- a/opm/simulators/flow/BaseAquiferModel.hpp
+++ b/opm/simulators/flow/BaseAquiferModel.hpp
@@ -50,6 +50,7 @@ class BaseAquiferModel
 {
     using Simulator = GetPropType<TypeTag, Properties::Simulator>;
     using RateVector = GetPropType<TypeTag, Properties::RateVector>;
+    using Scalar = GetPropType<TypeTag, Properties::Scalar>;
 
 public:
     explicit BaseAquiferModel(Simulator& simulator)
@@ -114,6 +115,8 @@ public:
                      unsigned) const
     { }
 
+    Scalar cachedConnectionInfluxRate(unsigned) const
+    { return Scalar{0}; }
 
     /*!
      * \brief This method is called after each Newton-Raphson successful iteration.

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -93,7 +93,7 @@ class FlowProblem : public GetPropType<TypeTag, Properties::BaseProblem>
                   , public FlowGenericProblem<GetPropType<TypeTag, Properties::GridView>,
                                               GetPropType<TypeTag, Properties::FluidSystem>>
 {
-public:
+protected:
     using BaseType = FlowGenericProblem<GetPropType<TypeTag, Properties::GridView>,
                                         GetPropType<TypeTag, Properties::FluidSystem>>;
     using ParentType = GetPropType<TypeTag, Properties::BaseProblem>;

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -93,7 +93,7 @@ class FlowProblem : public GetPropType<TypeTag, Properties::BaseProblem>
                   , public FlowGenericProblem<GetPropType<TypeTag, Properties::GridView>,
                                               GetPropType<TypeTag, Properties::FluidSystem>>
 {
-protected:
+public:
     using BaseType = FlowGenericProblem<GetPropType<TypeTag, Properties::GridView>,
                                         GetPropType<TypeTag, Properties::FluidSystem>>;
     using ParentType = GetPropType<TypeTag, Properties::BaseProblem>;

--- a/opm/simulators/flow/TracerModel.hpp
+++ b/opm/simulators/flow/TracerModel.hpp
@@ -42,6 +42,7 @@
 
 #include <opm/simulators/flow/GenericTracerModel.hpp>
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
+#include <opm/simulators/utils/gatherDeferredLogger.hpp>
 #include <opm/simulators/utils/VectorVectorDataHandle.hpp>
 
 #include <array>
@@ -148,6 +149,8 @@ public:
 
     void prepareTracerBatches()
     {
+        DeferredLogger local_deferredLogger;
+
         for (std::size_t tracerIdx = 0; tracerIdx < this->tracerPhaseIdx_.size(); ++tracerIdx) {
             if (this->tracerPhaseIdx_[tracerIdx] == FluidSystem::waterPhaseIdx) {
                 if (! FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)){
@@ -198,7 +201,13 @@ public:
             }
         }
 
-        this->buildAquiferTracerConnections_();
+        this->buildAquiferTracerConnections_(local_deferredLogger);
+
+        const auto& comm = simulator_.vanguard().grid().comm();
+        const auto global_logger = gatherDeferredLogger(local_deferredLogger, comm);
+        if (comm.rank() == 0) {
+            global_logger.logMessages();
+        }
     }
 
     void beginTimeStep()
@@ -805,7 +814,7 @@ protected:
         }
     }
 
-    void buildAquiferTracerConnections_()
+    void buildAquiferTracerConnections_(DeferredLogger& deferredLogger)
     {
         aquifer_tracer_cells_.clear();
 
@@ -832,8 +841,10 @@ protected:
 
             const auto tracer_pos = tracer_name_to_idx.find(spec.tracer_name);
             if (tracer_pos == tracer_name_to_idx.end()) {
-                OpmLog::warning(fmt::format("AQANTRC tracer '{}' is not declared in TRACER",
-                                            spec.tracer_name));
+                if (simulator_.vanguard().grid().comm().rank() == 0) {
+                    deferredLogger.warning(fmt::format("AQANTRC tracer '{}' is not declared in TRACER",
+                                                       spec.tracer_name));
+                }
                 continue;
             }
 

--- a/opm/simulators/flow/TracerModel.hpp
+++ b/opm/simulators/flow/TracerModel.hpp
@@ -204,7 +204,7 @@ public:
         this->buildAquiferTracerConnections_(local_deferredLogger);
 
         const auto& comm = simulator_.vanguard().grid().comm();
-        const auto global_logger = gatherDeferredLogger(local_deferredLogger, comm);
+        auto global_logger = gatherDeferredLogger(local_deferredLogger, comm);
         if (comm.rank() == 0) {
             global_logger.logMessages();
         }

--- a/opm/simulators/flow/TracerModel.hpp
+++ b/opm/simulators/flow/TracerModel.hpp
@@ -862,7 +862,7 @@ protected:
                 }
 
                 aquifer_tracer_cells_[cellIdx].push_back(
-                    AquiferTracerCellSpec { tracerIdx, phaseIdx, spec.concentration });
+                    AquiferTracerCellSpec { tracerIdx, phaseIdx, static_cast<Scalar>(spec.concentration) });
             }
         }
     }

--- a/opm/simulators/flow/TracerModel.hpp
+++ b/opm/simulators/flow/TracerModel.hpp
@@ -31,6 +31,7 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/TimingMacros.hpp>
 
+#include <opm/input/eclipse/EclipseState/Aquifer/AquiferConfig.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 
@@ -48,7 +49,10 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <vector>
+
+#include <fmt/format.h>
 
 namespace Opm::Properties {
 
@@ -193,6 +197,8 @@ public:
                 }
             }
         }
+
+        this->buildAquiferTracerConnections_();
     }
 
     void beginTimeStep()
@@ -623,6 +629,10 @@ protected:
                 }
             }
 
+            for (auto& tr : tbatch) {
+                this->assembleTracerEquationAquifer_(tr);
+            }
+
             // Parallel loop over element chunks
             #ifdef _OPENMP
             #pragma omp parallel for
@@ -790,6 +800,108 @@ protected:
                 splitRate[tr.idx_[tIdx]].rate += delta;
                 if (eclWell.isMultiSegment()) {
                     (*mswTracerRate)[tr.idx_[tIdx]].rate[eclWell.getConnections().get(i).segment()] += delta;
+                }
+            }
+        }
+    }
+
+    void buildAquiferTracerConnections_()
+    {
+        aquifer_tracer_cells_.clear();
+
+        const auto& aquifer_cfg = this->eclState_.aquifer();
+        if (!aquifer_cfg.active()) {
+            return;
+        }
+
+        const auto& specs = aquifer_cfg.aquiferTracers();
+        if (specs.empty()) {
+            return;
+        }
+
+        std::unordered_map<std::string, int> tracer_name_to_idx;
+        for (int tracerIdx = 0; tracerIdx < this->numTracers(); ++tracerIdx) {
+            tracer_name_to_idx.emplace(this->name(tracerIdx), tracerIdx);
+        }
+
+        const auto& vanguard = simulator_.vanguard();
+        for (const auto& spec : specs) {
+            if (!aquifer_cfg.hasAnalyticalAquifer(spec.aquifer_id)) {
+                continue;
+            }
+
+            const auto tracer_pos = tracer_name_to_idx.find(spec.tracer_name);
+            if (tracer_pos == tracer_name_to_idx.end()) {
+                OpmLog::warning(fmt::format("AQANTRC tracer '{}' is not declared in TRACER",
+                                            spec.tracer_name));
+                continue;
+            }
+
+            if (!aquifer_cfg.connections().hasAquiferConnections(spec.aquifer_id)) {
+                continue;
+            }
+
+            const int tracerIdx = tracer_pos->second;
+            const int phaseIdx = this->tracerPhaseIdx_[tracerIdx];
+
+            for (const auto& conn : aquifer_cfg.connections().getConnections(spec.aquifer_id)) {
+                const int cellIdx = vanguard.compressedIndex(conn.global_index);
+                if (cellIdx < 0) {
+                    continue;
+                }
+
+                aquifer_tracer_cells_[cellIdx].push_back(
+                    AquiferTracerCellSpec { tracerIdx, phaseIdx, spec.concentration });
+            }
+        }
+    }
+
+    template<class TrRe>
+    void assembleTracerEquationAquifer_(TrRe& tr)
+    {
+        if (tr.numTracer() == 0 || aquifer_tracer_cells_.empty()) {
+            return;
+        }
+
+        const auto& aquiferModel = simulator_.problem().aquiferModel();
+        const Scalar dt = simulator_.timeStepSize();
+
+        for (const auto& [cellIdx, specs] : aquifer_tracer_cells_) {
+            // Scalar influx from converged Qai_; do not recalculate or use getValue()
+            // in the flow Newton path (see AquiferAnalytical::addToSource).
+            const Scalar rate = aquiferModel.cachedConnectionInfluxRate(cellIdx);
+            if (rate == Scalar{0}) {
+                continue;
+            }
+
+            const unsigned I = cellIdx;
+            const Scalar rate_f = rate;
+
+            for (const auto& spec : specs) {
+                if (spec.phaseIdx != tr.phaseIdx_) {
+                    continue;
+                }
+
+                int localTIdx = -1;
+                for (int tIdx = 0; tIdx < tr.numTracer(); ++tIdx) {
+                    if (tr.idx_[tIdx] == spec.tracerIdx) {
+                        localTIdx = tIdx;
+                        break;
+                    }
+                }
+                if (localTIdx < 0) {
+                    continue;
+                }
+
+                if (rate_f > 0) {
+                    const Scalar delta = rate_f * spec.concentration;
+                    tr.residual_[localTIdx][I][Free] -= delta;
+                    dVol_[Free][tr.phaseIdx_][I] -= rate_f * dt;
+                }
+                else if (rate_f < 0) {
+                    tr.residual_[localTIdx][I][Free] -= rate_f * tr.concentration_[localTIdx][I][Free];
+                    dVol_[Free][tr.phaseIdx_][I] -= rate_f * dt;
+                    (*tr.mat)[I][I][Free][Free] -= rate_f * variable<TracerEvaluation>(1.0, 0).derivative(0);
                 }
             }
         }
@@ -977,6 +1089,14 @@ protected:
     std::array<std::array<std::vector<Scalar>,numPhases>,2> vol1_;
     std::array<std::array<std::vector<Scalar>,numPhases>,2> dVol_;
     ElementChunks<GridView, Dune::Partitions::All> element_chunks_;
+
+    struct AquiferTracerCellSpec {
+        int tracerIdx{};
+        int phaseIdx{};
+        Scalar concentration{};
+    };
+
+    std::unordered_map<unsigned, std::vector<AquiferTracerCellSpec>> aquifer_tracer_cells_;
 };
 
 } // namespace Opm

--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -52,7 +52,6 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"APIVD", {true, std::nullopt}},
         {"AQANCONL", {true, std::nullopt}},
         {"AQANNC", {true, std::nullopt}},
-        {"AQANTRC", {true, std::nullopt}},
         {"AQUALIST", {true, std::nullopt}},
         {"AQUCHGAS", {true, std::nullopt}},
         {"AQUCHWAT", {true, std::nullopt}},

--- a/tests/test_aqantrc_flow_keyword.cpp
+++ b/tests/test_aqantrc_flow_keyword.cpp
@@ -1,0 +1,32 @@
+/*
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
+#include <opm/simulators/utils/UnsupportedFlowKeywords.hpp>
+
+#define BOOST_TEST_MODULE AqantrcFlowKeywordTest
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(AQANTRC_NotBlockedByFlowValidator)
+{
+    const auto& blocked = Opm::FlowKeywordValidation::unsupportedKeywords();
+    BOOST_CHECK(blocked.find("AQANTRC") == blocked.end());
+}


### PR DESCRIPTION
## Summary

Implements tracer transport from **analytic aquifers** declared via `AQANTRC`, building on opm-common #5222 (`AquiferConfig::aquiferTracers()`).

- Map `AQANTRC` keyword to aquifer connection cells at tracer init.
- During the decoupled tracer solve, add aquifer influx terms using the **converged** per-connection volumetric rate `Qai_` from the flow step.
- Expose `cachedConnectionInfluxRate()` on the aquifer model so the tracer pass does not call `calculateInflowRate()` (which would corrupt Carter–Tracy state after `endTimeStep`).
- Allow `AQANTRC` through the Flow keyword validator.

## Depends on

- opm-common #5222 (merged): `AQANTRC` → `AquiferConfig`

## Verification

**Unit:** `test_aqantrc_flow_keyword` — `AQANTRC` not in unsupported keyword list.

**Integration (manual — see attached PDF + decks):** `AQBHP` variant with Aquifer No 2 on **`AQTAB=1`** (infinite acting) so finite-radius Carter–Tracy history does not confound tracer validation. 

**Tracer (primary acceptance):**

- Path-trace heatmaps and snapshot profiles (PDF ~pp. 12–14): `WAQF` / `WTPRWAQ` behaviour matches sufficiently for analytic-aquifer tracer influx.

**Flow / aquifer (secondary — documented, not blocking this PR):**

- Conn-block `PRESSURE(12,12,1)` with `AQTAB=1`: Flow plateaus _ca._ **217** bar vs Simulator _ca._ **218.75** bar (_ca._ **2 bar** residual). Larger than a naive half-cell hydrostatic estimate; may reflect connection weighting, face flux discretisation, or aquifer-pressure reporting — **not a tracer regression failure**.
- `summary_aquifer2_ct_diagnostics.png`: `AAQPD:2` (dimensionless CT pressure) and `AAQP − P_conn` proxy are **diagnostic only**; unable to have alternative overlay expected for `AAQPD`.

## Known binary file gaps

| Item | Notes |
|------|--------|
| **`AAQP:N` in Flow** | Carter–Tracy `aquiferData()` still reports **`pa0_`** (initial datum pressure), not evolving aquifer pressure — `AquiferCarterTracy.hpp` TODO. Conn P is **not** `AAQP`. |
| **Restart `WAQF`** | Tracer maps use restart; well tracer rates use `WTPRWAQ` in SUMMARY. |

These are **follow-up** aquifer-summary items (linked CT issue), not regressions for **AQANTRC tracer transport**.

**Not claimed in this PR:** `AQTAB=3` voidage–pressure parity on `AQBHP` (conn P collapse Apr–May 2012 while `AAQR:2` is active). Bisection: `AQTAB=1` isolates tracer; `AQTAB=3` fails → separate Carter–Tracy issue.

## Design notes

- Influx sign follows existing well tracer pattern: positive influx injects `rate × AQANTRC concentration`; negative influx uses local tracer concentration.
- `Qai_` remains `Evaluation` in `addToSource` for flow Jacobian; tracer uses scalar `getValue(Qai_)` only after the flow Newton solve.

## Attachments

`aqbhp.tgz` has the following files:
- **`aqbhp_compare.pdf`** — summary and diagnostic plots (conn P, `AAQPD`, support ratios).
- **`AQBHP.DATA`** / **`FLOWAQBHP.DATA`** — verification decks with AqNum=2 set to AQTAB=1 (Infinite acting).


## Follow-up (not blocking)

- opm-tests regression deck for `AQANTRC`.
- Carter–Tracy: `AQTAB=3` conn pressure, `AAQP` reporting, `AAQPD` table range (OPM issue TBD).
- Investigate ~2 bar conn-P residual at `(12,12,1)` under `AQTAB=1`.