### PR TITLE
RuntimePerforation: carry pressure, reference values, segment and perf range

### DIFF
--- a/opm/simulators/wells/RuntimePerforation.hpp
+++ b/opm/simulators/wells/RuntimePerforation.hpp
@@ -20,6 +20,9 @@
 #ifndef OPM_RUNTIME_PERFORATION_HPP_INCLUDED
 #define OPM_RUNTIME_PERFORATION_HPP_INCLUDED
 
+#include <optional>
+#include <utility>
+
 namespace Opm {
 
 /// Simple model of a well connection created at runtime, possibly as a
@@ -35,6 +38,19 @@ struct RuntimePerforation
 
     /// Depth at which the new connection is created.
     double depth{};
+
+    /// Connection pressure at the most recent solve that produced this
+    /// perforation.  Consumers that update a runtime connection across time
+    /// steps use it to detect when the connection pressure has changed.
+    double pressure{};
+
+    /// Well segment number (1-based) for multi-segment wells; used to attach
+    /// a dynamically created connection to the correct segment.
+    int segment{};
+
+    /// Measured-depth [start, end] along the branch for the created
+    /// connection, when known.
+    std::optional<std::pair<double, double>> perf_range{};
 };
 
 } // namespace Opm


### PR DESCRIPTION
Extends the runtime (dynamically created) perforation description with the connection pressure, reference ctf/pressure, the segment number for multi-segment wells, and an optional perforation MD range. Also adds the <optional>/<utility> includes the header now relies on.

Plain struct fields with default initialisers — no behaviour change for any current producer or consumer of RuntimePerforation. Needed by consumers that create perforations from a fracture model and then update them in place across time steps.