### PR TITLE
Fix segfault in convergence output thread on abnormal termination

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -467,6 +467,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_dilu.cpp
   tests/test_group_higher_constraints.cpp
   tests/test_equil.cpp
+  tests/test_extraconvergenceoutputthread.cpp
   tests/test_extractMatrix.cpp
   tests/test_flexiblesolver.cpp
   tests/test_GasSatfuncConsistencyChecks.cpp

--- a/opm/simulators/flow/ExtraConvergenceOutputThread.cpp
+++ b/opm/simulators/flow/ExtraConvergenceOutputThread.cpp
@@ -326,25 +326,31 @@ writeIterInfo(const std::vector<ConvergenceReportQueue::OutputRequest>& requests
         return;
     }
 
-    if (! this->haveOutputIterHeader_) {
-        std::tie(this->firstColSize_, this->colSize_) =
-            writeConvergenceHeader(this->infoIter_.value(),
-                                   this->getPhaseName_,
-                                   requests.front());
-        this->haveOutputIterHeader_ = true;
-    }
-
     for (const auto& request : requests) {
+        if (request.reports.empty()) {
+            // Empty request signals end of production.  Must be detected
+            // before the header is written, since forming the header needs a
+            // convergence report to name the metric columns.  A run that
+            // fails before completing a single non-linear iteration - e.g.,
+            // one that chops its way to the minimum time step - sends this
+            // sentinel as its very first request.
+            this->finalRequestWritten_ = true;
+            break;
+        }
+
+        if (! this->haveOutputIterHeader_) {
+            std::tie(this->firstColSize_, this->colSize_) =
+                writeConvergenceHeader(this->infoIter_.value(),
+                                       this->getPhaseName_,
+                                       request);
+            this->haveOutputIterHeader_ = true;
+        }
+
         writeConvergenceRequest(this->infoIter_.value(),
                                 this->convertTime_,
                                 this->firstColSize_,
                                 this->colSize_,
                                 request);
-
-        if (request.reports.empty()) {
-            this->finalRequestWritten_ = true;
-            break;
-        }
     }
 
     this->infoIter_.value().flush();

--- a/tests/test_extraconvergenceoutputthread.cpp
+++ b/tests/test_extraconvergenceoutputthread.cpp
@@ -1,0 +1,147 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#define BOOST_TEST_MODULE TestExtraConvergenceOutputThread
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/simulators/flow/ConvergenceOutputConfiguration.hpp>
+#include <opm/simulators/flow/ExtraConvergenceOutputThread.hpp>
+
+#include <opm/simulators/timestepping/ConvergenceReport.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+namespace {
+
+    std::string_view phaseName(const int comp)
+    {
+        return (comp == 0) ? "Water" : "Oil";
+    }
+
+    class OutputDir
+    {
+    public:
+        explicit OutputDir(const std::string& name)
+            : dir_ { std::filesystem::temp_directory_path() / name }
+        {
+            std::filesystem::remove_all(this->dir_);
+            std::filesystem::create_directories(this->dir_);
+        }
+
+        ~OutputDir()
+        {
+            std::filesystem::remove_all(this->dir_);
+        }
+
+        std::string path() const { return this->dir_.string(); }
+
+        std::vector<std::string> infoIterLines(const std::string& baseName) const
+        {
+            auto is = std::ifstream { this->dir_ / (baseName + ".INFOITER") };
+            auto lines = std::vector<std::string>{};
+
+            for (auto line = std::string{}; std::getline(is, line); ) {
+                lines.push_back(line);
+            }
+
+            return lines;
+        }
+
+    private:
+        std::filesystem::path dir_;
+    };
+
+    // Run the output thread against 'requests', then signal end of
+    // production and join.
+    void runOutputThread(const OutputDir&                                          dir,
+                         const std::string&                                        baseName,
+                         std::vector<Opm::ConvergenceReportQueue::OutputRequest>&&  requests)
+    {
+        auto queue = Opm::ConvergenceReportQueue{};
+        auto writer = Opm::ConvergenceOutputThread {
+            dir.path(), baseName, &phaseName,
+            [](const double t) { return t; },
+            Opm::ConvergenceOutputConfiguration{"steps,iterations"},
+            queue
+        };
+
+        auto thread = std::thread {
+            &Opm::ConvergenceOutputThread::writeASynchronous, &writer
+        };
+
+        if (! requests.empty()) {
+            queue.enqueue(std::move(requests));
+        }
+
+        queue.signalLastOutputRequest();
+        thread.join();
+    }
+
+    Opm::ConvergenceReport makeReport()
+    {
+        auto report = Opm::ConvergenceReport { 0.0 };
+
+        report.setReservoirConvergenceMetric
+            (Opm::ConvergenceReport::ReservoirFailure::Type::MassBalance,
+             0, 1.0e-6, 1.0e-5);
+
+        report.setCnvPoreVolSplit({{1.0, 0.0, 0.0}, {1, 0, 0}}, 1.0);
+
+        return report;
+    }
+
+} // Anonymous namespace
+
+// The end-of-production sentinel is an OutputRequest with no convergence
+// reports.  A run that fails before completing a single non-linear iteration
+// sends it as the very first request, so the output thread must not try to
+// form the column header from it.
+BOOST_AUTO_TEST_CASE(SentinelOnlyDoesNotWriteHeader)
+{
+    const auto dir = OutputDir { "test_extraconvergenceoutputthread_sentinel" };
+
+    runOutputThread(dir, "CASE", {});
+
+    BOOST_CHECK(dir.infoIterLines("CASE").empty());
+}
+
+BOOST_AUTO_TEST_CASE(HeaderAndOneIteration)
+{
+    const auto dir = OutputDir { "test_extraconvergenceoutputthread_normal" };
+
+    auto requests = std::vector<Opm::ConvergenceReportQueue::OutputRequest>{};
+    requests.push_back({ 0, 0, { makeReport() } });
+
+    runOutputThread(dir, "CASE", std::move(requests));
+
+    const auto lines = dir.infoIterLines("CASE");
+
+    BOOST_REQUIRE_EQUAL(lines.size(), std::size_t{2});
+    BOOST_CHECK(lines[0].find("ReportStep") != std::string::npos);
+    BOOST_CHECK(lines[1].find("CONV") != std::string::npos);
+}


### PR DESCRIPTION
With `--output-extra-convergence-info=...`, the writer thread formed the INFOITER header from `requests.front()` before checking for the empty end-of-production sentinel. A run that fails before completing a single non-linear iteration sends that sentinel first, so the header code read `reports.front()` on an empty vector and the thread segfaulted.

Repro (12 decks in opm-tests, e.g. `wconprod/WCONPROD-01.DATA`):

```
flow WCONPROD-01.DATA --output-extra-convergence-info=steps,iterations
```

Now exits with the intended "Solver failed to converge" error. Unit test added; it crashes without the fix.