### PR TITLE
Thermal msw refactoring

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -74,6 +74,13 @@ namespace Opm {
         static constexpr bool compositionSwitchEnabled =
             Indices::compositionSwitchIdx != std::numeric_limits<unsigned>::max();
 
+        // True when the segment fluid state stores a temperature (any thermal mode, not just
+        // the fully implicit one). Matches the fluid state's enableTemperature flag (see
+        // WellInterface::BlackOilFluidStateType); used to decide whether createFluidState()
+        // must set the temperature explicitly.
+        static constexpr bool enable_temperature =
+            Base::energyModuleType != EnergyModules::NoTemperature;
+
         // Scales the well-side energy equation onto the mass-balance residual
         // scale. Reuses the reservoir energy factor so both live on the same scale.
         static constexpr Scalar energy_scaling_factor_ =
@@ -396,7 +403,8 @@ namespace Opm {
                          const ValueType& pressure,
                          const ValueType& temperature,
                          const ValueType& saltConcentration,
-                         DeferredLogger& deferred_logger) const;
+                         DeferredLogger& deferred_logger,
+                         ValueType* volume_ratio = nullptr) const;
 
         SegmentFluidState<EvalWell>
         createSegmentFluidState(int seg, const FSInfo& info, DeferredLogger& deferred_logger,

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -387,7 +387,9 @@ namespace Opm {
         FSInfo getFirstPerforationFluidStateInfo(const Simulator& simulator) const;
 
         // this function can potentially be shared between multisegment wells and standard wells
-        // TODO: this function largely overlaps with calculatePhaseProperties(), some refactoring/unification should be done
+        // The optional @p volume_ratio output receives the segment volume ratio (reservoir
+        // volume per unit surface volume, i.e. the sum of the unnormalized phase saturations),
+        // so callers can cache and reuse it for the segment surface volume.
         template <typename ValueType = EvalWell>
         SegmentFluidState<ValueType>
         createFluidState(const std::vector<ValueType>& fluid_composition,
@@ -397,7 +399,8 @@ namespace Opm {
                          DeferredLogger& deferred_logger) const;
 
         SegmentFluidState<EvalWell>
-        createSegmentFluidState(int seg, const FSInfo& info, DeferredLogger& deferred_logger) const;
+        createSegmentFluidState(int seg, const FSInfo& info, DeferredLogger& deferred_logger,
+                                EvalWell* volume_ratio = nullptr) const;
 
         void computeInitialSegmentEnergy();
 

--- a/opm/simulators/wells/MultisegmentWellSegments.cpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.cpp
@@ -93,6 +93,7 @@ MultisegmentWellSegments(const int numSegments,
     , depth_diffs_(numSegments, 0.0)
     , surface_densities_(surfaceDensities<FluidSystem>(well.pvtRegionIdx(), well.numConservationQuantities()))
     , densities_(numSegments, 0.0)
+    , volume_ratios_(numSegments, 0.0)
     , mass_rates_(numSegments, 0.0)
     , viscosities_(numSegments, 0.0)
     , upwinding_segments_(numSegments, 0)
@@ -161,62 +162,6 @@ MultisegmentWellSegments(const int numSegments,
 
 template<class FluidSystem, class Indices>
 void MultisegmentWellSegments<FluidSystem,Indices>::
-computeFluidProperties(const Scalar firstPerfTemperature,
-                       const Scalar firstPerfSaltConcentration,
-                       const PrimaryVariables& primary_variables,
-                       DeferredLogger& deferred_logger)
-{
-    const int num_quantities = well_.numConservationQuantities();
-    PhaseCalcResult result(static_cast<size_t>(num_quantities));
-
-    // \Note: we do not have salt concentration supported as primary variable yet.
-    // \Note: this will change when we implement the brine equation in the multisegment well
-    const EvalWell saltConcentration = firstPerfSaltConcentration;
-
-    for (std::size_t seg = 0; seg < perforations_.size(); ++seg) {
-        const EvalWell temperature = enable_energy ?  primary_variables.getSegmentTemperature(seg) : firstPerfTemperature;
-
-        calculatePhaseProperties(result, temperature, saltConcentration,
-                                 primary_variables, seg, true, deferred_logger);
-
-        phase_densities_[seg] = result.phase_densities;
-        phase_viscosities_[seg] = result.phase_viscosities;
-
-        const auto& mix = result.mix;
-        const auto& mix_s = result.mix_s;
-        const auto& b = result.b;
-        const auto& volrat = result.vol_ratio;
-
-        viscosities_[seg] = 0.;
-        // calculate the average viscosity
-        for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
-            const EvalWell fraction =  mix[comp_idx] / b[comp_idx] / volrat;
-            // TODO: a little more work needs to be done to handle the negative fractions here
-            phase_fractions_[seg][comp_idx] = fraction; // >= 0.0 ? fraction : 0.0;
-            viscosities_[seg] += phase_viscosities_[seg][comp_idx] * phase_fractions_[seg][comp_idx];
-        }
-
-        EvalWell density(0.0);
-        for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
-            density += surface_densities_[comp_idx] * mix_s[comp_idx];
-        }
-        densities_[seg] = density / volrat;
-
-        // TODO: the enthalpy flux rate should be calculated in the similar manner.
-        // calculate the mass rates
-        mass_rates_[seg] = 0.;
-        for (int comp_idx = 0; comp_idx < well_.numConservationQuantities(); ++comp_idx) {
-            const int upwind_seg = upwinding_segments_[seg];
-            const EvalWell rate = primary_variables.getSegmentRateUpwinding(seg,
-                                                                            upwind_seg,
-                                                                            comp_idx);
-            mass_rates_[seg] += rate * surface_densities_[comp_idx];
-        }
-    }
-}
-
-template<class FluidSystem, class Indices>
-void MultisegmentWellSegments<FluidSystem,Indices>::
 updateUpwindingSegments(const PrimaryVariables& primary_variables)
 {
     for (std::size_t seg = 0; seg < perforations_.size(); ++seg) {
@@ -256,29 +201,6 @@ getPressureDiffSegLocalPerf(const int seg,
                             const int local_perf_index) const
 {
     return well_.gravity() * densities_[seg].value() * local_perforation_depth_diffs_[local_perf_index];
-}
-
-template<class FluidSystem, class Indices>
-typename MultisegmentWellSegments<FluidSystem,Indices>::EvalWell
-MultisegmentWellSegments<FluidSystem,Indices>::
-getSurfaceVolume(const Scalar firstPerfTemperature,
-                 const Scalar firstPerfSaltConcentration,
-                 const PrimaryVariables& primary_variables,
-                 const int seg_idx,
-                 DeferredLogger& deferred_logger) const
-{
-    const EvalWell saltConcentration {firstPerfSaltConcentration};
-    const EvalWell temperature = enable_energy ? primary_variables.getSegmentTemperature(seg_idx) : firstPerfTemperature;
-    PhaseCalcResult result(static_cast<size_t>(well_.numConservationQuantities()));
-    calculatePhaseProperties(result, temperature, saltConcentration,
-                             primary_variables, seg_idx, false, deferred_logger);
-
-    const EvalWell& vol_ratio = result.vol_ratio;
-
-    // We increase the segment volume with a factor 10 to stabilize the system.
-    const Scalar volume = well_.wellEcl().getSegments()[seg_idx].volume();
-
-    return volume / vol_ratio;
 }
 
 template<class FluidSystem, class Indices>
@@ -775,157 +697,6 @@ mixtureDensityWithExponents(const AutoICD& aicd, const int seg) const
     return mixDens;
 }
 
-template<class FluidSystem, class Indices>
-void
-MultisegmentWellSegments<FluidSystem, Indices>::
-calculatePhaseProperties(PhaseCalcResult& result,
-                         const EvalWell& temperature,
-                         const EvalWell& saltConcentration,
-                         const PrimaryVariables& primary_variables,
-                         const int seg,
-                         const bool update_visc_and_den,
-                         DeferredLogger& deferred_logger) const
-{
-    result.clear();
-
-    auto& b = result.b;
-    auto& mix_s = result.mix_s;
-    auto& mix = result.mix;
-    auto& vol_ratio = result.vol_ratio;
-    auto& phase_viscosities = result.phase_viscosities;
-    auto& phase_densities = result.phase_densities;
-
-    // we might use reference here
-    const EvalWell seg_pressure = primary_variables.getSegmentPressure(seg);
-
-    const int num_quantities = well_.numConservationQuantities();
-    for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
-        mix_s[comp_idx] = primary_variables.surfaceVolumeFraction(seg, comp_idx);
-    }
-
-    const bool waterActive = FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx);
-    const bool gasActive = FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx);
-    const bool oilActive = FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx);
-
-    const int waterActiveCompIdx = waterActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::waterCompIdx) : -1;
-    const int gasActiveCompIdx = gasActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::gasCompIdx) : -1;
-    const int oilActiveCompIdx = oilActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::oilCompIdx) : -1;
-
-    const int pvt_region_index = well_.pvtRegionIdx();
-
-    // water phase
-    if (waterActive) {
-        // rsw is only for interface usage
-        const EvalWell rsw{0.};
-        b[waterActiveCompIdx] = FluidSystem::waterPvt().inverseFormationVolumeFactor(
-                                             pvt_region_index, temperature, seg_pressure, rsw, saltConcentration);
-        if (update_visc_and_den) {
-            // TODO: should not we use phaseIndex here?
-            phase_viscosities[waterActiveCompIdx] = FluidSystem::waterPvt().viscosity(
-                                             pvt_region_index, temperature, seg_pressure, rsw, saltConcentration);
-            phase_densities[waterActiveCompIdx] = b[waterActiveCompIdx] * surface_densities_[waterActiveCompIdx];
-        }
-    }
-
-    EvalWell rv {0.};
-    // gas phase
-    if (gasActive) {
-        // rvw is only for interface usage
-        const EvalWell rvw{0.};
-        const bool oil_exist = oilActive && mix_s[oilActiveCompIdx] > 0.0;
-        if (oil_exist) {
-            const EvalWell rvmax = max(
-                    FluidSystem::gasPvt().saturatedOilVaporizationFactor(pvt_region_index, temperature, seg_pressure),
-                    0.);
-            if (mix_s[gasActiveCompIdx] > 0.0) {
-                rv = std::clamp(mix_s[oilActiveCompIdx] / mix_s[gasActiveCompIdx], EvalWell{0.}, rvmax);
-            }
-            b[gasActiveCompIdx] = FluidSystem::gasPvt().inverseFormationVolumeFactor(
-                                               pvt_region_index, temperature, seg_pressure, rv, rvw);
-            if (update_visc_and_den) {
-                phase_viscosities[gasActiveCompIdx] = FluidSystem::gasPvt().viscosity(
-                                                 pvt_region_index, temperature, seg_pressure, rv, rvw);
-                phase_densities[gasActiveCompIdx] = b[gasActiveCompIdx] * surface_densities_[gasActiveCompIdx]
-                                                    + rv * b[gasActiveCompIdx] * surface_densities_[oilActiveCompIdx];
-            }
-        } else { // no oil here
-            b[gasActiveCompIdx] = FluidSystem::gasPvt().saturatedInverseFormationVolumeFactor(
-                                                  pvt_region_index, temperature, seg_pressure);
-            if (update_visc_and_den) {
-                phase_viscosities[gasActiveCompIdx] = FluidSystem::gasPvt().saturatedViscosity(
-                                                       pvt_region_index, temperature, seg_pressure);
-                phase_densities[gasActiveCompIdx] = b[gasActiveCompIdx] * surface_densities_[gasActiveCompIdx];
-            }
-        }
-    }
-
-    EvalWell rs {0.};
-    // oil phase
-    if (oilActive) {
-        const bool gas_exist = gasActive && mix_s[gasActiveCompIdx] > 0.0;
-        if (gas_exist) {
-            const EvalWell rsmax = max(
-                    FluidSystem::oilPvt().saturatedGasDissolutionFactor(pvt_region_index, temperature, seg_pressure),
-                    0.);
-            if (mix_s[oilActiveCompIdx] > 0.0) {
-                rs = std::clamp(mix_s[gasActiveCompIdx] / mix_s[oilActiveCompIdx], EvalWell{0.}, rsmax);
-            }
-            b[oilActiveCompIdx] = FluidSystem::oilPvt().inverseFormationVolumeFactor(
-                                                        pvt_region_index, temperature, seg_pressure, rs);
-            if (update_visc_and_den) {
-                phase_viscosities[oilActiveCompIdx] = FluidSystem::oilPvt().viscosity(pvt_region_index, temperature,
-                                                                                      seg_pressure, rs);
-                phase_densities[oilActiveCompIdx] = b[oilActiveCompIdx] * surface_densities_[oilActiveCompIdx]
-                                              + rs * b[oilActiveCompIdx] * surface_densities_[gasActiveCompIdx];
-            }
-        } else { // no gas phase
-            b[oilActiveCompIdx] = FluidSystem::oilPvt().saturatedInverseFormationVolumeFactor(pvt_region_index,
-                                                                                              temperature, seg_pressure);
-            if (update_visc_and_den) {
-                phase_viscosities[oilActiveCompIdx] = FluidSystem::oilPvt().saturatedViscosity(pvt_region_index,
-                                                                                               temperature, seg_pressure);
-                phase_densities[oilActiveCompIdx] = b[oilActiveCompIdx] * surface_densities_[oilActiveCompIdx];
-            }
-        }
-    }
-
-    mix = mix_s;
-    if (oilActive && gasActive) {
-        const EvalWell d = 1.0 - rs * rv;
-        if (d <= 0.0) {
-            const std::string str =
-                fmt::format("Problematic d value {} obtained for well {} during segment density calculations "
-                            "with rs {}, rv {} and pressure {}. Continue as if no dissolution (rs = 0) and "
-                            "vaporization (rv = 0) for this connection.",
-                            d, well_.name(), rs, rv, seg_pressure);
-            deferred_logger.debug(str);
-        } else {
-            if (rs > 0.0) {
-                mix[gasActiveCompIdx] = (mix_s[gasActiveCompIdx] - mix_s[oilActiveCompIdx] * rs) / d;
-            }
-            if (rv > 0.0) {
-                mix[oilActiveCompIdx] = (mix_s[oilActiveCompIdx] - mix_s[gasActiveCompIdx] * rv) / d;
-            }
-        }
-    }
-
-    for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
-        vol_ratio += mix[comp_idx] / b[comp_idx];
-    }
-}
-
-template<typename FluidSystem, typename Indices>
-void
-MultisegmentWellSegments<FluidSystem, Indices>::
-PhaseCalcResult::clear()
-{
-    std::ranges::fill(b, 0.0);
-    std::ranges::fill(mix, 0.0);
-    std::ranges::fill(mix_s, 0.0);
-    std::ranges::fill(phase_viscosities, 0.0);
-    std::ranges::fill(phase_densities, 0.0);
-    vol_ratio = 0.0;
-}
 
 #include <opm/simulators/utils/InstantiationIndicesMacros.hpp>
 

--- a/opm/simulators/wells/MultisegmentWellSegments.hpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.hpp
@@ -24,7 +24,9 @@
 
 #include <opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp>
 #include <opm/simulators/wells/ParallelWellInfo.hpp>
+#include <opm/simulators/wells/WellInterfaceGeneric.hpp>
 
+#include <algorithm>
 #include <cstddef>
 #include <vector>
 
@@ -48,17 +50,21 @@ class MultisegmentWellSegments
     using EvalWell = typename PrimaryVariables::EvalWell;
     using IndexTraits = typename FluidSystem::IndexTraitsType;
 
-    static constexpr bool enable_energy = Indices::enableFullyImplicitThermal;
-
 public:
     MultisegmentWellSegments(const int numSegments,
                              const ParallelWellInfo<Scalar>& parallel_well_info,
                              WellInterfaceGeneric<Scalar, IndexTraits>& well);
 
-    void computeFluidProperties(const Scalar firstPerfTemperature,
-                                const Scalar firstPerfSaltConcentration,
-                                const PrimaryVariables& primary_variables,
-                                DeferredLogger& deferred_logger);
+    //! \brief Compute per-segment fluid properties from the pre-computed segment fluid states.
+    //!
+    //! A BlackOilFluidState is maintained for each segment (see MultisegmentWell::
+    //! updateSegmentFluidState) for all cases, thermal or not. It already holds the inverse
+    //! formation volume factors, dissolution/vaporization ratios, phase densities and
+    //! saturations, so only the phase viscosities require a fresh PVT evaluation here. This is
+    //! the single source of truth for the segment fluid properties.
+    template<class FluidState>
+    void computeFluidProperties(const std::vector<FluidState>& segment_fluid_states,
+                                const PrimaryVariables& primary_variables);
 
     //! \brief Update upwinding segments.
     void updateUpwindingSegments(const PrimaryVariables& primary_variables);
@@ -69,12 +75,6 @@ public:
     //! Pressure difference between segment and perforation.
     Scalar getPressureDiffSegLocalPerf(const int seg,
                                        const int local_perf_index) const;
-
-    EvalWell getSurfaceVolume(const Scalar firstPerfTemperature,
-                              const Scalar firstPerfSaltConcentration,
-                              const PrimaryVariables& primary_variables,
-                              const int seg_idx,
-                              DeferredLogger& deferred_logger) const;
 
     EvalWell getFrictionPressureLoss(const int seg,
                                      const bool extra_reverse_flow_derivatives = false) const;
@@ -128,6 +128,20 @@ public:
         return densities_[seg];
     }
 
+    //! \brief Segment volume ratio (reservoir volume per unit surface volume).
+    //!
+    //! Populated from the segment fluid state via setVolumeRatio() so that
+    //! getSegmentSurfaceVolume() can reuse it instead of recomputing the PVT quantities.
+    const EvalWell& volumeRatio(const int seg) const
+    {
+        return volume_ratios_[seg];
+    }
+
+    void setVolumeRatio(const int seg, const EvalWell& volume_ratio)
+    {
+        volume_ratios_[seg] = volume_ratio;
+    }
+
     Scalar local_perforation_depth_diff(const int local_perf_index) const
     {
         return local_perforation_depth_diffs_[local_perf_index];
@@ -166,6 +180,10 @@ private:
     // we should not have this member variable
     std::vector<EvalWell> densities_;
 
+    // the segment volume ratio (reservoir volume per unit surface volume); taken from the
+    // segment fluid state (see setVolumeRatio)
+    std::vector<EvalWell> volume_ratios_;
+
     // the mass rate of the segments
     std::vector<EvalWell> mass_rates_;
 
@@ -188,35 +206,60 @@ private:
     Scalar mixtureDensity(const int seg) const;
     Scalar mixtureDensityWithExponents(const int seg) const;
     Scalar mixtureDensityWithExponents(const AutoICD& aicd, const int seg) const;
-
-    // this class is used to store the result of phase property calculation
-    struct PhaseCalcResult {
-        explicit PhaseCalcResult(const std::size_t num_quantities)
-            : b(num_quantities, 0.0)
-            , mix(num_quantities, 0.0)
-            , mix_s(num_quantities, 0.0)
-            , phase_viscosities(num_quantities, 0.0)
-            , phase_densities(num_quantities, 0.0)
-        {}
-
-        void clear();
-
-        std::vector<EvalWell> b;
-        std::vector<EvalWell> mix;
-        std::vector<EvalWell> mix_s;
-        std::vector<EvalWell> phase_viscosities;
-        std::vector<EvalWell> phase_densities;
-        EvalWell vol_ratio{0.};
-    };
-
-    void calculatePhaseProperties(PhaseCalcResult& result,
-                                  const EvalWell& temperature,
-                                  const EvalWell& saltConcentration,
-                                  const PrimaryVariables& primary_variables,
-                                  int seg,
-                                  bool update_visc_and_den,
-                                  DeferredLogger& deferred_logger) const;
 };
+
+template<typename FluidSystem, typename Indices>
+template<class FluidState>
+void MultisegmentWellSegments<FluidSystem,Indices>::
+computeFluidProperties(const std::vector<FluidState>& segment_fluid_states,
+                       const PrimaryVariables& primary_variables)
+{
+    const int num_quantities = well_.numConservationQuantities();
+
+    typename FluidSystem::template ParameterCache<EvalWell> param_cache;
+    param_cache.setRegionIndex(well_.pvtRegionIdx());
+
+    for (std::size_t seg = 0; seg < perforations_.size(); ++seg) {
+        const auto& fs = segment_fluid_states[seg];
+
+        std::ranges::fill(phase_densities_[seg], 0.0);
+        std::ranges::fill(phase_fractions_[seg], 0.0);
+        std::ranges::fill(phase_viscosities_[seg], 0.0);
+
+        // The phase densities and saturations were already established when the
+        // segment fluid state was created; only the viscosities still require a
+        // PVT evaluation here.
+        EvalWell density(0.0);
+        viscosities_[seg] = 0.;
+        for (unsigned phaseIdx = 0; phaseIdx < FluidSystem::numPhases; ++phaseIdx) {
+            if (!FluidSystem::phaseIsActive(phaseIdx)) {
+                continue;
+            }
+            const unsigned comp_idx =
+                FluidSystem::canonicalToActiveCompIdx(FluidSystem::solventComponentIndex(phaseIdx));
+            const EvalWell rho = fs.density(phaseIdx);
+            const EvalWell saturation = fs.saturation(phaseIdx);
+
+            phase_densities_[seg][comp_idx] = rho;
+            phase_fractions_[seg][comp_idx] = saturation;
+            phase_viscosities_[seg][comp_idx] = FluidSystem::viscosity(fs, param_cache, phaseIdx);
+
+            density += rho * saturation;
+            viscosities_[seg] += phase_viscosities_[seg][comp_idx] * saturation;
+        }
+        densities_[seg] = density;
+
+        // calculate the mass rates (identical to the from-scratch path)
+        mass_rates_[seg] = 0.;
+        for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
+            const int upwind_seg = upwinding_segments_[seg];
+            const EvalWell rate = primary_variables.getSegmentRateUpwinding(seg,
+                                                                            upwind_seg,
+                                                                            comp_idx);
+            mass_rates_[seg] += rate * surface_densities_[comp_idx];
+        }
+    }
+}
 
 } // namespace Opm
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -274,10 +274,8 @@ namespace Opm
             this->linSys_.recoverSolutionWell(x, xw);
 
             updateWellState(simulator, xw, groupStateHelper, well_state);
-            if constexpr (has_energy) {
-                const FSInfo info = this->getFirstPerforationFluidStateInfo(simulator);
-                updateSegmentFluidState(info, deferred_logger);
-            }
+            const FSInfo info = this->getFirstPerforationFluidStateInfo(simulator);
+            updateSegmentFluidState(info, deferred_logger);
         }
         catch (const NumericalProblem& exp) {
             // Add information about the well and log to deferred logger
@@ -771,11 +769,13 @@ namespace Opm
 
         const auto info = this->getFirstPerforationFluidStateInfo(simulator);
 
+        // After updating the primary variables, refresh the segment fluid state. Do it before
+        // computeInitialSegmentFluids() so the latter can reuse the cached segment volume ratios
+        // in getSegmentSurfaceVolume(). The fluid state is used to derive the segment fluid
+        // properties for all cases (and the enthalpy for the energy equation).
+        updateSegmentFluidState(info, deferred_logger);
         computeInitialSegmentFluids(info, deferred_logger);
         if constexpr (has_energy) {
-            // after updating the primary variables, we need to update the segment fluid state
-            // it is only consumed by the energy equation, so we only do it when energy is active
-            updateSegmentFluidState(info, deferred_logger);
             computeInitialSegmentEnergy();
         }
     }
@@ -1148,26 +1148,16 @@ namespace Opm
     MultisegmentWell<TypeTag>::
     computeSegmentFluidProperties(const Simulator& simulator, DeferredLogger& deferred_logger)
     {
-        // TODO: the concept of phases and components are rather confusing in this function.
-        // needs to be addressed sooner or later.
-
-        // get the temperature for later use. It is only useful when we are not handling
-        // thermal related simulation
-        // basically, it is a single value for all the segments
-        // not sure how to handle the pvt region related to segment
-        // for the current approach, we use the pvt region of the first perforated cell
-        // although there are some text indicating using the pvt region of the lowest
-        // perforated cell
-        // TODO: later to investigate how to handle the pvt region
-
-        auto info = this->getFirstPerforationFluidStateInfo(simulator);
-        const Scalar firstPerfTemperature = std::get<0>(info);
-        const Scalar firstPerfSaltConcentration = std::get<1>(info);
-
-        this->segments_.computeFluidProperties(firstPerfTemperature,
-                                               firstPerfSaltConcentration,
-                                               this->primary_variables_,
-                                               deferred_logger);
+        // A fluid state is maintained for every segment (it is rebuilt right after every
+        // well-state update, see updateSegmentFluidState). It already holds the inverse
+        // formation volume factors, dissolution/vaporization ratios, phase densities and
+        // saturations, so we reuse it here for all cases (thermal or not) and only the phase
+        // viscosities still require a PVT evaluation. This avoids the duplicated work the
+        // from-scratch property calculation would otherwise redo from the primary variables.
+        static_cast<void>(simulator);
+        static_cast<void>(deferred_logger);
+        this->segments_.computeFluidProperties(this->segment_fluid_state_,
+                                               this->primary_variables_);
     }
 
     template<typename TypeTag>
@@ -1562,13 +1552,10 @@ namespace Opm
         bool converged = false;
         bool relax_convergence = false;
         this->regularize_ = false;
-        // The first-perforation fluid-state info is needed to refresh the segment
-        // fluid state for the energy equation. It depends solely on the reservoir cell
-        // state, which does not change during the inner iterations.
-        [[maybe_unused]] FSInfo info{};
-        if constexpr (has_energy) {
-            info = this->getFirstPerforationFluidStateInfo(simulator);
-        }
+        // The first-perforation fluid-state info is needed to refresh the segment fluid state.
+        // It depends solely on the reservoir cell state, which does not change during the inner
+        // iterations, so it is fetched once here.
+        const FSInfo info = this->getFirstPerforationFluidStateInfo(simulator);
         for (; it < max_iter_number; ++it, ++debug_cost_counter_) {
 
             if (it > this->param_.strict_inner_iter_wells_) {
@@ -1618,10 +1605,9 @@ namespace Opm
             try{
                 dx_well = this->linSys_.solve();
                 updateWellState(simulator, dx_well, groupStateHelper, well_state, relaxation_factor);
-                if constexpr (has_energy) {
-                    // segment fluid state is only consumed by the energy equation
-                    updateSegmentFluidState(info, deferred_logger);
-                }
+                // refresh the segment fluid state used to derive the segment fluid properties
+                // (and, when active, the energy equation)
+                updateSegmentFluidState(info, deferred_logger);
             }
             catch(const NumericalProblem& exp) {
                 // Add information about the well and log to deferred logger
@@ -1725,13 +1711,10 @@ namespace Opm
         this->operability_status_.resetOperability();
         this->operability_status_.solvable = true;
 
-        // The first-perforation fluid-state info is needed to refresh the segment
-        // fluid state for the energy equation. It depends solely on the reservoir cell
-        // state, which does not change during the inner iterations.
-        [[maybe_unused]] FSInfo info{};
-        if constexpr (has_energy) {
-            info = this->getFirstPerforationFluidStateInfo(simulator);
-        }
+        // The first-perforation fluid-state info is needed to refresh the segment fluid state.
+        // It depends solely on the reservoir cell state, which does not change during the inner
+        // iterations, so it is fetched once here.
+        const FSInfo info = this->getFirstPerforationFluidStateInfo(simulator);
         for (; it < max_iter_number; ++it, ++debug_cost_counter_) {
             ++its_since_last_switch;
             if (allow_switching && its_since_last_switch >= min_its_after_switch && status_switch_count < max_status_switch){
@@ -1811,10 +1794,9 @@ namespace Opm
             try{
                 const BVectorWell dx_well = this->linSys_.solve();
                 updateWellState(simulator, dx_well, groupStateHelper, well_state, relaxation_factor);
-                if constexpr (has_energy) {
-                    // segment fluid state is only consumed by the energy equation
-                    updateSegmentFluidState(info, deferred_logger);
-                }
+                // refresh the segment fluid state used to derive the segment fluid properties
+                // (and, when active, the energy equation)
+                updateSegmentFluidState(info, deferred_logger);
             }
             catch(const NumericalProblem& exp) {
                 // Add information about the well and log to deferred logger
@@ -2189,14 +2171,14 @@ namespace Opm
                             const FSInfo& info,
                             DeferredLogger& deferred_logger) const
     {
-        const Scalar firstPerfTemperature = std::get<0>(info);
-        const Scalar firstPerfSaltConcentration = std::get<1>(info);
-
-        return this->segments_.getSurfaceVolume(firstPerfTemperature,
-                                                firstPerfSaltConcentration,
-                                                this->primary_variables_,
-                                                seg_idx,
-                                                deferred_logger);
+        // The segment fluid state is maintained for all cases and the corresponding volume
+        // ratio is cached when it is created, so reuse it here instead of recomputing the PVT
+        // quantities. The cache is kept in sync with the primary variables (rebuilt right after
+        // every well-state update).
+        static_cast<void>(info);
+        static_cast<void>(deferred_logger);
+        const Scalar volume = this->wellEcl().getSegments()[seg_idx].volume();
+        return volume / this->segments_.volumeRatio(seg_idx);
     }
 
 
@@ -2486,7 +2468,12 @@ namespace Opm
                      DeferredLogger& deferred_logger) const
     {
         SegmentFluidState<ValueType> fluid_state;
-        if constexpr (has_energy) {
+        if constexpr (enable_temperature) {
+            // Set the temperature whenever the fluid state can store it (any thermal mode).
+            // In the fully implicit case @p temperature is the segment temperature primary
+            // variable; otherwise it is the (fixed) first-perforation temperature. When the
+            // fluid state does not store a temperature it falls back to the reservoir
+            // temperature, which matches what the from-scratch path used.
             fluid_state.setTemperature(temperature);
         }
         if constexpr (has_brine) {
@@ -2616,6 +2603,12 @@ namespace Opm
             }
         }
 
+        // The sum of the unnormalized phase saturations is the segment volume ratio (reservoir
+        // volume per unit surface volume). Expose it so getSurfaceVolume() need not recompute it.
+        if (volume_ratio != nullptr) {
+            *volume_ratio = sum_saturation;
+        }
+
         typename FluidSystem::template ParameterCache<ValueType> paramCache;
         paramCache.setRegionIndex(fluid_state.pvtRegionIndex());
         for (unsigned phaseIdx = 0; phaseIdx < FluidSystem::numPhases; ++phaseIdx) {
@@ -2637,7 +2630,8 @@ namespace Opm
     template <typename TypeTag>
     MultisegmentWell<TypeTag>::template SegmentFluidState<typename MultisegmentWell<TypeTag>::EvalWell>
     MultisegmentWell<TypeTag>::createSegmentFluidState(const int seg, const FSInfo& info,
-                                                       DeferredLogger& deferred_logger) const
+                                                       DeferredLogger& deferred_logger,
+                                                       EvalWell* volume_ratio) const
     {
         const EvalWell seg_pressure = this->primary_variables_.getSegmentPressure(seg);
         const Scalar firstPerfTemperature = std::get<0>(info);
@@ -2895,7 +2889,11 @@ namespace Opm
                                                        DeferredLogger& deferred_logger)
     {
         for (int seg = 0; seg < this->numberOfSegments(); ++seg) {
-            segment_fluid_state_[seg] = this->createSegmentFluidState(seg, info, deferred_logger);
+            EvalWell volume_ratio(0.0);
+            segment_fluid_state_[seg] =
+                this->createSegmentFluidState(seg, info, deferred_logger, &volume_ratio);
+            // cache the volume ratio so getSegmentSurfaceVolume() can reuse it
+            this->segments_.setVolumeRatio(seg, volume_ratio);
         }
     }
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -2505,12 +2505,22 @@ namespace Opm
                 case FluidSystem::oilPhaseIdx: {
                     if constexpr (compositionSwitchEnabled) {
                         if (both_oil_gas) {
-                            // starting with saturated rs value
+                            // Reproduce the legacy calculatePhaseProperties() Rs handling so the
+                            // segment fluid state matches the from-scratch path for all cases.
+                            // The decisive condition is whether *free gas* is present (it is what
+                            // can dissolve into the oil), not whether oil is present:
+                            //  - no free gas in the segment -> saturated oil (rs = rs_max)
+                            //  - free gas but no oil        -> dead oil      (rs = 0)
+                            //  - both present               -> rs = min(rs_max, gas/oil)
                             ValueType rs = FluidSystem::saturatedDissolutionFactor(fluid_state, phaseIdx,  fluid_state.pvtRegionIndex());
-                            if (fluid_composition[activeCompIdx] > epsilon) {
-                                const unsigned gasCompIdx = FluidSystem::canonicalToActiveCompIdx(FluidSystem::gasCompIdx);
-                                const ValueType max_possible_rs = fluid_composition[gasCompIdx] / fluid_composition[activeCompIdx];
-                                rs = std::min(rs, max_possible_rs);
+                            const unsigned gasCompIdx = FluidSystem::canonicalToActiveCompIdx(FluidSystem::gasCompIdx);
+                            if (fluid_composition[gasCompIdx] > epsilon) {
+                                if (fluid_composition[activeCompIdx] > epsilon) {
+                                    const ValueType max_possible_rs = fluid_composition[gasCompIdx] / fluid_composition[activeCompIdx];
+                                    rs = std::min(rs, max_possible_rs);
+                                } else {
+                                    rs = zero_value;
+                                }
                             }
                             fluid_state.setRs(rs);
                         } else {
@@ -2522,12 +2532,21 @@ namespace Opm
                 case FluidSystem::gasPhaseIdx: {
                     if constexpr (compositionSwitchEnabled) {
                         if (both_oil_gas) {
-                            // starting with saturated rv value
+                            // Mirror of the oil branch above (legacy Rv handling). The decisive
+                            // condition is whether *oil* is present (it is what can vaporize into
+                            // the gas), not whether gas is present:
+                            //  - no oil in the segment -> saturated gas (rv = rv_max)
+                            //  - oil but no free gas   -> dry gas       (rv = 0)
+                            //  - both present          -> rv = min(rv_max, oil/gas)
                             ValueType rv = FluidSystem::saturatedVaporizationFactor(fluid_state, phaseIdx, fluid_state.pvtRegionIndex());
                             const unsigned oilCompIdx = FluidSystem::canonicalToActiveCompIdx(FluidSystem::oilCompIdx);
-                            if (fluid_composition[activeCompIdx] > epsilon) {
-                                const ValueType max_possible_rv = fluid_composition[oilCompIdx] / fluid_composition[activeCompIdx];
-                                rv = std::min(rv, max_possible_rv);
+                            if (fluid_composition[oilCompIdx] > epsilon) {
+                                if (fluid_composition[activeCompIdx] > epsilon) {
+                                    const ValueType max_possible_rv = fluid_composition[oilCompIdx] / fluid_composition[activeCompIdx];
+                                    rv = std::min(rv, max_possible_rv);
+                                } else {
+                                    rv = zero_value;
+                                }
                             }
                             fluid_state.setRv(rv);
                         } else {

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -2465,7 +2465,8 @@ namespace Opm
                      const ValueType& pressure,
                      const ValueType& temperature,
                      const ValueType& saltConcentration,
-                     DeferredLogger& deferred_logger) const
+                     DeferredLogger& deferred_logger,
+                     ValueType* volume_ratio) const
     {
         SegmentFluidState<ValueType> fluid_state;
         if constexpr (enable_temperature) {
@@ -2665,7 +2666,7 @@ namespace Opm
         }
 
         return createFluidState(fluid_composition, seg_pressure, seg_temperature,
-                                seg_salt_concentration, deferred_logger);
+                                seg_salt_concentration, deferred_logger, volume_ratio);
     }
 
     template <typename TypeTag>


### PR DESCRIPTION
In the PR https://github.com/OPM/opm-simulators/pull/6816, we create a FluidState for each segment.

This PR aims at reusing of the FluidState in the calculating the surface volume of the segment and calculate the fluid properties.