### PR TITLE
build: link Hypre PUBLIC so downstream targets see HAVE_HYPRE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,11 @@ macro(opm-simulators_prereqs_hook)
   if(USE_HYPRE AND USE_MPI)
     find_package(HYPRE)
     if(HYPRE_FOUND)
-      target_link_libraries(opmsimulators PRIVATE HYPRE::HYPRE)
+      # PUBLIC: HYPRE::HYPRE carries HAVE_HYPRE=1 as an INTERFACE compile
+      # definition (see opm-common's FindHYPRE.cmake).  Downstream targets such
+      # as flow_blackoil instantiate the preconditioner factory themselves and
+      # must therefore see it too, so the dependency has to be re-exported.
+      target_link_libraries(opmsimulators PUBLIC HYPRE::HYPRE)
     else()
       message(WARNING "Hypre requested but not found. Continuing without Hypre support.")
     endif()


### PR DESCRIPTION
## What

The Hypre code paths in opm-simulators are guarded by `#if HAVE_HYPRE`. That macro comes from `HYPRE::HYPRE`, which carries it as an `INTERFACE` compile definition (opm-common's `FindHYPRE.cmake:68,116`), so linking the imported target is enough — for `opmsimulators` itself.

It is not enough for the targets that link `opmsimulators`. `flow_blackoil` and the other flow variants instantiate the preconditioner factory in their own translation units, and with a `PRIVATE` link the dependency is not re-exported, so they compile without `HAVE_HYPRE`.

## Why it matters

With `-DUSE_HYPRE=ON` the Hypre preconditioner (`"type": "hypre"`) is silently compiled out of every executable and cannot be selected at runtime — the build succeeds, Hypre is found and linked, and the option just does nothing.

## The change

One line: `PRIVATE` → `PUBLIC` on the `HYPRE::HYPRE` link, plus a comment recording why it has to be re-exported. No effect when Hypre is not found or `USE_HYPRE` is off.

## Testing

Built against opm-common/opm-grid master. With this, Hypre's BoomerAMG can be selected as the CPR coarse solver via `"coarsesolver": {"preconditioner": {"type": "hypre"}}`.
