### PR TITLE
Add system_cprw for coupled reservoir-well solves with CPRW

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -690,6 +690,10 @@ list (APPEND TEST_DATA_FILES
   tests/options_system_cpr_missing_smoother.json
   tests/options_system_cpr_missing_well.json
   tests/options_system_cpr_res_precond_not_cpr.json
+  tests/options_system_cprw_missing_well.json
+  tests/options_system_cprw_missing_ressolver.json
+  tests/options_system_cprw_missing_smoother.json
+  tests/options_system_cprw_res_precond_not_cprw.json
   tests/GCONSUMP.DATA
   tests/GCONSUMP_COMPLEX.DATA
   tests/GROUP_HIGHER_CONSTRAINTS.DATA
@@ -1122,6 +1126,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/linalg/ISTLSolverRuntimeOptionProxy.hpp
   opm/simulators/linalg/Preconditioner2InverseOperator.hpp
   opm/simulators/linalg/system/MultiComm.hpp
+  opm/simulators/linalg/system/SystemMatrixWellOperator.hpp
   opm/simulators/linalg/system/SystemPreconditioner.hpp
   opm/simulators/linalg/system/SystemPreconditionerFactory.hpp
   opm/simulators/linalg/system/SystemTypes.hpp

--- a/opm/simulators/linalg/ISTLSolverRuntimeOptionProxy.hpp
+++ b/opm/simulators/linalg/ISTLSolverRuntimeOptionProxy.hpp
@@ -51,7 +51,7 @@ public:
     using SparseMatrixAdapter = GetPropType<TypeTag, Properties::SparseMatrixAdapter>;
     using Vector = GetPropType<TypeTag, Properties::GlobalEqVector>;
     using Simulator = GetPropType<TypeTag, Properties::Simulator>;
-    using Matrix = typename SparseMatrixAdapter::IstlMatrix;
+    using Matrix =  SparseMatrixAdapter::IstlMatrix;
 
 #if HAVE_MPI
     using CommunicationType = Dune::OwnerOverlapCopyCommunication<int, int>;
@@ -155,21 +155,22 @@ private:
     void createSolver(const Simulator& simulator, Args&&... args)
     {
         auto linSolverConf = Parameters::Get<Parameters::LinearSolver>();
-        bool useSystemCpr = (linSolverConf == "system_cpr");
-        if (!useSystemCpr && linSolverConf.size() > 5
+        bool useSystemSolver = (linSolverConf == "system_cpr" || linSolverConf == "system_cprw");
+        if (!useSystemSolver && linSolverConf.size() > 5
             && linSolverConf.ends_with(".json")
             && std::filesystem::exists(linSolverConf)) {
             try {
                 PropertyTree prm(linSolverConf);
-                useSystemCpr = (prm.get<std::string>("preconditioner.type", "") == "system_cpr");
+                const auto precType = prm.get<std::string>("preconditioner.type", "");
+                useSystemSolver = (precType == "system_cpr" || precType == "system_cprw");
             } catch (...) {}
         }
-        if (useSystemCpr) {
+        if (useSystemSolver) {
             using Indices = GetPropType<TypeTag, Properties::Indices>;
             const auto backend = Parameters::linearSolverAcceleratorTypeFromCLI();
             if (backend != Parameters::LinearSolverAcceleratorType::CPU) {
                 OPM_THROW(std::invalid_argument,
-                          "The system_cpr preconditioner currently only "
+                          "The system_cpr/system_cprw preconditioner currently only "
                           "supports --linear-solver-accelerator=cpu");
             }
             // System solver types are hardcoded for 3-equation blackoil (see SystemTypes.hpp).
@@ -178,7 +179,7 @@ private:
                     simulator, std::forward<Args>(args)...);
             } else {
                 OPM_THROW(std::invalid_argument,
-                          "The system_cpr preconditioner is only supported for "
+                          "The system_cpr/system_cprw preconditioner is only supported for "
                           "standard 3-phase blackoil (3 equations). This model has " +
                               std::to_string(Indices::numEq) + " equations.");
             }

--- a/opm/simulators/linalg/ISTLSolverRuntimeOptionProxy.hpp
+++ b/opm/simulators/linalg/ISTLSolverRuntimeOptionProxy.hpp
@@ -51,7 +51,7 @@ public:
     using SparseMatrixAdapter = GetPropType<TypeTag, Properties::SparseMatrixAdapter>;
     using Vector = GetPropType<TypeTag, Properties::GlobalEqVector>;
     using Simulator = GetPropType<TypeTag, Properties::Simulator>;
-    using Matrix =  SparseMatrixAdapter::IstlMatrix;
+    using Matrix =  typename SparseMatrixAdapter::IstlMatrix;
 
 #if HAVE_MPI
     using CommunicationType = Dune::OwnerOverlapCopyCommunication<int, int>;

--- a/opm/simulators/linalg/setupPropertyTree.cpp
+++ b/opm/simulators/linalg/setupPropertyTree.cpp
@@ -27,6 +27,7 @@
 #include <opm/simulators/linalg/FlowLinearSolverParameters.hpp>
 
 #include <filesystem>
+#include <optional>
 #include <fmt/format.h>
 
 namespace Opm
@@ -173,6 +174,34 @@ namespace
     }
 } // anonymous namespace
 
+namespace {
+    // Validates that the reservoir_solver sub-tree of a system_cpr / system_cprw
+    // configuration uses a compatible CPR-family preconditioner.
+    void validateReservoirSolverPreconditioner(const std::string& type,
+                                               const PropertyTree& reservoir_solver)
+    {
+        const std::string precond_type = reservoir_solver.get<std::string>("preconditioner.type", "");
+        if (type == "system_cprw") {
+            if (precond_type != "cprw") {
+                OPM_THROW(std::invalid_argument,
+                          "In system_cprw configuration, the reservoir_solver must use the "
+                          "CPR-with-wells preconditioner (cprw) – found '" + precond_type + "'.");
+            }
+        } else if (precond_type != "cpr" && precond_type != "cprw") {
+            OPM_THROW(std::invalid_argument,
+                      "In system_cpr configuration, the reservoir_solver must use either the "
+                      "CPR preconditioner (cpr) or the CPR with wells (cprw) – found '"
+                      + precond_type + "'.");
+        }
+    }
+
+    // Forward declaration – defined after all setup helpers below.
+    std::optional<PropertyTree> tryCPRFamilySetup(const std::string& conf,
+                                                   FlowLinearSolverParameters p,
+                                                   bool maxIterSet,
+                                                   bool reductionSet);
+} // anonymous namespace
+
 /// Set up a property tree intended for FlexibleSolver by either reading
 /// the tree from a JSON file or creating a tree giving the default solver
 /// and preconditioner. If the latter, the parameters --linear-solver-reduction,
@@ -205,41 +234,10 @@ setupPropertyTree(FlowLinearSolverParameters p, // Note: copying the parameters 
     // We use lower case as the internal canonical representation of solver names.
     std::ranges::transform(conf, conf.begin(), ::tolower);
 
-    // Use CPR configuration.
+    // CPR-family configurations (only available outside TPSA mode).
     if (!tpsaSetup) {
-        if ((conf == "cpr_trueimpes") || (conf == "cpr_quasiimpes") || (conf == "cpr_trueimpesanalytic")) {
-            if (!linearSolverMaxIterSet) {
-                // Use our own default unless it was explicitly overridden by user.
-                p.linear_solver_maxiter_ = 20;
-            }
-            if (!linearSolverReductionSet) {
-                // Use our own default unless it was explicitly overridden by user.
-                p.linear_solver_reduction_ = 0.005;
-            }
-            return setupCPR(conf, p);
-        }
-
-        if ((conf == "cpr") || (conf == "cprw")) {
-            if (!linearSolverMaxIterSet) {
-                // Use our own default unless it was explicitly overridden by user.
-                p.linear_solver_maxiter_ = 20;
-            }
-            if (!linearSolverReductionSet) {
-                // Use our own default unless it was explicitly overridden by user.
-                p.linear_solver_reduction_ = 0.005;
-            }
-            return setupCPRW(conf, p);
-        }
-        
-        // System CPR configuration (coupled reservoir-well system solver).
-        if (conf == "system_cpr") {
-            if (!linearSolverMaxIterSet) {
-                p.linear_solver_maxiter_ = 20;
-            }
-            if (!linearSolverReductionSet) {
-                p.linear_solver_reduction_ = 0.005;
-            }
-            return setupSystemCPR(conf, p);
+        if (auto tree = tryCPRFamilySetup(conf, p, linearSolverMaxIterSet, linearSolverReductionSet)) {
+            return *tree;
         }
     }
 
@@ -297,7 +295,7 @@ setupPropertyTree(FlowLinearSolverParameters p, // Note: copying the parameters 
     else {
         OPM_THROW(std::invalid_argument,
                 conf + " is not a valid setting for --linear-solver-configuration."
-                " Please use ilu0, dilu, isai, cpr, cprw, cpr_trueimpes, cpr_quasiimpes, cpr_trueimpesanalytic, or system_cpr");
+                " Please use ilu0, dilu, isai, cpr, cprw, cpr_trueimpes, cpr_quasiimpes, cpr_trueimpesanalytic, system_cpr, or system_cprw");
     }
 
 
@@ -571,28 +569,109 @@ setupSystemCPR([[maybe_unused]] const std::string& conf, const FlowLinearSolverP
     return prm;
 }
 
+PropertyTree
+setupSystemCPRW([[maybe_unused]] const std::string& conf, const FlowLinearSolverParameters& p)
+{
+    using namespace std::string_literals;
+    PropertyTree prm;
+
+    // Outer solver
+    prm.put("maxiter", p.linear_solver_maxiter_);
+    prm.put("tol", p.linear_solver_reduction_);
+    prm.put("verbosity", p.linear_solver_verbosity_);
+    prm.put("solver", getSolverString(p));
+
+    // Top-level preconditioner: system_cprw
+    prm.put("preconditioner.type", "system_cprw"s);
+
+    // --- Reservoir smoother (ILU on A_rr, same as system_cpr) ---
+    prm.put("preconditioner.reservoir_smoother.maxiter", 1);
+    prm.put("preconditioner.reservoir_smoother.tol", p.linear_solver_reduction_);
+    prm.put("preconditioner.reservoir_smoother.verbosity", 0);
+    prm.put("preconditioner.reservoir_smoother.solver", "preconditioner2inverseoperator"s);
+    prm.put("preconditioner.reservoir_smoother.preconditioner.type", "paroverilu0"s);
+    prm.put("preconditioner.reservoir_smoother.preconditioner.relaxation", 1.0);
+
+    // --- Reservoir solver (CPRW: AMG on extended (nCells+nWells) pressure system) ---
+    prm.put("preconditioner.reservoir_solver.maxiter", 1);
+    prm.put("preconditioner.reservoir_solver.tol", p.linear_solver_reduction_);
+    prm.put("preconditioner.reservoir_solver.verbosity", 0);
+    prm.put("preconditioner.reservoir_solver.solver", "preconditioner2inverseoperator"s);
+    prm.put("preconditioner.reservoir_solver.preconditioner.type", "cprw"s);
+    prm.put("preconditioner.reservoir_solver.preconditioner.relaxation", 1.0);
+    prm.put("preconditioner.reservoir_solver.preconditioner.use_well_weights", "true"s);
+    prm.put("preconditioner.reservoir_solver.preconditioner.add_wells", "true"s);
+    prm.put("preconditioner.reservoir_solver.preconditioner.weight_type", "trueimpes"s);
+    prm.put("preconditioner.reservoir_solver.preconditioner.pre_smooth", 0);
+    prm.put("preconditioner.reservoir_solver.preconditioner.post_smooth", 0);
+    // Set unused finesmoother to jac to avoid spending time setting up an ILU smoother.
+    prm.put("preconditioner.reservoir_solver.preconditioner.finesmoother.type", "jac"s);
+    prm.put("preconditioner.reservoir_solver.preconditioner.finesmoother.relaxation", 1.0);
+    prm.put("preconditioner.reservoir_solver.preconditioner.verbosity", 0);
+    prm.put("preconditioner.reservoir_solver.preconditioner.coarsesolver.maxiter", 2);
+    prm.put("preconditioner.reservoir_solver.preconditioner.coarsesolver.tol", 1e-2);
+    prm.put("preconditioner.reservoir_solver.preconditioner.coarsesolver.solver", "loopsolver"s);
+    prm.put("preconditioner.reservoir_solver.preconditioner.coarsesolver.verbosity", 0);
+    prm.put("preconditioner.reservoir_solver.preconditioner.coarsesolver.preconditioner.type", "amg"s);
+    setupDuneAMG(prm, "preconditioner.reservoir_solver.preconditioner.coarsesolver.preconditioner.");
+
+    // --- Well solver ---
+    prm.put("preconditioner.well_solver.maxiter", 1);
+    prm.put("preconditioner.well_solver.tol", p.linear_solver_reduction_);
+    prm.put("preconditioner.well_solver.verbosity", 0);
+    prm.put("preconditioner.well_solver.solver", "umfpack"s);
+    return prm;
+}
+
+namespace {
+    // Dispatches to the appropriate CPR-family setup function and applies the
+    // CPR-specific solver defaults (maxiter=20, reduction=0.005) when not already
+    // set by the user. Returns std::nullopt when conf does not name a CPR variant.
+    std::optional<PropertyTree> tryCPRFamilySetup(const std::string& conf,
+                                                   FlowLinearSolverParameters p,
+                                                   bool maxIterSet,
+                                                   bool reductionSet)
+    {
+        // Apply CPR-specific defaults unless the user explicitly overrode them.
+        if (!maxIterSet) { p.linear_solver_maxiter_ = 20; }
+        if (!reductionSet) { p.linear_solver_reduction_ = 0.005; }
+
+        // Analytic / quasi-IMPES CPR variants.
+        if (conf == "cpr_trueimpes" || conf == "cpr_quasiimpes" || conf == "cpr_trueimpesanalytic") {
+            return setupCPR(conf, p);
+        }
+        // Plain CPR / CPR-with-wells.
+        if (conf == "cpr" || conf == "cprw") {
+            return setupCPRW(conf, p);
+        }
+        // System CPR (coupled reservoir-well, CPR coarse solve).
+        if (conf == "system_cpr") {
+            return setupSystemCPR(conf, p);
+        }
+        // System CPRW (coupled reservoir-well, CPRW coarse solve).
+        if (conf == "system_cprw") {
+            return setupSystemCPRW(conf, p);
+        }
+        return std::nullopt;
+    }
+} // anonymous namespace
 
 void validateSystemCPRTree(const PropertyTree& prm)
 {
-    if (prm.get("preconditioner.type", std::string{}) != "system_cpr") {
+    const std::string type = prm.get("preconditioner.type", std::string{});
+    if (type != "system_cpr" && type != "system_cprw") {
         return;
     }
     for (const char* sub : {"reservoir_solver", "reservoir_smoother", "well_solver"}) {
         if (!prm.get_child_optional(std::string("preconditioner.") + sub).has_value()) {
             OPM_THROW(std::invalid_argument,
-                      fmt::format("system_cpr JSON configuration is missing the required "
-                                  "'preconditioner.{}' sub-tree.", sub));
+                      fmt::format("{} JSON configuration is missing the required "
+                                  "'preconditioner.{}' sub-tree.", type, sub));
         }
     }
-    // Ensure reservoir_solver uses CPR preconditioner
     auto reservoir_solver = prm.get_child_optional("preconditioner.reservoir_solver");
     if (reservoir_solver) {
-        std::string precond_type = reservoir_solver->get<std::string>("preconditioner.type", "");
-        if (precond_type != "cpr") {
-            OPM_THROW(std::invalid_argument,
-                      "In system_cpr configuration, the reservoir_solver must use the CPR preconditioner "
-                      "(preconditioner.reservoir_solver.preconditioner.type = 'cpr').");
-        }
+        validateReservoirSolverPreconditioner(type, *reservoir_solver);
     }
 }
 
@@ -602,7 +681,7 @@ void checkSystemCPRMatrixAddWell(bool matrixAddWellContributions)
     if (matrixAddWellContributions) {
         OPM_THROW(std::invalid_argument,
                   "--matrix-add-well-contributions=true is incompatible with "
-                  "--linear-solver=system_cpr because the system CPR implementation assumes that well contributions are not added to the matrix.");
+                  "--linear-solver=system_cpr because the system CPR/CPRW implementation assumes that well contributions are not added to the matrix.");
     }
 }
 

--- a/opm/simulators/linalg/setupPropertyTree.cpp
+++ b/opm/simulators/linalg/setupPropertyTree.cpp
@@ -681,7 +681,7 @@ void checkSystemCPRMatrixAddWell(bool matrixAddWellContributions)
     if (matrixAddWellContributions) {
         OPM_THROW(std::invalid_argument,
                   "--matrix-add-well-contributions=true is incompatible with "
-                  "--linear-solver=system_cpr because the system CPR/CPRW implementation assumes that well contributions are not added to the matrix.");
+                  "--linear-solver=system_cpr or system_cprw because these implementations assume that well contributions are not added to the matrix.");
     }
 }
 

--- a/opm/simulators/linalg/setupPropertyTree.hpp
+++ b/opm/simulators/linalg/setupPropertyTree.hpp
@@ -37,10 +37,12 @@ PropertyTree setupPropertyTree(FlowLinearSolverParameters p,
 PropertyTree setupCPRW(const std::string& conf, const FlowLinearSolverParameters& p);
 PropertyTree setupCPR(const std::string& conf, const FlowLinearSolverParameters& p);
 PropertyTree setupSystemCPR(const std::string& conf, const FlowLinearSolverParameters& p);
+PropertyTree setupSystemCPRW(const std::string& conf, const FlowLinearSolverParameters& p);
 
-// Validates that a PropertyTree with preconditioner.type == "system_cpr" contains
-// all three required sub-trees. Throws std::invalid_argument if any are missing.
-// No-op when the preconditioner type is not system_cpr.
+// Validates that a PropertyTree with preconditioner.type == "system_cpr" or
+// "system_cprw" contains all three required sub-trees and that the
+// reservoir_solver uses a compatible CPR-family preconditioner.
+// Throws std::invalid_argument on violations. No-op for any other type.
 void validateSystemCPRTree(const PropertyTree& prm);
 
 // Throws std::invalid_argument when system_cpr is combined with

--- a/opm/simulators/linalg/system/ISTLSolverSystem.hpp
+++ b/opm/simulators/linalg/system/ISTLSolverSystem.hpp
@@ -153,6 +153,8 @@ private:
     using SysSolverType = Dune::InverseOperator<SystemVector<Scalar>, SystemVector<Scalar>>;
     using SysPrecondType = Dune::PreconditionerWithUpdate<SystemVector<Scalar>, SystemVector<Scalar>>;
     using SeqSysPrecondType = SystemPreconditioner<Scalar, SeqResOperator<Scalar>>;
+    using SeqSysCprwPrecondType = SystemPreconditioner<Scalar, SeqResOperator<Scalar>,
+                                                        Dune::Amg::SequentialInformation, true>;
 #if HAVE_MPI
     using ParSysPrecondType = SystemPreconditioner<Scalar, ParResOperator<Scalar>, ParResComm>;
 #endif
@@ -237,10 +239,14 @@ private:
 
         if (auto* precond = dynamic_cast<SeqSysPrecondType*>(sysPrecond_)) {
             precond->updateForChangedWellStructure();
-        } else
-        { // Rebuild the solver if the sequential preconditioner cannot be updated in-place
-            createSystemSolver(prm);
+            return;
         }
+        if (auto* precond = dynamic_cast<SeqSysCprwPrecondType*>(sysPrecond_)) {
+            precond->updateForChangedWellStructure();
+            return;
+        }
+        // Rebuild the solver if the sequential preconditioner cannot be updated in-place
+        createSystemSolver(prm);
     }
 
     void createSystemSolver(const Opm::PropertyTree& prm)

--- a/opm/simulators/linalg/system/SystemMatrixWellOperator.hpp
+++ b/opm/simulators/linalg/system/SystemMatrixWellOperator.hpp
@@ -22,6 +22,7 @@ Copyright Equinor ASA 2026
 
 #include "SystemTypes.hpp"
 
+#include <opm/common/Exceptions.hpp>
 #include <opm/simulators/linalg/WellOperators.hpp>
 
 #include <algorithm>
@@ -159,25 +160,9 @@ public:
             BwtArray& bwt = wellBwt[w];
             bwt.fill(Scalar(0));
 
-            if (use_well_weights) {
-                // bwt = inv(D[w][w])^T * e_bhp  →  row bhp of inv(D[w][w])
-                auto invD = (*S_.D)[w][w];   // 4×4 copy
-                detail::invertMatrix(invD);
-                Scalar abs_max = 0;
-                for (int i = 0; i < numWellDofs; ++i) {
-                    bwt[i] = invD[bhpIdx][i];
-                    abs_max = std::max(abs_max, std::abs(bwt[i]));
-                }
-                if (abs_max > 0) {
-                    for (int i = 0; i < numWellDofs; ++i) {
-                        bwt[i] /= abs_max;
-                    }
-                    wellDiag[w] = Scalar(1) / abs_max;
-                } else {
-                    wellDiag[w] = Scalar(1);
-                }
-            } else {
-                // bwt: average across all perforated reservoir cells (IMPES weights)
+            const auto setDefaultWellWeights = [&]() {
+                // Use averaged reservoir IMPES weights as a robust fallback when
+                // quasi-IMPES well weights are unavailable.
                 std::vector<Scalar> totalWeights(numResDofs, 0.0);
                 int nperf = 0;
                 for (auto colIt = (*S_.B)[w].begin(); colIt != (*S_.B)[w].end(); ++colIt) {
@@ -209,6 +194,31 @@ public:
                         break;
                     }
                 }
+            };
+
+            if (use_well_weights) {
+                // bwt = inv(D[w][w])^T * e_bhp  →  row bhp of inv(D[w][w])
+                try {
+                    auto invD = (*S_.D)[w][w];   // 4x4 copy
+                    detail::invertMatrix(invD);
+                    Scalar abs_max = 0;
+                    for (int i = 0; i < numWellDofs; ++i) {
+                        bwt[i] = invD[bhpIdx][i];
+                        abs_max = std::max(abs_max, std::abs(bwt[i]));
+                    }
+                    if (abs_max > 0) {
+                        for (int i = 0; i < numWellDofs; ++i) {
+                            bwt[i] /= abs_max;
+                        }
+                        wellDiag[w] = Scalar(1) / abs_max;
+                    } else {
+                        wellDiag[w] = Scalar(1);
+                    }
+                } catch (const NumericalProblem&) {
+                    setDefaultWellWeights();
+                }
+            } else {
+                setDefaultWellWeights();
             }
 
             // Set diagonal entry

--- a/opm/simulators/linalg/system/SystemMatrixWellOperator.hpp
+++ b/opm/simulators/linalg/system/SystemMatrixWellOperator.hpp
@@ -1,0 +1,241 @@
+/*
+Copyright Equinor ASA 2026
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_SYSTEMMATRIXWELLOPERATOR_HEADER_INCLUDED
+#define OPM_SYSTEMMATRIXWELLOPERATOR_HEADER_INCLUDED
+
+#include "SystemTypes.hpp"
+
+#include <opm/simulators/linalg/WellOperators.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <vector>
+
+namespace Opm
+{
+
+// LinearOperatorExtra bridge that exposes the B/C/D sub-blocks of a
+// SystemMatrix through the interface expected by WellModelMatrixAdapter and
+// PressureBhpTransferPolicy (used by the CPRW preconditioner).
+//
+// Follows SystemMatrix's block naming (same as SystemPreconditioner::apply()):
+//   S_.B  =  A_wr  (well-row, res-col, 4x3 blocks)  == S[_1][_0]
+//   S_.C  =  A_rw  (res-row,  well-col, 3x4 blocks)  == S[_0][_1]
+//   S_.D  =  A_ww  (well-well, 4x4 blocks)           == S[_1][_1]
+//
+// The apply() method is intentionally a no-op: well DOFs are updated
+// explicitly by wellSolver_ in SystemPreconditioner, so the CPRW fine-level
+// smoother (operating through WellModelMatrixAdapter) only sees A_rr.
+template<class Scalar>
+class SystemMatrixWellOperator
+    : public LinearOperatorExtra<ResVector<Scalar>, ResVector<Scalar>>
+{
+public:
+    using X = ResVector<Scalar>;
+    using Y = ResVector<Scalar>;
+    using PressureMatrix = Dune::BCRSMatrix<MatrixBlock<Scalar, 1, 1>>;
+
+    SystemMatrixWellOperator(const SystemMatrix<Scalar>& S, int pressureIndex)
+        : S_(S)
+        , pressureIndex_(pressureIndex)
+    {}
+
+    // -----------------------------------------------------------------------
+    // Dune::LinearOperator interface
+    // -----------------------------------------------------------------------
+
+    void apply(const X&, Y&) const override {}
+
+    void applyscaleadd(Scalar, const X&, Y&) const override {}
+
+    Dune::SolverCategory::Category category() const override
+    {
+        return Dune::SolverCategory::sequential;
+    }
+
+    // -----------------------------------------------------------------------
+    // LinearOperatorExtra interface
+    // -----------------------------------------------------------------------
+
+    int getNumberOfExtraEquations() const override
+    {
+        return static_cast<int>(S_.D->N());
+    }
+
+    // Add sparsity entries for the well rows/columns of the coarse pressure
+    // matrix.  Called once during coarse-matrix structure setup.
+    // Called while the coarse pressure matrix is still in implicit build mode
+    // (PressureBhpTransferPolicy calls compress() after this).  Must use
+    // entry() to insert new entries rather than operator[][], which only works
+    // on already-compressed rows.
+    void addWellPressureEquationsStruct(PressureMatrix& jacobian) const override
+    {
+        const std::size_t nCells = S_.A->N();
+
+        // A_wr (S_.B): well-row, res-col  →  jacobian[nCells+w][cell]
+        for (auto rowIt = S_.B->begin(); rowIt != S_.B->end(); ++rowIt) {
+            const std::size_t well_w = rowIt.index();
+            for (auto colIt = rowIt->begin(); colIt != rowIt->end(); ++colIt) {
+                jacobian.entry(nCells + well_w, colIt.index()) = 0.0;
+            }
+        }
+
+        // A_rw (S_.C): res-row, well-col  →  jacobian[cell][nCells+w]
+        for (auto rowIt = S_.C->begin(); rowIt != S_.C->end(); ++rowIt) {
+            const std::size_t cell = rowIt.index();
+            for (auto colIt = rowIt->begin(); colIt != rowIt->end(); ++colIt) {
+                jacobian.entry(cell, nCells + colIt.index()) = 0.0;
+            }
+        }
+
+        // A_ww (S_.D): well-row, well-col  →  jacobian[nCells+w][nCells+w']
+        for (auto rowIt = S_.D->begin(); rowIt != S_.D->end(); ++rowIt) {
+            const std::size_t well_w = rowIt.index();
+            for (auto colIt = rowIt->begin(); colIt != rowIt->end(); ++colIt) {
+                jacobian.entry(nCells + well_w, nCells + colIt.index()) = 0.0;
+            }
+        }
+    }
+
+    // Fill the well rows/columns of the coarse pressure matrix.
+    // Implements the CPRW extended pressure system from the paper:
+    //   A_cprw = [C_p^T W A_rr C_p     C_p^T W A_rw C_bhp  ]
+    //            [C_bhp^T Ww A_wr C_p   C_bhp^T Ww A_ww C_bhp]
+    //
+    // use_well_weights=false: well weights = cell IMPES weights.
+    // use_well_weights=true:  well weights = inv(D)^T * e_bhp (quasi-IMPES),
+    //                         matching the formula in StandardWellEquations.
+    void addWellPressureEquations(PressureMatrix& jacobian,
+                                  const X& weights,
+                                  bool use_well_weights) const override
+    {
+        const std::size_t nCells = S_.A->N();
+        constexpr int bhpIdx = numWellDofs - 1;
+
+        // Upper-right block: jacobian[cell][nCells + well_w]
+        // = sum_k  A_rw[cell][well_w][k][bhpIdx] * weights[cell][k]   (same for both modes)
+        for (auto rowIt = S_.C->begin(); rowIt != S_.C->end(); ++rowIt) {
+            const std::size_t cell = rowIt.index();
+            const auto& wt = weights[cell];
+            for (auto colIt = rowIt->begin(); colIt != rowIt->end(); ++colIt) {
+                const auto& block = *colIt;  // 3x4 block
+                Scalar val = 0;
+                for (int k = 0; k < numResDofs; ++k) {
+                    val += block[k][bhpIdx] * wt[k];
+                }
+                jacobian[cell][nCells + colIt.index()] = val;
+            }
+        }
+
+        // Pre-compute per-well weights (bwt) and diagonal values.
+        // use_well_weights=false: bwt from first connected cell's IMPES weights
+        // use_well_weights=true:  bwt = inv(D[w][w])^T[:,bhp] normalised
+        const std::size_t nWells = S_.D->N();
+        using BwtArray = std::array<Scalar, numWellDofs>;
+        std::vector<BwtArray> wellBwt(nWells);
+        std::vector<Scalar>   wellDiag(nWells, 1.0);
+
+        for (auto rowIt = S_.D->begin(); rowIt != S_.D->end(); ++rowIt) {
+            const std::size_t w = rowIt.index();
+            BwtArray& bwt = wellBwt[w];
+            bwt.fill(Scalar(0));
+
+            if (use_well_weights) {
+                // bwt = inv(D[w][w])^T * e_bhp  →  row bhp of inv(D[w][w])
+                auto invD = (*S_.D)[w][w];   // 4×4 copy
+                detail::invertMatrix(invD);
+                Scalar abs_max = 0;
+                for (int i = 0; i < numWellDofs; ++i) {
+                    bwt[i] = invD[bhpIdx][i];
+                    abs_max = std::max(abs_max, std::abs(bwt[i]));
+                }
+                if (abs_max > 0) {
+                    for (int i = 0; i < numWellDofs; ++i) {
+                        bwt[i] /= abs_max;
+                    }
+                    wellDiag[w] = Scalar(1) / abs_max;
+                } else {
+                    wellDiag[w] = Scalar(1);
+                }
+            } else {
+                // bwt: average across all perforated reservoir cells (IMPES weights)
+                std::vector<Scalar> totalWeights(numResDofs, 0.0);
+                int nperf = 0;
+                for (auto colIt = (*S_.B)[w].begin(); colIt != (*S_.B)[w].end(); ++colIt) {
+                    const auto& wt = weights[colIt.index()];
+                    for (int k = 0; k < numResDofs; ++k) {
+                        totalWeights[k] += wt[k];
+                    }
+                    nperf++;
+                }
+                if (nperf > 0) {
+                    for (int k = 0; k < numResDofs; ++k) {
+                        bwt[k] = totalWeights[k] / nperf;
+                    }
+                } else {
+                    // no perforations on this rank: use default weights for regularization
+                    for (int k = 0; k < numResDofs; ++k) {
+                        bwt[k] = Scalar(1);
+                    }
+                }
+                // diagonal: sum_k D[w][w][k][bhp] * bwt[k]  (k < numWellDofs-1)
+                for (auto colIt = rowIt->begin(); colIt != rowIt->end(); ++colIt) {
+                    if (colIt.index() == w) {
+                        const auto& block = *colIt;
+                        Scalar val = 0;
+                        for (int k = 0; k < numWellDofs - 1; ++k) {
+                            val += block[k][bhpIdx] * bwt[k];
+                        }
+                        wellDiag[w] = (val != 0) ? val : Scalar(1);
+                        break;
+                    }
+                }
+            }
+
+            // Set diagonal entry
+            jacobian[nCells + w][nCells + w] = wellDiag[w];
+        }
+
+        // Lower-left block: jacobian[nCells + well_w][cell]
+        // = sum_k  A_wr[well_w][cell][k][pressureIndex_] * bwt[well_w][k]
+        for (auto rowIt = S_.B->begin(); rowIt != S_.B->end(); ++rowIt) {
+            const std::size_t well_w = rowIt.index();
+            const BwtArray& bwt = wellBwt[well_w];
+            for (auto colIt = rowIt->begin(); colIt != rowIt->end(); ++colIt) {
+                const auto& block = *colIt;  // 4x3 block
+                Scalar val = 0;
+                for (int k = 0; k < numWellDofs; ++k) {
+                    val += block[k][pressureIndex_] * bwt[k];
+                }
+                jacobian[nCells + well_w][colIt.index()] = val;
+            }
+        }
+    }
+
+private:
+    const SystemMatrix<Scalar>& S_;
+    int pressureIndex_;
+};
+
+} // namespace Opm
+
+#endif // OPM_SYSTEMMATRIXWELLOPERATOR_HEADER_INCLUDED

--- a/opm/simulators/linalg/system/SystemPreconditioner.cpp
+++ b/opm/simulators/linalg/system/SystemPreconditioner.cpp
@@ -32,6 +32,7 @@
 #if HAVE_MPI
 #define INSTANTIATE_SYSTEM_PF_PAR(T)                                                                  \
     template class Opm::SystemPreconditioner<T, Opm::ParResOperator<T>, Opm::ParResComm>;            \
+    template class Opm::SystemPreconditioner<T, Opm::ParResOperator<T>, Opm::ParResComm, true>;      \
     template class Dune::FlexibleSolver<Opm::SystemParOp<T>>;                                        \
     template Dune::FlexibleSolver<Opm::SystemParOp<T>>::FlexibleSolver(                               \
         Opm::SystemParOp<T>& op,                                                                     \

--- a/opm/simulators/linalg/system/SystemPreconditioner.hpp
+++ b/opm/simulators/linalg/system/SystemPreconditioner.hpp
@@ -33,11 +33,11 @@
 #include <dune/istl/owneroverlapcopy.hh>
 #include <dune/istl/paamg/pinfo.hh>
 
+#include <algorithm>
 #include <functional>
 #include <limits>
 #include <memory>
 #include <type_traits>
-
 
 namespace Opm
 {

--- a/opm/simulators/linalg/system/SystemPreconditioner.hpp
+++ b/opm/simulators/linalg/system/SystemPreconditioner.hpp
@@ -20,15 +20,27 @@
 #define OPM_SYSTEMPRECONDITIONER_HEADER_INCLUDED
 
 #include <opm/simulators/linalg/system/MultiComm.hpp>
+#include <opm/simulators/linalg/system/SystemMatrixWellOperator.hpp>
 #include <opm/simulators/linalg/system/SystemTypes.hpp>
 #include <opm/simulators/linalg/FlexibleSolver.hpp>
 #include <opm/simulators/linalg/PreconditionerWithUpdate.hpp>
 #include <opm/simulators/linalg/PropertyTree.hpp>
+#include <opm/simulators/linalg/WellOperators.hpp>
+
+#include <opm/common/ErrorMacros.hpp>
 
 #include <dune/istl/operators.hh>
+#include <dune/istl/owneroverlapcopy.hh>
 #include <dune/istl/paamg/pinfo.hh>
 
-namespace Opm {
+#include <functional>
+#include <limits>
+#include <memory>
+#include <type_traits>
+
+
+namespace Opm
+{
 
 // Reservoir operator/comm types used as template arguments.
 template<typename Scalar>
@@ -44,19 +56,50 @@ using ParResOperator = Dune::OverlappingSchwarzOperator<RRMatrix<Scalar>, ResVec
 //
 // Templated on scalar type, reservoir operator and communication types to
 // unify sequential and parallel implementations. The 3-stage algorithm:
-//   1. Reservoir CPR solve
+//   1. Reservoir CPR (or CPRW when WithWellCoupling=true) solve
 //   2. Well solve + reservoir smoothing
 //   3. Final well solve
 //
+// When WithWellCoupling=true (system_cprw), the internal reservoir operator
+// is WellModelMatrixAdapter<RRMatrix,ResVector,ResVector> which exposes the
+// B/C/D blocks via SystemMatrixWellOperator, allowing the standard CPRW
+// preconditioner to build the extended (nCells+nWells) scalar pressure system.
+//
 // For parallel runs, copyOwnerToAll synchronises overlap DOFs before
 // each reservoir sub-solve.
-template <class Scalar, class ResOp, class ResComm = Dune::Amg::SequentialInformation>
+template <class Scalar, class ResOp,
+          class ResComm = Dune::Amg::SequentialInformation,
+          bool WithWellCoupling = false>
 class SystemPreconditioner : public Dune::PreconditionerWithUpdate<SystemVector<Scalar>, SystemVector<Scalar>>
 {
 public:
     static constexpr bool isParallel = !std::is_same_v<ResComm, Dune::Amg::SequentialInformation>;
 
-    using ResFlexibleSolverType = Dune::FlexibleSolver<ResOp>;
+    // When WithWellCoupling=true, the internal resSolver_ uses the "cprw"
+    // preconditioner type, which is registered for WellModelMatrixAdapter
+    // (sequential) and WellModelGhostLastMatrixAdapter (parallel, ghost-last
+    // ordered). Select the matching adapter by parallelism.
+    using SeqWellResOp = WellModelMatrixAdapter<RRMatrix<Scalar>,
+                                                ResVector<Scalar>,
+                                                ResVector<Scalar>>;
+#if HAVE_MPI
+    using ParWellResOp = WellModelGhostLastMatrixAdapter<RRMatrix<Scalar>,
+                                                         ResVector<Scalar>,
+                                                         ResVector<Scalar>,
+                                                         true>;
+#else
+    // Unreachable when MPI is off (isParallel is always false); kept so the
+    // std::conditional_t below stays well-formed.
+    using ParWellResOp = SeqWellResOp;
+#endif
+    using WellResOp = std::conditional_t<isParallel, ParWellResOp, SeqWellResOp>;
+    using InternalResOp = std::conditional_t<WithWellCoupling, WellResOp, ResOp>;
+    using ResFlexibleSolverType = Dune::FlexibleSolver<InternalResOp>;
+    // Smoother always uses ResOp (plain matrix adapter): standard preconditioners such as
+    // paroverilu0 are not registered in the factory for WellModelMatrixAdapter.
+    using SmoothFlexibleSolverType = Dune::FlexibleSolver<ResOp>;
+    using WellOperatorExtra = SystemMatrixWellOperator<Scalar>;
+
     using WellOperator = Dune::MatrixAdapter<WWMatrix<Scalar>, WellVector<Scalar>, WellVector<Scalar>>;
     using WellFlexibleSolverType = Dune::FlexibleSolver<WellOperator>;
 
@@ -116,7 +159,13 @@ public:
 
     void updateForChangedWellStructure()
     {
-        resSolver_->preconditioner().update();
+        if constexpr (WithWellCoupling) {
+            // Well structure change may alter coarse matrix dimensions (nWells changed):
+            // recreate the well operator and reservoir solver from scratch.
+            initResOpAndSolver();
+        } else {
+            resSolver_->preconditioner().update();
+        }
         resSmoother_->preconditioner().update();
         initWellSolver();
         resizeWellWorkVectors();
@@ -206,10 +255,22 @@ private:
     static constexpr int dummyWellPressureIndex = std::numeric_limits<int>::min();
     Opm::PropertyTree wellprm_;
 
-    std::unique_ptr<ResOp> rop_;
+    // Used only when WithWellCoupling=true: stored to allow rebuilding resSolver_
+    // when well structure changes (nWells may change, altering coarse matrix dims).
+    Opm::PropertyTree resSolverPrm_;
+    std::function<ResVector<Scalar>()> resSolverWeightsCalc_;
+
+    // When WithWellCoupling=true, systemWellOper_ must outlive rop_ (held by ref),
+    // and rop_ must outlive resSolver_. Declaration order below respects this so
+    // destruction (reverse order) tears them down safely.
+    std::unique_ptr<WellOperatorExtra> systemWellOper_;
+    std::unique_ptr<InternalResOp> rop_;
+    // When WithWellCoupling=true, rop_ is WellModelMatrixAdapter; the smoother needs a
+    // plain ResOp so that standard preconditioners (paroverilu0 etc.) can be looked up.
+    std::unique_ptr<ResOp> srop_;
     std::unique_ptr<WellOperator> wop_;
     std::unique_ptr<ResFlexibleSolverType> resSolver_;
-    std::unique_ptr<ResFlexibleSolverType> resSmoother_;
+    std::unique_ptr<SmoothFlexibleSolverType> resSmoother_;
     std::unique_ptr<WellFlexibleSolverType> wellSolver_;
 
     WellVector<Scalar> wSol_;
@@ -236,6 +297,52 @@ private:
             *wop_, wellprm_, weightsCalculatorWell, dummyWellPressureIndex);
     }
 
+    // Build the internal reservoir operator and solver for the CPRW
+    // (WithWellCoupling=true) case. The reservoir solver runs on a well-model
+    // adapter wrapping A_rr plus the well coupling exposed by
+    // SystemMatrixWellOperator, so it can use the "cprw" preconditioner type:
+    // WellModelMatrixAdapter serially, WellModelGhostLastMatrixAdapter in parallel.
+    void initResOpAndSolver()
+    {
+        if constexpr (WithWellCoupling) {
+            systemWellOper_ = std::make_unique<WellOperatorExtra>(S_, pressureIndex_);
+            if constexpr (isParallel) {
+                // WellModelGhostLastMatrixAdapter assumes interior rows precede
+                // ghost rows; interiorSize is the owner-row count derived from the
+                // reservoir communication's index set.
+                const std::size_t interiorSize = computeInteriorSize(*resComm_);
+                rop_ = std::make_unique<InternalResOp>(S_[_0][_0], *systemWellOper_, interiorSize);
+                resSolver_ = std::make_unique<ResFlexibleSolverType>(
+                    *rop_, *resComm_, resSolverPrm_, resSolverWeightsCalc_, pressureIndex_);
+            } else {
+                rop_ = std::make_unique<InternalResOp>(S_[_0][_0], *systemWellOper_);
+                resSolver_ = std::make_unique<ResFlexibleSolverType>(
+                    *rop_, resSolverPrm_, resSolverWeightsCalc_, pressureIndex_);
+            }
+        }
+    }
+
+    // Owner-row count for the ghost-last reservoir adapter, derived from the
+    // communication index set (mirrors GhostLastMatrixAdapter::setInteriorSize in
+    // WellOperators.hpp). No grid is available here, so the comm is the source.
+    static std::size_t computeInteriorSize(const ResComm& comm)
+    {
+        if constexpr (isParallel) {
+            const auto& indexSet = comm.indexSet();
+            if (indexSet.size() == 0)
+                return 0;
+            std::size_t is = 0;
+            for (auto idx = indexSet.begin(); idx != indexSet.end(); ++idx) {
+                if (idx->local().attribute() == Dune::OwnerOverlapCopyAttributeSet::owner) {
+                    is = std::max(is, static_cast<std::size_t>(idx->local().local()));
+                }
+            }
+            return is + 1;
+        } else {
+            return 0;
+        }
+    }
+
     void initSubSolvers(const Opm::PropertyTree& prm,
                         const std::function<ResVector<Scalar>()>& weightsCalculator)
     {
@@ -243,17 +350,40 @@ private:
         auto resprmsmoother = prm.get_child("reservoir_smoother");
         wellprm_ = prm.get_child("well_solver");
 
-        if constexpr (isParallel) {
+        if constexpr (WithWellCoupling) {
+            resSolverPrm_ = resprm;
+            resSolverWeightsCalc_ = weightsCalculator;
+            initResOpAndSolver();
+        } else if constexpr (isParallel) {
             rop_ = std::make_unique<ResOp>(S_[_0][_0], *resComm_);
             resSolver_ = std::make_unique<ResFlexibleSolverType>(
                 *rop_, *resComm_, resprm, weightsCalculator, pressureIndex_);
-            resSmoother_ = std::make_unique<ResFlexibleSolverType>(
-                *rop_, *resComm_, resprmsmoother, weightsCalculator, pressureIndex_);
         } else {
             rop_ = std::make_unique<ResOp>(S_[_0][_0]);
             resSolver_ = std::make_unique<ResFlexibleSolverType>(
                 *rop_, resprm, weightsCalculator, pressureIndex_);
-            resSmoother_ = std::make_unique<ResFlexibleSolverType>(
+        }
+
+        // Smoother always operates on a plain ResOp (A_rr only).
+        if constexpr (WithWellCoupling) {
+            // rop_ is a well-model adapter; paroverilu0 and other standard preconditioners
+            // are not registered for that type. Use a plain ResOp wrapper on A_rr instead.
+            // In parallel ResOp is OverlappingSchwarzOperator (full matrix + comm
+            // projection), so no ghost-last assumption is needed for the smoother.
+            if constexpr (isParallel) {
+                srop_ = std::make_unique<ResOp>(S_[_0][_0], *resComm_);
+                resSmoother_ = std::make_unique<SmoothFlexibleSolverType>(
+                    *srop_, *resComm_, resprmsmoother, weightsCalculator, pressureIndex_);
+            } else {
+                srop_ = std::make_unique<ResOp>(S_[_0][_0]);
+                resSmoother_ = std::make_unique<SmoothFlexibleSolverType>(
+                    *srop_, resprmsmoother, weightsCalculator, pressureIndex_);
+            }
+        } else if constexpr (isParallel) {
+            resSmoother_ = std::make_unique<SmoothFlexibleSolverType>(
+                *rop_, *resComm_, resprmsmoother, weightsCalculator, pressureIndex_);
+        } else {
+            resSmoother_ = std::make_unique<SmoothFlexibleSolverType>(
                 *rop_, resprmsmoother, weightsCalculator, pressureIndex_);
         }
 

--- a/opm/simulators/linalg/system/SystemPreconditionerFactory.cpp
+++ b/opm/simulators/linalg/system/SystemPreconditionerFactory.cpp
@@ -49,11 +49,36 @@ void addSystemCprSeq()
                   });
 }
 
+template<typename Scalar>
+void addSystemCprwSeq()
+{
+    using O = Opm::SystemSeqOp<Scalar>;
+    using F = Opm::PreconditionerFactory<O, Dune::Amg::SequentialInformation>;
+    using V = Opm::SystemVector<Scalar>;
+    using P = Opm::PropertyTree;
+
+    F::addCreator("system_cprw",
+                  [](const O& op, const P& prm,
+                     const std::function<V()>& sysWeightCalc,
+                     std::size_t pressureIndex) {
+                      std::function<Opm::ResVector<Scalar>()> resWeightCalc;
+                      if (sysWeightCalc) {
+                          resWeightCalc = [sysWeightCalc]() {
+                              return sysWeightCalc()[Dune::Indices::_0];
+                          };
+                      }
+                      return std::make_shared<
+                          Opm::SystemPreconditioner<Scalar, Opm::SeqResOperator<Scalar>,
+                                                    Dune::Amg::SequentialInformation, true>>(
+                          op.getmat(), resWeightCalc, pressureIndex, prm);
+                  });
+}
+
 #if HAVE_MPI
 // Register a sequential (non-MPI) version of the system_cpr preconditioner
-// for the parallel operator.  This allows each MPI rank to apply a local,
-// communication‑free CPR preconditioner inside the overlapping Schwarz
-// framework.  It is a lightweight alternative to the fully parallel
+// for the parallel operator. This allows each MPI rank to apply a local,
+// communication-free CPR preconditioner inside the overlapping Schwarz
+// framework. It is a lightweight alternative to the fully parallel
 // preconditioner registered by addSystemCprPar().
 template<typename Scalar>
 void addSystemCprParSeq()
@@ -79,6 +104,31 @@ void addSystemCprParSeq()
 }
 
 template<typename Scalar>
+void addSystemCprwParSeq()
+{
+    using O = Opm::SystemParOp<Scalar>;
+    using F = Opm::PreconditionerFactory<O, Dune::Amg::SequentialInformation>;
+    using V = Opm::SystemVector<Scalar>;
+    using P = Opm::PropertyTree;
+
+    F::addCreator("system_cprw",
+                  [](const O& op, const P& prm,
+                     const std::function<V()>& sysWeightCalc,
+                     std::size_t pressureIndex) {
+                      std::function<Opm::ResVector<Scalar>()> resWeightCalc;
+                      if (sysWeightCalc) {
+                          resWeightCalc = [sysWeightCalc]() {
+                              return sysWeightCalc()[Dune::Indices::_0];
+                          };
+                      }
+                      return std::make_shared<
+                          Opm::SystemPreconditioner<Scalar, Opm::SeqResOperator<Scalar>,
+                                                    Dune::Amg::SequentialInformation, true>>(
+                          op.getmat(), resWeightCalc, pressureIndex, prm);
+                  });
+}
+
+template<typename Scalar>
 void addSystemCprPar()
 {
     using O = Opm::SystemParOp<Scalar>;
@@ -98,7 +148,34 @@ void addSystemCprPar()
                           };
                       }
                       const auto& resComm = comm[Dune::Indices::_0];
-                      return std::make_shared<Opm::SystemPreconditioner<Scalar, Opm::ParResOperator<Scalar>, Opm::ParResComm>>(
+                      return std::make_shared<
+                          Opm::SystemPreconditioner<Scalar, Opm::ParResOperator<Scalar>, Opm::ParResComm>>(
+                          op.getmat(), resWeightCalc, pressureIndex, prm, resComm);
+                  });
+}
+
+template<typename Scalar>
+void addSystemCprwPar()
+{
+    using O = Opm::SystemParOp<Scalar>;
+    using F = Opm::PreconditionerFactory<O, Opm::SystemComm>;
+    using V = Opm::SystemVector<Scalar>;
+    using P = Opm::PropertyTree;
+
+    F::addCreator("system_cprw",
+                  [](const O& op, const P& prm,
+                     const std::function<V()>& sysWeightCalc,
+                     std::size_t pressureIndex,
+                     const Opm::SystemComm& comm) {
+                      std::function<Opm::ResVector<Scalar>()> resWeightCalc;
+                      if (sysWeightCalc) {
+                          resWeightCalc = [sysWeightCalc]() {
+                              return sysWeightCalc()[Dune::Indices::_0];
+                          };
+                      }
+                      const auto& resComm = comm[Dune::Indices::_0];
+                      return std::make_shared<
+                          Opm::SystemPreconditioner<Scalar, Opm::ParResOperator<Scalar>, Opm::ParResComm, true>>(
                           op.getmat(), resWeightCalc, pressureIndex, prm, resComm);
                   });
 }
@@ -111,12 +188,14 @@ namespace Opm {
 void StandardPreconditioners<SystemSeqOp<double>, Dune::Amg::SequentialInformation, void>::add()
 {
     addSystemCprSeq<double>();
+    addSystemCprwSeq<double>();
 }
 
 #if FLOW_INSTANTIATE_FLOAT
 void StandardPreconditioners<SystemSeqOp<float>, Dune::Amg::SequentialInformation, void>::add()
 {
     addSystemCprSeq<float>();
+    addSystemCprwSeq<float>();
 }
 #endif
 
@@ -124,22 +203,26 @@ void StandardPreconditioners<SystemSeqOp<float>, Dune::Amg::SequentialInformatio
 void StandardPreconditioners<SystemParOp<double>, Dune::Amg::SequentialInformation, void>::add()
 {
     addSystemCprParSeq<double>();
+    addSystemCprwParSeq<double>();
 }
 
 void StandardPreconditioners<SystemParOp<double>, SystemComm, void>::add()
 {
     addSystemCprPar<double>();
+    addSystemCprwPar<double>();
 }
 
 #if FLOW_INSTANTIATE_FLOAT
 void StandardPreconditioners<SystemParOp<float>, Dune::Amg::SequentialInformation, void>::add()
 {
     addSystemCprParSeq<float>();
+    addSystemCprwParSeq<float>();
 }
 
 void StandardPreconditioners<SystemParOp<float>, SystemComm, void>::add()
 {
     addSystemCprPar<float>();
+    addSystemCprwPar<float>();
 }
 #endif
 #endif

--- a/opm/simulators/linalg/system/SystemPreconditionerFactory.hpp
+++ b/opm/simulators/linalg/system/SystemPreconditionerFactory.hpp
@@ -20,8 +20,11 @@
 #define OPM_SYSTEMPRECONDITIONERFACTORY_HEADER_INCLUDED
 
 #include <opm/simulators/linalg/system/MultiComm.hpp>
+#include <opm/simulators/linalg/system/SystemPreconditioner.hpp>
 #include <opm/simulators/linalg/PreconditionerFactory.hpp>
 #include <opm/simulators/linalg/system/SystemTypes.hpp>
+
+#include <opm/common/ErrorMacros.hpp>
 
 #include <dune/istl/operators.hh>
 #include <dune/istl/paamg/pinfo.hh>
@@ -43,48 +46,225 @@ using SystemParOp = Dune::OverlappingSchwarzOperator<SystemMatrix<Scalar>, Syste
                                                       SystemVector<Scalar>, SystemComm>;
 #endif
 
+// Full specialisations of StandardPreconditioners for the coupled system
+// operators.  Partial specialisations would be ambiguous with the generic
+// serial factory (!is_gpu_operator_v guard), so full specialisations are
+// used; detail:: helpers factor out the shared logic.
 
-template <>
-struct StandardPreconditioners<SystemSeqOp<double>, Dune::Amg::SequentialInformation, void>
-{
-    static void add();
-};
+namespace detail {
 
-#if FLOW_INSTANTIATE_FLOAT
-template <>
-struct StandardPreconditioners<SystemSeqOp<float>, Dune::Amg::SequentialInformation, void>
+template<typename Scalar>
+void addSystemCprSeq()
 {
-    static void add();
-};
+    using O = SystemSeqOp<Scalar>;
+    using F = PreconditionerFactory<O, Dune::Amg::SequentialInformation>;
+    using V = SystemVector<Scalar>;
+    using P = PropertyTree;
+
+    F::addCreator("system_cpr",
+                  [](const O& op, const P& prm,
+                     const std::function<V()>& sysWeightCalc,
+                     std::size_t pressureIndex) {
+                      std::function<ResVector<Scalar>()> resWeightCalc;
+                      if (sysWeightCalc) {
+                          resWeightCalc = [sysWeightCalc]() {
+                              return sysWeightCalc()[Dune::Indices::_0];
+                          };
+                      }
+                      return std::make_shared<SystemPreconditioner<Scalar, SeqResOperator<Scalar>>>(
+                          op.getmat(), resWeightCalc, pressureIndex, prm);
+                  });
+}
+
+// CPRW variant (WithWellCoupling=true): the internal reservoir solver runs on a
+// WellModelMatrixAdapter so it can use the "cprw" preconditioner type.
+template<typename Scalar>
+void addSystemCprwSeq()
+{
+    using O = SystemSeqOp<Scalar>;
+    using F = PreconditionerFactory<O, Dune::Amg::SequentialInformation>;
+    using V = SystemVector<Scalar>;
+    using P = PropertyTree;
+
+    F::addCreator("system_cprw",
+                  [](const O& op, const P& prm,
+                     const std::function<V()>& sysWeightCalc,
+                     std::size_t pressureIndex) {
+                      std::function<ResVector<Scalar>()> resWeightCalc;
+                      if (sysWeightCalc) {
+                          resWeightCalc = [sysWeightCalc]() {
+                              return sysWeightCalc()[Dune::Indices::_0];
+                          };
+                      }
+                      return std::make_shared<
+                          SystemPreconditioner<Scalar, SeqResOperator<Scalar>,
+                                               Dune::Amg::SequentialInformation, true>>(
+                          op.getmat(), resWeightCalc, pressureIndex, prm);
+                  });
+}
+
+#if HAVE_MPI
+// Register a sequential (non-MPI) version of the system_cpr preconditioner
+// for the parallel operator.  This allows each MPI rank to apply a local,
+// communication-free CPR preconditioner inside the overlapping Schwarz
+// framework.  It is a lightweight alternative to the fully parallel
+// preconditioner registered by addSystemCprPar().
+template<typename Scalar>
+void addSystemCprParSeq()
+{
+    using O = SystemParOp<Scalar>;
+    using F = PreconditionerFactory<O, Dune::Amg::SequentialInformation>;
+    using V = SystemVector<Scalar>;
+    using P = PropertyTree;
+
+    F::addCreator("system_cpr",
+                  [](const O& op, const P& prm,
+                     const std::function<V()>& sysWeightCalc,
+                     std::size_t pressureIndex) {
+                      std::function<ResVector<Scalar>()> resWeightCalc;
+                      if (sysWeightCalc) {
+                          resWeightCalc = [sysWeightCalc]() {
+                              return sysWeightCalc()[Dune::Indices::_0];
+                          };
+                      }
+                      return std::make_shared<SystemPreconditioner<Scalar, SeqResOperator<Scalar>>>(
+                          op.getmat(), resWeightCalc, pressureIndex, prm);
+                  });
+}
+
+// Sequential (communication-free) CPRW for the parallel operator: each MPI rank
+// applies a local CPRW preconditioner inside the overlapping Schwarz framework.
+// Mirrors addSystemCprParSeq(), with WithWellCoupling=true.
+template<typename Scalar>
+void addSystemCprwParSeq()
+{
+    using O = SystemParOp<Scalar>;
+    using F = PreconditionerFactory<O, Dune::Amg::SequentialInformation>;
+    using V = SystemVector<Scalar>;
+    using P = PropertyTree;
+
+    F::addCreator("system_cprw",
+                  [](const O& op, const P& prm,
+                     const std::function<V()>& sysWeightCalc,
+                     std::size_t pressureIndex) {
+                      std::function<ResVector<Scalar>()> resWeightCalc;
+                      if (sysWeightCalc) {
+                          resWeightCalc = [sysWeightCalc]() {
+                              return sysWeightCalc()[Dune::Indices::_0];
+                          };
+                      }
+                      return std::make_shared<
+                          SystemPreconditioner<Scalar, SeqResOperator<Scalar>,
+                                               Dune::Amg::SequentialInformation, true>>(
+                          op.getmat(), resWeightCalc, pressureIndex, prm);
+                  });
+}
+
+template<typename Scalar>
+void addSystemCprPar()
+{
+    using O = SystemParOp<Scalar>;
+    using F = PreconditionerFactory<O, SystemComm>;
+    using V = SystemVector<Scalar>;
+    using P = PropertyTree;
+
+    F::addCreator("system_cpr",
+                  [](const O& op, const P& prm,
+                     const std::function<V()>& sysWeightCalc,
+                     std::size_t pressureIndex,
+                     const SystemComm& comm) {
+                      std::function<ResVector<Scalar>()> resWeightCalc;
+                      if (sysWeightCalc) {
+                          resWeightCalc = [sysWeightCalc]() {
+                              return sysWeightCalc()[Dune::Indices::_0];
+                          };
+                      }
+                      const auto& resComm = comm[Dune::Indices::_0];
+                      return std::make_shared<SystemPreconditioner<Scalar, ParResOperator<Scalar>, ParResComm>>(
+                          op.getmat(), resWeightCalc, pressureIndex, prm, resComm);
+                  });
+}
+
+// Fully parallel CPRW: the internal reservoir solver runs on a
+// WellModelGhostLastMatrixAdapter so it can use the parallel "cprw"
+// preconditioner type.  Mirrors addSystemCprPar(), with WithWellCoupling=true.
+template<typename Scalar>
+void addSystemCprwPar()
+{
+    using O = SystemParOp<Scalar>;
+    using F = PreconditionerFactory<O, SystemComm>;
+    using V = SystemVector<Scalar>;
+    using P = PropertyTree;
+
+    F::addCreator("system_cprw",
+                  [](const O& op, const P& prm,
+                     const std::function<V()>& sysWeightCalc,
+                     std::size_t pressureIndex,
+                     const SystemComm& comm) {
+                      std::function<ResVector<Scalar>()> resWeightCalc;
+                      if (sysWeightCalc) {
+                          resWeightCalc = [sysWeightCalc]() {
+                              return sysWeightCalc()[Dune::Indices::_0];
+                          };
+                      }
+                      const auto& resComm = comm[Dune::Indices::_0];
+                      return std::make_shared<
+                          SystemPreconditioner<Scalar, ParResOperator<Scalar>, ParResComm, true>>(
+                          op.getmat(), resWeightCalc, pressureIndex, prm, resComm);
+                  });
+}
 #endif
+
+} // namespace detail
+
+template <>
+struct StandardPreconditioners<SystemSeqOp<double>, Dune::Amg::SequentialInformation, void> {
+    static void add() {
+        detail::addSystemCprSeq<double>();
+        detail::addSystemCprwSeq<double>();
+    }
+};
+
+template <>
+struct StandardPreconditioners<SystemSeqOp<float>, Dune::Amg::SequentialInformation, void> {
+    static void add() {
+        detail::addSystemCprSeq<float>();
+        detail::addSystemCprwSeq<float>();
+    }
+};
 
 #if HAVE_MPI
 template <>
-struct StandardPreconditioners<SystemParOp<double>, Dune::Amg::SequentialInformation, void>
-{
-    static void add();
+struct StandardPreconditioners<SystemParOp<double>, Dune::Amg::SequentialInformation, void> {
+    static void add() {
+        detail::addSystemCprParSeq<double>();
+        detail::addSystemCprwParSeq<double>();
+    }
 };
 
 template <>
-struct StandardPreconditioners<SystemParOp<double>, SystemComm, void>
-{
-    static void add();
-};
-
-#if FLOW_INSTANTIATE_FLOAT
-template <>
-struct StandardPreconditioners<SystemParOp<float>, Dune::Amg::SequentialInformation, void>
-{
-    static void add();
+struct StandardPreconditioners<SystemParOp<float>, Dune::Amg::SequentialInformation, void> {
+    static void add() {
+        detail::addSystemCprParSeq<float>();
+        detail::addSystemCprwParSeq<float>();
+    }
 };
 
 template <>
-struct StandardPreconditioners<SystemParOp<float>, SystemComm, void>
-{
-    static void add();
+struct StandardPreconditioners<SystemParOp<double>, SystemComm, void> {
+    static void add() {
+        detail::addSystemCprPar<double>();
+        detail::addSystemCprwPar<double>();
+    }
 };
 
-#endif
+template <>
+struct StandardPreconditioners<SystemParOp<float>, SystemComm, void> {
+    static void add() {
+        detail::addSystemCprPar<float>();
+        detail::addSystemCprwPar<float>();
+    }
+};
 #endif
 
 } // namespace Opm

--- a/opm/simulators/linalg/system/SystemPreconditionerFactory.hpp
+++ b/opm/simulators/linalg/system/SystemPreconditionerFactory.hpp
@@ -20,11 +20,8 @@
 #define OPM_SYSTEMPRECONDITIONERFACTORY_HEADER_INCLUDED
 
 #include <opm/simulators/linalg/system/MultiComm.hpp>
-#include <opm/simulators/linalg/system/SystemPreconditioner.hpp>
 #include <opm/simulators/linalg/PreconditionerFactory.hpp>
 #include <opm/simulators/linalg/system/SystemTypes.hpp>
-
-#include <opm/common/ErrorMacros.hpp>
 
 #include <dune/istl/operators.hh>
 #include <dune/istl/paamg/pinfo.hh>
@@ -46,225 +43,48 @@ using SystemParOp = Dune::OverlappingSchwarzOperator<SystemMatrix<Scalar>, Syste
                                                       SystemVector<Scalar>, SystemComm>;
 #endif
 
-// Full specialisations of StandardPreconditioners for the coupled system
-// operators.  Partial specialisations would be ambiguous with the generic
-// serial factory (!is_gpu_operator_v guard), so full specialisations are
-// used; detail:: helpers factor out the shared logic.
 
-namespace detail {
-
-template<typename Scalar>
-void addSystemCprSeq()
+template <>
+struct StandardPreconditioners<SystemSeqOp<double>, Dune::Amg::SequentialInformation, void>
 {
-    using O = SystemSeqOp<Scalar>;
-    using F = PreconditionerFactory<O, Dune::Amg::SequentialInformation>;
-    using V = SystemVector<Scalar>;
-    using P = PropertyTree;
+    static void add();
+};
 
-    F::addCreator("system_cpr",
-                  [](const O& op, const P& prm,
-                     const std::function<V()>& sysWeightCalc,
-                     std::size_t pressureIndex) {
-                      std::function<ResVector<Scalar>()> resWeightCalc;
-                      if (sysWeightCalc) {
-                          resWeightCalc = [sysWeightCalc]() {
-                              return sysWeightCalc()[Dune::Indices::_0];
-                          };
-                      }
-                      return std::make_shared<SystemPreconditioner<Scalar, SeqResOperator<Scalar>>>(
-                          op.getmat(), resWeightCalc, pressureIndex, prm);
-                  });
-}
-
-// CPRW variant (WithWellCoupling=true): the internal reservoir solver runs on a
-// WellModelMatrixAdapter so it can use the "cprw" preconditioner type.
-template<typename Scalar>
-void addSystemCprwSeq()
+#if FLOW_INSTANTIATE_FLOAT
+template <>
+struct StandardPreconditioners<SystemSeqOp<float>, Dune::Amg::SequentialInformation, void>
 {
-    using O = SystemSeqOp<Scalar>;
-    using F = PreconditionerFactory<O, Dune::Amg::SequentialInformation>;
-    using V = SystemVector<Scalar>;
-    using P = PropertyTree;
-
-    F::addCreator("system_cprw",
-                  [](const O& op, const P& prm,
-                     const std::function<V()>& sysWeightCalc,
-                     std::size_t pressureIndex) {
-                      std::function<ResVector<Scalar>()> resWeightCalc;
-                      if (sysWeightCalc) {
-                          resWeightCalc = [sysWeightCalc]() {
-                              return sysWeightCalc()[Dune::Indices::_0];
-                          };
-                      }
-                      return std::make_shared<
-                          SystemPreconditioner<Scalar, SeqResOperator<Scalar>,
-                                               Dune::Amg::SequentialInformation, true>>(
-                          op.getmat(), resWeightCalc, pressureIndex, prm);
-                  });
-}
-
-#if HAVE_MPI
-// Register a sequential (non-MPI) version of the system_cpr preconditioner
-// for the parallel operator.  This allows each MPI rank to apply a local,
-// communication-free CPR preconditioner inside the overlapping Schwarz
-// framework.  It is a lightweight alternative to the fully parallel
-// preconditioner registered by addSystemCprPar().
-template<typename Scalar>
-void addSystemCprParSeq()
-{
-    using O = SystemParOp<Scalar>;
-    using F = PreconditionerFactory<O, Dune::Amg::SequentialInformation>;
-    using V = SystemVector<Scalar>;
-    using P = PropertyTree;
-
-    F::addCreator("system_cpr",
-                  [](const O& op, const P& prm,
-                     const std::function<V()>& sysWeightCalc,
-                     std::size_t pressureIndex) {
-                      std::function<ResVector<Scalar>()> resWeightCalc;
-                      if (sysWeightCalc) {
-                          resWeightCalc = [sysWeightCalc]() {
-                              return sysWeightCalc()[Dune::Indices::_0];
-                          };
-                      }
-                      return std::make_shared<SystemPreconditioner<Scalar, SeqResOperator<Scalar>>>(
-                          op.getmat(), resWeightCalc, pressureIndex, prm);
-                  });
-}
-
-// Sequential (communication-free) CPRW for the parallel operator: each MPI rank
-// applies a local CPRW preconditioner inside the overlapping Schwarz framework.
-// Mirrors addSystemCprParSeq(), with WithWellCoupling=true.
-template<typename Scalar>
-void addSystemCprwParSeq()
-{
-    using O = SystemParOp<Scalar>;
-    using F = PreconditionerFactory<O, Dune::Amg::SequentialInformation>;
-    using V = SystemVector<Scalar>;
-    using P = PropertyTree;
-
-    F::addCreator("system_cprw",
-                  [](const O& op, const P& prm,
-                     const std::function<V()>& sysWeightCalc,
-                     std::size_t pressureIndex) {
-                      std::function<ResVector<Scalar>()> resWeightCalc;
-                      if (sysWeightCalc) {
-                          resWeightCalc = [sysWeightCalc]() {
-                              return sysWeightCalc()[Dune::Indices::_0];
-                          };
-                      }
-                      return std::make_shared<
-                          SystemPreconditioner<Scalar, SeqResOperator<Scalar>,
-                                               Dune::Amg::SequentialInformation, true>>(
-                          op.getmat(), resWeightCalc, pressureIndex, prm);
-                  });
-}
-
-template<typename Scalar>
-void addSystemCprPar()
-{
-    using O = SystemParOp<Scalar>;
-    using F = PreconditionerFactory<O, SystemComm>;
-    using V = SystemVector<Scalar>;
-    using P = PropertyTree;
-
-    F::addCreator("system_cpr",
-                  [](const O& op, const P& prm,
-                     const std::function<V()>& sysWeightCalc,
-                     std::size_t pressureIndex,
-                     const SystemComm& comm) {
-                      std::function<ResVector<Scalar>()> resWeightCalc;
-                      if (sysWeightCalc) {
-                          resWeightCalc = [sysWeightCalc]() {
-                              return sysWeightCalc()[Dune::Indices::_0];
-                          };
-                      }
-                      const auto& resComm = comm[Dune::Indices::_0];
-                      return std::make_shared<SystemPreconditioner<Scalar, ParResOperator<Scalar>, ParResComm>>(
-                          op.getmat(), resWeightCalc, pressureIndex, prm, resComm);
-                  });
-}
-
-// Fully parallel CPRW: the internal reservoir solver runs on a
-// WellModelGhostLastMatrixAdapter so it can use the parallel "cprw"
-// preconditioner type.  Mirrors addSystemCprPar(), with WithWellCoupling=true.
-template<typename Scalar>
-void addSystemCprwPar()
-{
-    using O = SystemParOp<Scalar>;
-    using F = PreconditionerFactory<O, SystemComm>;
-    using V = SystemVector<Scalar>;
-    using P = PropertyTree;
-
-    F::addCreator("system_cprw",
-                  [](const O& op, const P& prm,
-                     const std::function<V()>& sysWeightCalc,
-                     std::size_t pressureIndex,
-                     const SystemComm& comm) {
-                      std::function<ResVector<Scalar>()> resWeightCalc;
-                      if (sysWeightCalc) {
-                          resWeightCalc = [sysWeightCalc]() {
-                              return sysWeightCalc()[Dune::Indices::_0];
-                          };
-                      }
-                      const auto& resComm = comm[Dune::Indices::_0];
-                      return std::make_shared<
-                          SystemPreconditioner<Scalar, ParResOperator<Scalar>, ParResComm, true>>(
-                          op.getmat(), resWeightCalc, pressureIndex, prm, resComm);
-                  });
-}
+    static void add();
+};
 #endif
 
-} // namespace detail
-
-template <>
-struct StandardPreconditioners<SystemSeqOp<double>, Dune::Amg::SequentialInformation, void> {
-    static void add() {
-        detail::addSystemCprSeq<double>();
-        detail::addSystemCprwSeq<double>();
-    }
-};
-
-template <>
-struct StandardPreconditioners<SystemSeqOp<float>, Dune::Amg::SequentialInformation, void> {
-    static void add() {
-        detail::addSystemCprSeq<float>();
-        detail::addSystemCprwSeq<float>();
-    }
-};
-
 #if HAVE_MPI
 template <>
-struct StandardPreconditioners<SystemParOp<double>, Dune::Amg::SequentialInformation, void> {
-    static void add() {
-        detail::addSystemCprParSeq<double>();
-        detail::addSystemCprwParSeq<double>();
-    }
+struct StandardPreconditioners<SystemParOp<double>, Dune::Amg::SequentialInformation, void>
+{
+    static void add();
 };
 
 template <>
-struct StandardPreconditioners<SystemParOp<float>, Dune::Amg::SequentialInformation, void> {
-    static void add() {
-        detail::addSystemCprParSeq<float>();
-        detail::addSystemCprwParSeq<float>();
-    }
+struct StandardPreconditioners<SystemParOp<double>, SystemComm, void>
+{
+    static void add();
+};
+
+#if FLOW_INSTANTIATE_FLOAT
+template <>
+struct StandardPreconditioners<SystemParOp<float>, Dune::Amg::SequentialInformation, void>
+{
+    static void add();
 };
 
 template <>
-struct StandardPreconditioners<SystemParOp<double>, SystemComm, void> {
-    static void add() {
-        detail::addSystemCprPar<double>();
-        detail::addSystemCprwPar<double>();
-    }
+struct StandardPreconditioners<SystemParOp<float>, SystemComm, void>
+{
+    static void add();
 };
 
-template <>
-struct StandardPreconditioners<SystemParOp<float>, SystemComm, void> {
-    static void add() {
-        detail::addSystemCprPar<float>();
-        detail::addSystemCprwPar<float>();
-    }
-};
+#endif
 #endif
 
 } // namespace Opm

--- a/tests/options_system_cprw_missing_ressolver.json
+++ b/tests/options_system_cprw_missing_ressolver.json
@@ -1,0 +1,26 @@
+{
+    "maxiter": "20",
+    "tol": "0.005",
+    "verbosity": "0",
+    "solver": "bicgstab",
+    "preconditioner": {
+        "type": "system_cprw",
+        "reservoir_smoother": {
+            "maxiter": "1",
+            "tol": "0.005",
+            "verbosity": "0",
+            "solver": "preconditioner2inverseoperator",
+            "preconditioner": {
+                "type": "paroverilu0",
+                "relaxation": "1"
+            }
+        },
+        "well_solver": {
+            "maxiter": "1",
+            "tol": "0.005",
+            "verbosity": "0",
+            "solver": "umfpack"
+        }
+    }
+}
+

--- a/tests/options_system_cprw_missing_smoother.json
+++ b/tests/options_system_cprw_missing_smoother.json
@@ -1,0 +1,25 @@
+{
+    "maxiter": "20",
+    "tol": "0.005",
+    "verbosity": "0",
+    "solver": "bicgstab",
+    "preconditioner": {
+        "type": "system_cprw",
+        "reservoir_solver": {
+            "maxiter": "1",
+            "tol": "0.005",
+            "verbosity": "0",
+            "solver": "preconditioner2inverseoperator",
+            "preconditioner": {
+                "type": "cprw"
+            }
+        },
+        "well_solver": {
+            "maxiter": "1",
+            "tol": "0.005",
+            "verbosity": "0",
+            "solver": "umfpack"
+        }
+    }
+}
+

--- a/tests/options_system_cprw_missing_well.json
+++ b/tests/options_system_cprw_missing_well.json
@@ -1,0 +1,29 @@
+{
+    "maxiter": "20",
+    "tol": "0.005",
+    "verbosity": "0",
+    "solver": "bicgstab",
+    "preconditioner": {
+        "type": "system_cprw",
+        "reservoir_smoother": {
+            "maxiter": "1",
+            "tol": "0.005",
+            "verbosity": "0",
+            "solver": "preconditioner2inverseoperator",
+            "preconditioner": {
+                "type": "paroverilu0",
+                "relaxation": "1"
+            }
+        },
+        "reservoir_solver": {
+            "maxiter": "1",
+            "tol": "0.005",
+            "verbosity": "0",
+            "solver": "preconditioner2inverseoperator",
+            "preconditioner": {
+                "type": "cprw"
+            }
+        }
+    }
+}
+

--- a/tests/options_system_cprw_res_precond_not_cprw.json
+++ b/tests/options_system_cprw_res_precond_not_cprw.json
@@ -1,0 +1,36 @@
+{
+    "maxiter": "20",
+    "tol": "0.005",
+    "verbosity": "0",
+    "solver": "bicgstab",
+    "preconditioner": {
+        "type": "system_cprw",
+        "reservoir_smoother": {
+            "maxiter": "1",
+            "tol": "0.005",
+            "verbosity": "0",
+            "solver": "preconditioner2inverseoperator",
+            "preconditioner": {
+                "type": "paroverilu0",
+                "relaxation": "1"
+            }
+        },
+        "reservoir_solver": {
+            "maxiter": "1",
+            "tol": "0.005",
+            "verbosity": "0",
+            "solver": "preconditioner2inverseoperator",
+            "preconditioner": {
+                "type": "cpr",
+                "relaxation": "1"
+            }
+        },
+        "well_solver": {
+            "maxiter": "1",
+            "tol": "0.005",
+            "verbosity": "0",
+            "solver": "umfpack"
+        }
+    }
+}
+

--- a/tests/test_setuppropertytree.cpp
+++ b/tests/test_setuppropertytree.cpp
@@ -72,6 +72,32 @@ BOOST_AUTO_TEST_CASE(JSONReservoirSolverPreconditionerTypeMissingOrWrong)
     BOOST_CHECK_THROW(Opm::validateSystemCPRTree(prm2), std::invalid_argument);
 }
 
+// Unit tests for system_cprw – same structural requirements as system_cpr.
+BOOST_AUTO_TEST_CASE(JSONSystemCPRWMissingWellSolver)
+{
+    Opm::PropertyTree prm("options_system_cprw_missing_well.json");
+    BOOST_CHECK_THROW(Opm::validateSystemCPRTree(prm), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(JSONSystemCPRWMissingReservoirSolver)
+{
+    Opm::PropertyTree prm("options_system_cprw_missing_ressolver.json");
+    BOOST_CHECK_THROW(Opm::validateSystemCPRTree(prm), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(JSONSystemCPRWMissingReservoirSmoother)
+{
+    Opm::PropertyTree prm("options_system_cprw_missing_smoother.json");
+    BOOST_CHECK_THROW(Opm::validateSystemCPRTree(prm), std::invalid_argument);
+}
+
+// system_cprw's reservoir_solver must use cprw, not plain cpr.
+BOOST_AUTO_TEST_CASE(JSONSystemCPRWReservoirSolverMustUseCPRW)
+{
+    Opm::PropertyTree prm("options_system_cprw_res_precond_not_cprw.json");
+    BOOST_CHECK_THROW(Opm::validateSystemCPRTree(prm), std::invalid_argument);
+}
+
 // Regression test: --matrix-add-well-contributions=true is incompatible
 // with system_cpr and must throw in both serial and parallel (MPI) runs.
 //


### PR DESCRIPTION
Extend the system CPR solver path with a new `system_cprw` preconditioner for full coupled (reservoir + well) linear systems. The CPRW path builds an extended pressure system of size (nCells + nWells) so well BHP variables are coupled directly in the pressure solve.

Main changes:
- add `SystemMatrixWellOperator` to expose `A_wr`, `A_rw`, and `A_ww` to well-model matrix adapters used by CPRW
- add `system_cprw` setup/dispatch in linear-solver configuration handling
- implement CPRW pressure-system assembly, including well-weight handling and robust diagonal fallback behavior
- support both sequential and parallel paths via `WellModelMatrixAdapter` and `WellModelGhostLastMatrixAdapter`
- register `system_cprw` preconditioner factories for seq/par variants
- extend JSON validation for `system_cpr`/`system_cprw` reservoir-solver compatibility and add dedicated `system_cprw` validation tests/fixtures

This provides a well-coupled baseline for cases with strong reservoir-well interaction while preserving compatibility with existing `system_cpr` usage.