### PR TITLE
Fix CT influence table at last tabulated Td.

### DIFF
--- a/opm/simulators/aquifers/AquiferCarterTracy.hpp
+++ b/opm/simulators/aquifers/AquiferCarterTracy.hpp
@@ -142,8 +142,7 @@ protected:
     AquiferCT::AQUCT_data aquct_data_;
 
     Scalar beta_; // Influx constant
-    // TODO: it is possible it should be a AD variable
-    Scalar fluxValue_{0}; // value of flux
+    Scalar fluxValue_{0}; // cumulative influx W (previous step)
 
     Scalar dimensionless_time_{0};
     Scalar dimensionless_pressure_{0};
@@ -157,19 +156,20 @@ protected:
     std::pair<Scalar, Scalar>
     getInfluenceTableValues(const Scalar td_plus_dt)
     {
-        // We use the opm-common numeric linear interpolator
         this->dimensionless_pressure_ =
-            linearInterpolation(this->aquct_data_.dimensionless_time,
+            linearInterpolationNoExtrapolation(this->aquct_data_.dimensionless_time,
                                 this->aquct_data_.dimensionless_pressure,
                                 this->dimensionless_time_);
 
         const auto PItd =
-            linearInterpolation(this->aquct_data_.dimensionless_time,
+            linearInterpolationNoExtrapolation(this->aquct_data_.dimensionless_time,
                                 this->aquct_data_.dimensionless_pressure,
                                 td_plus_dt);
-
-        const auto PItdprime =
-            linearInterpolationDerivative(this->aquct_data_.dimensionless_time,
+        // Fix PItd at td_max; set PItd' to zero for td_plus_dt >= td_max.
+        const Scalar td_max = this->aquct_data_.dimensionless_time.back();
+        const auto PItdprime = td_plus_dt >= td_max
+            ? Scalar{0}
+            : linearInterpolationDerivative(this->aquct_data_.dimensionless_time,
                                           this->aquct_data_.dimensionless_pressure,
                                           td_plus_dt);
 


### PR DESCRIPTION
## Summary
Finite-radius Carter–Tracy aquifers (`AQTAB` > 1) use influence tables that end at a
maximum dimensionless time `td_max`. After simulation time exceeds that point,
`linearInterpolation` extrapolates `PItd` and `PItd'` beyond the table. The
extrapolated derivative stays non-zero, the Eq. 5.8 history term `W·PItd'` grows,
and aquifer influx can be choked even when connection-block drawdown is still large.

This change:
- evaluates `PItd` with `linearInterpolationNoExtrapolation` (terminal table value
  beyond `td_max`);
- sets `PItd'` to zero for `td_plus_dt >= td_max`;
- removes a TODO suggesting `fluxValue_` should be an AD variable (should not be 
  the case). 
- document `fluxValue_` as cumulative influx `W` from the previous time step
  (explicit history in Eq. 5.8; `Qai_` remains `Evaluation` for implicit conn-pressure
  coupling in Eq. 5.7).

## Validation
Local dead-oil analytic-aquifer case with Aquifer 2 `AQTAB=3` (finite radius):
connection-block pressure, `AAQR:2`, and cumulative `AAQT:2` broadly match the
reference simulator after this fix. Prior behaviour showed conn pressure collapse
and weak aquifer support from Feb 2012 onward while the reference maintained support.

## Attachments
- **aqbhp-aqtab3_before.pdf:** Simulator output of Flow before modifications. 
- **aqbhp-aqtab3.pdf:** Simulator output of Flow after modifications.
- **faqbhp.tgz:** Flow simulation test case.

[aqbhp_aqtab3_before.pdf](https://github.com/user-attachments/files/29658309/aqbhp_aqtab3_before.pdf)
[aqbhp_aqtab3.pdf](https://github.com/user-attachments/files/29658353/aqbhp_aqtab3.pdf)
[faqbhp.tgz](https://github.com/user-attachments/files/29658460/faqbhp.tgz)
