### PR TITLE
NewtonIterationContext: RAII guard for mid-step setup passes

### DIFF
--- a/opm/models/discretization/common/fvbaseproblem.hh
+++ b/opm/models/discretization/common/fvbaseproblem.hh
@@ -844,8 +844,10 @@ public:
 
 private:
     // LocalContextGuard needs mutable access to save/restore the context
-    // during NLDD domain-local solves.
+    // during NLDD domain-local solves; SetupIterationContextGuard likewise
+    // for mid-step re-initialization passes.
     template<class P> friend class LocalContextGuard;
+    template<class P> friend class SetupIterationContextGuard;
 
     /*!
      * \brief Mutable access to the iteration context for LocalContextGuard.

--- a/opm/simulators/flow/NewtonIterationContext.hpp
+++ b/opm/simulators/flow/NewtonIterationContext.hpp
@@ -176,6 +176,36 @@ private:
     NewtonIterationContext saved_;
 };
 
+/// RAII guard for re-running once-per-timestep setup mid-step, e.g. after
+/// the well structure changed during the outer nonlinear loop.  Saves the
+/// current context, resets it so the next nonlinear iteration performs its
+/// timestep initialization at iteration 0, and restores the original
+/// context on destruction (the outer iteration count is unaffected).
+template<class Problem>
+class SetupIterationContextGuard {
+public:
+    SetupIterationContextGuard(Problem& problem)
+        : problem_(problem)
+        , saved_(problem.iterationContext())
+    {
+        problem_.mutableIterationContext().resetForNewTimestep();
+    }
+
+    ~SetupIterationContextGuard()
+    {
+        problem_.mutableIterationContext() = saved_;
+    }
+
+    SetupIterationContextGuard(const SetupIterationContextGuard&) = delete;
+    SetupIterationContextGuard& operator=(const SetupIterationContextGuard&) = delete;
+    SetupIterationContextGuard(SetupIterationContextGuard&&) = delete;
+    SetupIterationContextGuard& operator=(SetupIterationContextGuard&&) = delete;
+
+private:
+    Problem& problem_;
+    NewtonIterationContext saved_;
+};
+
 } // namespace Opm
 
 #endif // OPM_NEWTON_ITERATION_CONTEXT_HPP


### PR DESCRIPTION
Adds `SetupIterationContextGuard`, analogous to the existing `LocalContextGuard`: reset the iteration context so a re-run setup pass performs its iteration-0 initialization, restore on destruction. No behaviour change without a caller; needed when the well structure changes mid-step (e.g. fracture-created connections).