### PR TITLE
LGR: rebuild Cartesian->compressed map after refinement, enable serial summary output, fix rank-asymmetric throw

### DIFF
--- a/opm/simulators/flow/CpGridVanguard.hpp
+++ b/opm/simulators/flow/CpGridVanguard.hpp
@@ -27,6 +27,7 @@
 #ifndef OPM_CPGRID_VANGUARD_HPP
 #define OPM_CPGRID_VANGUARD_HPP
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/TimingMacros.hpp>
 
 #include <opm/models/common/multiphasebaseproperties.hh>
@@ -42,6 +43,8 @@
 #include <stdexcept>
 #include <tuple>
 #include <vector>
+
+#include <fmt/format.h>
 
 namespace Opm {
 template <class TypeTag>
@@ -118,14 +121,57 @@ public:
 
     int compressedIndexForInteriorLGR(const std::string& lgr_tag, const Connection& conn) const override
     {
-        const std::array<int,3> lgr_ijk = {conn.getI(), conn.getJ(), conn.getK()};
-        const auto& lgr_level = this->grid().getLgrNameToLevel().at(lgr_tag);
+        // Every rank registers every requested LGR name, with an empty level
+        // grid on ranks that hold no cell of the box (interior or overlap) --
+        // the level structure is identical on all ranks.  A name that fails to
+        // resolve is therefore a programming error, not a distribution effect,
+        // and must be fatal rather than silently skipped.
+        const auto& nameToLevel = this->grid().getLgrNameToLevel();
+        const auto levelIt = nameToLevel.find(lgr_tag);
+        if (levelIt == nameToLevel.end()) {
+            OPM_THROW(std::logic_error,
+                      fmt::format("Internal error: LGR '{}' is not known to the grid. "
+                                  "The level structure must be identical on all ranks.",
+                                  lgr_tag));
+        }
+        const int lgr_level = levelIt->second;
+
         if (ParentType::lgrMappers_.has_value() == false) {
             ParentType::lgrMappers_.emplace(this->grid().mapLocalCartesianIndexSetsToLeafIndexSet());
         }
+
+        // An out-of-range Cartesian position within the level is likewise a
+        // bug (a COMPDATL record addressing outside its LGR box has already
+        // been validated at parse time), so it is fatal too.
         const auto& lgr_dim = this->grid().currentData()[lgr_level]->logicalCartesianSize();
+        const std::array<int,3> lgr_ijk = {conn.getI(), conn.getJ(), conn.getK()};
+        if (lgr_ijk[0] < 0 || lgr_ijk[0] >= lgr_dim[0] ||
+            lgr_ijk[1] < 0 || lgr_ijk[1] >= lgr_dim[1] ||
+            lgr_ijk[2] < 0 || lgr_ijk[2] >= lgr_dim[2])
+        {
+            OPM_THROW(std::logic_error,
+                      fmt::format("Internal error: connection ({},{},{}) is outside "
+                                  "LGR '{}' with dimensions {}x{}x{}.",
+                                  lgr_ijk[0], lgr_ijk[1], lgr_ijk[2], lgr_tag,
+                                  lgr_dim[0], lgr_dim[1], lgr_dim[2]));
+        }
         const auto lgr_cartesian_index = (lgr_ijk[2]*lgr_dim[0]*lgr_dim[1]) + (lgr_ijk[1]*lgr_dim[0]) + (lgr_ijk[0]);
-        return ParentType::lgrMappers_.value()[lgr_level].at(lgr_cartesian_index);
+
+        // A cell that is absent from this rank's level mapper is the one
+        // legitimate miss: the box lives elsewhere and this rank's level grid
+        // is empty (or holds another part of it).  Mirror
+        // compressedIndexForInterior and return -1; the global existence of
+        // every connection cell is checked collectively afterwards
+        // (checkAllConnectionsFound).  Using .at() here threw
+        // std::out_of_range on such ranks -- asymmetrically, which deadlocked
+        // runs at higher rank counts where more ranks hold no part of the box.
+        const auto& mapper = ParentType::lgrMappers_.value()[lgr_level];
+        const auto it = mapper.find(lgr_cartesian_index);
+        if (it == mapper.end()) {
+            return -1;
+        }
+
+        return static_cast<int>(it->second);
     }
     /*!
      * Checking consistency of simulator

--- a/opm/simulators/flow/CpGridVanguard.hpp
+++ b/opm/simulators/flow/CpGridVanguard.hpp
@@ -299,14 +299,26 @@ public:
                              this->numJacobiBlocks(), this->enableEclOutput());
 #endif
 
-        this->updateGridView_();
-        this->updateCartesianToCompressedMapping_();
-        this->updateCellDepths_();
-        this->updateCellThickness_();
+        this->updateDerivedGridState_();
 
 #if HAVE_MPI
         this->distributeFieldProps_(this->eclState());
 #endif
+    }
+
+    /*!
+     * \brief Recompute everything the vanguard derives from the grid.
+     *
+     * Needed after every change to the leaf grid -- load balancing and local
+     * refinement both renumber the leaf cells.  Kept in one method so a
+     * future grid-changing step cannot miss one of the updates.
+     */
+    void updateDerivedGridState_()
+    {
+        this->updateGridView_();
+        this->updateCartesianToCompressedMapping_();
+        this->updateCellDepths_();
+        this->updateCellThickness_();
     }
 
     /*!
@@ -320,9 +332,12 @@ public:
             OpmLog::info("\nAdding LGRs to the grid and updating its leaf grid view");
             this->addLgrsUpdateLeafView(lgrs, lgrs.size(), *this->grid_);
 
-            this->updateGridView_();
-            this->updateCellDepths_();
-            this->updateCellThickness_();
+            // Refinement changed the leaf cell count and ordering, so the
+            // state derived at load-balance time -- in particular the
+            // (level-zero-only) Cartesian->compressed map used to resolve
+            // coarse well connections -- is stale and must be rebuilt before
+            // well connections are resolved.
+            this->updateDerivedGridState_();
 
             if (this->grid_->comm().size()>1) {
                 // Add LGRs and update the leaf grid view in the global (undistributed) simulation grid.

--- a/opm/simulators/flow/FlowBaseVanguard.hpp
+++ b/opm/simulators/flow/FlowBaseVanguard.hpp
@@ -338,12 +338,28 @@ protected:
         std::size_t num_cells = asImp_().grid().leafGridView().size(0);
         is_interior_.resize(num_cells);
 
+        // May run again after the grid changed (local refinement), so start
+        // from scratch rather than leaving entries for cells that no longer
+        // exist in the leaf.
+        cartesianToCompressed_.clear();
+
         ElementMapper elemMapper(this->gridView(), Dune::mcmgElementLayout());
         for (const auto& element : elements(this->gridView()))
         {
             const auto elemIdx = elemMapper.index(element);
-            unsigned cartesianCellIdx = cartesianIndex(elemIdx);
-            cartesianToCompressed_[cartesianCellIdx] = elemIdx;
+            // On a refined grid a level-zero Cartesian index is not a unique
+            // key: every child of a refined cell reports its ancestor's
+            // index, so inserting them would make the winner arbitrary.
+            // Only unrefined cells enter the map, making it a mapping for
+            // existing cells on level zero only; cells inside a refinement
+            // are addressed through the LGR-aware lookup instead, and a
+            // level-zero index that has been refined away resolves to
+            // "not present" rather than to an arbitrary child.
+            if (!element.hasFather())
+            {
+                unsigned cartesianCellIdx = cartesianIndex(elemIdx);
+                cartesianToCompressed_[cartesianCellIdx] = elemIdx;
+            }
             if (element.partitionType() == Dune::InteriorEntity)
             {
                 is_interior_[elemIdx] = 1;

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -524,12 +524,7 @@ public:
         // also updated.
         this->eclWriter().mutableOutputModule().invalidateLocalData();
 
-        // For CpGrid with LGRs, ecl/vtk output is not supported yet.
-        const auto& grid = this->simulator().vanguard().gridView().grid();
-
-        using GridType = std::remove_cv_t<std::remove_reference_t<decltype(grid)>>;
-        constexpr bool isCpGrid = std::is_same_v<GridType, Dune::CpGrid>;
-        if (!isCpGrid || (grid.maxLevel() == 0)) {
+        if (this->eclOutputEvalSupported_()) {
             this->eclWriter_->evalSummaryState(!this->episodeWillBeOver());
         }
 
@@ -641,16 +636,10 @@ public:
         // the initial solution.
         this->thresholdPressures_.finishInit();
 
-        // For CpGrid with LGRs, ecl-output is not supported yet.
-        const auto& grid = this->simulator().vanguard().gridView().grid();
-
-        using GridType = std::remove_cv_t<std::remove_reference_t<decltype(grid)>>;
-        constexpr bool isCpGrid = std::is_same_v<GridType, Dune::CpGrid>;
-        // Skip - for now -  calculate the initial fip values for CpGrid with LGRs.
-        if (!isCpGrid || (grid.maxLevel() == 0)) {
-            if (this->simulator().episodeIndex() == 0) {
-                eclWriter_->writeInitialFIPReport();
-            }
+        if (this->eclOutputEvalSupported_() &&
+            (this->simulator().episodeIndex() == 0))
+        {
+            eclWriter_->writeInitialFIPReport();
         }
     }
 
@@ -1776,6 +1765,26 @@ protected:
     HybridNewton hybridNewton_;
 
 private:
+    /// Whether ECL summary/FIP evaluation is wired up for this grid
+    /// configuration.
+    ///
+    /// The only unsupported case is a *distributed* CpGrid with LGRs:
+    /// CollectDataOnIORank does not build its index maps for a distributed
+    /// refined grid yet.  In serial the index maps are the identity and the
+    /// leaf-grid well/cell data is written directly, so refined serial runs
+    /// are fine.  Kept in one place so no call site can miss a condition.
+    bool eclOutputEvalSupported_() const
+    {
+        const auto& grid = this->simulator().vanguard().gridView().grid();
+
+        using GridType = std::remove_cv_t<std::remove_reference_t<decltype(grid)>>;
+        constexpr bool isCpGrid = std::is_same_v<GridType, Dune::CpGrid>;
+
+        return !isCpGrid
+            || (grid.maxLevel() == 0)
+            || (grid.comm().size() == 1);
+    }
+
     /// Whether or not the current epsiode will end at the end of the
     /// current time step.
     ///


### PR DESCRIPTION
Reworked per review — thanks, the comments improved all three fixes. Same three bugs, different shapes:

## 1. Serial LGR summary/FIP output

Unchanged in substance: `evalSummaryState` and `writeInitialFIPReport` were skipped for any refined CpGrid, so CARFIN decks wrote all-zero summaries and a FIP report segfaulted on the never-populated `inplace_`. The unsupported case is exactly a *distributed* refined grid (CollectDataOnIORank does not build its index maps there); serial is fine since the maps are the identity.

Per review, the condition now lives in one private helper, `eclOutputEvalSupported_()`, used at both call sites, so no future site can miss a condition.

## 2. `compressedIndexForInteriorLGR`: fatal vs −1, separated

Previously any miss threw `std::out_of_range` from `map::at()`, and an exception here fires on some ranks and not others — a collective hazard during well setup. The rank-without-the-box case is reachable by construction: a rank holding no cell of a COMPDATL box (interior or overlap) still resolves every LGR well when building the well containers. (To answer the inline question directly: I hit it as a np≥6 deadlock during development, on a faulted-box variant of `SIMPLE_2PH_W_FAULT_LGR` — that deck needs refinement across a fault, which CpGrid does not support yet, so the *deck* is not reproducible on master, but the code path is, from any COMPDATL deck whose box misses a rank.)

Per review, misses are no longer treated alike:
- **LGR name unknown** → fatal. Every rank registers every requested LGR (empty level grid where it holds no box cells — interior *or* overlap; the earlier comment's "rank-interior/owning rank" language was wrong and is gone), so the level structure is identical on all ranks and a failed name lookup is a programming error.
- **Connection (i,j,k) outside the LGR's dimensions** → fatal, same reasoning (validated at parse time).
- **Cell absent from this rank's level mapper** → −1, the one legitimate miss, mirroring `compressedIndexForInterior`'s contract; `checkAllConnectionsFound` still verifies global existence collectively.

## 3. The Cartesian→compressed map: level-zero cells only

Adopting the suggestion made inline: the map now **only contains unrefined cells** — "a mapping for existing cells on level 0 only" — and is cleared on rebuild. On a refined grid a level-zero Cartesian index is not a unique key (every child reports its ancestor's index), so inserting refined cells made the winner arbitrary. Now a refined-away level-zero index resolves to "not present" and flows into the existing cells-not-found handling instead of silently binding to an arbitrary child; cells inside a refinement are addressed only through the LGR-aware lookup.

The rebuild after refinement is still required — refinement renumbers the leaf, so the load-balance-time entries are stale (on `SPE1CASE1_CARFIN1`, `PROD` resolved to cart 91 instead of its perforation cell 299; fixed: active index 923, first-iteration CNV matches the non-LGR baseline, serial ≡ parallel). The post-grid-change updates are factored into `updateDerivedGridState_()`, shared by `loadBalance()` and `addLgrs()`, per review.

## Testing

Against opm-common/opm-grid master:

- `SPE1CASE1_CARFIN1` (coarse wells, box refined): serial 51 Newton with **non-zero summaries** (all-zero before); np=2 with `--enable-ecl-output=false` also 51 Newton — serial ≡ parallel. Parallel *with* output enabled still fails in `CollectDataOnIORank`, as on master; that is the separate parallel-output work, not this PR.
- `SPE1CASE1_CARFIN` at **np=4**, i.e. the configuration `spe1case1_carfin_parallel` runs in CI: completes, 60 Newton.
- `SPE1CASE1_CARFIN_GR` (COMPDATL well, whole grid refined — so the level-zero map is legitimately empty, which is what exercises the reworked LGR lookup): **serial** completes, 109 Newton. I did not get a np=2 run of this deck to complete — it sits in the first report step. Note CI registers `spe1case1_carfin_gr` serially only, and whole-grid LGR in parallel looks unsupported independently of this PR, so I am not claiming it as evidence either way.
- `SPE1CASE1` (no LGR): 313 Newton, unchanged — `hasFather()` is false everywhere, so the map is identical.
