### PR TITLE
wells: add --convert-to-multisegment-well option

### DIFF
--- a/opm/simulators/flow/BlackoilModelParameters.cpp
+++ b/opm/simulators/flow/BlackoilModelParameters.cpp
@@ -192,6 +192,10 @@ void BlackoilModelParameters<Scalar>::registerParameters()
     Parameters::Register<Parameters::UseMultisegmentWell>
         ("Use the well model for multi-segment wells instead of the "
          "one for single-segment wells");
+    Parameters::Register<Parameters::ConvertToMultisegmentWell>
+        ("Convert plain single-segment wells into multisegment wells so the "
+         "wellbore hydrostatic head is handled implicitly. 'none' (default) "
+         "or 'per-connection' (one linear tubing, a segment per connection)");
     Parameters::Register<Parameters::TolerancePressureMsWells<Scalar>>
         ("Tolerance for the pressure equations for multi-segment wells");
     Parameters::Register<Parameters::RelaxedWellFlowTol<Scalar>>

--- a/opm/simulators/flow/BlackoilModelParameters.hpp
+++ b/opm/simulators/flow/BlackoilModelParameters.hpp
@@ -108,6 +108,12 @@ struct MatrixAddWellContributions { static constexpr bool value = false; };
 
 struct UseMultisegmentWell { static constexpr bool value = true; };
 
+// Convert plain (single-segment) wells into multisegment wells at
+// construction, so the wellbore hydrostatic head is handled implicitly.
+// A string rather than a bool because more than one topology is useful:
+// "per-connection" gives one segment per connection. "none" is the default.
+struct ConvertToMultisegmentWell { static constexpr auto value = "none"; };
+
 template<class Scalar>
 struct TolerancePressureMsWells { static constexpr Scalar value = 0.01*1e5; };
 

--- a/opm/simulators/flow/FlowGenericVanguard.cpp
+++ b/opm/simulators/flow/FlowGenericVanguard.cpp
@@ -544,6 +544,10 @@ void FlowGenericVanguard::registerParameters_()
     // register here for the use in the tests without BlackoilModelParameters
     Parameters::Register<Parameters::UseMultisegmentWell>
         ("Use the well model for multi-segment wells instead of the one for single-segment wells");
+    Parameters::Register<Parameters::ConvertToMultisegmentWell>
+        ("Convert plain single-segment wells into multisegment wells so the "
+         "wellbore hydrostatic head is handled implicitly. 'none' (default) "
+         "or 'per-connection' (one linear tubing, a segment per connection)");
 }
 
 template void FlowGenericVanguard::registerParameters_<double>();

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -35,6 +35,7 @@
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 #include <opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp>
+#include <opm/input/eclipse/Schedule/MSW/makeMSWellFromStandardWell.hpp>
 #include <opm/input/eclipse/Schedule/Group/GConSale.hpp>
 #include <opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.hpp>
 #include <opm/input/eclipse/Schedule/Group/GConSump.hpp>
@@ -314,6 +315,26 @@ getLocalWells(const int timeStepIdx) const
                            [&st = this->schedule()[timeStepIdx]]
                            (const std::string& wname)
                            { return st.wells(wname); });
+
+    // Optionally turn plain single-segment wells into multisegment wells so the
+    // wellbore hydrostatic head is solved implicitly. No-op for wells that are
+    // already multisegment.
+    const auto& convert = this->param_.convert_to_multisegment_well_;
+    if (convert == "per-connection") {
+        // One linear tubing with a segment per connection: a pressure unknown
+        // per perforation, so the head between perforations is solved for.
+        constexpr double tubing_diameter = 0.1524; // 6"
+        const auto& units = this->schedule().getUnits();
+        for (auto& well : w) {
+            well = makeMultiSegmentWellPerConnection(well, units, tubing_diameter);
+        }
+    }
+    else if (convert != "none") {
+        OPM_THROW(std::runtime_error,
+                  fmt::format("Unknown value '{}' for ConvertToMultisegmentWell. "
+                              "Valid values are 'none' and 'per-connection'.",
+                              convert));
+    }
 
     return w;
 }

--- a/opm/simulators/wells/BlackoilWellModelGenericParameters.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGenericParameters.cpp
@@ -31,6 +31,7 @@ BlackoilWellModelGenericParameters<Scalar>::BlackoilWellModelGenericParameters()
     : nupcol_group_rate_tolerance_(Parameters::Get<Parameters::NupcolGroupRateTolerance<Scalar>>())
     , max_number_of_group_switches_(Parameters::Get<Parameters::MaximumNumberOfGroupSwitches>())
     , use_multisegment_well_(Parameters::Get<Parameters::UseMultisegmentWell>())
+    , convert_to_multisegment_well_(Parameters::Get<Parameters::ConvertToMultisegmentWell>())
 {}
 
 template struct BlackoilWellModelGenericParameters<double>;

--- a/opm/simulators/wells/BlackoilWellModelGenericParameters.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGenericParameters.hpp
@@ -20,6 +20,8 @@
 #ifndef OPM_BLACKOILWELLMODEL_GENERIC_PARAMETERS_HEADER_INCLUDED
 #define OPM_BLACKOILWELLMODEL_GENERIC_PARAMETERS_HEADER_INCLUDED
 
+#include <string>
+
 namespace Opm {
 
 /// Parameter bundle consumed by BlackoilWellModelGeneric.
@@ -40,6 +42,7 @@ struct BlackoilWellModelGenericParameters
     Scalar nupcol_group_rate_tolerance_;
     int max_number_of_group_switches_;
     bool use_multisegment_well_;
+    std::string convert_to_multisegment_well_;
 };
 
 } // namespace Opm


### PR DESCRIPTION
New boolean parameter ConvertToMultisegmentWell (default false). When set, plain single-segment wells are converted to simple multisegment wells at construction (one linear tubing, a segment per connection) via opm-common's makeSimpleMultiSegmentWell, applied to the local well copies in getLocalWells (the single choke point feeding wells_ecl_ and the MSW well-state init). Wells that are already multisegment are left unchanged.

The wellbore hydrostatic head is then solved implicitly rather than as a frozen explicit head — useful for ordinary forward runs and, in particular, for the adjoint, where the frozen StandardWell head biases well-objective gradients on thick multi-perforation wells.

Default off: no change to existing behaviour.