### PR TITLE
flow: route timestep failure/advance through the problem

### DIFF
--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -395,6 +395,24 @@ public:
     }
 
     /*!
+     * \brief Called by the simulator to restore the state captured at the
+     *        beginning of the timestep after a failed timestep.
+     */
+    void updateFailed()
+    {
+        this->model().updateFailed();
+    }
+
+    /*!
+     * \brief Called by the simulator to accept the current state as the new
+     *        time level after a successful timestep.
+     */
+    void advanceTimeLevel()
+    {
+        this->model().advanceTimeLevel();
+    }
+
+    /*!
      * \brief Called by the simulator before each Newton-Raphson iteration.
      */
     void beginIteration()

--- a/opm/simulators/flow/NonlinearSystem_impl.hpp
+++ b/opm/simulators/flow/NonlinearSystem_impl.hpp
@@ -193,10 +193,10 @@ prepareStep(const SimulatorTimerInterface& timer)
     }
 
     if (lastStepFailed) {
-        simulator_.model().updateFailed();
+        simulator_.problem().updateFailed();
     }
     else {
-        simulator_.model().advanceTimeLevel();
+        simulator_.problem().advanceTimeLevel();
     }
 
     // The model still needs the report-step time context even though flow owns time stepping.


### PR DESCRIPTION
Add FlowProblem::updateFailed() and advanceTimeLevel() that forward to the model, and call them from NonlinearSystem::prepareStep() instead of going directly to the model. This lets the problem (and the models it owns, such as the well model) hook into timestep failure recovery and time-level advance.

Behaviour is unchanged: the problem methods simply forward to the model.