### PR TITLE
Cleanup: Remove superfluous 'virtual' keyword from overridden methods

### DIFF
--- a/opm/simulators/linalg/DILU.hpp
+++ b/opm/simulators/linalg/DILU.hpp
@@ -157,12 +157,12 @@ public:
     }
 
     //! Category of the preconditioner (see SolverCategory::Category)
-    virtual SolverCategory::Category category() const override
+    SolverCategory::Category category() const override
     {
         return SolverCategory::sequential;
     }
 
-    virtual bool hasPerfectUpdate() const override {
+    bool hasPerfectUpdate() const override {
         return true;
     }
 

--- a/opm/simulators/linalg/FlexibleSolver.hpp
+++ b/opm/simulators/linalg/FlexibleSolver.hpp
@@ -63,14 +63,14 @@ public:
                    const std::function<VectorType()>& weightsCalculator,
                    std::size_t pressureIndex);
 
-    virtual void apply(VectorType& x, VectorType& rhs, Dune::InverseOperatorResult& res) override;
+    void apply(VectorType& x, VectorType& rhs, Dune::InverseOperatorResult& res) override;
 
-    virtual void apply(VectorType& x, VectorType& rhs, double reduction, Dune::InverseOperatorResult& res) override;
+    void apply(VectorType& x, VectorType& rhs, double reduction, Dune::InverseOperatorResult& res) override;
 
     /// Access the contained preconditioner.
     AbstractPrecondType& preconditioner();
 
-    virtual Dune::SolverCategory::Category category() const override;
+    Dune::SolverCategory::Category category() const override;
 
 private:
     using AbstractScalarProductType = Dune::ScalarProduct<VectorType>;

--- a/opm/simulators/linalg/OwningBlockPreconditioner.hpp
+++ b/opm/simulators/linalg/OwningBlockPreconditioner.hpp
@@ -44,37 +44,37 @@ public:
     using X = typename OriginalPreconditioner::domain_type;
     using Y = typename OriginalPreconditioner::range_type;
 
-    virtual void pre(X& x, Y& b) override
+    void pre(X& x, Y& b) override
     {
         OPM_TIMEBLOCK(pre);
         block_precond_.pre(x, b);
     }
 
-    virtual void apply(X& v, const Y& d) override
+    void apply(X& v, const Y& d) override
     {
         OPM_TIMEBLOCK(apply);
         block_precond_.apply(v, d);
     }
 
-    virtual void post(X& x) override
+    void post(X& x) override
     {
         OPM_TIMEBLOCK(post);
         block_precond_.post(x);
     }
 
-    virtual SolverCategory::Category category() const override
+    SolverCategory::Category category() const override
     {
         return block_precond_.category();
     }
 
     // The update() function does nothing for a wrapped preconditioner.
-    virtual void update() override
+    void update() override
     {
         OPM_TIMEBLOCK(update);
         orig_precond_.update();
     }
 
-    virtual bool hasPerfectUpdate() const override {
+    bool hasPerfectUpdate() const override {
         return orig_precond_.hasPerfectUpdate();
     }
 

--- a/opm/simulators/linalg/OwningTwoLevelPreconditioner.hpp
+++ b/opm/simulators/linalg/OwningTwoLevelPreconditioner.hpp
@@ -149,33 +149,33 @@ public:
         }
     }
 
-    virtual void pre(VectorType& x, VectorType& b) override
+    void pre(VectorType& x, VectorType& b) override
     {
         twolevel_method_.pre(x, b);
     }
 
-    virtual void apply(VectorType& v, const VectorType& d) override
+    void apply(VectorType& v, const VectorType& d) override
     {
         twolevel_method_.apply(v, d);
     }
 
-    virtual void post(VectorType& x) override
+    void post(VectorType& x) override
     {
         twolevel_method_.post(x);
     }
 
-    virtual void update() override
+    void update() override
     {
         weights_ = weightsCalculator_();
         updateImpl(comm_);
     }
 
-    virtual Dune::SolverCategory::Category category() const override
+    Dune::SolverCategory::Category category() const override
     {
         return linear_operator_.category();
     }
 
-    virtual bool hasPerfectUpdate() const override {
+    bool hasPerfectUpdate() const override {
         return twolevel_method_.hasPerfectUpdate();
     }
 

--- a/opm/simulators/linalg/ParallelOverlappingILU0.hpp
+++ b/opm/simulators/linalg/ParallelOverlappingILU0.hpp
@@ -144,7 +144,7 @@ public:
     using block_type = typename matrix_type::block_type;
     using size_type = typename matrix_type::size_type;
 
-    virtual bool hasPerfectUpdate() const override {
+    bool hasPerfectUpdate() const override {
         return true;
     }
 

--- a/opm/simulators/linalg/PreconditionerWithUpdate.hpp
+++ b/opm/simulators/linalg/PreconditionerWithUpdate.hpp
@@ -53,32 +53,32 @@ public:
     using X = typename OriginalPreconditioner::domain_type;
     using Y = typename OriginalPreconditioner::range_type;
 
-    virtual void pre(X& x, Y& b) override
+    void pre(X& x, Y& b) override
     {
         orig_precond_.pre(x, b);
     }
 
-    virtual void apply(X& v, const Y& d) override
+    void apply(X& v, const Y& d) override
     {
         orig_precond_.apply(v, d);
     }
 
-    virtual void post(X& x) override
+    void post(X& x) override
     {
         orig_precond_.post(x);
     }
 
-    virtual SolverCategory::Category category() const override
+    SolverCategory::Category category() const override
     {
         return orig_precond_.category();
     }
 
     // The update() function does nothing for a wrapped preconditioner.
-    virtual void update() override
+    void update() override
     {
     }
 
-    virtual bool hasPerfectUpdate() const override {
+    bool hasPerfectUpdate() const override {
         return true;
     }
 

--- a/opm/simulators/linalg/StandardPreconditioners_serial.hpp
+++ b/opm/simulators/linalg/StandardPreconditioners_serial.hpp
@@ -44,12 +44,12 @@ class TrivialPreconditioner : public Dune::PreconditionerWithUpdate<X, Y>
 {
     public:
     TrivialPreconditioner(){};
-    virtual void update() override {};
-    virtual bool hasPerfectUpdate() const override {return true;}
-    virtual void pre ([[maybe_unused]] X& x, [[maybe_unused]] Y& y) override {};
-    virtual void post ([[maybe_unused]] X& x) override {};
-    virtual void apply ([[maybe_unused]] X& x, [[maybe_unused]] const Y& y) override {};
-    virtual Dune::SolverCategory::Category category() const override { return Dune::SolverCategory::sequential; };
+    void update() override {};
+    bool hasPerfectUpdate() const override {return true;}
+    void pre ([[maybe_unused]] X& x, [[maybe_unused]] Y& y) override {};
+    void post ([[maybe_unused]] X& x) override {};
+    void apply ([[maybe_unused]] X& x, [[maybe_unused]] const Y& y) override {};
+    Dune::SolverCategory::Category category() const override { return Dune::SolverCategory::sequential; };
 };
 
 

--- a/opm/simulators/linalg/WellOperators.hpp
+++ b/opm/simulators/linalg/WellOperators.hpp
@@ -429,7 +429,7 @@ public:
         interiorSize_ = setInteriorSize(comm_);
     }
 
-    virtual void apply( const X& x, Y& y ) const override
+    void apply( const X& x, Y& y ) const override
     {
         for (auto row = A_->begin(); row.index() < interiorSize_; ++row)
         {
@@ -443,7 +443,7 @@ public:
     }
 
     // y += \alpha * A * x
-    virtual void applyscaleadd (field_type alpha, const X& x, Y& y) const override
+    void applyscaleadd (field_type alpha, const X& x, Y& y) const override
     {
         for (auto row = A_->begin(); row.index() < interiorSize_; ++row)
         {
@@ -455,7 +455,7 @@ public:
         ghostLastProject( y );
     }
 
-    virtual const matrix_type& getmat() const override { return *A_; }
+    const matrix_type& getmat() const override { return *A_; }
 
     size_t getInteriorSize() const { return interiorSize_;}
 

--- a/opm/simulators/linalg/gpuistl/GpuBlockPreconditioner.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuBlockPreconditioner.hpp
@@ -62,7 +62,7 @@ public:
     //! \brief Prepare the preconditioner.
     //!
     //! \copydoc Preconditioner::pre(X&,Y&)
-    virtual void pre(X& x, Y& b) override
+    void pre(X& x, Y& b) override
     {
         // TODO: [perf] Do we always need to copy, or only when we need the pre step?
         m_communication->copyOwnerToAll(x, x); // make Dirichlet values consistent
@@ -74,19 +74,19 @@ public:
     //! \brief Apply the preconditioner
     //!
     //! \copydoc Preconditioner::apply(X&,const Y&)
-    virtual void apply(X& v, const Y& d) override
+    void apply(X& v, const Y& d) override
     {
         m_preconditioner->apply(v, d);
         m_communication->copyOwnerToAll(v, v);
     }
 
 
-    virtual void update() override
+    void update() override
     {
         m_preconditioner->update();
     }
 
-    virtual void post(X& x) override
+    void post(X& x) override
     {
         if constexpr (detail::shouldCallPreconditionerPost<P>()) {
             m_preconditioner->post(x);
@@ -94,7 +94,7 @@ public:
     }
 
     //! Category of the preconditioner (see SolverCategory::Category)
-    virtual Dune::SolverCategory::Category category() const override
+    Dune::SolverCategory::Category category() const override
     {
         return Dune::SolverCategory::overlapping;
     }
@@ -108,12 +108,12 @@ public:
         return detail::shouldCallPreconditionerPre<P>();
     }
 
-    virtual std::shared_ptr<Dune::PreconditionerWithUpdate<X, Y>> getUnderlyingPreconditioner() override
+    std::shared_ptr<Dune::PreconditionerWithUpdate<X, Y>> getUnderlyingPreconditioner() override
     {
         return m_preconditioner;
     }
 
-    virtual bool hasPerfectUpdate() const override {
+    bool hasPerfectUpdate() const override {
         return true;
     }
 

--- a/opm/simulators/linalg/gpuistl/GpuDILU.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuDILU.hpp
@@ -116,7 +116,7 @@ public:
         return false;
     }
 
-    virtual bool hasPerfectUpdate() const override
+    bool hasPerfectUpdate() const override
     {
         return true;
     }

--- a/opm/simulators/linalg/gpuistl/GpuJac.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuJac.hpp
@@ -65,20 +65,20 @@ public:
 
     //! \brief Prepare the preconditioner.
     //! \note Does nothing at the time being.
-    virtual void pre(X& x, Y& b) override;
+    void pre(X& x, Y& b) override;
 
     //! \brief Apply the preconditoner.
-    virtual void apply(X& v, const Y& d) override;
+    void apply(X& v, const Y& d) override;
 
     //! \brief Post processing
     //! \note Does nothing at the moment
-    virtual void post(X& x) override;
+    void post(X& x) override;
 
     //! Category of the preconditioner (see SolverCategory::Category)
-    virtual Dune::SolverCategory::Category category() const override;
+    Dune::SolverCategory::Category category() const override;
 
     //! \brief Updates the matrix data.
-    virtual void update() override;
+    void update() override;
 
 
     //! \returns false
@@ -93,7 +93,7 @@ public:
         return false;
     }
 
-    virtual bool hasPerfectUpdate() const override {
+    bool hasPerfectUpdate() const override {
         return true;
     }
 

--- a/opm/simulators/linalg/gpuistl/GpuSeqILU0.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuSeqILU0.hpp
@@ -82,20 +82,20 @@ public:
 
     //! \brief Prepare the preconditioner.
     //! \note Does nothing at the time being.
-    virtual void pre(X& x, Y& b) override;
+    void pre(X& x, Y& b) override;
 
     //! \brief Apply the preconditoner.
-    virtual void apply(X& v, const Y& d) override;
+    void apply(X& v, const Y& d) override;
 
     //! \brief Post processing
     //! \note Does nothing at the moment
-    virtual void post(X& x) override;
+    void post(X& x) override;
 
     //! Category of the preconditioner (see SolverCategory::Category)
-    virtual Dune::SolverCategory::Category category() const override;
+    Dune::SolverCategory::Category category() const override;
 
     //! \brief Updates the matrix data.
-    virtual void update() override;
+    void update() override;
 
 
     //! \returns false
@@ -110,7 +110,7 @@ public:
         return false;
     }
 
-    virtual bool hasPerfectUpdate() const override {
+    bool hasPerfectUpdate() const override {
         return true;
     }
 

--- a/opm/simulators/linalg/gpuistl/OpmGpuILU0.hpp
+++ b/opm/simulators/linalg/gpuistl/OpmGpuILU0.hpp
@@ -118,7 +118,7 @@ public:
         return false;
     }
 
-    virtual bool hasPerfectUpdate() const override {
+    bool hasPerfectUpdate() const override {
         return true;
     }
 

--- a/opm/simulators/linalg/gpuistl/PreconditionerAdapter.hpp
+++ b/opm/simulators/linalg/gpuistl/PreconditionerAdapter.hpp
@@ -63,7 +63,7 @@ public:
     //! \brief Prepare the preconditioner.
     //!
     //! Currently not supported.
-    virtual void pre([[maybe_unused]] X& x, [[maybe_unused]] Y& b) override
+    void pre([[maybe_unused]] X& x, [[maybe_unused]] Y& b) override
     {
         static_assert(!detail::shouldCallPreconditionerPre<CudaPreconditionerType>(),
                       "We currently do not support Preconditioner::pre().");
@@ -73,7 +73,7 @@ public:
     //! \brief Apply the preconditoner.
     //!
     //! \copydoc Preconditioner::apply(X&,const Y&)
-    virtual void apply(X& v, const Y& d) override
+    void apply(X& v, const Y& d) override
     {
         if (!m_inputBuffer) {
             m_inputBuffer.reset(new GpuVector<field_type>(v.dim()));
@@ -88,7 +88,7 @@ public:
     //! \brief Clean up.
     //!
     //! Currently not supported.
-    virtual void post([[maybe_unused]] X& x) override
+    void post([[maybe_unused]] X& x) override
     {
         static_assert(!detail::shouldCallPreconditionerPost<CudaPreconditionerType>(),
                       "We currently do not support Preconditioner::post().");
@@ -102,7 +102,7 @@ public:
     }
 
     //! Calls update on the underlying CUDA preconditioner
-    virtual void update() override
+    void update() override
     {
         m_underlyingPreconditioner->update();
     }
@@ -116,13 +116,13 @@ public:
         return detail::shouldCallPreconditionerPre<CudaPreconditionerType>();
     }
 
-    virtual std::shared_ptr<Dune::PreconditionerWithUpdate<GpuVector<field_type>, GpuVector<field_type>>>
+    std::shared_ptr<Dune::PreconditionerWithUpdate<GpuVector<field_type>, GpuVector<field_type>>>
     getUnderlyingPreconditioner() override
     {
         return m_underlyingPreconditioner;
     }
 
-    virtual bool hasPerfectUpdate() const override {
+    bool hasPerfectUpdate() const override {
         return m_underlyingPreconditioner->hasPerfectUpdate();
     }
 

--- a/opm/simulators/linalg/gpuistl/PreconditionerCPUMatrixToGPUMatrix.hpp
+++ b/opm/simulators/linalg/gpuistl/PreconditionerCPUMatrixToGPUMatrix.hpp
@@ -110,7 +110,7 @@ public:
         return detail::shouldCallPreconditionerPre<CudaPreconditionerType>();
     }
 
-    virtual bool hasPerfectUpdate() const override
+    bool hasPerfectUpdate() const override
     {
         return m_underlyingPreconditioner.hasPerfectUpdate();
     }

--- a/opm/simulators/linalg/gpuistl/PreconditionerConvertFieldTypeAdapter.hpp
+++ b/opm/simulators/linalg/gpuistl/PreconditionerConvertFieldTypeAdapter.hpp
@@ -124,14 +124,14 @@ public:
     }
 
     //! \brief Not used at the moment
-    virtual void pre([[maybe_unused]] X& x, [[maybe_unused]] Y& b) override
+    void pre([[maybe_unused]] X& x, [[maybe_unused]] Y& b) override
     {
         static_assert(!detail::shouldCallPreconditionerPre<CudaPreconditionerType>(),
                       "We currently do not support Preconditioner::pre().");
     }
 
     //! \brief Apply the preconditoner.
-    virtual void apply(X& v, const Y& d) override
+    void apply(X& v, const Y& d) override
     {
         OPM_ERROR_IF(!m_underlyingPreconditioner,
                      "You need to set the underlying preconditioner with setUnderlyingPreconditioner.");
@@ -159,19 +159,19 @@ public:
     }
 
     //! \brief Not used at the moment
-    virtual void post([[maybe_unused]] X& x) override
+    void post([[maybe_unused]] X& x) override
     {
         static_assert(!detail::shouldCallPreconditionerPost<CudaPreconditionerType>(),
                       "We currently do not support Preconditioner::post().");
     }
 
     //! Category of the preconditioner (see SolverCategory::Category)
-    virtual Dune::SolverCategory::Category category() const override
+    Dune::SolverCategory::Category category() const override
     {
         return m_underlyingPreconditioner->category();
     }
 
-    virtual void update() override
+    void update() override
     {
         OPM_ERROR_IF(!m_underlyingPreconditioner,
                      "You need to set the underlying preconditioner with setUnderlyingPreconditioner.");
@@ -189,7 +189,7 @@ public:
         m_underlyingPreconditioner = conditioner;
     }
 
-    virtual bool hasPerfectUpdate() const override {
+    bool hasPerfectUpdate() const override {
         return m_underlyingPreconditioner->hasPerfectUpdate();
     }
 

--- a/opm/simulators/linalg/gpuistl/SolverAdapter.hpp
+++ b/opm/simulators/linalg/gpuistl/SolverAdapter.hpp
@@ -91,7 +91,7 @@ public:
             "Using WellModelMatrixAdapter with SolverAdapter is not well-defined so it will not work well, or at all.");
     }
 
-    virtual void apply(X& x, X& b, double reduction, Dune::InverseOperatorResult& res) override
+    void apply(X& x, X& b, double reduction, Dune::InverseOperatorResult& res) override
     {
         // TODO: Can we do this without reimplementing the other function?
         // TODO: [perf] Do we need to update the matrix every time? Probably yes
@@ -112,7 +112,7 @@ public:
         m_inputBuffer->copyToHost(b);
         m_outputBuffer->copyToHost(x);
     }
-    virtual void apply(X& x, X& b, Dune::InverseOperatorResult& res) override
+    void apply(X& x, X& b, Dune::InverseOperatorResult& res) override
     {
         // TODO: [perf] Do we need to update the matrix every time? Probably yes
         m_matrix.updateNonzeroValues(m_opOnCPUWithMatrix.getmat(), true);

--- a/opm/simulators/linalg/mixed/PreconditionerWrapper.hpp
+++ b/opm/simulators/linalg/mixed/PreconditionerWrapper.hpp
@@ -70,12 +70,12 @@ class MixedPreconditioner : public Dune::PreconditionerWithUpdate<X, Y>
         prec_free(prec_);
     }
 
-    virtual void update() override;
-    virtual bool hasPerfectUpdate() const override {return true;}
-    virtual void pre ([[maybe_unused]] X& x, [[maybe_unused]] Y& y) override {};
-    virtual void post ([[maybe_unused]] X& x) override {};
-    virtual void apply ([[maybe_unused]] X& x, [[maybe_unused]] const Y& y) override;
-    virtual Dune::SolverCategory::Category category() const override { return Dune::SolverCategory::sequential; };
+    void update() override;
+    bool hasPerfectUpdate() const override {return true;}
+    void pre ([[maybe_unused]] X& x, [[maybe_unused]] Y& y) override {};
+    void post ([[maybe_unused]] X& x) override {};
+    void apply ([[maybe_unused]] X& x, [[maybe_unused]] const Y& y) override;
+    Dune::SolverCategory::Category category() const override { return Dune::SolverCategory::sequential; };
 
     private:
     bool use_dilu_;

--- a/opm/simulators/linalg/mixed/SolverAdapter.hpp
+++ b/opm/simulators/linalg/mixed/SolverAdapter.hpp
@@ -33,7 +33,7 @@ public:
     static constexpr auto block_size = Vector::block_type::dimension;
 
     // Compute the dot product <vx, vy>
-    virtual double dot(const Vector& vx, const Vector& vy) const override
+    double dot(const Vector& vx, const Vector& vy) const override
     {
         // access underlying data
         double const *x = &vx[0][0];
@@ -59,7 +59,7 @@ public:
     }
 
     // Compute the norm ||x||
-    virtual double norm(const Vector& x) const override {
+    double norm(const Vector& x) const override {
         return std::sqrt(this->dot(x, x));
     }
 };
@@ -185,7 +185,7 @@ class MixedBiCGSTABSolver:public InverseOperator<Vector, Vector>
                                                               verbosity);
     }
 
-    virtual void apply(Vector &x, Vector &b, InverseOperatorResult &res) override
+    void apply(Vector &x, Vector &b, InverseOperatorResult &res) override
     {
         //transpose dense blocks and demote to single precision
         mixed_matrix_->update(double_data_);
@@ -194,7 +194,7 @@ class MixedBiCGSTABSolver:public InverseOperator<Vector, Vector>
         solver_->apply(x,b,res);
     }
 
-    virtual void apply(Vector &x, Vector &b, double reduction, InverseOperatorResult &res) override
+    void apply(Vector &x, Vector &b, double reduction, InverseOperatorResult &res) override
     {
         x=0;
         b=0;
@@ -202,7 +202,7 @@ class MixedBiCGSTABSolver:public InverseOperator<Vector, Vector>
         OPM_THROW(std::invalid_argument, "MixedBiCGSTABSolver::apply(...) not implemented yet.");
     }
 
-    virtual Dune::SolverCategory::Category category() const override{return Dune::SolverCategory::overlapping;};
+    Dune::SolverCategory::Category category() const override{return Dune::SolverCategory::overlapping;};
 
     private:
     using AbstractSolverType = Dune::InverseOperator<Vector,Vector>;

--- a/opm/simulators/linalg/mixed/wrapper.hpp
+++ b/opm/simulators/linalg/mixed/wrapper.hpp
@@ -64,7 +64,7 @@ class MixedSolver : public InverseOperator<X,X>
 
     }
 
-    virtual void apply (X& x, X& b, InverseOperatorResult& res) override
+    void apply (X& x, X& b, InverseOperatorResult& res) override
     {
         // transpose each dense block to make them column-major
         double B[9];
@@ -87,7 +87,7 @@ class MixedSolver : public InverseOperator<X,X>
         res.iterations = count;
     }
 
-    virtual void apply (X& x, X& b, double reduction, InverseOperatorResult& res) override
+    void apply (X& x, X& b, double reduction, InverseOperatorResult& res) override
     {
         x=0;
         b=0;
@@ -96,7 +96,7 @@ class MixedSolver : public InverseOperator<X,X>
 
     }
 
-    virtual Dune::SolverCategory::Category category() const override { return Dune::SolverCategory::sequential; };
+    Dune::SolverCategory::Category category() const override { return Dune::SolverCategory::sequential; };
 
     private:
     bsr_matrix  *jacobian_;
@@ -107,4 +107,3 @@ class MixedSolver : public InverseOperator<X,X>
 }
 
 #endif // OPM_MIXED_SOLVER_HEADER_INCLUDED
-

--- a/opm/simulators/linalg/overlappingoperator.hh
+++ b/opm/simulators/linalg/overlappingoperator.hh
@@ -55,14 +55,14 @@ public:
     { return Dune::SolverCategory::overlapping; }
 
     //! apply operator to x:  \f$ y = A(x) \f$
-    virtual void apply(const DomainVector& x, RangeVector& y) const override
+    void apply(const DomainVector& x, RangeVector& y) const override
     {
         A_.mv(x, y);
         y.sync();
     }
 
     //! apply operator to x, scale and add:  \f$ y = y + \alpha A(x) \f$
-    virtual void applyscaleadd(field_type alpha, const DomainVector& x,
+    void applyscaleadd(field_type alpha, const DomainVector& x,
                                RangeVector& y) const override
     {
         A_.usmv(alpha, x, y);
@@ -70,7 +70,7 @@ public:
     }
 
     //! returns the matrix
-    virtual const OverlappingMatrix& getmat() const override
+    const OverlappingMatrix& getmat() const override
     { return A_; }
 
     const Overlap& overlap() const


### PR DESCRIPTION
The `virtual` keyword is redundant when a method is explicitly marked with `override`, as `override` implies virtuality. This change improves code clarity.