### PR TITLE
Warn on GCONSALE injection error at low strictness

### DIFF
--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -769,6 +769,7 @@ void Opm::readDeck(Opm::Parallel::Communication    comm,
             auto parseContext = setupParseContext(exitOnAllErrors);
             if (treatCriticalAsNonCritical) { // Continue with invalid names if parsing strictness is set to low
                 parseContext->update(ParseContext::SCHEDULE_INVALID_NAME, InputErrorAction::WARN);
+                parseContext->update(ParseContext::SCHEDULE_GCONSALE_INVALID_INJECTION, InputErrorAction::WARN);
             }
             parseContext->setInputSkipMode(inputSkipMode);
             readOnIORank(comm, deckFilename, parseContext.get(),


### PR DESCRIPTION
Makes the new GCONSALE/GCONINJE-REIN safeguard a warning (instead of a hard error) when the user opts into `--parsing-strictness=low`.

#### Downgrade `SCHEDULE_GCONSALE_INVALID_INJECTION` at low strictness

- In `readDeck.cpp`, in the low-strictness (`treatCriticalAsNonCritical`) block, **downgrade `SCHEDULE_GCONSALE_INVALID_INJECTION` to `WARN`** so a group that combines `GCONSALE` with a non-`REIN` `GCONINJE GAS` control **parses with a warning instead of erroring out**.
- It remains a **hard error by default** and at `--parsing-strictness=high`. This **mirrors the existing low-strictness handling of `SCHEDULE_INVALID_NAME`**.

#### Dependency

- **Depends on the opm-common PR** that adds the `SCHEDULE_GCONSALE_INVALID_INJECTION` key and the safeguard: https://github.com/OPM/opm-common/pull/5228. 
