### PR TITLE
Let the problem cap the next time step

### DIFF
--- a/opm/models/discretization/common/fvbaseproblem.hh
+++ b/opm/models/discretization/common/fvbaseproblem.hh
@@ -570,6 +570,16 @@ public:
     { return Parameters::Get<Parameters::MinTimeStepSize<Scalar>>(); }
 
     /*!
+     * \brief Upper bound for the next time step imposed by the problem.
+     *
+     * The default is no limit; problems with their own step restrictions
+     * (e.g. a geomechanical fracture model throttling growth per step)
+     * override this.
+     */
+    virtual Scalar maxNextTimeStepSize() const
+    { return std::numeric_limits<Scalar>::max(); }
+
+    /*!
      * \brief Returns the maximum number of subsequent failures for the time integration
      *        before giving up.
      */

--- a/opm/models/discretization/common/fvbaseproblem.hh
+++ b/opm/models/discretization/common/fvbaseproblem.hh
@@ -570,6 +570,18 @@ public:
     { return Parameters::Get<Parameters::MinTimeStepSize<Scalar>>(); }
 
     /*!
+     * \brief Upper bound for the next time step imposed by the problem.
+     *
+     * The default is no limit; problems with their own step restrictions
+     * (e.g. a geomechanical fracture model throttling growth per step)
+     * override this.  Deliberately double rather than Scalar: time step
+     * quantities are kept in double throughout, since float has too little
+     * precision at the magnitudes involved.
+     */
+    virtual double maxNextTimeStepSize() const
+    { return std::numeric_limits<double>::max(); }
+
+    /*!
      * \brief Returns the maximum number of subsequent failures for the time integration
      *        before giving up.
      */

--- a/opm/simulators/flow/SimulatorFullyImplicit_impl.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicit_impl.hpp
@@ -37,6 +37,7 @@
 #include <fmt/format.h>
 
 #include <filesystem>
+#include <limits>
 #include <sstream>
 
 namespace Opm {
@@ -357,16 +358,26 @@ runStep(SimulatorTimer& timer)
             auto& schedule = this->simulator_.vanguard().schedule();
             auto& events = this->schedule()[reportStep].events();
 
-            bool result = false;
+            // The problem may cap the next time step (e.g. a geomechanical
+            // fracture model limiting steps while the fracture grows); seed
+            // the updater with that limit.
+            auto max_next_tstep = this->simulator_.problem().maxNextTimeStepSize();
+            bool result = max_next_tstep < std::numeric_limits<double>::max();
+            if (result) {
+                this->adaptiveTimeStepping_->updateNEXTSTEP(max_next_tstep);
+            }
             if (events.hasEvent(ScheduleEvents::TUNING_CHANGE)) {
                 // Unset the event to not trigger it again on the next sub step
                 schedule.clear_event(ScheduleEvents::TUNING_CHANGE, reportStep);
                 const auto& sched_state = schedule[reportStep];
-                const auto& max_next_tstep = sched_state.max_next_tstep(enableTUNING);
+                const auto& tuning_max_next_tstep = sched_state.max_next_tstep(enableTUNING);
+                if (tuning_max_next_tstep > 0) {
+                    max_next_tstep = std::max(max_next_tstep, tuning_max_next_tstep);
+                }
                 const auto& tuning = sched_state.tuning();
 
                 if (enableTUNING) {
-                    adaptiveTimeStepping_->updateTUNING(max_next_tstep, tuning);
+                    adaptiveTimeStepping_->updateTUNING(tuning_max_next_tstep, tuning);
                     // \Note: Assumes TUNING is only used with adaptive time-stepping
                     // \Note: Need to update both solver (model) and simulator since solver is re-created each report step.
                     solver_->model().updateTUNING(tuning);
@@ -374,9 +385,11 @@ runStep(SimulatorTimer& timer)
                     substep_length = this->adaptiveTimeStepping_->suggestedNextStep();
                 } else {
                     substep_length = max_next_tstep;
-                    this->adaptiveTimeStepping_->updateNEXTSTEP(max_next_tstep);
+                    if (max_next_tstep < std::numeric_limits<double>::max()) {
+                        this->adaptiveTimeStepping_->updateNEXTSTEP(max_next_tstep);
+                    }
                 }
-                result = max_next_tstep > 0;
+                result = max_next_tstep < std::numeric_limits<double>::max();
             }
 
             if (events.hasEvent(ScheduleEvents::TUNINGDP_CHANGE)) {

--- a/opm/simulators/flow/SimulatorFullyImplicit_impl.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicit_impl.hpp
@@ -37,6 +37,7 @@
 #include <fmt/format.h>
 
 #include <filesystem>
+#include <limits>
 #include <sstream>
 
 namespace Opm {
@@ -357,12 +358,30 @@ runStep(SimulatorTimer& timer)
             auto& schedule = this->simulator_.vanguard().schedule();
             auto& events = this->schedule()[reportStep].events();
 
-            bool result = false;
+            // The problem may cap the next time step (e.g. a geomechanical
+            // fracture model limiting steps while the fracture grows).
+            const double problem_max_next_tstep =
+                this->simulator_.problem().maxNextTimeStepSize();
+            const bool problem_caps =
+                problem_max_next_tstep < std::numeric_limits<double>::max();
+
+            bool result = problem_caps;
+            if (problem_caps) {
+                this->adaptiveTimeStepping_->updateNEXTSTEP(problem_max_next_tstep);
+            }
             if (events.hasEvent(ScheduleEvents::TUNING_CHANGE)) {
                 // Unset the event to not trigger it again on the next sub step
                 schedule.clear_event(ScheduleEvents::TUNING_CHANGE, reportStep);
                 const auto& sched_state = schedule[reportStep];
-                const auto& max_next_tstep = sched_state.max_next_tstep(enableTUNING);
+                double max_next_tstep = sched_state.max_next_tstep(enableTUNING);
+                // Both are upper bounds on the next step, so the effective cap is
+                // the smaller one.  max_next_tstep() is -1 when the schedule sets
+                // no limit at all, and then the problem's limit stands alone.
+                if (problem_caps) {
+                    max_next_tstep = (max_next_tstep > 0.0)
+                        ? std::min(max_next_tstep, problem_max_next_tstep)
+                        : problem_max_next_tstep;
+                }
                 const auto& tuning = sched_state.tuning();
 
                 if (enableTUNING) {


### PR DESCRIPTION
Adds a defaulted virtual `FvBaseProblem::maxNextTimeStepSize()` (default: no limit) and combines it with the TUNING-derived suggestion. No behaviour change unless a problem overrides it; opm-flowgeomechanics uses it to throttle fracture growth per step.