### PR TITLE
flow: let problems append a section to the simulation trailer

### DIFF
--- a/opm/simulators/flow/Banners.cpp
+++ b/opm/simulators/flow/Banners.cpp
@@ -116,7 +116,8 @@ void printFlowTrailer(int nprocs,
                       int nthreads,
                       const double total_setup_time,
                       const double deck_read_time,
-                      const SimulatorReport& report)
+                      const SimulatorReport& report,
+                      const std::string_view extra_summary)
 {
     std::ostringstream ss;
     ss << "\n\n================    End of simulation     ===============\n\n";
@@ -125,6 +126,15 @@ void printFlowTrailer(int nprocs,
     ss << fmt::format("Setup time:                 {:9.2f} s\n", total_setup_time);
     ss << fmt::format("  Deck input:               {:9.2f} s\n", deck_read_time);
     report.reportFullyImplicit(ss);
+    if (!extra_summary.empty()) {
+        if (extra_summary.front() != '\n') {
+            ss << '\n';
+        }
+        ss << extra_summary;
+        if (extra_summary.back() != '\n') {
+            ss << '\n';
+        }
+    }
     OpmLog::info(ss.str());
 }
 

--- a/opm/simulators/flow/Banners.hpp
+++ b/opm/simulators/flow/Banners.hpp
@@ -44,7 +44,8 @@ void printFlowTrailer(int nprocs,
                       int nthreads,
                       const double total_setup_time,
                       const double deck_read_time,
-                      const SimulatorReport& report);
+                      const SimulatorReport& report,
+                      std::string_view extra_summary);
 
 } // namespace Opm
 

--- a/opm/simulators/flow/FlowMain.hpp
+++ b/opm/simulators/flow/FlowMain.hpp
@@ -430,7 +430,8 @@ namespace Opm {
                 = omp_get_max_threads();
 #endif
 
-            printFlowTrailer(mpi_size_, threads, total_setup_time_, deck_read_time_, report);
+            printFlowTrailer(mpi_size_, threads, total_setup_time_, deck_read_time_, report,
+                             simulator_->model().simulator().problem().extraTrailerSummary());
 
             detail::handleExtraConvergenceOutput(report,
                                                  Parameters::Get<Parameters::OutputExtraConvergenceInfo>(),

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -170,6 +170,11 @@ protected:
     using DirectionalMobilityPtr = Utility::CopyablePtr<DirectionalMobility<TypeTag>>;
 
 public:
+
+    /// Extra module-specific lines appended to the final simulation trailer
+    /// (e.g. geomechanics timing). Derived problems may shadow this.
+    std::string extraTrailerSummary() const
+    { return {}; }
     using BaseType::briefDescription;
     using BaseType::helpPreamble;
     using BaseType::shouldWriteOutput;


### PR DESCRIPTION
`printFlowTrailer` gains a defaulted extra-summary argument, filled from a new `FlowProblem::extraTrailerSummary()` (default: empty). No output change for standard runs; opm-flowgeomechanics uses it for its timing summary.