### PR TITLE
Roll back simulator state on failed timesteps, and a replay test for it

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -90,7 +90,7 @@ function(add_test_compareECLFiles)
     RESTART_STEP
     RESTART_SCHED
   )
-  set(multiValueArgs TEST_ARGS)
+  set(multiValueArgs TEST_ARGS TEST_ARGS_REPLAY)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
   if(NOT PARAM_DIR)
     set(PARAM_DIR ${PARAM_CASENAME})
@@ -121,6 +121,9 @@ function(add_test_compareECLFiles)
   if(USE_DEV_SIMULATOR_IN_TESTS AND PARAM_DEV_SIMULATOR)
     set(PARAM_SIMULATOR ${PARAM_DEV_SIMULATOR})
   endif()
+  foreach(arg IN LISTS PARAM_TEST_ARGS_REPLAY)
+    list(APPEND DRIVER_ARGS -y ${arg})
+  endforeach()
   opm_add_test(${PARAM_PREFIX}_${PARAM_SIMULATOR}+${PARAM_FILENAME}
     EXE_TARGET
       ${PARAM_SIMULATOR}

--- a/flowexperimental/comp/wells/CompWellModel.hpp
+++ b/flowexperimental/comp/wells/CompWellModel.hpp
@@ -107,6 +107,11 @@ public:
     void beginIteration();
     void restoreLastValidState();
 
+     // FlowProblem calls these lifecycle hooks for well models.
+     // Compositional wells currently keep no extra timestep snapshot state.
+     void updateFailed() {}
+     void advanceTimeLevel() {}
+
     void init();
     void endIteration() const {}
     void endTimeStep();

--- a/opm/models/blackoil/blackoilnewtonmethod.hpp
+++ b/opm/models/blackoil/blackoilnewtonmethod.hpp
@@ -94,6 +94,12 @@ public:
         wasSwitched_.resize(this->model().numTotalDof(), false);
     }
 
+    void resetPrimaryVariableSwitches()
+    {
+        numPriVarsSwitched_ = 0;
+        std::fill(wasSwitched_.begin(), wasSwitched_.end(), false);
+    }
+
     /*!
      * \brief Register all run-time parameters for the blackoil newton method.
      */

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -369,6 +369,8 @@ public:
         const int episodeIdx = this->episodeIndex();
         const int timeStepSize = this->simulator().timeStepSize();
 
+        this->captureBeginTimeStepState_();
+
         this->beginTimeStep_(enableExperiments,
                              episodeIdx,
                              this->simulator().timeStepIndex(),
@@ -394,22 +396,17 @@ public:
 
     }
 
-    /*!
-     * \brief Called by the simulator to restore the state captured at the
-     *        beginning of the timestep after a failed timestep.
-     */
     void updateFailed()
     {
+        this->restoreBeginTimeStepState_();
+        wellModel_.updateFailed();
         this->model().updateFailed();
     }
 
-    /*!
-     * \brief Called by the simulator to accept the current state as the new
-     *        time level after a successful timestep.
-     */
     void advanceTimeLevel()
     {
         this->model().advanceTimeLevel();
+        wellModel_.advanceTimeLevel();
     }
 
     /*!
@@ -1294,6 +1291,26 @@ private:
     { return *static_cast<const Implementation *>(this); }
 
 protected:
+    virtual void captureBeginTimeStepState_()
+    {
+        prev_timestep_first_step_ = first_step_;
+        prev_timestep_max_polymer_adsorption_ = this->polymer_.maxAdsorption;
+        prev_timestep_max_oil_saturation_ = this->maxOilSaturation_;
+        prev_timestep_max_water_saturation_ = this->maxWaterSaturation_;
+        prev_timestep_min_ref_pressure_ = this->minRefPressure_;
+        prev_timestep_rock_comp_trans_mult_val_ = this->rockCompTransMultVal_;
+    }
+
+    virtual void restoreBeginTimeStepState_()
+    {
+        first_step_ = prev_timestep_first_step_;
+        this->polymer_.maxAdsorption = prev_timestep_max_polymer_adsorption_;
+        this->maxOilSaturation_ = prev_timestep_max_oil_saturation_;
+        this->maxWaterSaturation_ = prev_timestep_max_water_saturation_;
+        this->minRefPressure_ = prev_timestep_min_ref_pressure_;
+        this->rockCompTransMultVal_ = prev_timestep_rock_comp_trans_mult_val_;
+    }
+
     template<class UpdateFunc>
     void updateProperty_(const std::string& failureMsg,
                          UpdateFunc func)
@@ -1880,6 +1897,13 @@ protected:
     BCData<int> bcindex_;
     bool nonTrivialBoundaryConditions_ = false;
     bool first_step_ = true;
+    bool prev_timestep_first_step_ = true;
+
+    std::vector<Scalar> prev_timestep_max_polymer_adsorption_;
+    std::vector<Scalar> prev_timestep_max_oil_saturation_;
+    std::vector<Scalar> prev_timestep_max_water_saturation_;
+    std::vector<Scalar> prev_timestep_min_ref_pressure_;
+    std::vector<Scalar> prev_timestep_rock_comp_trans_mult_val_;
 
     /// Whether or not the current episode will end at the end of the
     /// current time step.

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -1291,24 +1291,31 @@ private:
     { return *static_cast<const Implementation *>(this); }
 
 protected:
+    //! \brief Snapshot the explicit quantities before the timestep runs.
+    //!
+    //! updateExplicitQuantities_() advances all of these from the current
+    //! solution at the start of every timestep.  They are running extrema, so
+    //! a step that later fails would otherwise leave the maxima raised (and the
+    //! minima lowered) by a solution that is being thrown away.
     virtual void captureBeginTimeStepState_()
     {
-        prev_timestep_first_step_ = first_step_;
-        prev_timestep_max_polymer_adsorption_ = this->polymer_.maxAdsorption;
-        prev_timestep_max_oil_saturation_ = this->maxOilSaturation_;
-        prev_timestep_max_water_saturation_ = this->maxWaterSaturation_;
-        prev_timestep_min_ref_pressure_ = this->minRefPressure_;
-        prev_timestep_rock_comp_trans_mult_val_ = this->rockCompTransMultVal_;
+        prev_timestep_.first_step = first_step_;
+        prev_timestep_.max_polymer_adsorption = this->polymer_.maxAdsorption;
+        prev_timestep_.max_oil_saturation = this->maxOilSaturation_;
+        prev_timestep_.max_water_saturation = this->maxWaterSaturation_;
+        prev_timestep_.min_ref_pressure = this->minRefPressure_;
+        prev_timestep_.rock_comp_trans_mult_val = this->rockCompTransMultVal_;
     }
 
+    //! \brief Put the explicit quantities back as they were before the step.
     virtual void restoreBeginTimeStepState_()
     {
-        first_step_ = prev_timestep_first_step_;
-        this->polymer_.maxAdsorption = prev_timestep_max_polymer_adsorption_;
-        this->maxOilSaturation_ = prev_timestep_max_oil_saturation_;
-        this->maxWaterSaturation_ = prev_timestep_max_water_saturation_;
-        this->minRefPressure_ = prev_timestep_min_ref_pressure_;
-        this->rockCompTransMultVal_ = prev_timestep_rock_comp_trans_mult_val_;
+        first_step_ = prev_timestep_.first_step;
+        this->polymer_.maxAdsorption = prev_timestep_.max_polymer_adsorption;
+        this->maxOilSaturation_ = prev_timestep_.max_oil_saturation;
+        this->maxWaterSaturation_ = prev_timestep_.max_water_saturation;
+        this->minRefPressure_ = prev_timestep_.min_ref_pressure;
+        this->rockCompTransMultVal_ = prev_timestep_.rock_comp_trans_mult_val;
     }
 
     template<class UpdateFunc>
@@ -1897,13 +1904,24 @@ protected:
     BCData<int> bcindex_;
     bool nonTrivialBoundaryConditions_ = false;
     bool first_step_ = true;
-    bool prev_timestep_first_step_ = true;
 
-    std::vector<Scalar> prev_timestep_max_polymer_adsorption_;
-    std::vector<Scalar> prev_timestep_max_oil_saturation_;
-    std::vector<Scalar> prev_timestep_max_water_saturation_;
-    std::vector<Scalar> prev_timestep_min_ref_pressure_;
-    std::vector<Scalar> prev_timestep_rock_comp_trans_mult_val_;
+    //! \brief Explicit quantities as they stood at the start of the current
+    //!        timestep, restored if that timestep fails.
+    //!
+    //! Only written by captureBeginTimeStepState_() and only read by
+    //! restoreBeginTimeStepState_(), both of which run inside a single
+    //! timestep, so this never has to survive a restart.
+    struct PrevTimestepState
+    {
+        bool first_step = true;                            //!< first step of the episode
+        std::vector<Scalar> max_polymer_adsorption;        //!< POLYMER
+        std::vector<Scalar> max_oil_saturation;            //!< VAPPARS / DRSDT saturation history
+        std::vector<Scalar> max_water_saturation;          //!< ROCKCOMP water-induced compaction
+        std::vector<Scalar> min_ref_pressure;              //!< ROCKCOMP irreversible compaction
+        std::vector<Scalar> rock_comp_trans_mult_val;      //!< ROCKCOMP transmissibility multiplier
+    };
+
+    PrevTimestepState prev_timestep_;
 
     /// Whether or not the current episode will end at the end of the
     /// current time step.

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -190,6 +190,7 @@ public:
         : FlowProblemType(simulator)
         , thresholdPressures_(simulator)
         , mixControls_(simulator.vanguard().schedule())
+        , prev_timestep_mixControls_(simulator.vanguard().schedule())
         , actionHandler_(simulator.vanguard().eclState(),
                          simulator.vanguard().schedule(),
                          simulator.vanguard().actionState(),
@@ -1207,6 +1208,18 @@ public:
     }
 
 protected:
+    void captureBeginTimeStepState_() override
+    {
+        FlowProblemType::captureBeginTimeStepState_();
+        prev_timestep_mixControls_ = mixControls_;
+    }
+
+    void restoreBeginTimeStepState_() override
+    {
+        FlowProblemType::restoreBeginTimeStepState_();
+        mixControls_ = prev_timestep_mixControls_;
+    }
+
     void updateExplicitQuantities_(int episodeIdx, int timeStepSize, const bool first_step_after_restart) override
     {
         this->updateExplicitQuantities_(first_step_after_restart);
@@ -1768,6 +1781,7 @@ protected:
     std::unique_ptr<DamarisWriterType> damarisWriter_;
 #endif
     MixingRateControls<FluidSystem> mixControls_;
+    MixingRateControls<FluidSystem> prev_timestep_mixControls_;
 
     ActionHandler<Scalar, IndexTraits> actionHandler_;
 

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -190,7 +190,7 @@ public:
         : FlowProblemType(simulator)
         , thresholdPressures_(simulator)
         , mixControls_(simulator.vanguard().schedule())
-        , prev_timestep_mixControls_(simulator.vanguard().schedule())
+        , prev_timestep_(simulator.vanguard().schedule())
         , actionHandler_(simulator.vanguard().eclState(),
                          simulator.vanguard().schedule(),
                          simulator.vanguard().actionState(),
@@ -1211,13 +1211,13 @@ protected:
     void captureBeginTimeStepState_() override
     {
         FlowProblemType::captureBeginTimeStepState_();
-        prev_timestep_mixControls_ = mixControls_;
+        prev_timestep_.mixControls = mixControls_;
     }
 
     void restoreBeginTimeStepState_() override
     {
         FlowProblemType::restoreBeginTimeStepState_();
-        mixControls_ = prev_timestep_mixControls_;
+        mixControls_ = prev_timestep_.mixControls;
     }
 
     void updateExplicitQuantities_(int episodeIdx, int timeStepSize, const bool first_step_after_restart) override
@@ -1781,7 +1781,19 @@ protected:
     std::unique_ptr<DamarisWriterType> damarisWriter_;
 #endif
     MixingRateControls<FluidSystem> mixControls_;
-    MixingRateControls<FluidSystem> prev_timestep_mixControls_;
+
+    //! \brief Blackoil part of the begin-of-timestep snapshot; see
+    //!        FlowProblem::PrevTimestepState.
+    struct PrevTimestepState
+    {
+        explicit PrevTimestepState(const Schedule& schedule)
+            : mixControls(schedule)
+        {}
+
+        MixingRateControls<FluidSystem> mixControls; //!< DRSDT / DRVDT
+    };
+
+    PrevTimestepState prev_timestep_;
 
     ActionHandler<Scalar, IndexTraits> actionHandler_;
 

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
@@ -115,6 +115,7 @@ prepareStep(const SimulatorTimerInterface& timer)
     unsigned numDof = this->simulator_.model().numGridDof();
     wasSwitched_.resize(numDof);
     std::fill(wasSwitched_.begin(), wasSwitched_.end(), false);
+    this->simulator_.model().newtonMethod().resetPrimaryVariableSwitches();
 
     if (this->param_.update_equations_scaling_) {
         OpmLog::error("Equation scaling not supported");

--- a/opm/simulators/flow/NonlinearSystem_impl.hpp
+++ b/opm/simulators/flow/NonlinearSystem_impl.hpp
@@ -194,6 +194,7 @@ prepareStep(const SimulatorTimerInterface& timer)
 
     if (lastStepFailed) {
         simulator_.problem().updateFailed();
+        simulator_.model().newtonMethod().eraseMatrix();
     }
     else {
         simulator_.problem().advanceTimeLevel();

--- a/opm/simulators/linalg/ISTLSolver.hpp
+++ b/opm/simulators/linalg/ISTLSolver.hpp
@@ -323,9 +323,18 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
             element_chunks_ = std::make_unique<ElementChunksType>(simulator_.vanguard().gridView(), Dune::Partitions::all, ThreadManager::maxThreads());
         }
 
-        // nothing to clean here
         void eraseMatrix() override
         {
+            matrix_ = nullptr;
+            rhs_ = nullptr;
+            iterations_ = 0;
+            solveCount_ = 0;
+
+            for (auto& solverInfo : flexibleSolver_) {
+                solverInfo.pre_ = nullptr;
+                solverInfo.solver_.reset();
+                solverInfo.op_.reset();
+            }
         }
 
         void setActiveSolver(const int num) override

--- a/opm/simulators/linalg/ISTLSolverTPSA.hpp
+++ b/opm/simulators/linalg/ISTLSolverTPSA.hpp
@@ -274,7 +274,15 @@ public:
     * \copydoc AbstractISTLSolver::eraseMatrix
     */
     void eraseMatrix() override
-    { }
+    {
+        matrix_ = nullptr;
+        rhs_ = nullptr;
+        iterations_ = 0;
+        solveCount_ = 0;
+        flexibleSolver_.pre_ = nullptr;
+        flexibleSolver_.solver_.reset();
+        flexibleSolver_.op_.reset();
+    }
 
     /*!
     * \copydoc AbstractISTLSolver::setActiveSolver

--- a/opm/simulators/linalg/gpuistl/ISTLSolverGPUISTL.hpp
+++ b/opm/simulators/linalg/gpuistl/ISTLSolverGPUISTL.hpp
@@ -141,12 +141,21 @@ public:
 
     /**
      * \copydoc AbstractISTLSolver::eraseMatrix
-     *
-     * \note This method will not do anything.
      */
     void eraseMatrix() override
     {
-        // Nothing, this is the same as the ISTLSolver
+        m_lastSeenIterations = 0;
+        m_solveCount = 0;
+        m_matrix.reset();
+        m_gpuSolver.reset();
+        m_rhs.reset();
+        m_x.reset();
+        m_pinnedMatrixMemory.reset();
+        m_pinnedRhsMemory.reset();
+        m_pinnedXMemory.reset();
+        m_pinnedWeightsMemory.reset();
+        m_weights.reset();
+        m_diagonalIndices.reset();
     }
 
     /**

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -158,6 +158,10 @@ template<class Scalar> class WellContributions;
 
             void beginTimeStep();
 
+            void updateFailed();
+
+            void advanceTimeLevel();
+
             void beginIteration()
             {
                 OPM_TIMEBLOCK(beginIteration);

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -112,9 +112,8 @@ BlackoilWellModelGeneric(Schedule& schedule,
     , guideRate_(schedule)
     , active_wgstate_(pu)
     , last_valid_wgstate_(pu)
-    , prev_timestep_wgstate_(pu)
     , nupcol_wgstate_(pu)
-    , prev_timestep_nupcol_wgstate_(pu)
+    , prev_timestep_(pu)
     , group_state_helper_(this->wellState(),
                           this->groupState(),
                           this->schedule(),
@@ -1990,12 +1989,10 @@ operator==(const BlackoilWellModelGeneric& rhs) const
         && this->last_run_wellpi_ == rhs.last_run_wellpi_
         && this->local_shut_wells_ == rhs.local_shut_wells_
         && this->closed_this_step_ == rhs.closed_this_step_
-        && this->prev_timestep_closed_this_step_ == rhs.prev_timestep_closed_this_step_
         && this->genNetwork_ == rhs.genNetwork_
         && this->prev_inj_multipliers_ == rhs.prev_inj_multipliers_
         && this->active_wgstate_ == rhs.active_wgstate_
         && this->last_valid_wgstate_ == rhs.last_valid_wgstate_
-        && this->prev_timestep_wgstate_ == rhs.prev_timestep_wgstate_
         && this->nupcol_wgstate_ == rhs.nupcol_wgstate_
         && this->switched_prod_groups_ == rhs.switched_prod_groups_
         && this->switched_inj_groups_ == rhs.switched_inj_groups_

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -112,7 +112,9 @@ BlackoilWellModelGeneric(Schedule& schedule,
     , guideRate_(schedule)
     , active_wgstate_(pu)
     , last_valid_wgstate_(pu)
+    , prev_timestep_wgstate_(pu)
     , nupcol_wgstate_(pu)
+    , prev_timestep_nupcol_wgstate_(pu)
     , group_state_helper_(this->wellState(),
                           this->groupState(),
                           this->schedule(),
@@ -1988,10 +1990,12 @@ operator==(const BlackoilWellModelGeneric& rhs) const
         && this->last_run_wellpi_ == rhs.last_run_wellpi_
         && this->local_shut_wells_ == rhs.local_shut_wells_
         && this->closed_this_step_ == rhs.closed_this_step_
+        && this->prev_timestep_closed_this_step_ == rhs.prev_timestep_closed_this_step_
         && this->genNetwork_ == rhs.genNetwork_
         && this->prev_inj_multipliers_ == rhs.prev_inj_multipliers_
         && this->active_wgstate_ == rhs.active_wgstate_
         && this->last_valid_wgstate_ == rhs.last_valid_wgstate_
+        && this->prev_timestep_wgstate_ == rhs.prev_timestep_wgstate_
         && this->nupcol_wgstate_ == rhs.nupcol_wgstate_
         && this->switched_prod_groups_ == rhs.switched_prod_groups_
         && this->switched_inj_groups_ == rhs.switched_inj_groups_

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -215,6 +215,35 @@ public:
 
     data::GroupAndNetworkValues groupAndNetworkData(const int reportStepIdx) const;
 
+    // Snapshot dynamic state at start of timestep for failure recovery.
+    void advanceTimeLevel()
+    {
+        this->prev_timestep_wgstate_ = this->active_wgstate_;
+        this->prev_timestep_nupcol_wgstate_ = this->nupcol_wgstate_;
+        this->prev_timestep_closed_this_step_ = this->closed_this_step_;
+        // Guide rates are not updated during the Newton iterations, so they do not
+        // need to be snapshotted/reset across a failed timestep. (GuideRate is also
+        // non-copyable.) TODO: verify exact replay is still correct without this.
+        this->prev_timestep_well_open_times_ = this->well_open_times_;
+        this->prev_timestep_well_close_times_ = this->well_close_times_;
+        this->genNetwork_.commitState();
+    }
+
+    // Restore dynamic state captured at the start of the failing timestep.
+    void updateFailed()
+    {
+        this->active_wgstate_ = this->prev_timestep_wgstate_;
+        this->nupcol_wgstate_ = this->prev_timestep_nupcol_wgstate_;
+        this->closed_this_step_ = this->prev_timestep_closed_this_step_;
+        // Guide rates are not updated during the Newton iterations, so they do not
+        // need to be reset across a failed timestep. (GuideRate is also non-copyable.)
+        // TODO: verify exact replay is still correct without this.
+        this->well_open_times_ = this->prev_timestep_well_open_times_;
+        this->well_close_times_ = this->prev_timestep_well_close_times_;
+        this->genNetwork_.resetState();
+        this->group_state_helper_.updateState(this->wellState(), this->groupState());
+    }
+
     /// Shut down any single well
     /// Returns true if the well was actually found and shut.
     bool forceShutWellByName(const std::string& wellname,
@@ -257,11 +286,13 @@ public:
         serializer(last_run_wellpi_);
         serializer(local_shut_wells_);
         serializer(closed_this_step_);
+        serializer(prev_timestep_closed_this_step_);
         serializer(guideRate_);
         serializer(genNetwork_);
         serializer(prev_inj_multipliers_);
         serializer(active_wgstate_);
         serializer(last_valid_wgstate_);
+        serializer(prev_timestep_wgstate_);
         serializer(nupcol_wgstate_);
         serializer(switched_prod_groups_);
         serializer(switched_inj_groups_);
@@ -535,9 +566,11 @@ protected:
 
     // Times at which wells were opened (for WCYCLE)
     std::map<std::string, double> well_open_times_;
+    std::map<std::string, double> prev_timestep_well_open_times_;
 
     // Times at which wells were shut (for WCYCLE)
     std::map<std::string, double> well_close_times_;
+    std::map<std::string, double> prev_timestep_well_close_times_;
 
     std::vector<ConnectionIndexMap> conn_idx_map_{};
     std::function<bool(const std::string&)> not_on_process_{};
@@ -555,6 +588,7 @@ protected:
     std::vector<int> pvt_region_idx_;
 
     mutable std::unordered_set<std::string> closed_this_step_;
+    std::unordered_set<std::string> prev_timestep_closed_this_step_;
 
     GuideRate guideRate_;
     std::unique_ptr<VFPProperties<Scalar, IndexTraits>> vfp_properties_{};
@@ -573,7 +607,9 @@ protected:
     */
     WGState<Scalar, IndexTraits> active_wgstate_;
     WGState<Scalar, IndexTraits> last_valid_wgstate_;
+    WGState<Scalar, IndexTraits> prev_timestep_wgstate_;
     WGState<Scalar, IndexTraits> nupcol_wgstate_;
+    WGState<Scalar, IndexTraits> prev_timestep_nupcol_wgstate_;
     GroupStateHelperType group_state_helper_;
     WellGroupEvents report_step_start_events_; //!< Well group events at start of report step
 

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -215,31 +215,31 @@ public:
 
     data::GroupAndNetworkValues groupAndNetworkData(const int reportStepIdx) const;
 
-    // Snapshot dynamic state at start of timestep for failure recovery.
+    //! \brief Snapshot the mutable well-model state at the start of a timestep.
+    //!
+    //! Everything a timestep can modify and that the next attempt must not
+    //! inherit goes in here; see PrevTimestepState for what each member is for.
+    //! Guide rates are deliberately absent: they are updated between timesteps,
+    //! not during the Newton iterations, so a failed step leaves them untouched
+    //! (GuideRate is also non-copyable).
     void advanceTimeLevel()
     {
-        this->prev_timestep_wgstate_ = this->active_wgstate_;
-        this->prev_timestep_nupcol_wgstate_ = this->nupcol_wgstate_;
-        this->prev_timestep_closed_this_step_ = this->closed_this_step_;
-        // Guide rates are not updated during the Newton iterations, so they do not
-        // need to be snapshotted/reset across a failed timestep. (GuideRate is also
-        // non-copyable.) TODO: verify exact replay is still correct without this.
-        this->prev_timestep_well_open_times_ = this->well_open_times_;
-        this->prev_timestep_well_close_times_ = this->well_close_times_;
+        this->prev_timestep_.wgstate = this->active_wgstate_;
+        this->prev_timestep_.nupcol_wgstate = this->nupcol_wgstate_;
+        this->prev_timestep_.closed_this_step = this->closed_this_step_;
+        this->prev_timestep_.well_open_times = this->well_open_times_;
+        this->prev_timestep_.well_close_times = this->well_close_times_;
         this->genNetwork_.commitState();
     }
 
-    // Restore dynamic state captured at the start of the failing timestep.
+    //! \brief Restore the state captured at the start of the failing timestep.
     void updateFailed()
     {
-        this->active_wgstate_ = this->prev_timestep_wgstate_;
-        this->nupcol_wgstate_ = this->prev_timestep_nupcol_wgstate_;
-        this->closed_this_step_ = this->prev_timestep_closed_this_step_;
-        // Guide rates are not updated during the Newton iterations, so they do not
-        // need to be reset across a failed timestep. (GuideRate is also non-copyable.)
-        // TODO: verify exact replay is still correct without this.
-        this->well_open_times_ = this->prev_timestep_well_open_times_;
-        this->well_close_times_ = this->prev_timestep_well_close_times_;
+        this->active_wgstate_ = this->prev_timestep_.wgstate;
+        this->nupcol_wgstate_ = this->prev_timestep_.nupcol_wgstate;
+        this->closed_this_step_ = this->prev_timestep_.closed_this_step;
+        this->well_open_times_ = this->prev_timestep_.well_open_times;
+        this->well_close_times_ = this->prev_timestep_.well_close_times;
         this->genNetwork_.resetState();
         this->group_state_helper_.updateState(this->wellState(), this->groupState());
     }
@@ -286,13 +286,11 @@ public:
         serializer(last_run_wellpi_);
         serializer(local_shut_wells_);
         serializer(closed_this_step_);
-        serializer(prev_timestep_closed_this_step_);
         serializer(guideRate_);
         serializer(genNetwork_);
         serializer(prev_inj_multipliers_);
         serializer(active_wgstate_);
         serializer(last_valid_wgstate_);
-        serializer(prev_timestep_wgstate_);
         serializer(nupcol_wgstate_);
         serializer(switched_prod_groups_);
         serializer(switched_inj_groups_);
@@ -566,11 +564,9 @@ protected:
 
     // Times at which wells were opened (for WCYCLE)
     std::map<std::string, double> well_open_times_;
-    std::map<std::string, double> prev_timestep_well_open_times_;
 
     // Times at which wells were shut (for WCYCLE)
     std::map<std::string, double> well_close_times_;
-    std::map<std::string, double> prev_timestep_well_close_times_;
 
     std::vector<ConnectionIndexMap> conn_idx_map_{};
     std::function<bool(const std::string&)> not_on_process_{};
@@ -588,7 +584,6 @@ protected:
     std::vector<int> pvt_region_idx_;
 
     mutable std::unordered_set<std::string> closed_this_step_;
-    std::unordered_set<std::string> prev_timestep_closed_this_step_;
 
     GuideRate guideRate_;
     std::unique_ptr<VFPProperties<Scalar, IndexTraits>> vfp_properties_{};
@@ -607,9 +602,27 @@ protected:
     */
     WGState<Scalar, IndexTraits> active_wgstate_;
     WGState<Scalar, IndexTraits> last_valid_wgstate_;
-    WGState<Scalar, IndexTraits> prev_timestep_wgstate_;
     WGState<Scalar, IndexTraits> nupcol_wgstate_;
-    WGState<Scalar, IndexTraits> prev_timestep_nupcol_wgstate_;
+
+    //! \brief Well-model state as it was at the start of the current timestep.
+    //!
+    //! Retaken by advanceTimeLevel() at the start of every timestep and only
+    //! read by updateFailed(), so it never has to survive a restart and is not
+    //! serialized.
+    struct PrevTimestepState
+    {
+        explicit PrevTimestepState(const PhaseUsageInfo<IndexTraits>& pu)
+            : wgstate(pu), nupcol_wgstate(pu)
+        {}
+
+        WGState<Scalar, IndexTraits> wgstate;        //!< well and group rates, pressures, controls
+        WGState<Scalar, IndexTraits> nupcol_wgstate; //!< NUPCOL: the state group control targets are computed from
+        std::unordered_set<std::string> closed_this_step; //!< wells shut by the solver during this step
+        std::map<std::string, double> well_open_times;    //!< WCYCLE
+        std::map<std::string, double> well_close_times;   //!< WCYCLE
+    };
+
+    PrevTimestepState prev_timestep_;
     GroupStateHelperType group_state_helper_;
     WellGroupEvents report_step_start_events_; //!< Well group events at start of report step
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -557,6 +557,22 @@ namespace Opm {
 
     template<typename TypeTag>
     void
+    BlackoilWellModel<TypeTag>::
+    updateFailed()
+    {
+        this->BlackoilWellModelGeneric<Scalar, IndexTraits>::updateFailed();
+    }
+
+    template<typename TypeTag>
+    void
+    BlackoilWellModel<TypeTag>::
+    advanceTimeLevel()
+    {
+        this->BlackoilWellModelGeneric<Scalar, IndexTraits>::advanceTimeLevel();
+    }
+
+    template<typename TypeTag>
+    void
     BlackoilWellModel<TypeTag>::wellTesting(const int timeStepIdx,
                                             const double simulationTime,
                                             DeferredLogger& deferred_logger)

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -2753,3 +2753,49 @@ if(BUILD_FLOW_FLOAT_VARIANTS)
       --tolerance-mb=1e-6
   )
 endif()
+
+###########################################################################
+# Deterministic timestep-replay regression tests
+###########################################################################
+# Run a case, record the accepted substep end times, then re-run with the
+# hardcoded timestep controller replaying those times and compare the output.
+# --truncate-timestep-to-float makes the recorded step sizes exactly
+# reproducible on replay (see Simulator::setTimeStepSize).
+set(timestep_replay_abs_tol 2e-14)
+set(timestep_replay_rel_tol 2e-14)
+
+opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-timestep-replay-regressionTest.sh "")
+
+add_test_compareECLFiles(CASENAME spe1_timestep_replay
+                         FILENAME SPE1CASE1
+                         SIMULATOR flow_blackoil
+                         PREFIX compareTimestepReplay
+                         ABS_TOL ${timestep_replay_abs_tol}
+                         REL_TOL ${timestep_replay_rel_tol}
+                         DIR spe1
+                         TEST_ARGS --truncate-time-step-to-float=true
+                         TEST_ARGS_REPLAY --initial-time-step-in-days=11111111)
+
+add_test_compareECLFiles(CASENAME spe9_timestep_replay
+                         FILENAME SPE9_CP_SHORT
+                         SIMULATOR flow_blackoil
+                         PREFIX compareTimestepReplay
+                         ABS_TOL ${timestep_replay_abs_tol}
+                         REL_TOL ${timestep_replay_rel_tol}
+                         DIR spe9
+                         TEST_ARGS --truncate-time-step-to-float=true
+                         TEST_ARGS_REPLAY --initial-time-step-in-days=11111111)
+
+# Larger model2 case: forcing the full report step initially exercises failed
+# steps and the per-step state rollback before the replay must still match.
+add_test_compareECLFiles(CASENAME model2_base_timestep_replay
+                         FILENAME 0_BASE_MODEL2
+                         SIMULATOR flow_blackoil
+                         PREFIX compareTimestepReplay
+                         ABS_TOL ${timestep_replay_abs_tol}
+                         REL_TOL ${timestep_replay_rel_tol}
+                         DIR model2
+                         TEST_ARGS --truncate-time-step-to-float=true --full-time-step-initially=true --cpr-reuse-setup=0 --newton-max-iterations=8 --tolerance-cnv-relaxed=1e-3
+                         TEST_ARGS_REPLAY --initial-time-step-in-days=11111111)
+
+opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-regressionTest.sh "")

--- a/tests/run-timestep-replay-regressionTest.sh
+++ b/tests/run-timestep-replay-regressionTest.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+
+# This runs a simulator, extracts the accepted substep end times from the
+# generated INFOSTEP file, reruns the same case using the hardcoded timestep
+# controller, and compares the two outputs.
+
+set -u
+
+if test $# -eq 0
+then
+  echo -e "Usage:\t$0 <options> -- [additional simulator options]"
+  echo -e "\tMandatory options:"
+  echo -e "\t\t -i <path>     Path to read deck from"
+  echo -e "\t\t -r <path>     Path to store results in"
+  echo -e "\t\t -b <path>     Path to simulator binary"
+  echo -e "\t\t -f <filename> Deck file name"
+  echo -e "\t\t -a <tol>      Absolute tolerance in comparison"
+  echo -e "\t\t -t <tol>      Relative tolerance in comparison"
+  echo -e "\t\t -c <path>     Path to comparison tool"
+  echo -e "\t\t -e <filename> Simulator binary to use"
+  echo -e "\tOptional options:"
+  echo -e "\t\t -d <path>     Unused, accepted for compatibility with other drivers"
+  echo -e "\t\t -u <name>     Unused, accepted for compatibility with other drivers"
+  exit 1
+fi
+
+OPTIND=1
+declare -a TEST_ARGS_REPLAY=()
+while getopts "i:r:b:f:a:t:c:d:e:u:y:" OPT
+do
+  case "${OPT}" in
+    i) INPUT_DATA_PATH=${OPTARG} ;;
+    r) RESULT_PATH=${OPTARG} ;;
+    b) BINPATH=${OPTARG} ;;
+    f) FILENAME=${OPTARG} ;;
+    a) ABS_TOL=${OPTARG} ;;
+    t) REL_TOL=${OPTARG} ;;
+    c) COMPARE_ECL_COMMAND=${OPTARG} ;;
+    d) : ;;
+    e) EXE_NAME=${OPTARG} ;;
+    u) : ;;
+    y) TEST_ARGS_REPLAY+=("${OPTARG}") ;;
+  esac
+done
+shift $(($OPTIND-1))
+declare -a TEST_ARGS=("$@")
+
+BASELINE_PATH=${RESULT_PATH}/baseline
+REPLAY_PATH=${RESULT_PATH}/replay
+TIMESTEP_FILE=${RESULT_PATH}/${FILENAME}.timesteps
+BASELINE_LOG=${RESULT_PATH}/${FILENAME}.baseline.log
+REPLAY_LOG=${RESULT_PATH}/${FILENAME}.replay.log
+BASELINE_INFOSTEP=${BASELINE_PATH}/${FILENAME}.INFOSTEP
+
+resolve_simulator_binary() {
+    # The test framework passes the full path to the simulator binary via -e.
+    if [ -x "${EXE_NAME}" ]; then
+        printf '%s\n' "${EXE_NAME}"
+        return 0
+    fi
+
+    # Fall back to a flow_blackoil binary sitting next to a requested "flow".
+    local bindir base
+    bindir=$(dirname -- "${EXE_NAME}")
+    base=$(basename -- "${EXE_NAME}")
+    if [ "${base}" = "flow" ] && [ -x "${bindir}/flow_blackoil" ]; then
+        printf '%s\n' "${bindir}/flow_blackoil"
+        return 0
+    fi
+
+    echo "ERROR: Simulator binary not found: ${EXE_NAME}" >&2
+    return 1
+}
+
+run_simulation() {
+    local output_path=$1
+    local log_path=$2
+    shift 2
+    local simulator_binary
+
+    simulator_binary=$(resolve_simulator_binary) || return 1
+
+    mkdir -p "${output_path}"
+    "${simulator_binary}" "$@" --output-dir="${output_path}" "${INPUT_DATA_PATH}/${FILENAME}" > "${log_path}" 2>&1
+    local status=$?
+    if [ ${status} -ne 0 ]; then
+        cat "${log_path}"
+        return ${status}
+    fi
+
+    return 0
+}
+
+extract_timesteps() {
+    local infostep_path=$1
+    local log_path=$2
+    local output_file=$3
+
+    python3 - "$infostep_path" "$log_path" "$output_file" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+infostep = Path(sys.argv[1])
+log_path = Path(sys.argv[2])
+output = Path(sys.argv[3])
+
+if not infostep.exists():
+    raise FileNotFoundError(f"INFOSTEP file not found: {infostep}")
+if not log_path.exists():
+    raise FileNotFoundError(f"Simulation log not found: {log_path}")
+
+lines = [line.strip() for line in infostep.read_text().splitlines() if line.strip()]
+header_idx = next((i for i, line in enumerate(lines) if "Time(day)" in line and "Conv" in line), None)
+if header_idx is None:
+    raise ValueError(f"Unable to locate INFOSTEP header in {infostep}")
+
+header = lines[header_idx].split()
+time_idx = header.index("Time(day)")
+conv_idx = header.index("Conv")
+
+accepted_times = []
+for row in lines[header_idx + 1:]:
+    cols = row.split()
+    if len(cols) <= max(time_idx, conv_idx):
+        continue
+    if cols[conv_idx] not in {"1", "1.0", "true", "True"}:
+        continue
+    accepted_times.append(cols[time_idx])
+
+if not accepted_times:
+    raise ValueError(f"No accepted timesteps found in {infostep}")
+
+# INFOSTEP currently omits the last accepted endpoint of the full simulation,
+# so append the total simulation time from the baseline log if needed.
+final_time = None
+for line in reversed(log_path.read_text().splitlines()):
+    match = re.search(r"day\s+[^/]+/(\S+)", line)
+    if match:
+        final_time = match.group(1).rstrip(",;")
+        break
+
+if final_time is None:
+    raise ValueError(f"Unable to determine final simulation time from {log_path}")
+
+if accepted_times[-1] != final_time:
+    accepted_times.append(final_time)
+
+output.write_text("\n".join(accepted_times) + "\n")
+PY
+}
+
+rm -rf "${RESULT_PATH}"
+mkdir -p "${RESULT_PATH}"
+
+# Generate precise accepted substep end times from INFOSTEP.
+run_simulation "${BASELINE_PATH}" "${BASELINE_LOG}" ${TEST_ARGS[@]+"${TEST_ARGS[@]}"} --output-extra-convergence-info=steps
+test $? -eq 0 || exit 1
+
+extract_timesteps "${BASELINE_INFOSTEP}" "${BASELINE_LOG}" "${TIMESTEP_FILE}"
+test $? -eq 0 || exit 1
+
+run_simulation "${REPLAY_PATH}" "${REPLAY_LOG}" ${TEST_ARGS[@]+"${TEST_ARGS[@]}"} ${TEST_ARGS_REPLAY[@]+"${TEST_ARGS_REPLAY[@]}"} --output-extra-convergence-info=steps --time-step-control=hardcoded --time-step-control-file-name="${TIMESTEP_FILE}"
+test $? -eq 0 || exit 1
+
+ecode=0
+echo "=== Executing comparison for EGRID, INIT, UNRST, UNSMRY and RFT files ==="
+"${COMPARE_ECL_COMMAND}" "${BASELINE_PATH}/${FILENAME}" "${REPLAY_PATH}/${FILENAME}" "${ABS_TOL}" "${REL_TOL}"
+if [ $? -ne 0 ]
+then
+  ecode=1
+  "${COMPARE_ECL_COMMAND}" -a "${BASELINE_PATH}/${FILENAME}" "${REPLAY_PATH}/${FILENAME}" "${ABS_TOL}" "${REL_TOL}"
+fi
+
+exit ${ecode}


### PR DESCRIPTION
**Draft — blocked on #7296.**

Restores the simulator state that a timestep mutates, so a failed step leaves nothing behind for the retry, and adds a replay regression test that proves it.

### Why this is a draft

An audit of what the snapshot actually buys turned up an uncomfortable answer. Measured on `SPE1CASE2_ROCK2DTR --full-time-step-initially=true` (16 failed steps), disabling the restore of individual members one at a time:

| Member | Effect of not restoring it |
|---|---|
| `maxWaterSaturation_` | **the entire difference** — 859 vs 865 Newton iterations, reproduces the fully-disabled result byte-for-byte |
| `maxOilSaturation_`, `minRefPressure_`, `rockCompTransMultVal_` | none |
| `mixControls_` (DRSDT/DRVDT) | none |
| `first_step_`, polymer adsorption | none, or empty on the decks tested |

None of these are touched inside the Newton loop — `updateExplicitQuantities_()` runs once per `beginTimeStep()`, and `Model::updateFailed()` restores `solution(0) = solution(1)` before the retry, so each is recomputed from the same converged solution. For a monotone extremum that is idempotent, which is why they measure inert.

`maxWaterSaturation_` is the exception only because `updateMaxWaterSaturation_()` opens with a stray assignment that overwrites cell 1's maximum with cell 0's. That is #7296. Once it lands, the FlowProblem side of this snapshot should be inert as well and most of it can go.

Holding this as a draft rather than defending a rollback that compensates for a one-line bug.

### What is captured

`FlowProblem::PrevTimestepState` — `first_step`, `max_polymer_adsorption` (POLYMER), `max_oil_saturation` (VAPPARS/DRSDT), `max_water_saturation`, `min_ref_pressure`, `rock_comp_trans_mult_val` (all ROCKCOMP), plus `mixControls` (DRSDT/DRVDT) on the blackoil side.

`BlackoilWellModelGeneric::PrevTimestepState` — `wgstate`, `nupcol_wgstate` (NUPCOL), `closed_this_step`, `well_open_times` / `well_close_times` (WCYCLE).

Guide rates are deliberately excluded: they are updated between timesteps, not during the Newton iterations. Neither snapshot is serialized — both are retaken at the start of every step and read only by the matching restore.

### Test coverage is not yet sufficient

`tests/run-timestep-replay-regressionTest.sh` records the accepted substep end times, replays them exactly, and compares. Any state leaking across a failed step makes the replay diverge, so it is the right shape of test. But the three decks it runs on cover almost none of the state being restored:

| Deck | Features present |
|---|---|
| `SPE1CASE1` | DRSDT |
| `SPE9_CP_SHORT` | none of the relevant ones |
| `0_BASE_MODEL2` | none of the relevant ones |

So NUPCOL, WCYCLE, ROCKCOMP, POLYMER, VAPPARS and MSW — the features that own most of the snapshot — are untested by the replay. That needs decks that actually exercise them before this is worth merging.

**Caveat on exact replay.** It depends on `--truncate-time-step-to-float`, which rounds every `setTimeStepSize()` to float so the recorded step sizes are exactly representable in the replay file. That means the test proves determinism in a float-truncated regime, not for production double-precision dt; step sizes that differ below float epsilon are indistinguishable to it.

### This changes results

Measured on `0_BASE_MODEL2 --full-time-step-initially=true` against the merge base:

| | base | this PR | rel. diff |
|---|---|---|---|
| FOPT | 6.984924e+06 | 6.985254e+06 | 4.7e-05 |
| FGPT | 1.179876e+09 | 1.179715e+09 | 1.4e-04 |
| FWPT | 4.735503e+04 | 4.789604e+04 | 1.1e-02 |
| FPR | 2.436497e+02 | 2.436483e+02 | 5.9e-06 |
| Newton iterations | 395 | 411 | |

Pressure and hydrocarbon totals move at solver-tolerance level; field water production moves 1.1 % relative, which is 541 sm3 against 6.98e6 sm3 of oil.
