### PR TITLE
adding regression test for WECON_PLUSCON_COMPLUMP

### DIFF
--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -1039,6 +1039,25 @@ add_test_compareECLFiles(
 
 add_test_compareECLFiles(
   CASENAME
+    wecon_pluscon_complump
+  FILENAME
+    WECON_PLUSCON_COMPLUMP
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_oilwater
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    wecon_wtest
+  TEST_ARGS
+    --enable-tuning=true
+)
+
+add_test_compareECLFiles(
+  CASENAME
     gconinje_resv_gas_01
   FILENAME
     GCONINJE_RESV_GAS-01


### PR DESCRIPTION
WECON with water cut limit, and +CON work over. COMPLUMP is used to re-group the connections.

It is a regression test based on https://github.com/OPM/opm-tests/pull/1546 to test the development introduced in https://github.com/OPM/opm-simulators/pull/7141#event-27819478401 . 