### PR TITLE
[LGR] flow: gather parallel LGR INIT transmissibilities

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -1039,6 +1039,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/flow/HybridNewtonConfig.hpp
   opm/simulators/flow/InterRegFlows.hpp
   opm/simulators/flow/KeywordValidation.hpp
+  opm/simulators/flow/LgrOutputTransGather.hpp
   opm/simulators/flow/LogOutputHelper.hpp
   opm/simulators/flow/Main.hpp
   opm/simulators/flow/MechContainer.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -479,6 +479,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_invert.cpp
   tests/test_keyword_validator.cpp
   tests/test_LgrBlockData.cpp
+  tests/test_LgrTransIndex.cpp
   tests/test_linearleastsquares.cpp
   tests/test_LogOutputHelper.cpp
   tests/test_milu.cpp

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -289,6 +289,7 @@ function(add_test_compare_parallel_simulation)
     DIR
     POSTFIX
     MPI_PROCS
+    COMPARE_MODE
   )
   set(multiValueArgs TEST_ARGS)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
@@ -313,6 +314,17 @@ function(add_test_compare_parallel_simulation)
     set(PARAM_SIMULATOR ${PARAM_DEV_SIMULATOR})
   endif()
 
+  # COMPARE_MODE "init": dry-run, compares EGRID+INIT only (parallel INIT-file regressions,
+  # e.g. parallel LGR transmissibility). Default (unset): compares SMRY+UNRST as before.
+  if(PARAM_COMPARE_MODE STREQUAL "init")
+    set(TEST_NAME_PREFIX compareParallelInitSim_)
+  elseif(PARAM_COMPARE_MODE)
+    message(FATAL_ERROR "add_test_compare_parallel_simulation(${PARAM_CASENAME}): "
+                        "unknown COMPARE_MODE '${PARAM_COMPARE_MODE}' (expected 'init' or unset)")
+  else()
+    set(TEST_NAME_PREFIX compareParallelSim_)
+  endif()
+
   if(MPIEXEC_MAX_NUMPROCS GREATER_EQUAL MPI_PROCS)
     # Local computer system has at least ${MPI_PROCS} CPUs. Register test.
     set(RESULT_PATH ${BASE_RESULT_PATH}/parallel/${PARAM_SIMULATOR}+${PARAM_CASENAME})
@@ -325,9 +337,12 @@ function(add_test_compare_parallel_simulation)
                     -t ${PARAM_REL_TOL}
                     -c $<TARGET_FILE:compareECL>
                     -n ${MPI_PROCS})
+    if(PARAM_COMPARE_MODE STREQUAL "init")
+      list(APPEND DRIVER_ARGS -m init)
+    endif()
 
     # Add test that runs flow_mpi and outputs the results to file
-    opm_add_test(compareParallelSim_${PARAM_SIMULATOR}+${PARAM_FILENAME}${PARAM_POSTFIX}
+    opm_add_test(${TEST_NAME_PREFIX}${PARAM_SIMULATOR}+${PARAM_FILENAME}${PARAM_POSTFIX}
       EXE_TARGET
         ${PARAM_SIMULATOR}
       DRIVER_ARGS
@@ -335,7 +350,7 @@ function(add_test_compare_parallel_simulation)
       TEST_ARGS
         ${TEST_ARGS}
     )
-    set_tests_properties(compareParallelSim_${PARAM_SIMULATOR}+${PARAM_FILENAME}${PARAM_POSTFIX}
+    set_tests_properties(${TEST_NAME_PREFIX}${PARAM_SIMULATOR}+${PARAM_FILENAME}${PARAM_POSTFIX}
                          PROPERTIES PROCESSORS ${MPI_PROCS})
   endif()
 endfunction()

--- a/opm/simulators/flow/EclGenericWriter.hpp
+++ b/opm/simulators/flow/EclGenericWriter.hpp
@@ -33,9 +33,11 @@
 #include <opm/output/data/Groups.hpp>
 
 #include <opm/simulators/flow/CollectDataOnIORank.hpp>
+#include <opm/simulators/flow/LgrOutputTransGather.hpp>
 #include <opm/simulators/flow/Transmissibility.hpp>
 #include <opm/simulators/timestepping/SimulatorReport.hpp>
 
+#include <array>
 #include <map>
 #include <memory>
 #include <optional>
@@ -93,6 +95,15 @@ public:
         globalTrans_ = globalTrans;
     }
 
+    // Parallel LGR INIT output: connection transmissibilities gathered from the
+    // ranks' own (distributed) simulator transmissibilities. When set,
+    // computeTrans_ / exportNncStructure_ take values from these instead of
+    // querying a whole-grid transmissibility object. Complete on the I/O rank only.
+    void setGatheredLgrTrans(std::optional<GatheredLgrOutputTrans> gatheredTrans)
+    {
+        gatheredLgrTrans_ = std::move(gatheredTrans);
+    }
+
     void setSubStepReport(const SimulatorReportSingle& report)
     {
         sub_step_report_ = report;
@@ -117,6 +128,21 @@ public:
 protected:
     const TransmissibilityType& globalTrans() const;
     unsigned int gridEquilIdxToGridIdx(unsigned int elemIndex) const;
+
+    // Value for `key` from the gathered records, or nullptr when the key is
+    // absent or no gathered records are set. N = 3 selects the same-level
+    // records, N = 4 the level-crossing (NNC) ones -- see GatheredLgrOutputTrans.
+    template <std::size_t N>
+    const double* findGatheredTrans_(const std::array<int,N>& key) const;
+
+    // Output transmissibility value for a connection: from the gathered per-rank
+    // simulator transmissibilities when set (parallel LGR runs; a missing key is
+    // a hard error), otherwise from the whole-grid transmissibility object
+    // (c1, c2). Key shape as in findGatheredTrans_.
+    template <std::size_t N>
+    double gatheredOrGlobalTrans_(const std::array<int,N>& key,
+                                  unsigned c1,
+                                  unsigned c2) const;
 
     void doWriteOutput(const int                          reportStepNum,
                        const std::optional<int>           timeStepNum,
@@ -165,6 +191,7 @@ protected:
     std::unique_ptr<TaskletRunner> taskletRunner_;
     Scalar restartTimeStepSize_;
     const TransmissibilityType* globalTrans_ = nullptr;
+    std::optional<GatheredLgrOutputTrans> gatheredLgrTrans_;
     const Dune::CartesianIndexMapper<Grid>& cartMapper_;
     const Dune::CartesianIndexMapper<EquilGrid>* equilCartMapper_;
     const EquilGrid* equilGrid_;

--- a/opm/simulators/flow/EclGenericWriter_impl.hpp
+++ b/opm/simulators/flow/EclGenericWriter_impl.hpp
@@ -51,6 +51,8 @@
 
 #include <opm/simulators/flow/EclGenericWriter.hpp>
 
+#include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
+
 #if HAVE_MPI
 #include <opm/simulators/utils/MPISerializer.hpp>
 #endif
@@ -66,6 +68,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -295,6 +298,7 @@ writeInit()
         }
         this->outputTrans_.reset();
     }
+    this->gatheredLgrTrans_.reset();
 }
 
 template<class Grid, class EquilGrid, class GridView, class ElementMapper, class Scalar>
@@ -302,6 +306,12 @@ void
 EclGenericWriter<Grid,EquilGrid,GridView,ElementMapper,Scalar>::
 extractOutputTransAndNNC(const std::function<unsigned int(unsigned int)>& map)
 {
+    // The work below runs on the I/O rank only, but an exception there (e.g. a
+    // missing gathered LGR transmissibility) must not leave the other ranks
+    // blocked in the broadcast that follows -- so failure is agreed on
+    // collectively and every rank throws together.
+    OPM_BEGIN_PARALLEL_TRY_CATCH()
+
     if (collectOnIORank_.isIORank()) {
         constexpr bool equilGridIsCpGrid = std::is_same_v<EquilGrid, Dune::CpGrid>;
 
@@ -317,6 +327,9 @@ extractOutputTransAndNNC(const std::function<unsigned int(unsigned int)>& map)
         exportNncStructure_(levelCartToLevelCompressed, map, computeLevelIndices, computeLevelCartIdx,
                             computeLevelCartDimensions, computeOriginIndices);
     }
+
+    OPM_END_PARALLEL_TRY_CATCH("EclGenericWriter::extractOutputTransAndNNC() failed: ",
+                               grid_.comm());
 
 #if HAVE_MPI
     if (collectOnIORank_.isParallel()) {
@@ -574,12 +587,14 @@ computeTrans_(const std::vector<std::unordered_map<int,int>>&  levelCartToLevelC
             }
 
             if (maxLevelCartIdx - minLevelCartIdx == 1 && levelCartDims[0] > 1 ) {
-                outputTrans_->at(level).at("TRANX").template data<double>()[minLevelCartIdx] = globalTrans().transmissibility(c1, c2);
+                outputTrans_->at(level).at("TRANX").template data<double>()[minLevelCartIdx] =
+                    gatheredOrGlobalTrans_(std::array{level, minLevelCartIdx, maxLevelCartIdx}, c1, c2);
                 continue; // skip other if clauses as they are false, last one needs some computation
             }
 
             if (maxLevelCartIdx - minLevelCartIdx == levelCartDims[0] && levelCartDims[1] > 1) {
-                outputTrans_->at(level).at("TRANY").template data<double>()[minLevelCartIdx] = globalTrans().transmissibility(c1, c2);
+                outputTrans_->at(level).at("TRANY").template data<double>()[minLevelCartIdx] =
+                    gatheredOrGlobalTrans_(std::array{level, minLevelCartIdx, maxLevelCartIdx}, c1, c2);
                 continue; // skipt next if clause as it needs some computation
             }
 
@@ -588,7 +603,8 @@ computeTrans_(const std::vector<std::unordered_map<int,int>>&  levelCartToLevelC
                                          levelCartToLevelCompressed[level],
                                          minLevelCartIdx,
                                          maxLevelCartIdx)) {
-                outputTrans_->at(level).at("TRANZ").template data<double>()[minLevelCartIdx] = globalTrans().transmissibility(c1, c2);
+                outputTrans_->at(level).at("TRANZ").template data<double>()[minLevelCartIdx] =
+                    gatheredOrGlobalTrans_(std::array{level, minLevelCartIdx, maxLevelCartIdx}, c1, c2);
             }
         }
     }
@@ -720,7 +736,9 @@ exportNncStructure_(const std::vector<std::unordered_map<int,int>>& levelCartToL
                 const auto& [smallerLevel, smallerLevelCartIdx] = smallerPair;
                 const auto& [largerLevel, largerLevelCartIdx] = largerPair;
 
-                auto t = this->globalTrans().transmissibility(c1, c2);
+                auto t = this->gatheredOrGlobalTrans_(std::array{smallerLevel, smallerLevelCartIdx,
+                                                                 largerLevel, largerLevelCartIdx},
+                                                      c1, c2);
 
                 // ECLIPSE ignores NNCs with zero transmissibility
                 // (different threshold than for NNC with corresponding
@@ -781,7 +799,9 @@ exportNncStructure_(const std::vector<std::unordered_map<int,int>>& levelCartToL
                                           levelCartIdxIn, levelCartIdxOut)) {
                     // We need to check whether an NNC for this face was also
                     // specified via the NNC keyword in the deck.
-                    auto t = this->globalTrans().transmissibility(c1, c2);
+                    // (levelCartIdxIn/Out are already swapped into min/max order above.)
+                    auto t = this->gatheredOrGlobalTrans_(std::array{level, levelCartIdxIn, levelCartIdxOut},
+                                                          c1, c2);
 
                     if (level == 0) {
                         auto candidate = std::lower_bound(nncData.begin(), nncData.end(),
@@ -879,13 +899,24 @@ exportNncStructure_(const std::vector<std::unordered_map<int,int>>& levelCartToL
                     continue;
                 }
 
-                trans = this->globalTrans().transmissibility(c1, c2);
+                // A deck NNC names a pair of level-zero cells. When one of them is
+                // refined by an LGR the pair is no longer a leaf connection, so the
+                // gathered records (correctly) hold no value for it -- keep the
+                // deck-specified transmissibility in that case.
+                const auto key = std::array{0, static_cast<int>(entry.cell1),
+                                            static_cast<int>(entry.cell2)};
+                const double* gathered = this->findGatheredTrans_(key);
+                if (!this->gatheredLgrTrans_.has_value() || gathered != nullptr) {
+                    trans = (gathered != nullptr)
+                        ? *gathered
+                        : this->globalTrans().transmissibility(c1, c2);
 
-                if (! generatedNnc.empty()) {
-                    for (const auto& generated : generatedNnc) {
-                        if (entry.cell1 == generated.cell1 && entry.cell2 == generated.cell2) {
-                            trans -= generated.trans;
-                            break;
+                    if (! generatedNnc.empty()) {
+                        for (const auto& generated : generatedNnc) {
+                            if (entry.cell1 == generated.cell1 && entry.cell2 == generated.cell2) {
+                                trans -= generated.trans;
+                                break;
+                            }
                         }
                     }
                 }
@@ -1099,6 +1130,49 @@ evalSummary(const int                                            reportStepNum,
         ser.append(summaryState);
     }
 #endif
+}
+
+template<class Grid, class EquilGrid, class GridView, class ElementMapper, class Scalar>
+template<std::size_t N>
+const double*
+EclGenericWriter<Grid,EquilGrid,GridView,ElementMapper,Scalar>::
+findGatheredTrans_(const std::array<int,N>& key) const
+{
+    static_assert(N == 3 || N == 4, "unknown gathered LGR record shape");
+
+    if (!gatheredLgrTrans_.has_value()) {
+        return nullptr;
+    }
+
+    if constexpr (N == 3) {
+        return gatheredLgrTrans_->sameLevel.find(key);
+    } else {
+        return gatheredLgrTrans_->crossLevel.find(key);
+    }
+}
+
+template<class Grid, class EquilGrid, class GridView, class ElementMapper, class Scalar>
+template<std::size_t N>
+double
+EclGenericWriter<Grid,EquilGrid,GridView,ElementMapper,Scalar>::
+gatheredOrGlobalTrans_(const std::array<int,N>& key,
+                       unsigned c1,
+                       unsigned c2) const
+{
+    if (!gatheredLgrTrans_.has_value()) {
+        return this->globalTrans().transmissibility(c1, c2);
+    }
+
+    if (const double* value = this->findGatheredTrans_(key); value != nullptr) {
+        return *value;
+    }
+
+    std::string msg = "Gathered LGR transmissibilities: no value for connection key (";
+    for (std::size_t j = 0; j < N; ++j) {
+        msg += std::to_string(key[j]);
+        msg += (j + 1 < N) ? ", " : ")";
+    }
+    throw std::logic_error { msg };
 }
 
 template<class Grid, class EquilGrid, class GridView, class ElementMapper, class Scalar>

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -52,6 +52,7 @@
 #include <opm/simulators/flow/FlowProblem.hpp>
 #include <opm/simulators/flow/FlowProblemBlackoilProperties.hpp>
 #include <opm/simulators/flow/FlowThresholdPressure.hpp>
+#include <opm/simulators/flow/LgrOutputTransGather.hpp>
 #include <opm/simulators/flow/MixingRateControls.hpp>
 #include <opm/simulators/flow/OutputBlackoilModule.hpp>
 #include <opm/simulators/flow/VtkTracerModule.hpp>
@@ -72,6 +73,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <vector>
 
 namespace Opm {
@@ -347,8 +349,43 @@ public:
         // we try to avoid for the parallel running, has both global trans_ and transmissibilities_ allocated at the same time
         if (enableEclOutput_) {
             if (simulator.vanguard().grid().comm().size() > 1) {
-                if (simulator.vanguard().grid().comm().rank() == 0)
+                bool wholeGridTransNeeded = simulator.vanguard().grid().comm().rank() == 0;
+                // Parallel LGR: reuse the simulator's own (distributed) transmissibilities for the
+                // INIT output -- each rank contributes its interior connections, gathered on the
+                // I/O rank and keyed by level-Cartesian indices so the output walk over the global
+                // (equil) grid can look them up directly. This reuses the values already computed
+                // in parallel for the simulation itself instead of recomputing a whole-grid
+                // transmissibility. finishTransmissibilities() is idempotent; calling it here only
+                // moves the (anyway required) local trans build before the INIT write.
+                if constexpr (std::is_same_v<GetPropType<TypeTag, Properties::Grid>, Dune::CpGrid>) {
+                    // Gate on the deck's LGRs -- the same condition the writer keys its LGR
+                    // output walk on (writeInit / extractOutputTransAndNNC). Grid refinement
+                    // alone (grid().maxLevel() > 0, e.g. after adapt()) must not enable the
+                    // gathered mode: the writer would look up different keys than the ones
+                    // the leaf-grid walk records.
+                    if (simulator.vanguard().eclState().getLgrs().size() > 0) {
+                        if (simulator.vanguard().numOverlap() < 1) {
+                            throw std::runtime_error("Parallel LGR output requires at least one "
+                                                     "overlap layer (--num-overlap >= 1): a "
+                                                     "rank-boundary connection is recorded by the "
+                                                     "rank owning the lower-index cell, which needs "
+                                                     "the partner cell in its overlap layer.");
+                        }
+                        finishTransmissibilities();
+                        const auto& localTrans = simulator.problem().eclTransmissibilities();
+                        eclWriter_->setGatheredLgrTrans(
+                            gatherLgrOutputTrans(simulator.vanguard().grid(),
+                                                 simulator.vanguard().gridView(),
+                                                 [&localTrans](unsigned c1, unsigned c2)
+                                                 { return static_cast<double>(localTrans.transmissibility(c1, c2)); }));
+                        // All output values (TRANX/Y/Z and NNC) come from the gathered records --
+                        // no whole-grid transmissibility object is needed on the I/O rank.
+                        wholeGridTransNeeded = false;
+                    }
+                }
+                if (wholeGridTransNeeded) {
                     eclWriter_->setTransmissibilities(&simulator.vanguard().globalTransmissibility());
+                }
             } else {
                 finishTransmissibilities();
                 eclWriter_->setTransmissibilities(&simulator.problem().eclTransmissibilities());

--- a/opm/simulators/flow/LgrOutputTransGather.hpp
+++ b/opm/simulators/flow/LgrOutputTransGather.hpp
@@ -1,0 +1,235 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+#ifndef OPM_LGR_OUTPUT_TRANS_GATHER_HPP
+#define OPM_LGR_OUTPUT_TRANS_GATHER_HPP
+
+#include <dune/grid/common/mcmgmapper.hh>
+#include <dune/grid/common/partitionset.hh>
+
+#include <opm/grid/common/CommunicationUtils.hpp>
+#include <opm/grid/cpgrid/LevelCartesianIndexMapper.hpp>
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+namespace Opm {
+
+/// Flat open-addressing (linear-probe) index over gathered LGR connection records.
+///
+/// The I/O rank holds every connection of the global grid and looks each one up
+/// exactly once per output pass; the same gather machinery is reused for the
+/// per-report-step summary/restart output, so the lookup is on a hot path. A
+/// contiguous open-addressing table is the fastest option measured (see
+/// ADR-0001): it beats both a sorted vector + binary search and std::unordered_map
+/// on build and lookup, while staying node-free. The key is the level-Cartesian
+/// index tuple (see GatheredLgrOutputTrans); values are transmissibilities.
+template <std::size_t N>
+class LgrTransIndex
+{
+public:
+    using Key = std::array<int, N>;
+
+    LgrTransIndex() = default;
+
+    /// Build the index from the gathered (key, value) records. Keys are unique by
+    /// construction (every connection is recorded by exactly one rank).
+    explicit LgrTransIndex(const std::vector<std::pair<Key, double>>& records)
+    {
+        // Power-of-two capacity at load factor <= 0.7 (cap*7 >= size*10).
+        std::size_t cap = 1;
+        while (cap * 7 < records.size() * 10) {
+            cap <<= 1;
+        }
+        slots_.assign(cap, Slot{});
+        mask_ = cap - 1;
+        for (const auto& record : records) {
+            insert_(record.first, record.second);
+        }
+    }
+
+    /// \return pointer to the value for \p key, or nullptr if absent.
+    const double* find(const Key& key) const
+    {
+        if (slots_.empty()) {
+            return nullptr;
+        }
+        std::size_t i = hash_(key) & mask_;
+        while (slots_[i].occupied) {
+            if (slots_[i].key == key) {
+                return &slots_[i].value;
+            }
+            i = (i + 1) & mask_;
+        }
+        return nullptr;
+    }
+
+private:
+    struct Slot
+    {
+        Key key{};
+        double value{};
+        bool occupied{false};
+    };
+
+    void insert_(const Key& key, double value)
+    {
+        std::size_t i = hash_(key) & mask_;
+        while (slots_[i].occupied) {
+            assert(slots_[i].key != key && "duplicate LGR transmissibility key");
+            i = (i + 1) & mask_;
+        }
+        slots_[i] = Slot{key, value, true};
+    }
+
+    static std::size_t hash_(const Key& key)
+    {
+        // FNV-1a over the N ints -- cheap and well-spread for small integer tuples.
+        std::size_t h = 1469598103934665603ULL;
+        for (int x : key) {
+            h ^= static_cast<std::size_t>(static_cast<unsigned>(x));
+            h *= 1099511628211ULL;
+        }
+        return h;
+    }
+
+    std::vector<Slot> slots_;
+    std::size_t mask_ = 0;
+};
+
+/// Connection transmissibilities gathered for parallel LGR INIT output.
+///
+/// Held on the I/O rank as key-indexed tables (see LgrTransIndex); empty on all
+/// other ranks.
+///
+/// sameLevel:  key (level, min level-Cartesian index, max level-Cartesian index)
+///             -- every connection between two cells of the same level grid
+///                (TRANX/TRANY/TRANZ and same-level NNCs).
+/// crossLevel: key (smaller level, its level-Cartesian index,
+///                  larger level, its level-Cartesian index)
+///             -- every connection between cells of different level grids
+///                (global<->LGR and LGR<->LGR NNCs; TRANGL/TRANLL).
+struct GatheredLgrOutputTrans
+{
+    LgrTransIndex<3> sameLevel;
+    LgrTransIndex<4> crossLevel;
+};
+
+/// Gather the simulator's own (distributed) transmissibilities for parallel LGR INIT output.
+///
+/// Each rank walks its interior leaf cells and records every connection it owns, keyed by
+/// level-Cartesian indices (see GatheredLgrOutputTrans), then the records are gathered on the
+/// I/O rank (rank 0). The level-Cartesian key is geometrically canonical -- defined by the LGR
+/// specification, identical on the distributed grid and the undistributed (equil) copy -- so
+/// the I/O rank's output walk over the equil grid can look values up directly.
+///
+/// Every connection is recorded exactly once. A same-level connection is recorded by the rank
+/// that owns the cell with the smaller level-Cartesian index; that comparison is
+/// rank-independent, so at a rank boundary only one of the two owner ranks records the
+/// connection -- which it can, because its partner cell is present in its overlap layer (this
+/// requires at least one overlap layer; the caller guards --num-overlap). A cross-level
+/// connection is recorded from the smaller-level side only.
+///
+/// This reuses the values the simulation itself computed in parallel instead of recomputing a
+/// whole-grid transmissibility on the I/O rank.
+///
+/// \return the complete records indexed on rank 0; empty index on all other ranks.
+template <class GridView, class TransFn>
+GatheredLgrOutputTrans
+gatherLgrOutputTrans(const Dune::CpGrid& grid,
+                     const GridView& gridView,
+                     TransFn&& transFn)
+{
+    // Build the final (key, value) records directly -- no separate flat key/value
+    // buffers, no zip pass afterwards.
+    std::vector<std::pair<std::array<int,3>, double>> same;   // level, minCart, maxCart
+    std::vector<std::pair<std::array<int,4>, double>> cross;  // smallLevel, smallCart, largeLevel, largeCart
+
+    const LevelCartesianIndexMapper<Dune::CpGrid> levelCartMapp(grid);
+    const Dune::MultipleCodimMultipleGeomTypeMapper<GridView>
+        elemMapper(gridView, Dune::mcmgElementLayout());
+
+    for (const auto& elem : elements(gridView, Dune::Partitions::interior)) {
+        // The inside cell is the same for every intersection of this element.
+        const int levelIn = elem.level();
+        const int cartIn = levelCartMapp.cartesianIndex(elem.getLevelElem().index(), levelIn);
+        const auto idxIn = elemMapper.index(elem);
+
+        for (const auto& is : intersections(gridView, elem)) {
+            if (!is.neighbor()) {
+                continue;
+            }
+
+            const auto outside = is.outside();
+            const int levelOut = outside.level();
+
+            if (levelIn != levelOut) {
+                if (levelIn > levelOut) {
+                    continue; // recorded exactly once, from the smaller-level side
+                }
+
+                cross.emplace_back(
+                    std::array<int,4>{levelIn, cartIn, levelOut,
+                                      levelCartMapp.cartesianIndex(outside.getLevelElem().index(), levelOut)},
+                    transFn(idxIn, elemMapper.index(outside)));
+                continue;
+            }
+
+            const int cartOut = levelCartMapp.cartesianIndex(
+                outside.getLevelElem().index(), levelIn);
+
+            if (cartIn > cartOut) {
+                // Record each connection once, in canonical direction. The comparison
+                // is rank-independent, so at a rank boundary exactly one of the two
+                // owner ranks records the connection.
+                continue;
+            }
+
+            same.emplace_back(std::array<int,3>{levelIn, cartIn, cartOut},
+                              transFn(idxIn, elemMapper.index(outside)));
+        }
+    }
+
+    // Gather each record vector directly to the I/O rank -- ONE collective per kind
+    // (was two: separate keys and values). gatherv is generic; Dune's
+    // MPITraits<std::pair<std::array<int,N>,double>> composes a byte-blob array with
+    // MPI_DOUBLE, so the record moves as a single MPI datatype. gatherv is collective
+    // and returns empty vectors on the non-root ranks. MPI's int counts/displacements
+    // bound the total record count across ALL ranks at ~2^31 records -- a shared
+    // MPI-wide ceiling, not a per-rank one.
+    const auto& comm = grid.comm();
+    const auto allSame  = gatherv(same,  comm, 0).first;
+    const auto allCross = gatherv(cross, comm, 0).first;
+
+    // Index the gathered records on the I/O rank; empty on the others.
+    GatheredLgrOutputTrans gathered;
+    gathered.sameLevel  = LgrTransIndex<3>(allSame);
+    gathered.crossLevel = LgrTransIndex<4>(allCross);
+    return gathered;
+}
+
+} // namespace Opm
+
+#endif // OPM_LGR_OUTPUT_TRANS_GATHER_HPP

--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -946,6 +946,33 @@ add_test_compare_parallel_simulation(
     --linear-solver-reduction=1e-7
 )
 
+# Parallel LGR INIT/EGRID regression: reuses the existing SPE1CASE1_CARFIN deck (opm-tests/lgr,
+# already registered for spe1case1_carfin/spe1case1_carfin_parallel in compareECLFiles.cmake) and
+# the existing run-parallel-regressionTest.sh driver (COMPARE_MODE init: dry-run, compares
+# EGRID+INIT instead of SMRY+UNRST). Guards the parallel LGR INIT transmissibility output
+# (gatherLgrOutputTrans + the EclGenericWriter gathered-record lookups) -- pre-fix, the
+# parallel run deadlocks here.
+add_test_compare_parallel_simulation(
+  CASENAME
+    spe1case1_carfin
+  FILENAME
+    SPE1CASE1_CARFIN
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  DIR
+    lgr
+  ABS_TOL
+    1e-3
+  REL_TOL
+    1e-5
+  COMPARE_MODE
+    init
+  TEST_ARGS
+    --parsing-strictness=low
+)
+
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-comparison.sh "")
 
 add_test_compareSeparateECLFiles(
@@ -1011,3 +1038,4 @@ add_test_compareSeparateECLFiles(
     --matrix-add-well-contributions=true
     --linear-solver=ilu0
 )
+

--- a/tests/run-parallel-regressionTest.sh
+++ b/tests/run-parallel-regressionTest.sh
@@ -17,13 +17,18 @@ then
   echo -e "\t\t -e <filename> Simulator binary to use"
   echo -e "\tOptional options:"
   echo -e "\t\t -n <procs>    Number of MPI processes to use"
+  echo -e "\t\t -m <mode>     Comparison mode: summary (default, compares SMRY+UNRST"
+  echo -e "\t\t               against a normal run) or init (dry-run, compares"
+  echo -e "\t\t               EGRID+INIT only -- for tracking parallel INIT-file"
+  echo -e "\t\t               regressions, e.g. parallel LGR transmissibility)"
   exit 1
 fi
 
 MPI_PROCS=4
+MODE=summary
 OPTIND=1
 
-while getopts "i:r:f:a:t:c:e:n:" OPT
+while getopts "i:r:f:a:t:c:e:n:m:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
@@ -34,38 +39,71 @@ do
     c) COMPARE_ECL_COMMAND=${OPTARG} ;;
     e) EXE_NAME=${OPTARG} ;;
     n) MPI_PROCS=${OPTARG} ;;
+    m) MODE=${OPTARG} ;;
   esac
 done
 shift $(($OPTIND-1))
 TEST_ARGS="$@"
 
+case "${MODE:-summary}" in
+  summary|init) ;;
+  *) echo "Unknown mode '${MODE}' (expected 'summary' or 'init')"; exit 1 ;;
+esac
+
+if [ "${MODE}" = "init" ]
+then
+  RUN_FLAG="--enable-dry-run=true --enable-ecl-output=true"
+else
+  RUN_FLAG="--enable-opm-rst-file=true"
+fi
+
 rm -Rf ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-"${EXE_NAME}" ${TEST_ARGS} --enable-opm-rst-file=true --output-dir=${RESULT_PATH}
+"${EXE_NAME}" ${TEST_ARGS} ${RUN_FLAG} --output-dir=${RESULT_PATH}
 
 test $? -eq 0 || exit 1
 mkdir mpi
 cd mpi
-mpirun -np ${MPI_PROCS} "${EXE_NAME}" ${TEST_ARGS} --enable-opm-rst-file=true --output-dir=${RESULT_PATH}/mpi
+mpirun -np ${MPI_PROCS} "${EXE_NAME}" ${TEST_ARGS} ${RUN_FLAG} --output-dir=${RESULT_PATH}/mpi
 test $? -eq 0 || exit 1
 cd ..
 
 ecode=0
-echo "=== Executing comparison for summary file ==="
-${COMPARE_ECL_COMMAND} -t SMRY -R ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
-if [ $? -ne 0 ]
+if [ "${MODE}" = "init" ]
 then
-  ecode=1
-  ${COMPARE_ECL_COMMAND} -t SMRY -a -R ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
-fi
+  echo "=== Executing comparison for EGRID file ==="
+  ${COMPARE_ECL_COMMAND} -t EGRID ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  if [ $? -ne 0 ]
+  then
+    ecode=1
+    ${COMPARE_ECL_COMMAND} -a -t EGRID ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  fi
 
-echo "=== Executing comparison for restart file ==="
-${COMPARE_ECL_COMMAND} -l -t UNRST ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
-if [ $? -ne 0 ]
-then
-  ecode=1
-  ${COMPARE_ECL_COMMAND} -a -l -t UNRST ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  # -x ignores the parallel-only MPI_RANK keyword, which has no serial counterpart to compare against.
+  echo "=== Executing comparison for INIT file (ignoring parallel-only MPI_RANK) ==="
+  ${COMPARE_ECL_COMMAND} -t INIT -x ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  if [ $? -ne 0 ]
+  then
+    ecode=1
+    ${COMPARE_ECL_COMMAND} -a -t INIT -x ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  fi
+else
+  echo "=== Executing comparison for summary file ==="
+  ${COMPARE_ECL_COMMAND} -t SMRY -R ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  if [ $? -ne 0 ]
+  then
+    ecode=1
+    ${COMPARE_ECL_COMMAND} -t SMRY -a -R ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  fi
+
+  echo "=== Executing comparison for restart file ==="
+  ${COMPARE_ECL_COMMAND} -l -t UNRST ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  if [ $? -ne 0 ]
+  then
+    ecode=1
+    ${COMPARE_ECL_COMMAND} -a -l -t UNRST ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  fi
 fi
 
 exit $ecode

--- a/tests/test_LgrTransIndex.cpp
+++ b/tests/test_LgrTransIndex.cpp
@@ -1,0 +1,154 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#define BOOST_TEST_MODULE LgrTransIndex
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/simulators/flow/LgrOutputTransGather.hpp>
+
+#include <array>
+#include <utility>
+#include <vector>
+
+// Unit tests for Opm::LgrTransIndex<N> -- the flat open-addressing table that holds the
+// gathered LGR output transmissibilities on the I/O rank (see ADR-0001). The parallel INIT
+// regression exercises it end to end; these tests pin the container in isolation: empty
+// state (the non-I/O-rank case), exact value round-trip, absent-key termination (no infinite
+// probe), N=3 and N=4 key widths, negative/large key components, and sizes straddling the
+// power-of-two capacity boundary.
+
+using Opm::LgrTransIndex;
+
+namespace {
+    using Key3 = std::array<int, 3>;
+    using Rec3 = std::pair<Key3, double>;
+    using Key4 = std::array<int, 4>;
+    using Rec4 = std::pair<Key4, double>;
+}
+
+BOOST_AUTO_TEST_CASE(DefaultConstructedIsEmpty)
+{
+    // The state on every non-I/O rank: no records, every lookup misses (and must not crash).
+    const LgrTransIndex<3> idx;
+    BOOST_CHECK(idx.find(Key3{0, 0, 0}) == nullptr);
+    BOOST_CHECK(idx.find(Key3{1, 2, 3}) == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(EmptyRecords)
+{
+    const LgrTransIndex<3> idx{std::vector<Rec3>{}};
+    BOOST_CHECK(idx.find(Key3{0, 0, 0}) == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(SingleRecord)
+{
+    const std::vector<Rec3> recs{ {Key3{1, 4, 5}, 42.5} };
+    const LgrTransIndex<3> idx{recs};
+
+    const double* v = idx.find(Key3{1, 4, 5});
+    BOOST_REQUIRE(v != nullptr);
+    BOOST_CHECK_EQUAL(*v, 42.5);
+
+    BOOST_CHECK(idx.find(Key3{1, 4, 6}) == nullptr);  // same level, absent
+    BOOST_CHECK(idx.find(Key3{0, 4, 5}) == nullptr);  // different level, absent
+}
+
+BOOST_AUTO_TEST_CASE(ManyRecordsFoundWithExactValues)
+{
+    // Real-shaped keys: +X/+Y/+Z neighbour connections of a small refined grid, several levels.
+    std::vector<Rec3> recs;
+    const int NX = 6, NY = 5, NZ = 4;
+    double v = 1.0;
+    for (int level = 1; level <= 3; ++level) {
+        for (int iz = 0; iz < NZ; ++iz) {
+            for (int iy = 0; iy < NY; ++iy) {
+                for (int ix = 0; ix < NX; ++ix) {
+                    const int c = ix + iy * NX + iz * NX * NY;
+                    if (ix + 1 < NX) recs.push_back({Key3{level, c, c + 1},          v += 1.0});
+                    if (iy + 1 < NY) recs.push_back({Key3{level, c, c + NX},         v += 1.0});
+                    if (iz + 1 < NZ) recs.push_back({Key3{level, c, c + NX * NY},    v += 1.0});
+                }
+            }
+        }
+    }
+
+    const LgrTransIndex<3> idx{recs};
+
+    for (const auto& r : recs) {
+        const double* got = idx.find(r.first);
+        BOOST_REQUIRE_MESSAGE(got != nullptr, "inserted key not found");
+        BOOST_CHECK_EQUAL(*got, r.second);
+    }
+    // A clearly-absent key must terminate (the table always keeps at least one empty slot).
+    BOOST_CHECK(idx.find(Key3{9, 999999, 1000000}) == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(CrossLevelN4)
+{
+    std::vector<Rec4> recs;
+    double v = 100.0;
+    for (int i = 0; i < 500; ++i) {
+        recs.push_back({Key4{0, i, 1, i + 3}, v += 0.25});
+    }
+    const LgrTransIndex<4> idx{recs};
+
+    for (const auto& r : recs) {
+        const double* got = idx.find(r.first);
+        BOOST_REQUIRE(got != nullptr);
+        BOOST_CHECK_EQUAL(*got, r.second);
+    }
+    BOOST_CHECK(idx.find(Key4{0, 12345, 1, 67890}) == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(NegativeAndLargeKeyComponents)
+{
+    // hash mixes the ints through unsigned; negative and large components must round-trip.
+    const std::vector<Rec3> recs{
+        {Key3{-1, -2, -3},                  1.0},
+        {Key3{0, 2000000000, 2000000001},   2.0},
+        {Key3{-5, 7, 7},                    3.0},  // equal trailing components
+    };
+    const LgrTransIndex<3> idx{recs};
+
+    BOOST_REQUIRE(idx.find(Key3{-1, -2, -3}) != nullptr);
+    BOOST_CHECK_EQUAL(*idx.find(Key3{-1, -2, -3}),                1.0);
+    BOOST_CHECK_EQUAL(*idx.find(Key3{0, 2000000000, 2000000001}), 2.0);
+    BOOST_CHECK_EQUAL(*idx.find(Key3{-5, 7, 7}),                  3.0);
+    BOOST_CHECK(idx.find(Key3{-1, -2, -4}) == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(LoadFactorBoundaryAllFound)
+{
+    // Sizes straddling the power-of-two capacity boundaries (load approaching the 0.7 cap):
+    // every key must still be found and every miss must terminate.
+    for (const int n : {1, 2, 3, 7, 8, 9, 100, 127, 128, 129, 1000}) {
+        std::vector<Rec3> recs;
+        recs.reserve(n);
+        for (int i = 0; i < n; ++i) {
+            recs.push_back({Key3{i % 4, i, i + 1}, static_cast<double>(i)});
+        }
+        const LgrTransIndex<3> idx{recs};
+
+        for (const auto& r : recs) {
+            BOOST_REQUIRE(idx.find(r.first) != nullptr);
+        }
+        BOOST_CHECK(idx.find(Key3{0, -1, -1}) == nullptr);  // absent must not loop forever
+    }
+}


### PR DESCRIPTION
This PR carries both the reusable parallel INIT compare infrastructure (the `COMPARE_MODE init` driver, first commit) and the parallel LGR INIT output feature. It supersedes and consolidates #7211, which is now closed — the infrastructure commit lives here as the branch base so the regression test lands together with the feature that makes it pass.

A parallel (MPI) `flow` run with LGRs cannot otherwise write a correct INIT file: the output path queries transmissibilities on the global refined grid, which the coarse per-rank `globalTrans_` cannot answer. This PR makes the parallel LGR INIT output (TRANX/TRANY/TRANZ + NNC arrays) correct by reusing the transmissibilities the distributed simulator already computed.

**Approach.** Each rank walks its interior leaf cells and records every connection it owns from its own distributed transmissibilities, keyed by level-Cartesian index — same-level connections as `(level, min, max)`, level-crossing ones as `(smaller level, its index, larger level, its index)`. These keys are geometrically canonical: identical on the distributed grid and the I/O rank's global view. Each rank builds its `(key, value)` records directly and gathers them to the I/O rank with `Opm::gatherv` — one collective per kind. Every connection is recorded exactly once: a same-level connection by the owner of the smaller level-Cartesian index (a rank-independent comparison; the recording rank has its partner cell in the overlap layer), a level-crossing connection from the smaller-level side. Nothing is recomputed on the I/O rank, and in parallel LGR runs no whole-grid transmissibility object is stored. Serial runs and parallel runs without LGRs are unchanged.

**Storage and lookup.** On the I/O rank the gathered records are held in a flat open-addressing (linear-probe) table, `LgrTransIndex`, behind the `findGatheredTrans_` seam (`opm/simulators/flow/LgrOutputTransGather.hpp`). The gather utility is templated on the value function so the same machinery can be reused per report step by summary and restart output, where the lookup runs on every step; a contiguous table is faster to build and query than a sorted vector + binary search and cache-friendlier than a node-based map, which also cannot be MPI-gathered. The sorted-vector lookup remains available behind the same seam. The gathered mode is an explicit `std::optional`, so an empty record set never silently falls back to the whole-grid object; a missing key during the output walk is a hard error agreed collectively before the NNC broadcast, so all ranks abort together.

**Requirements and limitations.**
- At least one overlap layer is required (`--num-overlap >= 1`); runs with LGRs and zero overlap abort with a message.
- A deck NNC whose endpoint cell is refined by an LGR is no longer a leaf connection and keeps its deck-specified transmissibility.
- MPI's int counts/displacements bound the gathered record total across all ranks.

**Testing.**
- `compareParallelInitSim_flow+SPE1CASE1_CARFIN` — serial vs 4-rank INIT/EGRID compare on the `SPE1CASE1_CARFIN` deck (two LGRs straddling rank boundaries). Passed.
- `compareParallelSim_flow+SPE1CASE2` — unchanged non-LGR path. Passed.
- `test_LgrTransIndex` — unit test for the container: empty/non-I/O-rank state, exact value round-trip, absent-key termination, N=3 and N=4 key widths, and sizes straddling the capacity boundary. Passed.

**Scope.** INIT output only. Summary, restart write, restart read, and RFT for parallel LGR runs are separate work.
