### PR TITLE
Fix FieldMatrix<T,1,1> and FieldVector<T,1> warnings

### DIFF
--- a/opm/simulators/flow/GenericTracerModel_impl.hpp
+++ b/opm/simulators/flow/GenericTracerModel_impl.hpp
@@ -120,7 +120,7 @@ freeTracerConcentration(int tracerIdx, int globalDofIdx) const
         return 0.0;
     }
 
-    return freeTracerConcentration_[tracerIdx][globalDofIdx];
+    return freeTracerConcentration_[tracerIdx][globalDofIdx][0];
 }
 
 template<class Grid, class GridView, class DofMapper, class Stencil, class FluidSystem, class Scalar>
@@ -131,14 +131,14 @@ solTracerConcentration(int tracerIdx, int globalDofIdx) const
         return 0.0;
     }
 
-    return solTracerConcentration_[tracerIdx][globalDofIdx];
+    return solTracerConcentration_[tracerIdx][globalDofIdx][0];
 }
 
 template<class Grid, class GridView, class DofMapper, class Stencil, class FluidSystem, class Scalar>
 void GenericTracerModel<Grid,GridView,DofMapper,Stencil,FluidSystem,Scalar>::
 setFreeTracerConcentration(int tracerIdx, int globalDofIdx, Scalar value)
 {
-    this->freeTracerConcentration_[tracerIdx][globalDofIdx] = value;
+    this->freeTracerConcentration_[tracerIdx][globalDofIdx][0] = value;
     this->tracerConcentration_[tracerIdx][globalDofIdx][0] = value;
 }
 
@@ -146,7 +146,7 @@ template<class Grid, class GridView, class DofMapper, class Stencil, class Fluid
 void GenericTracerModel<Grid,GridView,DofMapper,Stencil,FluidSystem,Scalar>::
 setSolTracerConcentration(int tracerIdx, int globalDofIdx, Scalar value)
 {
-    this->solTracerConcentration_[tracerIdx][globalDofIdx] = value;
+    this->solTracerConcentration_[tracerIdx][globalDofIdx][0] = value;
     this->tracerConcentration_[tracerIdx][globalDofIdx][1] = value;
 }
 

--- a/opm/simulators/flow/TemperatureModel.hpp
+++ b/opm/simulators/flow/TemperatureModel.hpp
@@ -462,7 +462,7 @@ protected:
             const auto pvValue =  simulator_.problem().referencePorosity(globI, /*timeIdx=*/0)
             *  simulator_.model().dofTotalVolume(globI);
 
-            const Scalar scaled_norm = dt * std::abs(this->energyVector_[globI])/ pvValue;
+            const Scalar scaled_norm = dt * std::abs(this->energyVector_[globI][0])/ pvValue;
             maxNorm = max(maxNorm, scaled_norm);
             sumNorm += scaled_norm;
             if (!isNumericalAquiferCell(elem)) {
@@ -605,7 +605,7 @@ protected:
                 Scalar storefac = volume / dt;
                 Evaluation storage = 0.0;
                 computeStorageTerm(globI, storage);
-                this->energyVector_[globI] += storefac * ( getValue(storage) - storage1_[globI] );
+                this->energyVector_[globI][0] += storefac * ( getValue(storage) - storage1_[globI][0] );
                 bMat[0][0] = storefac * storage.derivative(temperatureIdx);
                 *diagMatAddress_[globI] += bMat;
             }
@@ -639,7 +639,7 @@ protected:
                     Evaluation heatFlux = 0.0;
                     computeHeatFluxTerm(intQuantsIn, intQuantsEx, nbInfo.res_nbinfo, heatFlux);
                     heatFlux += flux;
-                    this->energyVector_[globI] += getValue(heatFlux);
+                    this->energyVector_[globI][0] += getValue(heatFlux);
                     bMat[0][0] = heatFlux.derivative(temperatureIdx);
                     *diagMatAddress_[globI] += bMat;
                     bMat *= -1.0;

--- a/opm/simulators/linalg/PressureBhpTransferPolicy.hpp
+++ b/opm/simulators/linalg/PressureBhpTransferPolicy.hpp
@@ -244,10 +244,10 @@ namespace Opm
             if (transpose) {
                 const auto& bw = weights_[block.index()];
                 for (std::size_t i = 0; i < block->size(); ++i) {
-                    (*block)[i] = this->lhs_[block - begin] * bw[i];
+                    (*block)[i] = this->lhs_[block - begin][0] * bw[i];
                 }
             } else {
-                (*block)[pressure_var_index_] = this->lhs_[block - begin];
+                (*block)[pressure_var_index_] = this->lhs_[block - begin][0];
             }
         }
     }

--- a/opm/simulators/linalg/PressureTransferPolicy.hpp
+++ b/opm/simulators/linalg/PressureTransferPolicy.hpp
@@ -153,10 +153,10 @@ public:
             if (transpose) {
                 const auto& bw = weights_[block.index()];
                 for (std::size_t i = 0; i < block->size(); ++i) {
-                    (*block)[i] = this->lhs_[block - begin] * bw[i];
+                    (*block)[i] = this->lhs_[block - begin][0] * bw[i];
                 }
             } else {
-                (*block)[pressure_var_index_] = this->lhs_[block - begin];
+                (*block)[pressure_var_index_] = this->lhs_[block - begin][0];
             }
         }
     }

--- a/opm/simulators/linalg/gpubridge/CprCreation.cpp
+++ b/opm/simulators/linalg/gpubridge/CprCreation.cpp
@@ -144,7 +144,7 @@ create_preconditioner_amg(BlockedMatrix<Scalar> *mat_)
                 int end = mat->rowPointers[row + 1];
                 for (int idx = start; idx < end; ++idx) {
                     int col = mat->colIndices[idx];
-                    (*dune_coarse)[row][col] = coarse_vals[idx];
+                    (*dune_coarse)[row][col][0][0] = coarse_vals[idx];
                 }
             }
 
@@ -183,7 +183,7 @@ create_preconditioner_amg(BlockedMatrix<Scalar> *mat_)
                 int end = mat->rowPointers[row + 1];
                 for (int idx = start; idx < end; ++idx) {
                     int col = mat->colIndices[idx];
-                    (*dune_coarse)[row][col] = coarse_vals[idx];
+                    (*dune_coarse)[row][col][0][0] = coarse_vals[idx];
                 }
             }
 
@@ -242,7 +242,7 @@ analyzeHierarchy()
         const bool fillDiagIndices = diagIndices[level].empty();
         for (typename DuneMat::const_iterator r = A.begin(); r != A.end(); ++r) {
             for (auto c = r->begin(); c != r->end(); ++c) {
-                Amatrices.back().nnzValues[nnz_idx] = A[r.index()][c.index()];
+                Amatrices.back().nnzValues[nnz_idx] = A[r.index()][c.index()][0][0];
                 if (fillDiagIndices && r.index() == c.index()) {
                     diagIndices[level].emplace_back(nnz_idx);
                 }

--- a/opm/simulators/wells/MultisegmentWellEquations.cpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.cpp
@@ -377,6 +377,9 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
                          const int seg_pressure_var_ind,
                          const WellState<Scalar, IndexTraits>& well_state) const
 {
+    using BlockType = PressureMatrix::block_type;
+    static_assert(BlockType::rows == 1);
+    static_assert(BlockType::cols == 1);
     // Add the pressure contribution to the cpr system for the well
 
     // Add for coupling from well to reservoir
@@ -389,12 +392,12 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
                 // map the well perforated cell index to global cell index
                 const auto row_index = cells_[colC.index()];
                 const auto& bw = weights[row_index];
-                double matel = 0.0;
+                Scalar matel = 0.0;
 
                 for (std::size_t i = 0; i< bw.size(); ++i) {
                     matel += bw[i]*(*colC)[seg_pressure_var_ind][i];
                 }
-                jacobian[row_index][welldof_ind] += matel;
+                jacobian[row_index][welldof_ind][0][0] += matel;
             }
         }
     }
@@ -419,18 +422,18 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
         assert(num_perfs > 0);
 
         // Add for coupling from reservoir to well and caclulate diag elelement corresping to incompressible standard well
-        double diag_ell = 0.0;
+        Scalar diag_ell = 0.0;
         for (std::size_t rowB = 0; rowB < duneB_.N(); ++rowB) {
             const auto& bw = well_weight;
             for (auto colB = duneB_[rowB].begin(),
                       endB = duneB_[rowB].end(); colB != endB; ++colB) {
                 // map the well perforated cell index to global cell index
                 const auto col_index = cells_[colB.index()];
-                double matel = 0.0;
+                Scalar matel = 0.0;
                 for (std::size_t i = 0; i< bw.size(); ++i) {
                     matel += bw[i] *(*colB)[i][pressureVarIndex];
                 }
-                jacobian[welldof_ind][col_index] += matel;
+                jacobian[welldof_ind][col_index][0][0] += matel;
                 diag_ell -= matel;
             }
         }
@@ -446,9 +449,9 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
         }
 #endif
 #undef EXTRA_DEBUG_MSW
-        jacobian[welldof_ind][welldof_ind] = diag_ell;
+        jacobian[welldof_ind][welldof_ind][0][0] = diag_ell;
     } else {
-        jacobian[welldof_ind][welldof_ind] = 1.0; // maybe we could have used diag_ell if calculated
+        jacobian[welldof_ind][welldof_ind][0][0] = Scalar{1.0}; // maybe we could have used diag_ell if calculated
     }
 }
 


### PR DESCRIPTION
This avoids a new DUNE warnings where these two types should not be treated as scalar objects (e.g. using the += operator).