### PR TITLE
In the pressure system, move the well DoFs before interior and overlap.

### DIFF
--- a/opm/simulators/linalg/PressureBhpTransferPolicy.hpp
+++ b/opm/simulators/linalg/PressureBhpTransferPolicy.hpp
@@ -33,6 +33,7 @@
 
 namespace Opm
 {
+    // add wells to the communicator. Wells are first, before the interior and overlap cells.
     template <class Communication>
     void extendCommunicatorWithWells(const Communication& comm,
                                      std::shared_ptr<Communication>& commRW,
@@ -50,22 +51,21 @@ namespace Opm
         std::size_t loc_max = 0;
         indset_rw.beginResize();
         for (auto ind = indset.begin(), indend = indset.end(); ind != indend; ++ind) {
-            indset_rw.add(ind->global(), LocalIndex(ind->local(), ind->local().attribute(), true));
+            // comm does not have wells, indices start from nw
             const int glo = ind->global();
             const std::size_t loc = ind->local().local();
+            indset_rw.add(glo, LocalIndex(loc+nw, ind->local().attribute(), true));
             glo_max = std::max(glo_max, glo);
             loc_max = std::max(loc_max, loc);
         }
         const int global_max = comm.communicator().max(glo_max);
-        // used append the welldofs at the end
+        // put the welldofs to the beginning
         assert(loc_max + 1 == indset.size());
-        std::size_t local_ind = loc_max + 1;
         for (int i = 0; i < nw; ++i) {
-            // need to set unique global number
+            // need to set unique global number, distributed wells are not matched across ranks
+            // and make one smaller well per rank and each rank owns its part
             const std::size_t v = global_max + max_nw * rank + i + 1;
-            // set to true to not have problems with higher levels if growing of domains is used
-            indset_rw.add(v, LocalIndex(local_ind, Dune::OwnerOverlapCopyAttributeSet::owner, true));
-            ++local_ind;
+            indset_rw.add(v, LocalIndex(i, Dune::OwnerOverlapCopyAttributeSet::owner, false));
         }
         indset_rw.endResize();
         assert(indset_rw.size() == indset.size() + nw);
@@ -120,24 +120,25 @@ namespace Opm
             OPM_TIMEBLOCK(createCoarseLevelSystem);
             using CoarseMatrix = typename CoarseOperator::matrix_type;
             const auto& fineLevelMatrix = fineOperator.getmat();
-            const auto& nw = fineOperator.getNumberOfExtraEquations();
+            nrWells_ = fineOperator.getNumberOfExtraEquations();
             if (prm_.get<bool>("add_wells")) {
                 const std::size_t average_elements_per_row
                     = static_cast<std::size_t>(std::ceil(fineLevelMatrix.nonzeroes() / fineLevelMatrix.N()));
                 const double overflow_fraction = 1.2;
-                coarseLevelMatrix_.reset(new CoarseMatrix(fineLevelMatrix.N() + nw,
-                                                          fineLevelMatrix.M() + nw,
+                coarseLevelMatrix_.reset(new CoarseMatrix(fineLevelMatrix.N() + nrWells_,
+                                                          fineLevelMatrix.M() + nrWells_,
                                                           average_elements_per_row,
                                                           overflow_fraction,
                                                           CoarseMatrix::implicit));
                 int rownum = 0;
                 for (const auto& row : fineLevelMatrix) {
                     for (auto col = row.begin(), cend = row.end(); col != cend; ++col) {
-                        coarseLevelMatrix_->entry(rownum, col.index()) = 0.0;
+                        coarseLevelMatrix_->entry(rownum+nrWells_, col.index()+nrWells_) = 0.0;
                     }
                     ++rownum;
                 }
             } else {
+                // TODO! not adding wells might make the matrix incopatible with other changed parts of the code
                 coarseLevelMatrix_.reset(
                     new CoarseMatrix(fineLevelMatrix.N(), fineLevelMatrix.M(), fineLevelMatrix.nonzeroes(), CoarseMatrix::row_wise));
                 auto createIter = coarseLevelMatrix_->createbegin();
@@ -158,7 +159,7 @@ namespace Opm
             fineOperator.addWellPressureEquationsStruct(*coarseLevelMatrix_);
             coarseLevelMatrix_->compress(); // all elemenst should be set
             if constexpr (!std::is_same_v<Communication, Dune::Amg::SequentialInformation>) {
-                extendCommunicatorWithWells(*communication_, coarseLevelCommunication_, nw);
+                extendCommunicatorWithWells(*communication_, coarseLevelCommunication_, nrWells_);
             }
         }
         calculateCoarseEntries(fineOperator);
@@ -176,11 +177,16 @@ namespace Opm
         const auto& fineMatrix = fineOperator.getmat();
         *coarseLevelMatrix_ = 0;
         auto rowCoarse = coarseLevelMatrix_->begin();
+        std::advance(rowCoarse, nrWells_);
         for (auto row = fineMatrix.begin(), rowEnd = fineMatrix.end(); row != rowEnd; ++row, ++rowCoarse) {
-            assert(row.index() == rowCoarse.index());
+            assert(row.index() + nrWells_ == rowCoarse.index());
             auto entryCoarse = rowCoarse->begin();
+            // skip columns with wells
+            while (entryCoarse.index() < nrWells_)
+                ++entryCoarse;
+
             for (auto entry = row->begin(), entryEnd = row->end(); entry != entryEnd; ++entry, ++entryCoarse) {
-                assert(entry.index() == entryCoarse.index());
+                assert(entry.index() + nrWells_ == entryCoarse.index());
                 Scalar matrix_el = 0;
                 if (transpose) {
                     const auto& bw = weights_[entry.index()];
@@ -202,7 +208,6 @@ namespace Opm
             bool use_well_weights = prm_.get<bool>("use_well_weights");
             fineOperator.addWellPressureEquations(*coarseLevelMatrix_, weights_, use_well_weights);
 #ifndef NDEBUG
-            std::advance(rowCoarse, fineOperator.getNumberOfExtraEquations());
             assert(rowCoarse == coarseLevelMatrix_->end());
 #endif
 
@@ -212,7 +217,9 @@ namespace Opm
     void moveToCoarseLevel(const typename ParentType::FineRangeType& fine) override
     {
         OPM_TIMEBLOCK(moveToCoarseLevel);
-        //NB we iterate over fine assumming welldofs is at the end
+        //NB we iterate over fine assumming welldofs is at the beginning
+        assert(nrWells_ >= 0);
+        assert(fine.size() + nrWells_ == this->rhs_.size());
         // Set coarse vector to zero
         this->rhs_ = 0;
 
@@ -228,7 +235,8 @@ namespace Opm
                     rhs_el += (*block)[i] * bw[i];
                 }
             }
-            this->rhs_[block - begin] = rhs_el;
+            // rhs of well equations remains empty
+            this->rhs_[block - begin + nrWells_] = rhs_el;
         }
 
         this->lhs_ = 0;
@@ -237,17 +245,19 @@ namespace Opm
     void moveToFineLevel(typename ParentType::FineDomainType& fine) override
     {
         OPM_TIMEBLOCK(moveToFineLevel);
-        //NB we iterate over fine assumming welldofs is at the end
+        //NB we iterate over fine assumming welldofs is at the beginning
+        assert(nrWells_ >= 0);
+        assert(fine.size() + nrWells_ == this->lhs_.size());
         auto end = fine.end(), begin = fine.begin();
 
         for (auto block = begin; block != end; ++block) {
             if (transpose) {
                 const auto& bw = weights_[block.index()];
                 for (std::size_t i = 0; i < block->size(); ++i) {
-                    (*block)[i] = this->lhs_[block - begin][0] * bw[i];
+                    (*block)[i] = this->lhs_[block - begin + nrWells_][0] * bw[i];
                 }
             } else {
-                (*block)[pressure_var_index_] = this->lhs_[block - begin][0];
+                (*block)[pressure_var_index_] = this->lhs_[block - begin + nrWells_][0];
             }
         }
     }
@@ -269,6 +279,7 @@ private:
     const int pressure_var_index_;
     std::shared_ptr<Communication> coarseLevelCommunication_;
     std::shared_ptr<typename CoarseOperator::matrix_type> coarseLevelMatrix_;
+    int nrWells_{-1};
 };
 
 } // namespace Opm

--- a/opm/simulators/linalg/PressureBhpTransferPolicy.hpp
+++ b/opm/simulators/linalg/PressureBhpTransferPolicy.hpp
@@ -62,9 +62,12 @@ namespace Opm
         // put the welldofs to the beginning
         assert(loc_max + 1 == indset.size());
         for (int i = 0; i < nw; ++i) {
-            // need to set unique global number, distributed wells are not matched across ranks
-            // and make one smaller well per rank and each rank owns its part
+            // Each well DoF has a unique ID. A distributed well gets
+            // a different ID on each rank, which makes it appear as several
+            // smaller wells - one per rank.
             const std::size_t v = global_max + max_nw * rank + i + 1;
+            // The last argument "false" signifies that this
+            // DoF is not on any other rank (small optimization).
             indset_rw.add(v, LocalIndex(i, Dune::OwnerOverlapCopyAttributeSet::owner, false));
         }
         indset_rw.endResize();
@@ -120,8 +123,8 @@ namespace Opm
             OPM_TIMEBLOCK(createCoarseLevelSystem);
             using CoarseMatrix = typename CoarseOperator::matrix_type;
             const auto& fineLevelMatrix = fineOperator.getmat();
-            nrWells_ = fineOperator.getNumberOfExtraEquations();
             if (prm_.get<bool>("add_wells")) {
+                nrWells_ = fineOperator.getNumberOfExtraEquations();
                 const std::size_t average_elements_per_row
                     = static_cast<std::size_t>(std::ceil(fineLevelMatrix.nonzeroes() / fineLevelMatrix.N()));
                 const double overflow_fraction = 1.2;
@@ -138,7 +141,7 @@ namespace Opm
                     ++rownum;
                 }
             } else {
-                // TODO! not adding wells might make the matrix incopatible with other changed parts of the code
+                nrWells_ = 0;
                 coarseLevelMatrix_.reset(
                     new CoarseMatrix(fineLevelMatrix.N(), fineLevelMatrix.M(), fineLevelMatrix.nonzeroes(), CoarseMatrix::row_wise));
                 auto createIter = coarseLevelMatrix_->createbegin();

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1487,10 +1487,8 @@ namespace Opm {
                              const bool use_well_weights) const
     {
         int nw = this->numLocalWellsEnd();
-        int rdofs = local_num_cells_;
         for ( int i = 0; i < nw; i++ ) {
-            int wdof = rdofs + i;
-            jacobian[wdof][wdof] = 1.0;// better scaling ?
+            jacobian[i][i] = 1.0;// better scaling ?
         }
 
         for (const auto& well : well_container_) {
@@ -1498,7 +1496,8 @@ namespace Opm {
                                            weights,
                                            pressureVarIndex,
                                            use_well_weights,
-                                           this->wellState());
+                                           this->wellState(),
+                                           nw);
         }
     }
 
@@ -1537,15 +1536,13 @@ namespace Opm {
     addWellPressureEquationsStruct(PressureMatrix& jacobian) const
     {
         int nw =  this->numLocalWellsEnd();
-        int rdofs = local_num_cells_;
         const auto wellconnections = this->getMaxWellConnections();
         for (int i = 0; i < nw; ++i) {
-            int wdof = rdofs + i;
-            jacobian.entry(wdof,wdof) = 0.0;
+            jacobian.entry(i,i) = 0.0;
             const auto& perfcells = wellconnections[i];
             for (int perfcell : perfcells) {
-                jacobian.entry(wdof, perfcell) = 0.0;
-                jacobian.entry(perfcell, wdof) = 0.0;
+                jacobian.entry(i, perfcell + nw) = 0.0;
+                jacobian.entry(perfcell + nw, i) = 0.0;
             }
         }
     }

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1503,10 +1503,8 @@ namespace Opm {
                              const bool use_well_weights) const
     {
         int nw = this->numLocalWellsEnd();
-        int rdofs = local_num_cells_;
         for ( int i = 0; i < nw; i++ ) {
-            int wdof = rdofs + i;
-            jacobian[wdof][wdof] = 1.0;// better scaling ?
+            jacobian[i][i] = 1.0;// better scaling ?
         }
 
         for (const auto& well : well_container_) {
@@ -1514,7 +1512,8 @@ namespace Opm {
                                            weights,
                                            pressureVarIndex,
                                            use_well_weights,
-                                           this->wellState());
+                                           this->wellState(),
+                                           nw);
         }
     }
 
@@ -1553,15 +1552,13 @@ namespace Opm {
     addWellPressureEquationsStruct(PressureMatrix& jacobian) const
     {
         int nw =  this->numLocalWellsEnd();
-        int rdofs = local_num_cells_;
         const auto wellconnections = this->getMaxWellConnections();
         for (int i = 0; i < nw; ++i) {
-            int wdof = rdofs + i;
-            jacobian.entry(wdof,wdof) = 0.0;
+            jacobian.entry(i,i) = 0.0;
             const auto& perfcells = wellconnections[i];
             for (int perfcell : perfcells) {
-                jacobian.entry(wdof, perfcell) = 0.0;
-                jacobian.entry(perfcell, wdof) = 0.0;
+                jacobian.entry(i, perfcell + nw) = 0.0;
+                jacobian.entry(perfcell + nw, i) = 0.0;
             }
         }
     }

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -175,7 +175,8 @@ namespace Opm {
                                       const BVector& x,
                                       const int pressureVarIndex,
                                       const bool use_well_weights,
-                                      const WellStateType& well_state) const override;
+                                      const WellStateType& well_state,
+                                      const int nrWells) const override;
 
         std::vector<Scalar>
         computeCurrentWellRates(const Simulator& simulator,

--- a/opm/simulators/wells/MultisegmentWellEquations.cpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.cpp
@@ -375,7 +375,8 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
                          const bool /*use_well_weights*/,
                          const WellInterfaceGeneric<Scalar, IndexTraits>& well,
                          const int seg_pressure_var_ind,
-                         const WellState<Scalar, IndexTraits>& well_state) const
+                         const WellState<Scalar, IndexTraits>& well_state,
+                         const int nrWells) const
 {
     using BlockType = PressureMatrix::block_type;
     static_assert(BlockType::rows == 1);
@@ -384,7 +385,7 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
 
     // Add for coupling from well to reservoir
     const int number_cells = weights.size();
-    const int welldof_ind = number_cells + well.indexOfWell();
+    const int welldof_ind = well.indexOfWell();
     if (!well.isPressureControlled(well_state)) {
         for (std::size_t rowC = 0; rowC < duneC_.N(); ++rowC) {
             for (auto colC = duneC_[rowC].begin(),
@@ -397,7 +398,7 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
                 for (std::size_t i = 0; i< bw.size(); ++i) {
                     matel += bw[i]*(*colC)[seg_pressure_var_ind][i];
                 }
-                jacobian[row_index][welldof_ind][0][0] += matel;
+                jacobian[row_index + nrWells][welldof_ind][0][0] += matel;
             }
         }
     }
@@ -433,7 +434,7 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
                 for (std::size_t i = 0; i< bw.size(); ++i) {
                     matel += bw[i] *(*colB)[i][pressureVarIndex];
                 }
-                jacobian[welldof_ind][col_index][0][0] += matel;
+                jacobian[welldof_ind][col_index + nrWells][0][0] += matel;
                 diag_ell -= matel;
             }
         }
@@ -476,7 +477,8 @@ sumDistributed(Parallel::Communication comm)
                                  const bool,                                                   \
                                  const WellInterfaceGeneric<T,BlackOilDefaultFluidSystemIndices>&,                               \
                                  const int,                                                    \
-                                 const WellState<T,BlackOilDefaultFluidSystemIndices>&) const;
+                                 const WellState<T,BlackOilDefaultFluidSystemIndices>&,        \
+                                 const int) const;
 
 #define INSTANTIATE_TYPE(T) \
     INSTANTIATE(T,2,1)      \

--- a/opm/simulators/wells/MultisegmentWellEquations.cpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.cpp
@@ -391,14 +391,14 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
             for (auto colC = duneC_[rowC].begin(),
                       endC = duneC_[rowC].end(); colC != endC; ++colC) {
                 // map the well perforated cell index to global cell index
-                const auto row_index = cells_[colC.index()];
-                const auto& bw = weights[row_index];
+                const auto row_index = cells_[colC.index()] + nrWells;
+                const auto& bw = weights[row_index - nrWells];
                 Scalar matel = 0.0;
 
                 for (std::size_t i = 0; i< bw.size(); ++i) {
                     matel += bw[i]*(*colC)[seg_pressure_var_ind][i];
                 }
-                jacobian[row_index + nrWells][welldof_ind][0][0] += matel;
+                jacobian[row_index][welldof_ind][0][0] += matel;
             }
         }
     }
@@ -429,12 +429,12 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
             for (auto colB = duneB_[rowB].begin(),
                       endB = duneB_[rowB].end(); colB != endB; ++colB) {
                 // map the well perforated cell index to global cell index
-                const auto col_index = cells_[colB.index()];
+                const auto col_index = cells_[colB.index()] + nrWells;
                 Scalar matel = 0.0;
                 for (std::size_t i = 0; i< bw.size(); ++i) {
                     matel += bw[i] *(*colB)[i][pressureVarIndex];
                 }
-                jacobian[welldof_ind][col_index + nrWells][0][0] += matel;
+                jacobian[welldof_ind][col_index][0][0] += matel;
                 diag_ell -= matel;
             }
         }

--- a/opm/simulators/wells/MultisegmentWellEquations.hpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.hpp
@@ -124,7 +124,8 @@ public:
                                   const bool /*use_well_weights*/,
                                   const WellInterfaceGeneric<Scalar, IndexTraits>& well,
                                   const int seg_pressure_var_ind,
-                                  const WellState<Scalar, IndexTraits>& well_state) const;
+                                  const WellState<Scalar, IndexTraits>& well_state,
+                                  const int nrWells) const;
 
     //! \brief Sum with off-process contribution.
     void sumDistributed(Parallel::Communication comm);

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -908,7 +908,8 @@ namespace Opm
                              const BVector& weights,
                              const int pressureVarIndex,
                              const bool use_well_weights,
-                             const WellStateType& well_state) const
+                             const WellStateType& well_state,
+                             const int nrWells) const
     {
         if (this->number_of_local_perforations_ == 0) {
             // If there are no open perforations on this process, there are no contributions the cpr pressure matrix.
@@ -921,7 +922,8 @@ namespace Opm
                                                use_well_weights,
                                                *this,
                                                this->SPres,
-                                               well_state);
+                                               well_state,
+                                               nrWells);
     }
 
 

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -181,7 +181,8 @@ namespace Opm
                                       const BVector& x,
                                       const int pressureVarIndex,
                                       const bool use_well_weights,
-                                      const WellStateType& well_state) const override;
+                                      const WellStateType& well_state,
+                                      const int nrWells) const override;
 
         // iterate well equations with the specified control until converged
         bool iterateWellEqWithControl(const Simulator& simulator,

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -289,7 +289,8 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
                          const bool use_well_weights,
                          const WellInterfaceGeneric<Scalar, IndexTraits>& well,
                          const int bhp_var_index,
-                         const WellState<Scalar, IndexTraits>& well_state) const
+                         const WellState<Scalar, IndexTraits>& well_state,
+                         const int nrWells) const
 {
     // This adds pressure quation for cpr
     // For use_well_weights=true
@@ -308,7 +309,7 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
     auto cell_weights = weights[0];// not need for not(use_well_weights)
     cell_weights = 0.0;
     const int number_cells = weights.size();
-    const int welldof_ind = number_cells + well.indexOfWell();
+    const int welldof_ind = well.indexOfWell();
     // do not assume anything about pressure controlled with use_well_weights (work fine with the assumtion also)
     if (!well.isPressureControlled(well_state) || use_well_weights) {
         // make coupling for reservoir to well
@@ -323,7 +324,7 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
                 matel += (*colC)[bhp_var_index][i] * bw[i];
             }
 
-            jacobian[row_index][welldof_ind] = matel;
+            jacobian[row_index + nrWells][welldof_ind] = matel;
             cell_weights += bw;
             nperf += 1;
         }
@@ -404,7 +405,7 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
             for (std::size_t i = 0; i < bw.size(); ++i) {
                  matel += (*colB)[i][pressureVarIndex] * bw[i];
             }
-            jacobian[welldof_ind][col_index] = matel;
+            jacobian[welldof_ind][col_index + nrWells] = matel;
         }
     }
 }
@@ -428,7 +429,8 @@ sumDistributed(Parallel::Communication comm)
                                  const bool,                                          \
                                  const WellInterfaceGeneric<T,BlackOilDefaultFluidSystemIndices>&,                      \
                                  const int,                                           \
-                                 const WellState<T,BlackOilDefaultFluidSystemIndices>&) const;
+                                 const WellState<T,BlackOilDefaultFluidSystemIndices>&,                                 \
+                                 const int) const;
 
 #define INSTANTIATE_TYPE(T) \
     INSTANTIATE(T,1)        \

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -316,15 +316,15 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
         for (auto colC = duneC_[0].begin(),
                   endC = duneC_[0].end(); colC != endC; ++colC) {
             // map the well perforated cell index to global cell index
-            const auto row_index = cells_[colC.index()];
-            const auto& bw = weights[row_index];
+            const auto row_index = cells_[colC.index()] + nrWells;
+            const auto& bw = weights[row_index - nrWells];
             Scalar matel = 0;
             assert((*colC).M() == bw.size());
             for (std::size_t i = 0; i < bw.size(); ++i) {
                 matel += (*colC)[bhp_var_index][i] * bw[i];
             }
 
-            jacobian[row_index + nrWells][welldof_ind] = matel;
+            jacobian[row_index][welldof_ind] = matel;
             cell_weights += bw;
             nperf += 1;
         }
@@ -399,13 +399,13 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
         for (auto colB = duneB_[0].begin(),
                   endB = duneB_[0].end(); colB != endB; ++colB) {
             // map the well perforated cell index to global cell index
-            const auto col_index = cells_[colB.index()];
+            const auto col_index = cells_[colB.index()] + nrWells;
             const auto& bw = bweights[0];
             Scalar matel = 0;
             for (std::size_t i = 0; i < bw.size(); ++i) {
                  matel += (*colB)[i][pressureVarIndex] * bw[i];
             }
-            jacobian[welldof_ind][col_index + nrWells] = matel;
+            jacobian[welldof_ind][col_index] = matel;
         }
     }
 }

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -115,7 +115,8 @@ public:
                                   const bool use_well_weights,
                                   const WellInterfaceGeneric<Scalar, IndexTraits>& well,
                                   const int bhp_var_index,
-                                  const WellState<Scalar, IndexTraits>& well_state) const;
+                                  const WellState<Scalar, IndexTraits>& well_state,
+                                  const int nrWells) const;
 
     //! \brief Get the number of blocks of the C and B matrices.
     unsigned int getNumBlocks() const;

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1987,7 +1987,8 @@ namespace Opm
                                                     const BVector& weights,
                                                     const int pressureVarIndex,
                                                     const bool use_well_weights,
-                                                    const WellStateType& well_state) const
+                                                    const WellStateType& well_state,
+                                                    const int nrWells) const
     {
         this->linSys_.extractCPRPressureMatrix(jacobian,
                                                weights,
@@ -1995,7 +1996,8 @@ namespace Opm
                                                use_well_weights,
                                                *this,
                                                Bhp,
-                                               well_state);
+                                               well_state,
+                                               nrWells);
     }
 
 

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -284,7 +284,8 @@ public:
                                           const BVector& x,
                                           const int pressureVarIndex,
                                           const bool use_well_weights,
-                                          const WellStateType& well_state) const = 0;
+                                          const WellStateType& well_state,
+                                          const int nrWells) const = 0;
 
     void addCellRates(std::map<int, RateVector>& cellRates_) const;
 


### PR DESCRIPTION
This PR moves the well DoFs before interior and overlap. As a result, all owned DoFs are grouped together. All well DoFs are owned, interior DoFs are owned too, and overlap is not owned (ghost). The previous order was interior-overlap-wells and this PR changes it to wells-interior-overlap.

This opens the door to optimizations that use the fact that all owned DoFs precede nonowned DoFs.