### PR TITLE
RESCOUP: Fix group limit violation on master level 

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1673,7 +1673,7 @@ namespace Opm {
     updateWellControls(DeferredLogger& deferred_logger)
     {
         OPM_TIMEFUNCTION();
-        if (!this->wellsActive()) {
+        if (!this->wellsActive() && !this->isReservoirCouplingMaster()) {
             return false;
         }
         const int episodeIdx = simulator_.episodeIndex();
@@ -1793,15 +1793,6 @@ namespace Opm {
                         const int reportStepIdx)
     {
         OPM_TIMEFUNCTION();
-        // Reservoir coupling: a master group's control and target are assigned
-        // by RescoupConstraintsCalculator at the start of each sync step and
-        // must be treated as read-only for the remainder of the step.  Skip
-        // higher-level and individual-control checks so they don't override
-        // the assigned state.  Master groups have no subordinate wells or
-        // groups, so no recursion is needed.
-        if (this->isReservoirCouplingMasterGroup(group.name())) {
-            return false;
-        }
         const auto& iterCtx = simulator_.problem().iterationContext();
         bool changed = false;
         // restrict the number of group switches but only after nupcol iterations.

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1676,7 +1676,7 @@ namespace Opm {
     updateWellControls(DeferredLogger& deferred_logger)
     {
         OPM_TIMEFUNCTION();
-        if (!this->wellsActive()) {
+        if (!this->wellsActive() && !this->isReservoirCouplingMaster()) {
             return false;
         }
         const int episodeIdx = simulator_.episodeIndex();
@@ -1785,15 +1785,6 @@ namespace Opm {
                         const int reportStepIdx)
     {
         OPM_TIMEFUNCTION();
-        // Reservoir coupling: a master group's control and target are assigned
-        // by RescoupConstraintsCalculator at the start of each sync step and
-        // must be treated as read-only for the remainder of the step.  Skip
-        // higher-level and individual-control checks so they don't override
-        // the assigned state.  Master groups have no subordinate wells or
-        // groups, so no recursion is needed.
-        if (this->isReservoirCouplingMasterGroup(group.name())) {
-            return false;
-        }
         const auto& iterCtx = simulator_.problem().iterationContext();
         bool changed = false;
         // restrict the number of group switches but only after nupcol iterations.

--- a/opm/simulators/wells/rescoup/RescoupConstraintsCalculator.cpp
+++ b/opm/simulators/wells/rescoup/RescoupConstraintsCalculator.cpp
@@ -211,7 +211,6 @@ calculateMasterGroupConstraintsAndSendToSlaves()
         this->well_model_,
         this->group_state_helper_
     };
-    this->restoreMasterGroupControlsFromSchedule_();
     // Reset effective-GCW entries from the previous sync step to GCW=1 before
     // excludeInactiveSlaveMasterGroupsFromDistribution_() (and later the
     // Phase 2 cap) repopulate the 0-entries for this step.

--- a/opm/simulators/wells/rescoup/RescoupConstraintsCalculator.cpp
+++ b/opm/simulators/wells/rescoup/RescoupConstraintsCalculator.cpp
@@ -211,7 +211,6 @@ calculateMasterGroupConstraintsAndSendToSlaves()
         this->well_model_,
         this->group_state_helper_
     };
-    this->restoreMasterGroupControlsFromSchedule_();
     // Reset effective-GCW entries from the previous sync step to GCW=1 before
     // excludeInactiveSlaveMasterGroupsFromDistribution_() (and later the
     // Phase 2 cap) repopulate the 0-entries for this step.
@@ -406,9 +405,7 @@ capAndRedistributeProductionTargets_(
     // Step 4: switch ALL master groups to individual control with their
     // allocated targets. I.e. the master completes its own time step, assuming
     // that the production and injection rates of the slave groups remain constant
-    // over the time step. The controls are reset from schedule at the start of the
-    // next sync step (before Phase 1, see calculateMasterGroupConstraintsAndSendToSlaves()
-    // above) so guide rate distribution works correctly.
+    // over the time step.
     for (std::size_t slave_idx = 0; slave_idx < num_slaves; ++slave_idx) {
         const auto& master_groups = rescoup_master.getMasterGroupNamesForSlave(slave_idx);
         for (auto& pc : all_production_constraints[slave_idx]) {
@@ -496,43 +493,6 @@ potentialForProductionCmode_(
                            potentials[RcPhase::Oil] + potentials[RcPhase::Water]);
     default:
         return -1;  // No capping for RESV, FLD, NONE, etc.
-    }
-}
-
-// Restore master groups' control modes to their original GCONPROD values
-// (from the Schedule) so they participate correctly in guide rate
-// distribution during Phase 1 (see calculateMasterGroupConstraintsAndSendToSlaves()).
-// The previous sync step's final step may have switched them to individual control.
-//
-// Reading from the Schedule (rather than caching the pre-sync mode) is
-// intentional:
-//   - Master group control modes are treated as read-only outside the
-//     constraint calculation invoked from sendMasterGroupConstraintsToSlaves()
-//     at BlackoilWellModel_impl.hpp:555 (see also the master-group guard at
-//     the top of BlackoilWellModel::updateGroupControls).
-//   - Modes are only changed inside calculateMasterGroupConstraintsAndSendToSlaves(),
-//     which runs once per sync step.  A sync step may be shorter than a
-//     report step, so multiple sync steps can occur within the same report
-//     step.
-//   - The Schedule's cmode is constant within a report step, so reading it
-//     here is equivalent to restoring to the pre-sync state for any sync
-//     step within the report step.  At a report-step boundary, a new
-//     GCONPROD record is picked up automatically.
-template <class Scalar, class IndexTraits>
-void
-RescoupConstraintsCalculator<Scalar, IndexTraits>::
-restoreMasterGroupControlsFromSchedule_()
-{
-    auto& rescoup_master = this->reservoir_coupling_master_;
-    const auto num_slaves = rescoup_master.numSlaves();
-    for (std::size_t slave_idx = 0; slave_idx < num_slaves; ++slave_idx) {
-        const auto& master_groups = rescoup_master.getMasterGroupNamesForSlave(slave_idx);
-        for (const auto& group_name : master_groups) {
-            const auto& group = this->schedule_.getGroup(group_name, this->report_step_idx_);
-            const auto original_cmode = group.productionProperties().cmode;
-            this->group_state_helper_.groupState().production_control(
-                group_name, original_cmode);
-        }
     }
 }
 


### PR DESCRIPTION
Add the possibility for master rescoup models to switch group controls. 

Fixes gas sales constraint violation on test model in opm-tests/rescoup/

<img width="1000" height="870" alt="image" src="https://github.com/user-attachments/assets/2525831b-89b1-4619-a66f-e718ca0ea407" />

