### PR TITLE
timestepping: support deterministic timestep replay

### DIFF
--- a/opm/models/utils/basicparameters.hh
+++ b/opm/models/utils/basicparameters.hh
@@ -66,6 +66,12 @@ struct ParameterFile { static constexpr auto value = ""; };
 //! By default, do not force any time steps
 struct PredeterminedTimeStepsFile { static constexpr auto value = ""; };
 
+//! By default, do not truncate the time step size to float precision.
+//! Enabling this makes accepted step sizes reproducible from the limited
+//! precision recorded in output files, which is used by the timestep-replay
+//! regression test. It is not meant for production runs.
+struct TruncateTimeStepToFloat { static constexpr bool value = false; };
+
 /*!
  * \brief Print all parameters on startup?
  *

--- a/opm/models/utils/simulator.hh
+++ b/opm/models/utils/simulator.hh
@@ -123,6 +123,7 @@ public:
         if (!predetTimeStepFile.empty()) {
             forcedTimeSteps_ = readTimeStepFile<Scalar>(predetTimeStepFile);
         }
+        truncateTimeStepToFloat_ = Parameters::Get<Parameters::TruncateTimeStepToFloat>();
 
         episodeIdx_ = 0;
         episodeStartTime_ = 0;
@@ -222,6 +223,10 @@ public:
         Parameters::Register<Parameters::PredeterminedTimeStepsFile>
             ("A file with a list of predetermined time step sizes "
              "(one time step per line)");
+        Parameters::Register<Parameters::TruncateTimeStepToFloat>
+            ("Truncate the time step size to float precision. Only used to make "
+             "time steps reproducible for the timestep-replay regression test; "
+             "do not enable for production runs.");
 
         Vanguard::registerParameters();
         Model::registerParameters();
@@ -395,7 +400,7 @@ public:
      * \param value The new value for the time step size \f$\mathrm{[s]}\f$
      */
     void setTimeStepSize(Scalar value)
-    { timeStepSize_ = value; }
+    { timeStepSize_ = truncateTimeStepToFloat_ ? static_cast<Scalar>(float(value)) : value; }
 
     /*!
      * \brief Set the current time step index to a given value.
@@ -958,6 +963,7 @@ private:
 
     bool finished_;
     bool verbose_;
+    bool truncateTimeStepToFloat_ = false;
 
 #ifdef RESERVOIR_COUPLING_ENABLED
     ReservoirCouplingMaster<Scalar> *reservoirCouplingMaster_ = nullptr;

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -523,6 +523,34 @@ maybeModifySuggestedTimeStepAtBeginningOfReportStep_(const double original_time_
     this->adaptive_time_stepping_.maybeModifySuggestedTimeStepAtBeginningOfReportStep_(
         original_time_step, this->is_event_
     );
+
+    if (this->adaptive_time_stepping_.time_step_control_type_ != TimeStepControlType::HardCodedTimeStep) {
+        return;
+    }
+
+    struct ZeroRelativeChange final : RelativeChangeInterface {
+        double relativeChange() const override { return 0.0; }
+    } zero_relative_change;
+
+    const auto* hardcoded_control = static_cast<const HardcodedTimeStepControl*>(
+        this->adaptive_time_stepping_.time_step_control_.get());
+    AdaptiveSimulatorTimer report_step_timer{
+        this->simulator_timer_.startDateTime(),
+        original_time_step,
+        this->simulator_timer_.simulationTimeElapsed(),
+        original_time_step,
+        this->simulator_timer_.reportStepNum(),
+        maxTimeStep_()
+    };
+
+    const double hardcoded_initial_step = hardcoded_control->computeTimeStepSize(
+        original_time_step,
+        0,
+        zero_relative_change,
+        report_step_timer);
+    if (std::isfinite(hardcoded_initial_step) && hardcoded_initial_step > 0.0) {
+        this->adaptive_time_stepping_.setSuggestedNextStep(hardcoded_initial_step);
+    }
 }
 
 // The maybeUpdateTuning_() lambda callback is defined in SimulatorFullyImplicit::runStep()

--- a/opm/simulators/timestepping/SimulatorReport.cpp
+++ b/opm/simulators/timestepping/SimulatorReport.cpp
@@ -395,7 +395,7 @@ namespace Opm
         os << "  Time(day)  TStep(day)  Assembly    LSetup    LSolve    LocSol    Update    Output WellIt Lins NewtIt LinIt Conv\n";
         for (std::size_t i = 0; i < this->stepreports.size(); ++i) {
             const SimulatorReportSingle& sr = this->stepreports[i];
-            os.precision(10);
+            os.precision(20);
             os << std::defaultfloat;
             os << std::setw(11) << unit::convert::to(sr.global_time, unit::day) << " ";
             os << std::setw(11) << unit::convert::to(sr.timestep_length, unit::day) << " ";

--- a/opm/simulators/timestepping/TimeStepControl.cpp
+++ b/opm/simulators/timestepping/TimeStepControl.cpp
@@ -41,6 +41,14 @@
 
 namespace Opm
 {
+    namespace {
+    double hardcodedTimeTolerance(const double a, const double b, const double c = 0.0)
+    {
+        const double scale = std::max({1.0, std::abs(a), std::abs(b), std::abs(c)});
+        return 64.0 * std::numeric_limits<double>::epsilon() * scale;
+    }
+    }
+
     ////////////////////////////////////////////////////////
     //
     //  InterationCountTimeStepControl Implementation
@@ -128,12 +136,14 @@ namespace Opm
         std::string::size_type sz;
         std::string line;
         while ( std::getline(infile, line)) {
-            if( line[0] != '-') { // ignore lines starting with '-'
+            if (!line.empty() && line[0] != '-') { // ignore lines starting with '-'
                 const double time = std::stod(line,&sz); // read the first number i.e. the actual substep time
                 subStepTime_.push_back( time * unit::day );
             }
 
         }
+
+        std::sort(subStepTime_.begin(), subStepTime_.end());
     }
 
     HardcodedTimeStepControl HardcodedTimeStepControl::serializationTestObject()
@@ -145,14 +155,25 @@ namespace Opm
     }
 
     double
-    HardcodedTimeStepControl::computeTimeStepSize(const double /*dt */,
+    HardcodedTimeStepControl::computeTimeStepSize(const double dt,
                                                   const int /*iterations */,
                                                   const RelativeChangeInterface& /* relativeChange */,
                                                   const AdaptiveSimulatorTimer& substepTimer) const
     {
-        auto nextTime
-            = std::upper_bound(subStepTime_.begin(), subStepTime_.end(), substepTimer.simulationTimeElapsed());
-        return (*nextTime - substepTimer.simulationTimeElapsed());
+        const double currentTime = substepTimer.simulationTimeElapsed();
+        const double remaining = substepTimer.totalTime() - currentTime;
+        const double tol = hardcodedTimeTolerance(currentTime, substepTimer.totalTime(), dt);
+
+        auto nextTime = std::upper_bound(subStepTime_.begin(), subStepTime_.end(), currentTime + tol);
+        while (nextTime != subStepTime_.end() && (*nextTime - currentTime) <= tol) {
+            ++nextTime;
+        }
+
+        if (nextTime == subStepTime_.end()) {
+            return remaining > tol ? remaining : std::max(dt, tol);
+        }
+
+        return std::max(*nextTime - currentTime, tol);
     }
 
     bool HardcodedTimeStepControl::operator==(const HardcodedTimeStepControl& ctrl) const


### PR DESCRIPTION
Improve the HardcodedTimeStepControl and add a gated float-precision mode so a simulation can be re-run with a recorded sequence of accepted time steps and reproduce the original results:

- HardcodedTimeStepControl: tolerance-based matching of the next substep time, sort the parsed substep times, and ignore empty lines.
- AdaptiveTimeStepping: seed the suggested step at the start of a report step from the hardcoded control so the very first substep matches.
- SimulatorReport: print INFOSTEP times with full (20-digit) precision.
- Add a TruncateTimeStepToFloat parameter (default off) that truncates the time step size to float precision. This is only used by the timestep-replay regression test to make recorded step sizes exactly reproducible; production runs are unaffected.