### PR TITLE
Map region arrays onto the leaf grid for LGR (EQLNUM, PVTNUM, SWATINIT, FIP)

### DIFF
--- a/opm/simulators/flow/FlowGenericProblem_impl.hpp
+++ b/opm/simulators/flow/FlowGenericProblem_impl.hpp
@@ -544,6 +544,22 @@ readBlackoilExtentionsInitialConditions_(std::size_t numDof,
                                          bool enableBioeffects,
                                          bool enableMICP)
 {
+    // LGR (local grid refinement / CARFIN) is supported for black-oil only. The
+    // solvent/polymer/biofilm/MICP initial conditions below are read straight
+    // from the input-grid field properties and indexed by leaf cell; they are
+    // NOT mapped onto refined cells (see the black-oil EQLNUM/FIPNUM handling via
+    // LookUpData), so refined cells would get wrong/out-of-range values. Fail
+    // early with a clear message rather than producing silently wrong results.
+    if ((enableSolvent || enablePolymer || enablePolymerMolarWeight ||
+         enableBioeffects || enableMICP) &&
+        (eclState_.getLgrs().size() > 0))
+    {
+        throw std::runtime_error(
+            "Local grid refinement (LGR/CARFIN) is only supported for black-oil "
+            "runs. It is not supported together with the solvent, polymer, "
+            "biofilm or MICP extensions.");
+    }
+
     auto getArray = [](const std::vector<double>& input)
     {
         if constexpr (std::is_same_v<Scalar,double>) {

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -176,7 +176,7 @@ public:
         , collectOnIORank_(collectOnIORank)
     {
         for (auto& region_pair : this->regions_) {
-            this->createLocalRegion_(region_pair.first, region_pair.second);
+            this->createLocalRegion_(region_pair.second);
         }
 
         auto isCartIdxOnThisRank = [&collectOnIORank](const int idx) {
@@ -227,26 +227,27 @@ public:
             auto rset = this->eclState_.fieldProps().fip_regions();
             rset.push_back("PVTNUM");
 
-            // The region arrays (PVTNUM, FIP regions) are given on the input
-            // grid, but RegionPhasePoreVolAverage indexes them by leaf cell.
-            // With LGRs the leaf has more cells, so map each onto the leaf (a
-            // refined cell inherits its parent cell's region; identity without
-            // LGRs) and let the lambda serve those. The map is captured by value
-            // so it outlives in the stored callable; decltype(auto) keeps the
-            // required "reference to vector" return semantics.
+            // RegionPhasePoreVolAverage indexes by leaf cell.  The FIP entries of
+            // regions_ are already on the leaf (createLocalRegion_ maps them), so
+            // serve those directly.  PVTNUM is not an FIP region and is deliberately
+            // kept out of regions_, so it needs its own leaf-mapped copy - with LGRs
+            // a refined cell inherits its parent's PVTNUM; identity without.
+            // decltype(auto) keeps the required "reference to vector" semantics.
             const LookUpData<Grid, GridView> lookUpData(this->simulator_.gridView());
-            std::map<std::string, std::vector<int>> leafRegions;
-            for (const auto& rsetName : rset) {
-                leafRegions[rsetName] = lookUpData.template assignFieldPropsIntOnLeaf<int>(
-                    this->eclState_.fieldProps(), rsetName, /*needsTranslation=*/false);
-            }
+            auto pvtnum = lookUpData.template assignFieldPropsIntOnLeaf<int>(
+                this->eclState_.fieldProps(), "PVTNUM", /*needsTranslation=*/false);
 
             this->regionAvgDensity_
                 .emplace(this->simulator_.gridView().comm(),
                          FluidSystem::numPhases, rset,
-                         [regions = std::move(leafRegions)]
+                         [&regions = std::as_const(this->regions_),
+                          pvtnum = std::move(pvtnum)]
                          (const std::string& rsetName) -> decltype(auto)
-                         { return regions.at(rsetName); });
+                         {
+                             return (rsetName == "PVTNUM")
+                                 ? static_cast<const std::vector<int>&>(pvtnum)
+                                 : static_cast<const std::vector<int>&>(regions.at(rsetName));
+                         });
         }
     }
 
@@ -906,31 +907,27 @@ private:
         }
     }
 
-    void createLocalRegion_(const std::string& name, std::vector<int>& region)
+    void createLocalRegion_(std::vector<int>& region)
     {
-        // FIP region arrays (FIPNUM, ...) are given on the (unrefined) input grid,
-        // but the FIP/field sums run over the leaf grid. With LGRs the leaf has
-        // more cells than the input grid, so the array must be MAPPED onto the
-        // leaf - a refined cell inherits its parent cell's region. Previously this
-        // only resize()d the global array to the leaf size, which zero-padded the
-        // appended refined cells: every refined cell landed in region 0 and was
-        // dropped from the FIP/field sums, giving a wrong field pressure (FPR) and
-        // region FIP whenever an LGR was present. LookUpData performs the parent
-        // inheritance and is the identity without LGRs, so non-LGR runs are
-        // unchanged.
+        // The array arrives on the (unrefined) input grid, but the FIP/field sums
+        // run over the leaf.  With LGRs the leaf has more cells, so it must be
+        // MAPPED - a refined cell inherits its parent's region - not merely
+        // resize()d, which zero-padded the refined cells into region 0 and dropped
+        // them from the sums.  LookUpData is the identity without LGRs.
         const LookUpData<Grid, GridView> lookUpData(simulator_.gridView());
-        region = lookUpData.template assignFieldPropsIntOnLeaf<int>(
-            this->eclState_.fieldProps(), name, /*needsTranslation=*/false);
 
-        // Exclude non-interior (overlap/ghost) cells from the region sums.
+        std::vector<int> onLeaf(simulator_.gridView().size(0), 0);
         std::size_t elemIdx = 0;
         for (const auto& elem : elements(simulator_.gridView())) {
-            if (elem.partitionType() != Dune::InteriorEntity) {
-                region[elemIdx] = 0;
+            // Non-interior (overlap/ghost) cells stay out of the region sums.
+            if (elem.partitionType() == Dune::InteriorEntity) {
+                onLeaf[elemIdx] = lookUpData(elem, region);
             }
 
             ++elemIdx;
         }
+
+        region = std::move(onLeaf);
     }
 
     template <typename FluidState>

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -175,6 +175,12 @@ public:
         , simulator_(simulator)
         , collectOnIORank_(collectOnIORank)
     {
+        // The region arrays arrive on the (unrefined) input grid, but everything
+        // downstream indexes them by leaf cell.  With an LGR the leaf has more
+        // cells, so map each onto it here - a refined cell inherits its parent's
+        // region - before anything looks at them.  Identity without LGRs.
+        this->mapRegionsOntoLeaf_();
+
         for (auto& region_pair : this->regions_) {
             this->createLocalRegion_(region_pair.second);
         }
@@ -228,7 +234,7 @@ public:
             rset.push_back("PVTNUM");
 
             // RegionPhasePoreVolAverage indexes by leaf cell.  The FIP entries of
-            // regions_ are already on the leaf (createLocalRegion_ maps them), so
+            // regions_ are already on the leaf (mapRegionsOntoLeaf_ does that), so
             // serve those directly.  PVTNUM is not an FIP region and is deliberately
             // kept out of regions_, so it needs its own leaf-mapped copy - with LGRs
             // a refined cell inherits its parent's PVTNUM; identity without.
@@ -907,27 +913,36 @@ private:
         }
     }
 
+    /// \brief Put every region array on the leaf grid.
+    ///
+    /// Called once, before the arrays are used.  A refined cell inherits its
+    /// parent's region; without LGRs this is the identity.
+    void mapRegionsOntoLeaf_()
+    {
+        const LookUpData<Grid, GridView> lookUpData(simulator_.gridView());
+        const auto numLeaf = simulator_.gridView().size(0);
+
+        std::vector<int> onLeaf(numLeaf, 0);
+        for (auto& [name, region] : this->regions_) {
+            std::size_t elemIdx = 0;
+            for (const auto& elem : elements(simulator_.gridView())) {
+                onLeaf[elemIdx++] = lookUpData(elem, region);
+            }
+
+            region = onLeaf;
+        }
+    }
+
     void createLocalRegion_(std::vector<int>& region)
     {
-        // The array arrives on the (unrefined) input grid, but the FIP/field sums
-        // run over the leaf.  With LGRs the leaf has more cells, so it must be
-        // MAPPED - a refined cell inherits its parent's region - not merely
-        // resize()d, which zero-padded the refined cells into region 0 and dropped
-        // them from the sums.  LookUpData is the identity without LGRs.
-        const LookUpData<Grid, GridView> lookUpData(simulator_.gridView());
-
-        std::vector<int> onLeaf(simulator_.gridView().size(0), 0);
         std::size_t elemIdx = 0;
         for (const auto& elem : elements(simulator_.gridView())) {
-            // Non-interior (overlap/ghost) cells stay out of the region sums.
-            if (elem.partitionType() == Dune::InteriorEntity) {
-                onLeaf[elemIdx] = lookUpData(elem, region);
+            if (elem.partitionType() != Dune::InteriorEntity) {
+                region[elemIdx] = 0;
             }
 
             ++elemIdx;
         }
-
-        region = std::move(onLeaf);
     }
 
     template <typename FluidState>

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -227,15 +227,26 @@ public:
             auto rset = this->eclState_.fieldProps().fip_regions();
             rset.push_back("PVTNUM");
 
-            // Note: We explicitly use decltype(auto) here because the
-            // default scheme (-> auto) will deduce an undesirable type.  We
-            // need the "reference to vector" semantics in this instance.
+            // The region arrays (PVTNUM, FIP regions) are given on the input
+            // grid, but RegionPhasePoreVolAverage indexes them by leaf cell.
+            // With LGRs the leaf has more cells, so map each onto the leaf (a
+            // refined cell inherits its parent cell's region; identity without
+            // LGRs) and let the lambda serve those. The map is captured by value
+            // so it outlives in the stored callable; decltype(auto) keeps the
+            // required "reference to vector" return semantics.
+            const LookUpData<Grid, GridView> lookUpData(this->simulator_.gridView());
+            std::map<std::string, std::vector<int>> leafRegions;
+            for (const auto& rsetName : rset) {
+                leafRegions[rsetName] = lookUpData.template assignFieldPropsIntOnLeaf<int>(
+                    this->eclState_.fieldProps(), rsetName, /*needsTranslation=*/false);
+            }
+
             this->regionAvgDensity_
                 .emplace(this->simulator_.gridView().comm(),
                          FluidSystem::numPhases, rset,
-                         [fp = std::cref(this->eclState_.fieldProps())]
+                         [regions = std::move(leafRegions)]
                          (const std::string& rsetName) -> decltype(auto)
-                         { return fp.get().get_int(rsetName); });
+                         { return regions.at(rsetName); });
         }
     }
 

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -30,6 +30,7 @@
 #include <dune/common/fvector.hh>
 
 #include <opm/grid/CpGrid.hpp>
+#include <opm/grid/LookUpData.hh>
 
 #include <opm/simulators/utils/moduleVersion.hpp>
 
@@ -175,7 +176,7 @@ public:
         , collectOnIORank_(collectOnIORank)
     {
         for (auto& region_pair : this->regions_) {
-            this->createLocalRegion_(region_pair.second);
+            this->createLocalRegion_(region_pair.first, region_pair.second);
         }
 
         auto isCartIdxOnThisRank = [&collectOnIORank](const int idx) {
@@ -790,13 +791,23 @@ private:
         }
     }
 
-    void createLocalRegion_(std::vector<int>& region)
+    void createLocalRegion_(const std::string& name, std::vector<int>& region)
     {
-        // For CpGrid with LGRs, where level zero grid has been distributed,
-        // resize region is needed, since in this case the total amount of
-        // element - per process - in level zero grid and leaf grid do not
-        // coincide, in general.
-        region.resize(simulator_.gridView().size(0));
+        // FIP region arrays (FIPNUM, ...) are given on the (unrefined) input grid,
+        // but the FIP/field sums run over the leaf grid. With LGRs the leaf has
+        // more cells than the input grid, so the array must be MAPPED onto the
+        // leaf - a refined cell inherits its parent cell's region. Previously this
+        // only resize()d the global array to the leaf size, which zero-padded the
+        // appended refined cells: every refined cell landed in region 0 and was
+        // dropped from the FIP/field sums, giving a wrong field pressure (FPR) and
+        // region FIP whenever an LGR was present. LookUpData performs the parent
+        // inheritance and is the identity without LGRs, so non-LGR runs are
+        // unchanged.
+        const LookUpData<Grid, GridView> lookUpData(simulator_.gridView());
+        region = lookUpData.template assignFieldPropsIntOnLeaf<int>(
+            this->eclState_.fieldProps(), name, /*needsTranslation=*/false);
+
+        // Exclude non-interior (overlap/ghost) cells from the region sums.
         std::size_t elemIdx = 0;
         for (const auto& elem : elements(simulator_.gridView())) {
             if (elem.partitionType() != Dune::InteriorEntity) {

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -30,6 +30,7 @@
 #include <dune/common/fvector.hh>
 
 #include <opm/grid/CpGrid.hpp>
+#include <opm/grid/LookUpData.hh>
 
 #include <opm/simulators/utils/moduleVersion.hpp>
 
@@ -175,7 +176,7 @@ public:
         , collectOnIORank_(collectOnIORank)
     {
         for (auto& region_pair : this->regions_) {
-            this->createLocalRegion_(region_pair.second);
+            this->createLocalRegion_(region_pair.first, region_pair.second);
         }
 
         auto isCartIdxOnThisRank = [&collectOnIORank](const int idx) {
@@ -894,13 +895,23 @@ private:
         }
     }
 
-    void createLocalRegion_(std::vector<int>& region)
+    void createLocalRegion_(const std::string& name, std::vector<int>& region)
     {
-        // For CpGrid with LGRs, where level zero grid has been distributed,
-        // resize region is needed, since in this case the total amount of
-        // element - per process - in level zero grid and leaf grid do not
-        // coincide, in general.
-        region.resize(simulator_.gridView().size(0));
+        // FIP region arrays (FIPNUM, ...) are given on the (unrefined) input grid,
+        // but the FIP/field sums run over the leaf grid. With LGRs the leaf has
+        // more cells than the input grid, so the array must be MAPPED onto the
+        // leaf - a refined cell inherits its parent cell's region. Previously this
+        // only resize()d the global array to the leaf size, which zero-padded the
+        // appended refined cells: every refined cell landed in region 0 and was
+        // dropped from the FIP/field sums, giving a wrong field pressure (FPR) and
+        // region FIP whenever an LGR was present. LookUpData performs the parent
+        // inheritance and is the identity without LGRs, so non-LGR runs are
+        // unchanged.
+        const LookUpData<Grid, GridView> lookUpData(simulator_.gridView());
+        region = lookUpData.template assignFieldPropsIntOnLeaf<int>(
+            this->eclState_.fieldProps(), name, /*needsTranslation=*/false);
+
+        // Exclude non-interior (overlap/ghost) cells from the region sums.
         std::size_t elemIdx = 0;
         for (const auto& elem : elements(simulator_.gridView())) {
             if (elem.partitionType() != Dune::InteriorEntity) {

--- a/opm/simulators/flow/equil/InitStateEquil.hpp
+++ b/opm/simulators/flow/equil/InitStateEquil.hpp
@@ -745,7 +745,7 @@ private:
                                  const bool co2store_or_h2store);
 
     template<class RMap>
-    void setRegionPvtIdx(const EclipseState& eclState, const RMap& reg);
+    void setRegionPvtIdx(const EclipseState& eclState, const GridView& gridView, const RMap& reg);
 
     template <class RMap, class MaterialLawManager, class Comm>
     void calcPressSatRsRv(const RMap& reg,

--- a/opm/simulators/flow/equil/InitStateEquil_impl.hpp
+++ b/opm/simulators/flow/equil/InitStateEquil_impl.hpp
@@ -1517,10 +1517,13 @@ InitialStateComputer(MaterialLawManager& materialLawManager,
             // onto the leaf via LookUpData (a refined cell inherits its parent
             // cell's value; identity without LGRs).
             const LookUpData<Grid, GridView> lookUpData(gridView);
-            const auto input =
+            auto input =
                 lookUpData.assignFieldPropsDoubleOnLeaf(eclipseState.fieldProps(), "SWATINIT");
-            swatInit_.resize(input.size());
-            std::ranges::copy(input, swatInit_.begin());
+            if constexpr (std::is_same_v<Scalar, double>) {
+                swatInit_ = std::move(input);
+            } else {
+                swatInit_.assign(input.begin(), input.end());
+            }
         }
     }
 

--- a/opm/simulators/flow/equil/InitStateEquil_impl.hpp
+++ b/opm/simulators/flow/equil/InitStateEquil_impl.hpp
@@ -28,6 +28,7 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 
 #include <opm/grid/utility/RegionMapping.hpp>
+#include <opm/grid/LookUpData.hh>
 
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PbvdTable.hpp>
@@ -1449,8 +1450,18 @@ equilnum(const EclipseState& eclipseState,
     std::vector<int> eqlnum(gridview.size(0), 0);
 
     if (eclipseState.fieldProps().has_int("EQLNUM")) {
-        const auto& e = eclipseState.fieldProps().get_int("EQLNUM");
-        std::ranges::transform(e, eqlnum.begin(), [](int n) { return n - 1; });
+        // EQLNUM is given on the (unrefined) input grid, but the equilibration
+        // works on the leaf grid. With LGRs the leaf has more cells than the
+        // input grid and a different ordering, so copying the input array
+        // directly into a leaf-sized vector misaligns it (and leaves refined
+        // cells at region 1). LookUpData maps each leaf cell to its input-grid
+        // origin - a refined cell inherits its parent cell's EQLNUM - which for
+        // an unrefined grid reduces to the identity, so non-LGR cases are
+        // unchanged. needsTranslation == true applies the 1-based -> 0-based
+        // shift previously done by the transform.
+        const LookUpData<typename GridView::Grid, GridView> lookUpData(gridview);
+        eqlnum = lookUpData.template assignFieldPropsIntOnLeaf<int>(
+            eclipseState.fieldProps(), "EQLNUM", /*needsTranslation=*/true);
     }
     OPM_BEGIN_PARALLEL_TRY_CATCH();
     const int num_regions = eclipseState.getTableManager().getEqldims().getNumEquilRegions();
@@ -1501,13 +1512,15 @@ InitialStateComputer(MaterialLawManager& materialLawManager,
     //Check for presence of kw SWATINIT
     if (applySwatInit) {
         if (eclipseState.fieldProps().has_double("SWATINIT")) {
-            if constexpr (std::is_same_v<Scalar,double>) {
-                swatInit_ = eclipseState.fieldProps().get_double("SWATINIT");
-            } else {
-                const auto& input = eclipseState.fieldProps().get_double("SWATINIT");
-                swatInit_.resize(input.size());
-                std::ranges::copy(input, swatInit_.begin());
-            }
+            // SWATINIT is given on the (unrefined) input grid but is consumed per
+            // leaf cell; with LGRs the leaf is larger and reordered, so map it
+            // onto the leaf via LookUpData (a refined cell inherits its parent
+            // cell's value; identity without LGRs).
+            const LookUpData<Grid, GridView> lookUpData(gridView);
+            const auto input =
+                lookUpData.assignFieldPropsDoubleOnLeaf(eclipseState.fieldProps(), "SWATINIT");
+            swatInit_.resize(input.size());
+            std::ranges::copy(input, swatInit_.begin());
         }
     }
 
@@ -1520,10 +1533,10 @@ InitialStateComputer(MaterialLawManager& materialLawManager,
     const std::vector<EquilRecord> rec = getEquil(eclipseState);
     const auto& tables = eclipseState.getTableManager();
     // Create (inverse) region mapping.
-    const RegionMapping<> eqlmap(equilnum(eclipseState, grid));
+    const RegionMapping<> eqlmap(equilnum(eclipseState, gridView));
     const int invalidRegion = -1;
     regionPvtIdx_.resize(rec.size(), invalidRegion);
-    setRegionPvtIdx(eclipseState, eqlmap);
+    setRegionPvtIdx(eclipseState, gridView, eqlmap);
 
     // Create Rs functions.
     rsFunc_.reserve(rec.size());
@@ -1979,13 +1992,22 @@ void InitialStateComputer<FluidSystem,
                           GridView,
                           ElementMapper,
                           CartesianIndexMapper>::
-setRegionPvtIdx(const EclipseState& eclState, const RMap& reg)
+setRegionPvtIdx(const EclipseState& eclState, const GridView& gridView, const RMap& reg)
 {
-    const auto& pvtnumData = eclState.fieldProps().get_int("PVTNUM");
+    // PVTNUM is given on the (unrefined) input grid, but reg.cells(r) are leaf
+    // cell indices. With LGRs the leaf has more cells (and a different ordering)
+    // than the input grid, so indexing the input PVTNUM array by a leaf index is
+    // wrong (and out of bounds for refined cells). Map PVTNUM onto the leaf via
+    // LookUpData - a refined cell inherits its parent cell's PVTNUM - which is
+    // the identity without LGRs. needsTranslation == true applies the 1-based ->
+    // 0-based shift previously done explicitly.
+    const LookUpData<typename GridView::Grid, GridView> lookUpData(gridView);
+    const auto pvtnumData = lookUpData.template assignFieldPropsIntOnLeaf<int>(
+        eclState.fieldProps(), "PVTNUM", /*needsTranslation=*/true);
 
     for (const auto& r : reg.activeRegions()) {
         const auto& cells = reg.cells(r);
-        regionPvtIdx_[r] = pvtnumData[*cells.begin()] - 1;
+        regionPvtIdx_[r] = pvtnumData[*cells.begin()];
     }
 }
 

--- a/opm/simulators/flow/equil/InitStateEquil_impl.hpp
+++ b/opm/simulators/flow/equil/InitStateEquil_impl.hpp
@@ -28,6 +28,7 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 
 #include <opm/grid/utility/RegionMapping.hpp>
+#include <opm/grid/LookUpData.hh>
 
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PbvdTable.hpp>
@@ -1446,8 +1447,18 @@ equilnum(const EclipseState& eclipseState,
     std::vector<int> eqlnum(gridview.size(0), 0);
 
     if (eclipseState.fieldProps().has_int("EQLNUM")) {
-        const auto& e = eclipseState.fieldProps().get_int("EQLNUM");
-        std::ranges::transform(e, eqlnum.begin(), [](int n) { return n - 1; });
+        // EQLNUM is given on the (unrefined) input grid, but the equilibration
+        // works on the leaf grid. With LGRs the leaf has more cells than the
+        // input grid and a different ordering, so copying the input array
+        // directly into a leaf-sized vector misaligns it (and leaves refined
+        // cells at region 1). LookUpData maps each leaf cell to its input-grid
+        // origin - a refined cell inherits its parent cell's EQLNUM - which for
+        // an unrefined grid reduces to the identity, so non-LGR cases are
+        // unchanged. needsTranslation == true applies the 1-based -> 0-based
+        // shift previously done by the transform.
+        const LookUpData<typename GridView::Grid, GridView> lookUpData(gridview);
+        eqlnum = lookUpData.template assignFieldPropsIntOnLeaf<int>(
+            eclipseState.fieldProps(), "EQLNUM", /*needsTranslation=*/true);
     }
     OPM_BEGIN_PARALLEL_TRY_CATCH();
     const int num_regions = eclipseState.getTableManager().getEqldims().getNumEquilRegions();
@@ -1498,13 +1509,15 @@ InitialStateComputer(MaterialLawManager& materialLawManager,
     //Check for presence of kw SWATINIT
     if (applySwatInit) {
         if (eclipseState.fieldProps().has_double("SWATINIT")) {
-            if constexpr (std::is_same_v<Scalar,double>) {
-                swatInit_ = eclipseState.fieldProps().get_double("SWATINIT");
-            } else {
-                const auto& input = eclipseState.fieldProps().get_double("SWATINIT");
-                swatInit_.resize(input.size());
-                std::ranges::copy(input, swatInit_.begin());
-            }
+            // SWATINIT is given on the (unrefined) input grid but is consumed per
+            // leaf cell; with LGRs the leaf is larger and reordered, so map it
+            // onto the leaf via LookUpData (a refined cell inherits its parent
+            // cell's value; identity without LGRs).
+            const LookUpData<Grid, GridView> lookUpData(gridView);
+            const auto input =
+                lookUpData.assignFieldPropsDoubleOnLeaf(eclipseState.fieldProps(), "SWATINIT");
+            swatInit_.resize(input.size());
+            std::ranges::copy(input, swatInit_.begin());
         }
     }
 
@@ -1517,10 +1530,10 @@ InitialStateComputer(MaterialLawManager& materialLawManager,
     const std::vector<EquilRecord> rec = getEquil(eclipseState);
     const auto& tables = eclipseState.getTableManager();
     // Create (inverse) region mapping.
-    const RegionMapping<> eqlmap(equilnum(eclipseState, grid));
+    const RegionMapping<> eqlmap(equilnum(eclipseState, gridView));
     const int invalidRegion = -1;
     regionPvtIdx_.resize(rec.size(), invalidRegion);
-    setRegionPvtIdx(eclipseState, eqlmap);
+    setRegionPvtIdx(eclipseState, gridView, eqlmap);
 
     // Create Rs functions.
     rsFunc_.reserve(rec.size());
@@ -1976,13 +1989,22 @@ void InitialStateComputer<FluidSystem,
                           GridView,
                           ElementMapper,
                           CartesianIndexMapper>::
-setRegionPvtIdx(const EclipseState& eclState, const RMap& reg)
+setRegionPvtIdx(const EclipseState& eclState, const GridView& gridView, const RMap& reg)
 {
-    const auto& pvtnumData = eclState.fieldProps().get_int("PVTNUM");
+    // PVTNUM is given on the (unrefined) input grid, but reg.cells(r) are leaf
+    // cell indices. With LGRs the leaf has more cells (and a different ordering)
+    // than the input grid, so indexing the input PVTNUM array by a leaf index is
+    // wrong (and out of bounds for refined cells). Map PVTNUM onto the leaf via
+    // LookUpData - a refined cell inherits its parent cell's PVTNUM - which is
+    // the identity without LGRs. needsTranslation == true applies the 1-based ->
+    // 0-based shift previously done explicitly.
+    const LookUpData<typename GridView::Grid, GridView> lookUpData(gridView);
+    const auto pvtnumData = lookUpData.template assignFieldPropsIntOnLeaf<int>(
+        eclState.fieldProps(), "PVTNUM", /*needsTranslation=*/true);
 
     for (const auto& r : reg.activeRegions()) {
         const auto& cells = reg.cells(r);
-        regionPvtIdx_[r] = pvtnumData[*cells.begin()] - 1;
+        regionPvtIdx_[r] = pvtnumData[*cells.begin()];
     }
 }
 


### PR DESCRIPTION
EQLNUM, PVTNUM, SWATINIT and the FIP region arrays are given on the unrefined input grid, but are consumed per leaf cell. With an LGR the leaf is larger and reordered, so the arrays were only `resize()`d — zero-padding the refined cells into region 0 and dropping them from the sums. `LookUpData` maps each leaf cell to its input-grid origin instead (a refined cell inherits its parent's value), which is the identity without LGRs.

**Depends on #7245, and is not observable without it.** On master all cell-based output is zero when an LGR is present, so this PR alone changes nothing you can measure.

Measured on `lgr/SPE1CASE1_CARFIN1-3DCORNERPOINT_XYZ` (which refines fine on upstream opm-grid), against the same deck with the `CARFIN` block removed:

| | no LGR | LGR, master | LGR, #7245 | LGR, #7245 + this |
|---|---|---|---|---|
| FPR | 4992.268066 | 0 | 4992.047363 | **4992.268066** |
| FOIP | 8.513534e+07 | 0 | 8.393247e+07 | **8.513534e+07** |
| FGIP | 1.081219e+08 | 0 | 1.065942e+08 | **1.081219e+08** |
| FRPV | 1.832981e+08 | 0 | 1.807087e+08 | **1.832981e+08** |
| FHPV | 1.429725e+08 | 0 | 1.409528e+08 | **1.429725e+08** |

#7245 turns the output on; this PR makes it right. With both, refinement reproduces the unrefined field totals exactly — which is the property that should hold.

No LGR deck in opm-tests currently requests region FIP, and only one requests FPR, so nothing in CI covers this today.
