### PR TITLE
ParallelOverlappingILU0: handle an empty parallel partition

### DIFF
--- a/opm/simulators/linalg/ParallelOverlappingILU0_impl.hpp
+++ b/opm/simulators/linalg/ParallelOverlappingILU0_impl.hpp
@@ -207,15 +207,25 @@ size_t set_interiorSize(size_t N, size_t interiorSize, const Dune::OwnerOverlapC
         return 0;
 
     size_t new_is = 0;
+    bool anyOwner = false;
     for (auto idx = indexSet.begin(); idx!=indexSet.end(); ++idx)
     {
         if (idx->local().attribute()==1)
         {
+            anyOwner = true;
             auto loc = idx->local().local();
             if (loc > new_is) {
                 new_is = loc;
             }
         }
+    }
+    // An owner local index of new_is implies new_is+1 interior rows (owners are
+    // ordered first). But on a partition with no owner cells (e.g. an empty/
+    // zero-row sub-system on this rank, which an LGR distribution can produce)
+    // there are zero interior rows; returning new_is+1 == 1 would exceed N == 0
+    // and trip the interiorSize_ <= A.N() assertion. Guard the empty case.
+    if (!anyOwner) {
+        return 0;
     }
     return new_is + 1;
 }

--- a/opm/simulators/linalg/ParallelOverlappingILU0_impl.hpp
+++ b/opm/simulators/linalg/ParallelOverlappingILU0_impl.hpp
@@ -200,6 +200,34 @@ size_t set_interiorSize( [[maybe_unused]] size_t N, size_t interiorSize, [[maybe
 template<>
 size_t set_interiorSize(size_t N, size_t interiorSize, const Dune::OwnerOverlapCopyCommunication<int,int>& comm)
 {
+    // Fail with a clear message when a genuinely parallel smoother level (the
+    // communicator still spans more than one rank) has a process with zero rows.
+    //
+    // This is the symptom of an unbalanced partition meeting a limitation in
+    // dune-amg's parallel coarsening: AMG triggers redistribution to fewer ranks
+    // on the *global* level size vs coarsenTarget, not on a per-rank minimum, so
+    // a small partition can coarsen to zero rows at the first coarse level while
+    // the global size is still above coarsenTarget. That level is then NOT
+    // redistributed and AMG's presmooth() runs the smoother on the empty rank and
+    // segfaults. Detect it collectively (every rank on this level calls this) and
+    // throw the same error everywhere instead of crashing.
+    //
+    // TODO: the real fix belongs in dune-amg (redistribute/accumulate based on a
+    // per-rank minimum, or make presmooth tolerate an empty local partition);
+    // tracked as separate work. Workarounds: --linear-solver=ilu0 (no CPR/AMG),
+    // a larger coarsenTarget so the first coarse level is redistributed, or fewer
+    // MPI processes.
+    if (comm.communicator().size() > 1
+        && comm.communicator().max(static_cast<int>(N == 0)) != 0)
+    {
+        OPM_THROW(std::runtime_error,
+                  "Empty partition: too unbalanced partition for dune-amg? "
+                  "A process has zero rows on a parallel AMG coarse level that "
+                  "dune-amg did not redistribute to fewer processes. "
+                  "Try --linear-solver=ilu0, a larger coarsenTarget, or fewer MPI "
+                  "processes.");
+    }
+
     if (interiorSize<=N)
         return interiorSize;
     auto indexSet = comm.indexSet();

--- a/opm/simulators/linalg/ParallelOverlappingILU0_impl.hpp
+++ b/opm/simulators/linalg/ParallelOverlappingILU0_impl.hpp
@@ -217,9 +217,7 @@ size_t set_interiorSize(size_t N, size_t interiorSize, const Dune::OwnerOverlapC
     // tracked as separate work. Workarounds: --linear-solver=ilu0 (no CPR/AMG),
     // a larger coarsenTarget so the first coarse level is redistributed, or fewer
     // MPI processes.
-    if (comm.communicator().size() > 1
-        && comm.communicator().max(static_cast<int>(N == 0)) != 0)
-    {
+    if (comm.communicator().size() > 1 && comm.communicator().min(N) == 0) {
         OPM_THROW(std::runtime_error,
                   "Empty partition: too unbalanced partition for dune-amg? "
                   "A process has zero rows on a parallel AMG coarse level that "


### PR DESCRIPTION
## What

Two related robustness fixes in `ParallelOverlappingILU0` for the case where a rank ends up with an empty (zero-owner) partition:

1. `set_interiorSize` handles a partition with no owned rows instead of computing an interior size from an empty range.
2. A clear exception is thrown when the parallel AMG hands down an empty partition, instead of continuing into a segfault.

## Why it matters

On an unbalanced partitioning — easily reproduced by over-decomposing a small model, e.g. `mpirun -np 8` on a case whose active cell count does not spread that far — a rank can be left owning nothing. Today that crashes inside the preconditioner with no indication of the cause. After this it either works or says what happened.

## Notes

The error text attributes the empty partition to dune-amg coarsening, which is where it originates; the `TODO` in the commit records that the real fix belongs there. This change makes the failure diagnosable rather than papering over it.

## Testing

Built against opm-common/opm-grid master. Non-LGR parallel regression cases unchanged.
