### PR TITLE
Allow a downstream driver to re-run report steps from its own state

### DIFF
--- a/opm/simulators/flow/FlowMain.hpp
+++ b/opm/simulators/flow/FlowMain.hpp
@@ -210,6 +210,15 @@ namespace Opm {
             return simtimer_.get();
         }
 
+        /// The report-step driver, for callers that step the simulation
+        /// themselves via executeStep() and need to configure it -- e.g. to
+        /// install a SimulatorFullyImplicit::setRestoreStateHook. Null until
+        /// executeInitStep() has run.
+        Simulator* getStepDriverPtr()
+        {
+            return simulator_.get();
+        }
+
         /// Get the size of the previous report step
         double getPreviousReportStepSize()
         {

--- a/opm/simulators/flow/SimulatorFullyImplicit.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicit.hpp
@@ -54,6 +54,7 @@
 #endif
 
 #include <array>
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -272,6 +273,23 @@ public:
      */
     bool runStep(SimulatorTimer& timer);
 
+    /** \brief Install a callback that restores simulation state at the start of
+     *         each report step, from a store the caller owns.
+     *
+     * Invoked inside \ref runStep at the same point as the `--load-step`
+     * OPMRST restore: after the episode has been set up and before the solve,
+     * with the current report-step number. Intended for drivers that re-run
+     * stretches of a simulation from their own checkpoints -- the adjoint
+     * checkpoint/recompute sweep -- and must therefore reproduce the recorded
+     * trajectory rather than start from the deck.
+     *
+     * The callback is responsible for the whole restore, including
+     * `prepareDeserialize` and invalidating the intensive quantities, exactly
+     * as the OPMRST path does. Pass an empty function to disable.
+     */
+    void setRestoreStateHook(std::function<void(int)> hook)
+    { restoreStateHook_ = std::move(hook); }
+
     /** \brief Stop the timers and emit the final OPMRST output.
      *
      * Called by \ref run after the report-step loop finishes.  Stops
@@ -385,6 +403,10 @@ protected:
 
     /// OPMRST save / load.
     SimulatorSerializer serializer_;
+
+    /// Caller-supplied per-report-step state restore; see
+    /// \ref setRestoreStateHook. Empty (inactive) unless installed.
+    std::function<void(int)> restoreStateHook_{};
 };
 
 } // namespace Opm

--- a/opm/simulators/flow/SimulatorFullyImplicit_impl.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicit_impl.hpp
@@ -331,6 +331,14 @@ runStep(SimulatorTimer& timer)
         simulator_.model().invalidateAndUpdateIntensiveQuantities(/*timeIdx=*/0);
     }
 
+    // Same position as the OPMRST restore above -- after the episode has been
+    // set up and before the solve -- for callers that keep their own state
+    // store. Used by the adjoint's checkpoint/recompute driver, which restores
+    // from its own archive rather than from an .OPMRST file. Off unless set.
+    if (restoreStateHook_) {
+        restoreStateHook_(timer.currentStepNum());
+    }
+
     this->solver_->model().beginReportStep();
 
     const bool enableTUNING = Parameters::Get<Parameters::EnableTuning>();


### PR DESCRIPTION
Title: Allow a downstream driver to re-run report steps from its own state

Two small additions, no behaviour change by default.

SimulatorFullyImplicit::setRestoreStateHook(std::function<void(int)>) installs a callback that runStep invokes at exactly the point the --load-step OPMRST restore uses — after startNextEpisode()/setEpisodeIndex(), before the solve — with the current report-step number. Empty by default, so runStep is unchanged unless a caller opts in. The callback owns the whole restore, including prepareDeserialize() and invalidating the intensive quantities, just as the OPMRST path does.

FlowMain::getStepDriverPtr() — getSimulatorPtr() returns the model Simulator, so a caller driving stepping through the existing executeStep() has no way to reach the SimulatorFullyImplicit that owns it, and therefore no way to install the hook. Returns null until executeInitStep() has run.

Title: Allow a downstream driver to re-run report steps from its own state

Two small additions, no behaviour change by default.

SimulatorFullyImplicit::setRestoreStateHook(std::function<void(int)>) installs a callback that runStep invokes at exactly the point the --load-step OPMRST restore uses — after startNextEpisode()/setEpisodeIndex(), before the solve — with the current report-step number. Empty by default, so runStep is unchanged unless a caller opts in. The callback owns the whole restore, including prepareDeserialize() and invalidating the intensive quantities, just as the OPMRST path does.

FlowMain::getStepDriverPtr() — getSimulatorPtr() returns the model Simulator, so a caller driving stepping through the existing executeStep() has no way to reach the SimulatorFullyImplicit that owns it, and therefore no way to install the hook. Returns null until executeInitStep() has run.

Why
A checkpoint/recompute adjoint sweep stores state only every M-th step and re-runs the steps between, so it must resume from its own archive rather than from an .OPMRST file. SimulatorSerializer cannot serve that: loadStep_ is private, armed only by the constructor and cleared by loadState(), so it is single-use; and saveState/loadState are protected behind a private SerializableSim base, so a driver cannot call them at all.

Placing the hook at the same point as the OPMRST restore matters — that position is already validated by tests/run-serialization-regressionTest.sh. Confirmed independently while developing this: a save/load/continue on SPE9 reproduces the subsequent residuals and Jacobians bitwise for all 11 restarted steps, and on a Norne-derived deck (36 wells, hysteresis, group control) the residual and Jacobian are likewise bitwise identical.

The two commits are separable if you would rather take only one.