### PR TITLE
[LGR] flow: reuse parallel regression driver for INIT compare

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -289,6 +289,7 @@ function(add_test_compare_parallel_simulation)
     DIR
     POSTFIX
     MPI_PROCS
+    COMPARE_MODE
   )
   set(multiValueArgs TEST_ARGS)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
@@ -313,6 +314,17 @@ function(add_test_compare_parallel_simulation)
     set(PARAM_SIMULATOR ${PARAM_DEV_SIMULATOR})
   endif()
 
+  # COMPARE_MODE "init": dry-run, compares EGRID+INIT only (parallel INIT-file regressions,
+  # e.g. parallel LGR transmissibility). Default (unset): compares SMRY+UNRST as before.
+  if(PARAM_COMPARE_MODE STREQUAL "init")
+    set(TEST_NAME_PREFIX compareParallelInitSim_)
+  elseif(PARAM_COMPARE_MODE)
+    message(FATAL_ERROR "add_test_compare_parallel_simulation(${PARAM_CASENAME}): "
+                        "unknown COMPARE_MODE '${PARAM_COMPARE_MODE}' (expected 'init' or unset)")
+  else()
+    set(TEST_NAME_PREFIX compareParallelSim_)
+  endif()
+
   if(MPIEXEC_MAX_NUMPROCS GREATER_EQUAL MPI_PROCS)
     # Local computer system has at least ${MPI_PROCS} CPUs. Register test.
     set(RESULT_PATH ${BASE_RESULT_PATH}/parallel/${PARAM_SIMULATOR}+${PARAM_CASENAME})
@@ -325,9 +337,12 @@ function(add_test_compare_parallel_simulation)
                     -t ${PARAM_REL_TOL}
                     -c $<TARGET_FILE:compareECL>
                     -n ${MPI_PROCS})
+    if(PARAM_COMPARE_MODE STREQUAL "init")
+      list(APPEND DRIVER_ARGS -m init)
+    endif()
 
     # Add test that runs flow_mpi and outputs the results to file
-    opm_add_test(compareParallelSim_${PARAM_SIMULATOR}+${PARAM_FILENAME}${PARAM_POSTFIX}
+    opm_add_test(${TEST_NAME_PREFIX}${PARAM_SIMULATOR}+${PARAM_FILENAME}${PARAM_POSTFIX}
       EXE_TARGET
         ${PARAM_SIMULATOR}
       DRIVER_ARGS
@@ -335,7 +350,7 @@ function(add_test_compare_parallel_simulation)
       TEST_ARGS
         ${TEST_ARGS}
     )
-    set_tests_properties(compareParallelSim_${PARAM_SIMULATOR}+${PARAM_FILENAME}${PARAM_POSTFIX}
+    set_tests_properties(${TEST_NAME_PREFIX}${PARAM_SIMULATOR}+${PARAM_FILENAME}${PARAM_POSTFIX}
                          PROPERTIES PROCESSORS ${MPI_PROCS})
   endif()
 endfunction()

--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -946,6 +946,33 @@ add_test_compare_parallel_simulation(
     --linear-solver-reduction=1e-7
 )
 
+# Parallel LGR INIT/EGRID regression: reuses the existing SPE1CASE1_CARFIN deck (opm-tests/lgr,
+# already registered for spe1case1_carfin/spe1case1_carfin_parallel in compareECLFiles.cmake) and
+# the existing run-parallel-regressionTest.sh driver (COMPARE_MODE init: dry-run, compares
+# EGRID+INIT instead of SMRY+UNRST). Guards the parallel LGR INIT transmissibility output
+# (gatherLgrOutputTrans + the EclGenericWriter gathered-record lookups) -- pre-fix, the
+# parallel run deadlocks here.
+add_test_compare_parallel_simulation(
+  CASENAME
+    spe1case1_carfin
+  FILENAME
+    SPE1CASE1_CARFIN
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  DIR
+    lgr
+  ABS_TOL
+    1e-3
+  REL_TOL
+    1e-5
+  COMPARE_MODE
+    init
+  TEST_ARGS
+    --parsing-strictness=low
+)
+
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-comparison.sh "")
 
 add_test_compareSeparateECLFiles(
@@ -1011,3 +1038,4 @@ add_test_compareSeparateECLFiles(
     --matrix-add-well-contributions=true
     --linear-solver=ilu0
 )
+

--- a/tests/run-parallel-regressionTest.sh
+++ b/tests/run-parallel-regressionTest.sh
@@ -17,13 +17,18 @@ then
   echo -e "\t\t -e <filename> Simulator binary to use"
   echo -e "\tOptional options:"
   echo -e "\t\t -n <procs>    Number of MPI processes to use"
+  echo -e "\t\t -m <mode>     Comparison mode: summary (default, compares SMRY+UNRST"
+  echo -e "\t\t               against a normal run) or init (dry-run, compares"
+  echo -e "\t\t               EGRID+INIT only -- for tracking parallel INIT-file"
+  echo -e "\t\t               regressions, e.g. parallel LGR transmissibility)"
   exit 1
 fi
 
 MPI_PROCS=4
+MODE=summary
 OPTIND=1
 
-while getopts "i:r:f:a:t:c:e:n:" OPT
+while getopts "i:r:f:a:t:c:e:n:m:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
@@ -34,38 +39,71 @@ do
     c) COMPARE_ECL_COMMAND=${OPTARG} ;;
     e) EXE_NAME=${OPTARG} ;;
     n) MPI_PROCS=${OPTARG} ;;
+    m) MODE=${OPTARG} ;;
   esac
 done
 shift $(($OPTIND-1))
 TEST_ARGS="$@"
 
+case "${MODE:-summary}" in
+  summary|init) ;;
+  *) echo "Unknown mode '${MODE}' (expected 'summary' or 'init')"; exit 1 ;;
+esac
+
+if [ "${MODE}" = "init" ]
+then
+  RUN_FLAG="--enable-dry-run=true --enable-ecl-output=true"
+else
+  RUN_FLAG="--enable-opm-rst-file=true"
+fi
+
 rm -Rf ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-"${EXE_NAME}" ${TEST_ARGS} --enable-opm-rst-file=true --output-dir=${RESULT_PATH}
+"${EXE_NAME}" ${TEST_ARGS} ${RUN_FLAG} --output-dir=${RESULT_PATH}
 
 test $? -eq 0 || exit 1
 mkdir mpi
 cd mpi
-mpirun -np ${MPI_PROCS} "${EXE_NAME}" ${TEST_ARGS} --enable-opm-rst-file=true --output-dir=${RESULT_PATH}/mpi
+mpirun -np ${MPI_PROCS} "${EXE_NAME}" ${TEST_ARGS} ${RUN_FLAG} --output-dir=${RESULT_PATH}/mpi
 test $? -eq 0 || exit 1
 cd ..
 
 ecode=0
-echo "=== Executing comparison for summary file ==="
-${COMPARE_ECL_COMMAND} -t SMRY -R ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
-if [ $? -ne 0 ]
+if [ "${MODE}" = "init" ]
 then
-  ecode=1
-  ${COMPARE_ECL_COMMAND} -t SMRY -a -R ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
-fi
+  echo "=== Executing comparison for EGRID file ==="
+  ${COMPARE_ECL_COMMAND} -t EGRID ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  if [ $? -ne 0 ]
+  then
+    ecode=1
+    ${COMPARE_ECL_COMMAND} -a -t EGRID ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  fi
 
-echo "=== Executing comparison for restart file ==="
-${COMPARE_ECL_COMMAND} -l -t UNRST ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
-if [ $? -ne 0 ]
-then
-  ecode=1
-  ${COMPARE_ECL_COMMAND} -a -l -t UNRST ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  # -x ignores the parallel-only MPI_RANK keyword, which has no serial counterpart to compare against.
+  echo "=== Executing comparison for INIT file (ignoring parallel-only MPI_RANK) ==="
+  ${COMPARE_ECL_COMMAND} -t INIT -x ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  if [ $? -ne 0 ]
+  then
+    ecode=1
+    ${COMPARE_ECL_COMMAND} -a -t INIT -x ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  fi
+else
+  echo "=== Executing comparison for summary file ==="
+  ${COMPARE_ECL_COMMAND} -t SMRY -R ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  if [ $? -ne 0 ]
+  then
+    ecode=1
+    ${COMPARE_ECL_COMMAND} -t SMRY -a -R ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  fi
+
+  echo "=== Executing comparison for restart file ==="
+  ${COMPARE_ECL_COMMAND} -l -t UNRST ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  if [ $? -ne 0 ]
+  then
+    ecode=1
+    ${COMPARE_ECL_COMMAND} -a -l -t UNRST ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  fi
 fi
 
 exit $ecode


### PR DESCRIPTION
This PR is now intentionally scoped to the reusable test infrastructure only.

It keeps the existing parallel regression driver and adds an `init` comparison mode so parallel INIT output can be checked through the standard infrastructure:

- `run-parallel-regressionTest.sh` gains `-m init` while keeping the default summary behavior unchanged.
- `add_test_compare_parallel_simulation` gains `COMPARE_MODE init`.
- The registration reuses the existing `SPE1CASE1_CARFIN` deck from opm-tests.

The parallel LGR INIT feature commit has been split out into a follow-up PR as requested, so this PR can be reviewed/merged as the small infrastructure step.

Testing reported earlier on the folded branch:
- `compareParallelInitSim_flow+SPE1CASE1_CARFIN` passed
- `compareParallelSim_flow+SPE1CASE2` passed
