### PR TITLE
FlexibleSolver: support conjugate gradients (solver: cg)

### DIFF
--- a/opm/simulators/linalg/FlexibleSolver_impl.hpp
+++ b/opm/simulators/linalg/FlexibleSolver_impl.hpp
@@ -255,6 +255,13 @@ namespace Dune
                                                                             comm);
             }
 #endif
+        } else if (solver_type == "cg") {
+            linsolver_ = std::make_shared<Dune::CGSolver<VectorType>>(*linearoperator_for_solver_,
+                                                                      *scalarproduct_,
+                                                                      *preconditioner_,
+                                                                      tol, // desired residual reduction factor
+                                                                      maxiter, // maximum number of iterations
+                                                                      verbosity);
         } else if (solver_type == "loopsolver") {
             linsolver_ = std::make_shared<Dune::LoopSolver<VectorType>>(*linearoperator_for_solver_,
                                                                         *scalarproduct_,


### PR DESCRIPTION
Adds "solver": "cg" to the FlexibleSolver dispatch, alongside the existing bicgstab / gmres / loopsolver branches. CG is the right Krylov method for the SPD systems that arise in elasticity/mechanics solves, where bicgstab wastes roughly half its work.

Guarded against GPU operators in exactly the same style as the neighbouring branches; no behaviour change for any existing configuration, since the key is new.