### PR TITLE
flow: optionally store one-sided half transmissibilities

### DIFF
--- a/opm/simulators/flow/Transmissibility.hpp
+++ b/opm/simulators/flow/Transmissibility.hpp
@@ -100,6 +100,24 @@ public:
      */
     Scalar thermalHalfTrans(unsigned insideElemIdx, unsigned outsideElemIdx) const;
 
+    /*!
+     * \brief One-sided (half) transmissibility of the face between two
+     *        cells, seen from the inside cell (NTG applied, before face
+     *        multipliers). Only available when setStoreHalfTrans(true)
+     *        was called before update(); used by the adjoint module for
+     *        the permeability chain rule
+     *        dT/dK_inside = (h_out/(h_in+h_out))^2 dh_in/dK_inside.
+     */
+    Scalar halfTransmissibility(unsigned insideElemIdx, unsigned outsideElemIdx) const;
+
+    //! \brief Enable storage of the one-sided half transmissibilities
+    //!        (call before update()).
+    void setStoreHalfTrans(bool yesno)
+    { storeHalfTrans_ = yesno; }
+
+    bool storeHalfTrans() const
+    { return storeHalfTrans_; }
+
     Scalar thermalHalfTransBoundary(unsigned insideElemIdx, unsigned boundaryFaceIdx) const;
 
     const std::map<std::pair<unsigned, unsigned>, Scalar>& getThermalHalfTransBoundary() const;
@@ -296,6 +314,8 @@ protected:
     bool enableDispersivity_;
     bool warnEditNNC_ = true;
     std::unordered_map<std::uint64_t, Scalar> thermalHalfTrans_; //NB this is based on direction map size is ca 2*trans_ (diffusivity_)
+    std::unordered_map<std::uint64_t, Scalar> halfTrans_; // directional, only filled when storeHalfTrans_
+    bool storeHalfTrans_ = false;
     std::unordered_map<std::uint64_t, Scalar> diffusivity_;
     std::unordered_map<std::uint64_t, Scalar> dispersivity_;
 

--- a/opm/simulators/flow/Transmissibility_impl.hpp
+++ b/opm/simulators/flow/Transmissibility_impl.hpp
@@ -140,6 +140,13 @@ thermalHalfTrans(unsigned insideElemIdx, unsigned outsideElemIdx) const
 
 template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>
 Scalar Transmissibility<Grid,GridView,ElementMapper,CartesianIndexMapper,Scalar>::
+halfTransmissibility(unsigned insideElemIdx, unsigned outsideElemIdx) const
+{
+    return halfTrans_.at(details::directionalIsId(insideElemIdx, outsideElemIdx));
+}
+
+template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>
+Scalar Transmissibility<Grid,GridView,ElementMapper,CartesianIndexMapper,Scalar>::
 thermalHalfTransBoundary(unsigned insideElemIdx, unsigned boundaryFaceIdx) const
 {
     return thermalHalfTransBoundary_.at(std::make_pair(insideElemIdx, boundaryFaceIdx));
@@ -211,6 +218,13 @@ update(bool global, const TransUpdateQuantities update_quantities,
     }
 
     transBoundary_.clear();
+
+    if (storeHalfTrans_) {
+        halfTrans_.clear();
+        if (num_threads == 1) {
+            halfTrans_.reserve(numElements*6*1.05);
+        }
+    }
 
     // if energy is enabled, let's do the same for the "thermal half transmissibilities"
     if ( enableEnergy_ && !onlyTrans) {
@@ -312,6 +326,8 @@ update(bool global, const TransUpdateQuantities update_quantities,
                                                   MapBuilderInsertionMode::Insert_Or_Assign);
     ThreadSafeMapBuilder thermalHalfTrans(thermalHalfTrans_, num_threads,
                                           MapBuilderInsertionMode::Insert_Or_Assign);
+    ThreadSafeMapBuilder halfTransMap(halfTrans_, num_threads,
+                                      MapBuilderInsertionMode::Insert_Or_Assign);
     ThreadSafeMapBuilder diffusivity(diffusivity_, num_threads,
                                      MapBuilderInsertionMode::Insert_Or_Assign);
     ThreadSafeMapBuilder dispersivity(dispersivity_, num_threads,
@@ -457,6 +473,22 @@ update(bool global, const TransUpdateQuantities update_quantities,
 
                 Scalar trans = computeHalfMean(computeHalfTrans_, permeability_);
 
+                if (storeHalfTrans_) {
+                    // one-sided half transmissibilities (NTG applied),
+                    // for the adjoint permeability chain rule
+                    auto onesided = computeHalf(computeHalfTrans_,
+                                                permeability_[inside.elemIdx],
+                                                permeability_[outside.elemIdx]);
+                    applyNtg_(onesided[0], inside, ntg);
+                    applyNtg_(onesided[1], outside, ntg);
+                    halfTransMap.insert_or_assign(
+                        details::directionalIsId(inside.elemIdx, outside.elemIdx),
+                        onesided[0]);
+                    halfTransMap.insert_or_assign(
+                        details::directionalIsId(outside.elemIdx, inside.elemIdx),
+                        onesided[1]);
+                }
+
                 // apply the full face transmissibility multipliers
                 // for the inside ...
                 if (!pinchActive) {
@@ -559,6 +591,10 @@ update(bool global, const TransUpdateQuantities update_quantities,
 #pragma omp section
 #endif
         dispersivity.finalize();
+#ifdef _OPENMP
+#pragma omp section
+#endif
+        halfTransMap.finalize();
     }
 
     // Potentially overwrite and/or modify transmissibilities based on input from deck

--- a/opm/simulators/flow/Transmissibility_impl.hpp
+++ b/opm/simulators/flow/Transmissibility_impl.hpp
@@ -142,6 +142,17 @@ template<class Grid, class GridView, class ElementMapper, class CartesianIndexMa
 Scalar Transmissibility<Grid,GridView,ElementMapper,CartesianIndexMapper,Scalar>::
 halfTransmissibility(unsigned insideElemIdx, unsigned outsideElemIdx) const
 {
+    if (!storeHalfTrans_) {
+        // Without this the caller gets a bare std::out_of_range from the empty
+        // map.  One branch on a bool, and this is not a hot path: only the
+        // adjoint code asks for these today.
+        OPM_THROW(std::logic_error,
+                  "One-sided half transmissibilities were not stored. "
+                  "Call setStoreHalfTrans(true) before update() to have them "
+                  "computed; they are off by default because only the adjoint "
+                  "code needs them.");
+    }
+
     return halfTrans_.at(details::directionalIsId(insideElemIdx, outsideElemIdx));
 }
 


### PR DESCRIPTION
setStoreHalfTrans(true) before update() fills a directional map with the NTG-applied one-sided half transmissibilities of every interior face, retrievable with halfTransmissibility(inside, outside). Needed by the (downstream) adjoint module for the permeability chain rule dT/dK_in = (h_out/(h_in+h_out))^2 dh_in/dK_in; off by default and costing nothing when disabled. Mirrors the thermalHalfTrans_ pattern.