### PR TITLE
wells: resize the well state unconditionally in prepareDeserialize

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -273,14 +273,27 @@ prepareDeserialize(int report_step, const std::size_t numCells, bool enable_dist
     this->initializeWellProdIndCalculators();
     initializeWellPerfData();
 
-    if (! this->wells_ecl_.empty()) {
-        const bool handle_ms_well = param_.use_multisegment_well_ && anyMSWellOpenLocal();
-        this->wellState().resize(this->wells_ecl_, this->local_parallel_well_info_,
-                                 this->schedule(), handle_ms_well, numCells,
-                                 this->well_perf_data_, this->summaryState_, enable_distributed_wells,
-                                 this->eclState().getSimulationConfig().isThermal());
-
-    }
+    // Resize unconditionally, including when this rank has no local wells at
+    // report_step. Skipping it there leaves the PREVIOUS call's well state in
+    // place, so the well state no longer describes report_step and a
+    // subsequent deserialization fails on the size check in
+    // WellState::serializeOp.
+    //
+    // A forward restart never notices, because it deserializes one step into a
+    // fresh model. Walking a run backwards does: a rank goes from "has wells"
+    // to "has none" as it moves to earlier report steps, and a stale non-empty
+    // well state survives into a step whose stored state is empty. Norne, where
+    // wells are drilled progressively, hits this; decks whose wells all exist
+    // from step 0 (SPE1, SPE9) never do.
+    //
+    // WellState::resize handles an empty well list correctly - base_init clears
+    // the well container and init returns early after the bookkeeping.
+    const bool handle_ms_well = param_.use_multisegment_well_ &&
+                                !this->wells_ecl_.empty() && anyMSWellOpenLocal();
+    this->wellState().resize(this->wells_ecl_, this->local_parallel_well_info_,
+                             this->schedule(), handle_ms_well, numCells,
+                             this->well_perf_data_, this->summaryState_, enable_distributed_wells,
+                             this->eclState().getSimulationConfig().isThermal());
     this->wellState().clearWellRates();
     this->commitWGState();
     this->updateNupcolWGState();


### PR DESCRIPTION
prepareDeserialize only called wellState().resize(...) inside if (!wells_ecl_.empty()). On a rank with no local wells at report_step the resize was skipped, so the previous call's well state survived and no longer described report_step. A subsequent deserialization then failed the size check in WellState::serializeOp:

Error deserializing WellState: size mismatch
A forward restart never notices, because it deserializes one step into a fresh model. Walking a run backwards does: a rank goes from "has wells" to "has none" as it moves to earlier report steps, and a stale non-empty well state meets a stored empty one. Decks whose wells are drilled progressively (Norne) hit this; decks whose wells all exist from step 0 (SPE1, SPE9) never do.

resize() handles an empty well list correctly — base_init clears the container and init returns after the bookkeeping — so the guard was unnecessary. anyMSWellOpenLocal() is now guarded by the empty check instead, since calling it with no wells was previously unreachable.

Verified on a Norne-derived deck at np=2, where the failure was previously reproducible.

