### PR TITLE
Fixing compiling error in macOS due to missing flags for AVX

### DIFF
--- a/opm/simulators/linalg/StandardPreconditioners_mpi.hpp
+++ b/opm/simulators/linalg/StandardPreconditioners_mpi.hpp
@@ -33,7 +33,9 @@
 #include <memory>
 #include <type_traits>
 
+#if HAVE_AVX2_EXTENSION
 #include <opm/simulators/linalg/mixed/PreconditionerWrapper.hpp>
+#endif
 
 namespace Opm {
 
@@ -165,6 +167,7 @@ struct StandardPreconditioners
             DUNE_UNUSED_PARAMETER(prm);
             return wrapBlockPreconditioner<MultithreadDILU<M, V, V>>(comm, op.getmat());
         });
+#if HAVE_AVX2_EXTENSION
         F::addCreator("mixed-ilu0", [](const O& op, const P& prm, const std::function<V()>&, std::size_t, const C& comm) {
             DUNE_UNUSED_PARAMETER(prm);
             if  constexpr (std::is_same_v<typename V::field_type, float>) {
@@ -183,6 +186,7 @@ struct StandardPreconditioners
                 return wrapBlockPreconditioner<MixedPreconditioner<M,V,V>>(comm, op.getmat(), true);
             }
         });
+#endif
         F::addCreator("jac", [](const O& op, const P& prm, const std::function<V()>&, std::size_t, const C& comm) {
             const int n = prm.get<int>("repeats", 1);
             const double w = prm.get<double>("relaxation", 1.0);

--- a/opm/simulators/linalg/StandardPreconditioners_serial.hpp
+++ b/opm/simulators/linalg/StandardPreconditioners_serial.hpp
@@ -33,9 +33,9 @@
 #include <memory>
 #include <type_traits>
 
-
+#if HAVE_AVX2_EXTENSION
 #include <opm/simulators/linalg/mixed/PreconditionerWrapper.hpp>
-
+#endif
 
 namespace Opm {
 
@@ -92,6 +92,7 @@ struct StandardPreconditioners<Operator, Dune::Amg::SequentialInformation, typen
             DUNE_UNUSED_PARAMETER(prm);
             return std::make_shared<MultithreadDILU<M, V, V>>(op.getmat());
         });
+#if HAVE_AVX2_EXTENSION
         F::addCreator("mixed-ilu0", [](const O& op, const P& prm, const std::function<V()>&, std::size_t) {
             DUNE_UNUSED_PARAMETER(prm);
             if  constexpr (std::is_same_v<typename V::field_type, float>) {
@@ -110,6 +111,7 @@ struct StandardPreconditioners<Operator, Dune::Amg::SequentialInformation, typen
                 return std::make_shared<MixedPreconditioner<M,V,V>>(op.getmat(),true);
             }
         });
+#endif
         F::addCreator("legacy-mixed-ilu0", [](const O& op, const P& prm, const std::function<V()>&, std::size_t) {
             DUNE_UNUSED_PARAMETER(prm);
             DUNE_UNUSED_PARAMETER(op);


### PR DESCRIPTION
Fixing compiling error in macOS due to missing flags for AVX