### PR TITLE
Enable zoltan coarse graph partitioning in opm-grid

### DIFF
--- a/opm/simulators/flow/CpGridVanguard.hpp
+++ b/opm/simulators/flow/CpGridVanguard.hpp
@@ -250,7 +250,9 @@ public:
                              this->imbalanceTol(),
                              this->gridView(), this->schedule(),
                              this->eclState(), this->parallelWells_,
-                             this->numJacobiBlocks(), this->enableEclOutput());
+                             this->numJacobiBlocks(), this->enableEclOutput(),
+                             this->coarsePartitionGraphThreshold(),
+                             this->coarsePartitionMaxNodeSize());
 #endif
 
         this->updateGridView_();

--- a/opm/simulators/flow/FlowGenericVanguard.cpp
+++ b/opm/simulators/flow/FlowGenericVanguard.cpp
@@ -129,6 +129,8 @@ FlowGenericVanguard::FlowGenericVanguard(SimulationModelParams&& params)
         OpmLog::error(msg);
         throw std::runtime_error(msg);
     }
+    coarsePartitionGraphThreshold_ = Parameters::Get<Parameters::CoarsePartitionGraphThreshold<double>>();
+    coarsePartitionMaxNodeSize_ = Parameters::Get<Parameters::CoarsePartitionMaxNodeSize>();
 
 #if HAVE_OPENCL || HAVE_ROCSPARSE || HAVE_CUDA
     numJacobiBlocks_ = Parameters::Get<Parameters::NumJacobiBlocks>();
@@ -150,9 +152,11 @@ FlowGenericVanguard::FlowGenericVanguard(SimulationModelParams&& params)
         partitionMethod_ = Dune::PartitionMethod::metis;
     } else if (pm == "zoltanwell") {
         partitionMethod_ = Dune::PartitionMethod::zoltanGoG;
+    } else if (pm == "zoltanCG") {
+        partitionMethod_ = Dune::PartitionMethod::zoltanCG;
     } else {
         std::string msg = fmt::format("Unknown value for --partition-method parameter: '{}'. "
-                                      "Accepted values are 'simple', 'zoltan', 'metis', and 'zoltanwell'.",
+                                      "Accepted values are 'simple', 'zoltan', 'metis', 'zoltanCG' and 'zoltanwell'.",
                                       pm);
         OpmLog::error(msg);
         throw std::runtime_error(msg);
@@ -482,7 +486,10 @@ void FlowGenericVanguard::registerParameters_()
          "groups from historical SCHEDULE section.");
     Parameters::Register<Parameters::EdgeWeightsMethod>
         ("Choose edge-weighing strategy: 'uniform', 'transmissibility', or 'logtrans' (logarithm of transmissibility).");
-
+    Parameters::Register<Parameters::CoarsePartitionGraphThreshold<Scalar>>
+        ("Merge large transmissibility connected vertices in the partitioning graph. Number between 0 and 1.");
+    Parameters::Register<Parameters::CoarsePartitionMaxNodeSize>
+        ("Maximal size of a single node in coarse graph partitioning method.");
 #if HAVE_OPENCL || HAVE_ROCSPARSE || HAVE_CUDA
     Parameters::Register<Parameters::NumJacobiBlocks>
         ("Number of blocks to be created for the Block-Jacobi preconditioner.");
@@ -499,7 +506,7 @@ void FlowGenericVanguard::registerParameters_()
     Parameters::Register<Parameters::NumOverlap>
         ("Numbers of layers overlap in parallel partition");
     Parameters::Register<Parameters::PartitionMethod>
-        ("Choose partitioning method: 'simple', 'zoltan', 'metis', or "
+        ("Choose partitioning method: 'simple', 'zoltan', 'metis', zoltanCG or "
          "'zoltanwell' (Zoltan with all cells perforated by a well represented by a single vertex).");
     Parameters::Register<Parameters::SerialPartitioning>
         ("Perform partitioning for parallel runs on a single process.");

--- a/opm/simulators/flow/FlowGenericVanguard.hpp
+++ b/opm/simulators/flow/FlowGenericVanguard.hpp
@@ -52,6 +52,9 @@ struct AllowSplittingInactiveWells { static constexpr bool value = true; };
 
 struct EclOutputInterval { static constexpr int value = -1; };
 struct EdgeWeightsMethod  { static constexpr auto value = "transmissibility"; };
+template<class Scalar>
+struct CoarsePartitionGraphThreshold { static constexpr Scalar value = 0.9; };
+struct CoarsePartitionMaxNodeSize { static constexpr int value = -1; };
 struct EnableDryRun { static constexpr auto value = "auto"; };
 struct EnableEclOutput { static constexpr auto value = true; };
 struct EnableOpmRstFile { static constexpr bool value = false; };
@@ -242,6 +245,11 @@ public:
     Dune::EdgeWeightMethod edgeWeightsMethod() const
     { return edgeWeightsMethod_; }
 
+    double coarsePartitionGraphThreshold() const
+    {return coarsePartitionGraphThreshold_; }
+    
+    int coarsePartitionMaxNodeSize() const
+    {return coarsePartitionMaxNodeSize_;}
     /*!
      * \brief Number of blocks in the Block-Jacobi preconditioner.
      */
@@ -370,6 +378,8 @@ protected:
     std::string caseName_;
     std::string fileName_;
     Dune::EdgeWeightMethod edgeWeightsMethod_;
+    double coarsePartitionGraphThreshold_;
+    int coarsePartitionMaxNodeSize_;
 
 #if HAVE_OPENCL || HAVE_ROCSPARSE || HAVE_CUDA
     int numJacobiBlocks_{0};

--- a/opm/simulators/flow/GenericCpGridVanguard.cpp
+++ b/opm/simulators/flow/GenericCpGridVanguard.cpp
@@ -165,10 +165,13 @@ doLoadBalance_(const Dune::EdgeWeightMethod             edgeWeightsMethod,
                EclipseState&                            eclState1,
                FlowGenericVanguard::ParallelWellStruct& parallelWells,
                const int                                numJacobiBlocks,
-               const bool                               enableEclOutput)
+               const bool                               enableEclOutput,
+               const double                             coarsePartitionGraphThreshold,
+               const int                                coarsePartitionMaxNodeSize)
 {
     if (((partitionMethod == Dune::PartitionMethod::zoltan) ||
-         (partitionMethod == Dune::PartitionMethod::zoltanGoG)) &&
+         (partitionMethod == Dune::PartitionMethod::zoltanGoG ||
+          partitionMethod == Dune::PartitionMethod::zoltanCG)) &&
         !this->zoltanParams().empty())
     {
         this->grid_->setPartitioningParams
@@ -212,6 +215,23 @@ doLoadBalance_(const Dune::EdgeWeightMethod             edgeWeightsMethod,
             }
         }
 
+        Dune::BCRSMatrix<Dune::FieldMatrix<double, 1, 1>> graph;
+        double coarseThreshold = -1;
+        int coarseMaxNodeSize = coarsePartitionMaxNodeSize;
+        if (partitionMethod == Dune::PartitionMethod::zoltanCG) {
+            if (this->grid_->comm().rank() == 0) {
+
+                //Construct transmissibility graph and calculate coarseThreshold 
+                coarseThreshold = this->constructTransGraph(gridView, graph, coarsePartitionGraphThreshold);
+
+                if (coarseMaxNodeSize == -1) {
+
+                    //Set max-node size to max( 1, 0.5 * numCells/numPart )
+                    coarseMaxNodeSize = std::max (1, (int) ( this->grid_->numCells() / ( 2.0 * this->grid_->comm().size() ) ) );
+                }
+            }
+        }
+
         // Skipping inactive wells in partitioning currently does not play nice with restart..
         const bool restart = eclState1.getInitConfig().restartRequested();
         const bool split_inactive = (!restart && allowSplittingInactiveWells);
@@ -234,7 +254,8 @@ doLoadBalance_(const Dune::EdgeWeightMethod             edgeWeightsMethod,
                                                                  useTransToFilterOverlap,
                                  faceTrans, wells,
                                  possibleFutureConnections,
-                                 eclState1, parallelWells);
+                                 eclState1, parallelWells, graph,
+                                 coarseThreshold, coarseMaxNodeSize);
         }
 
         // Add inactive wells to all ranks with connections (not solved, so OK even without distributed wells)
@@ -359,6 +380,58 @@ extractFaceTrans(const GridView& gridView) const
 }
 
 template <class ElementMapper, class GridView, class Scalar>
+double
+GenericCpGridVanguard<ElementMapper, GridView, Scalar>::
+constructTransGraph(const GridView& gridView,
+                    Dune::BCRSMatrix<Dune::FieldMatrix<double, 1, 1>>& graph,
+                    const double coarsePartitionGraphThreshold) const
+{
+    size_t numCells = this->grid_->numCells();
+
+    Dune::MatrixIndexSet op;
+    op.resize( numCells, numCells );
+
+    const auto elemMapper = ElementMapper { gridView, Dune::mcmgElementLayout() };
+
+    // Create adjecency for transmissibility graph
+    for (const auto& elem : elements(gridView, Dune::Partitions::interiorBorder)) {
+
+        auto d = elemMapper.index(elem);
+        op.add(d,d);
+        for (const auto& is : intersections(gridView, elem)) {
+            if (!is.neighbor()) {
+                continue;
+            }
+
+            const auto J = static_cast<unsigned int>(elemMapper.index(is.outside()));
+            op.add(d,J);
+        }
+    }
+
+    // Add transmissibilities to the graph
+    op.exportIdx(graph);
+    std::vector<double> transForSort;
+    for (const auto& elem : elements(gridView, Dune::Partitions::interiorBorder)) {
+        for (const auto& is : intersections(gridView, elem)) {
+            if (!is.neighbor()) {
+                continue;
+            }
+
+            const auto I = static_cast<unsigned int>(elemMapper.index(is.inside()));
+            const auto J = static_cast<unsigned int>(elemMapper.index(is.outside()));
+            double t = this->getTransmissibility(I, J);
+            graph[I][J] = t;
+            transForSort.push_back(t);
+        }
+    }
+
+    // Sort the transmissibilities so we can find the treshold value with coarsePartitionGraphThreshold
+    std::sort(transForSort.begin(), transForSort.end());
+
+    return transForSort[(int) (coarsePartitionGraphThreshold * transForSort.size())];
+}
+
+template <class ElementMapper, class GridView, class Scalar>
 void
 GenericCpGridVanguard<ElementMapper, GridView, Scalar>::
 distributeGrid(const Dune::EdgeWeightMethod                          edgeWeightsMethod,
@@ -375,7 +448,10 @@ distributeGrid(const Dune::EdgeWeightMethod                          edgeWeights
                const std::vector<Well>&                              wells,
                const std::unordered_map<std::string, std::set<int>>& possibleFutureConnections,
                EclipseState&                                         eclState1,
-               FlowGenericVanguard::ParallelWellStruct&              parallelWells)
+               FlowGenericVanguard::ParallelWellStruct&              parallelWells,
+               Dune::BCRSMatrix<Dune::FieldMatrix<double, 1, 1>>&    graph,
+               double                                                coarseThreshold,
+               const int                                             coarsePartitionMaxNodeSize)
 {
     if (auto* eclState = dynamic_cast<ParallelEclipseState*>(&eclState1);
         eclState != nullptr)
@@ -386,7 +462,8 @@ distributeGrid(const Dune::EdgeWeightMethod                          edgeWeights
                              imbalanceTol, loadBalancerSet,
                              useTransToFilterOverlap, faceTrans,
                              wells, possibleFutureConnections,
-                             eclState, parallelWells);
+                             eclState, parallelWells, graph,
+                             coarseThreshold, coarsePartitionMaxNodeSize);
     }
     else {
         const auto message = std::string {
@@ -419,7 +496,10 @@ distributeGrid(const Dune::EdgeWeightMethod                          edgeWeights
                const std::vector<Well>&                              wells,
                const std::unordered_map<std::string, std::set<int>>& possibleFutureConnections,
                ParallelEclipseState*                                 eclState,
-               FlowGenericVanguard::ParallelWellStruct&              parallelWells)
+               FlowGenericVanguard::ParallelWellStruct&              parallelWells,
+               Dune::BCRSMatrix<Dune::FieldMatrix<double, 1, 1>>&    graph,
+               double                                                coarseThreshold,
+               const int                                             coarsePartitionMaxNodeSize)
 {
     OPM_TIMEBLOCK(gridDistribute);
     const auto isIORank = this->grid_->comm().rank() == 0;
@@ -451,7 +531,8 @@ distributeGrid(const Dune::EdgeWeightMethod                          edgeWeights
                                       addCornerCells, overlapLayers,
                                       partitionMethod, imbalanceTol,
                                       enableDistributedWells,
-                                      useTransToFilterOverlap));
+                                      useTransToFilterOverlap, &graph,
+                                      coarseThreshold, coarsePartitionMaxNodeSize));
     }
 }
 

--- a/opm/simulators/flow/GenericCpGridVanguard.hpp
+++ b/opm/simulators/flow/GenericCpGridVanguard.hpp
@@ -27,6 +27,9 @@
 #ifndef OPM_GENERIC_CPGRID_VANGUARD_HPP
 #define OPM_GENERIC_CPGRID_VANGUARD_HPP
 
+#include <dune/istl/bcrsmatrix.hh>
+#include <dune/istl/matrixindexset.hh>
+
 #include <opm/grid/CpGrid.hpp>
 #include <opm/grid/cpgrid/LevelCartesianIndexMapper.hpp>
 
@@ -170,13 +173,19 @@ protected:
                         EclipseState&                            eclState,
                         FlowGenericVanguard::ParallelWellStruct& parallelWells,
                         const int                                numJacobiBlocks,
-                        const bool                               enableEclOutput);
+                        const bool                               enableEclOutput,
+                        const double                             coarsePartitionGraphThreshold,
+                        const int                                coarsePartitionMaxNodeSize);
 
     void distributeFieldProps_(EclipseState& eclState);
 
 private:
     std::vector<double> extractFaceTrans(const GridView& gridView) const;
 
+    double constructTransGraph(const GridView& gridView,
+                               Dune::BCRSMatrix<Dune::FieldMatrix<double, 1, 1>>& graph,
+                               const double coarsePartitionGraphThreshold) const;
+    
     void distributeGrid(const Dune::EdgeWeightMethod                          edgeWeightsMethod,
                         const bool                                            ownersFirst,
                         const bool                                            addCorners,
@@ -191,7 +200,10 @@ private:
                         const std::vector<Well>&                              wells,
                         const std::unordered_map<std::string, std::set<int>>& possibleFutureConnections,
                         EclipseState&                                         eclState,
-                        FlowGenericVanguard::ParallelWellStruct&              parallelWells);
+                        FlowGenericVanguard::ParallelWellStruct&              parallelWells,
+                        Dune::BCRSMatrix<Dune::FieldMatrix<double, 1, 1>>&    graph,
+                        double                                                coarseThreshold,
+                        const int                                             coarsePartitionMaxNodeSize);
 
     void distributeGrid(const Dune::EdgeWeightMethod                          edgeWeightsMethod,
                         const bool                                            ownersFirst,
@@ -207,7 +219,10 @@ private:
                         const std::vector<Well>&                              wells,
                         const std::unordered_map<std::string, std::set<int>>& possibleFutureConnections,
                         ParallelEclipseState*                                 eclState,
-                        FlowGenericVanguard::ParallelWellStruct&              parallelWells);
+                        FlowGenericVanguard::ParallelWellStruct&              parallelWells,
+                        Dune::BCRSMatrix<Dune::FieldMatrix<double, 1, 1>>&    graph,
+                        double                                                coarseThreshold,
+                        const int                                             coarsePartitionMaxNodeSize);
 
 protected:
     virtual const std::string& zoltanParams() const = 0;


### PR DESCRIPTION
This PR enables zoltanCG partitioning in opm-grid. Based on OPM/opm-grid#1050.

Runs with `--partition-method=zoltanCG`. 

Additional parameters added are:

* `--coarse-partition-graph-threshold`: Default: 0.9
* `--coarse-partition-max-node-size`: Default: -1