### PR TITLE
Fix warning

### DIFF
--- a/opm/simulators/flow/CollectDataOnIORank_impl.hpp
+++ b/opm/simulators/flow/CollectDataOnIORank_impl.hpp
@@ -45,13 +45,6 @@
 #include <utility>
 #include <vector>
 
-namespace {
-    std::vector<std::string> toVector(const std::set<std::string>& string_set)
-    {
-        return { string_set.begin(), string_set.end() };
-    }
-}
-
 namespace Opm {
 
 // global id
@@ -939,7 +932,10 @@ CollectDataOnIORank(const Grid& grid, const EquilGrid* equilGrid,
                     const Dune::CartesianIndexMapper<EquilGrid>* equilCartMapper,
                     const std::set<std::string>& fipRegionsInterregFlow)
     : toIORankComm_(grid.comm())
-    , globalInterRegFlows_(InterRegFlowMap::createMapFromNames(toVector(fipRegionsInterregFlow)))
+    , globalInterRegFlows_(InterRegFlowMap::createMapFromNames({
+            fipRegionsInterregFlow.begin(),
+            fipRegionsInterregFlow.end()
+        }))
 {
     // Build index maps only when reordering is needed; skip in parallel runs for CpGrid with LGRs
     if ((!needsReordering && !isParallel()) || (isParallel() && (grid.maxLevel()>0)))


### PR DESCRIPTION
```bash
opm/opm-simulators/tests/test_LgrBlockData.cpp:24:
/Users/dmar/opm/opm-simulators/opm/simulators/flow/CollectDataOnIORank_impl.hpp:49:30: warning: function 'toVector' is not needed and will not be emitted [-Wunneeded-internal-declaration]
   49 |     std::vector<std::string> toVector(const std::set<std::string>& string_set)
```