### PR TITLE
NonlinearSystemBlackOilReservoir: accept the configured WellModel type

### DIFF
--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir.hpp
@@ -145,7 +145,7 @@ public:
     /// \param[in] terminal_output  request output to cout/cerr
     NonlinearSystemBlackOilReservoir(Simulator& simulator,
                   const ModelParameters& param,
-                  BlackoilWellModel<TypeTag>& well_model,
+                  typename ParentType::WellModel& well_model,
                   const bool terminal_output);
 
     const EclipseState& eclState() const

--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
@@ -77,7 +77,7 @@ template <class TypeTag>
 NonlinearSystemBlackOilReservoir<TypeTag>::
 NonlinearSystemBlackOilReservoir(Simulator& simulator,
               const ModelParameters& param,
-              BlackoilWellModel<TypeTag>& well_model,
+              typename ParentType::WellModel& well_model,
               const bool terminal_output)
     : ParentType(simulator, param, well_model, terminal_output)
     , conv_monitor_(param.monitor_params_)


### PR DESCRIPTION
Take the WellModel property type in the constructor instead of hard-coding `BlackoilWellModel<TypeTag>`; the base already stores `WellModel&`. No change for type tags using the default well model.