### PR TITLE
wells: add read accessors for the well linear-system blocks and primary variables

### DIFF
--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -78,6 +78,12 @@ public:
     const Equations& linSys() const
     { return linSys_; }
 
+    //! \brief Read access to the primary variables, needed by the adjoint
+    //!        module to build dJ/dx_w (segment-0 BHP / surface-rate
+    //!        derivatives), mirroring the StandardWellEval hook.
+    const PrimaryVariables& primaryVariables() const
+    { return primary_variables_; }
+
     static constexpr int numResDofs = Indices::numEq;
     static constexpr int numWellDofs = PrimaryVariables::numWellEq;// numResDofs + 1; // NB will fail for for thermal for now
     using BMatrix = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, numWellDofs, numResDofs>>;

--- a/opm/simulators/wells/StandardWellEval.hpp
+++ b/opm/simulators/wells/StandardWellEval.hpp
@@ -71,6 +71,11 @@ public:
     const StandardWellEquations<Scalar, IndexTraits, Indices::numEq>& linSys() const
     { return linSys_; }
 
+    //! \brief Read access to the well primary variables (adjoint module:
+    //!        rate <-> primary-variable derivatives via getQs()).
+    const PrimaryVariables& primaryVariables() const
+    { return primary_variables_; }
+
     static constexpr int numResDofs = Indices::numEq;
     static constexpr int numWellDofs = numResDofs + 1;// NB will fail for for thermal for now
     using BMatrix = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, numWellDofs, numResDofs>>;


### PR DESCRIPTION
These expose state that is already computed and stored; nothing is recomputed or copied. An out-of-tree adjoint module needs the well blocks to build the transposed coupled system [Aᵀ Bᵀ; Cᵀ Dᵀ] and the primary variables to seed derivatives. They are read-only by design so no caller can perturb the solve through them. Split into three commits by class in case you want only some.