### PR TITLE
Fix segfault when an ACTIONX block drills a new well

### DIFF
--- a/opm/simulators/linalg/ISTLSolver.hpp
+++ b/opm/simulators/linalg/ISTLSolver.hpp
@@ -510,6 +510,7 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
                                                          weightCalculator,
                                                          forceSerial_,
                                                          comm_.get());
+                numWellEquations_ = this->numWellEquations();
             }
             else
             {
@@ -518,6 +519,14 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
             }
         }
 
+
+        /// Number of extra equations the well operator contributes.
+        int numWellEquations() const
+        {
+            return useWellConn_
+                ? 0
+                : simulator_.problem().wellModel().numLocalWellsEnd();
+        }
 
         /// Return true if we should (re)create the whole solver,
         /// instead of just calling update() on the preconditioner.
@@ -529,6 +538,14 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
                 return true;
             }
             if (!flexibleSolver_[activeSolverNum_].solver_) {
+                return true;
+            }
+
+            // The CPRW coarse system reserves a row per well, so its size is
+            // fixed when the solver is built.  A well drilled by an ACTIONX
+            // block changes the well count mid-run; updating in place would
+            // then write past the end of the coarse matrix.
+            if (this->numWellEquations() != numWellEquations_) {
                 return true;
             }
 
@@ -668,6 +685,10 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
         std::vector<int> interiorRows_;
 
         int domainIndex_ = -1;
+
+        // Number of well equations the current solver was built for, or -1 if
+        // no solver has been built yet.  See shouldCreateSolver().
+        int numWellEquations_ = -1;
 
         bool useWellConn_;
 

--- a/opm/simulators/linalg/ISTLSolver.hpp
+++ b/opm/simulators/linalg/ISTLSolver.hpp
@@ -520,6 +520,7 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
                                                          weightCalculator,
                                                          forceSerial_,
                                                          comm_.get());
+                numWellEquations_ = this->numWellEquations();
             }
             else
             {
@@ -528,6 +529,14 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
             }
         }
 
+
+        /// Number of extra equations the well operator contributes.
+        int numWellEquations() const
+        {
+            return useWellConn_
+                ? 0
+                : simulator_.problem().wellModel().numLocalWellsEnd();
+        }
 
         /// Return true if we should (re)create the whole solver,
         /// instead of just calling update() on the preconditioner.
@@ -545,6 +554,14 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
             }
 
             if (!flexibleSolver_[activeSolverNum_].solver_) {
+                return true;
+            }
+
+            // The CPRW coarse system reserves a row per well, so its size is
+            // fixed when the solver is built.  A well drilled by an ACTIONX
+            // block changes the well count mid-run; updating in place would
+            // then write past the end of the coarse matrix.
+            if (this->numWellEquations() != numWellEquations_) {
                 return true;
             }
 
@@ -684,6 +701,10 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
         std::vector<int> interiorRows_;
 
         int domainIndex_ = -1;
+
+        // Number of well equations the current solver was built for, or -1 if
+        // no solver has been built yet.  See shouldCreateSolver().
+        int numWellEquations_ = -1;
 
         bool useWellConn_;
 

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -358,10 +358,29 @@ createLocalParallelWellInfo(const std::vector<Well>& wells)
 }
 
 template<typename Scalar, typename IndexTraits>
-ParallelWellInfo<Scalar>*
+const ParallelWellInfo<Scalar>*
 BlackoilWellModelGeneric<Scalar, IndexTraits>::
 findParallelWellInfo(const std::string& wname) const
 {
+    auto pwell = std::lower_bound(this->parallel_well_info_.begin(),
+                                  this->parallel_well_info_.end(), wname,
+                                  [](const auto& pwInfo, const std::string& name)
+                                  { return pwInfo->name() < name; });
+
+    return ((pwell == this->parallel_well_info_.end()) ||
+            ((*pwell)->name() != wname))
+        ? nullptr
+        : pwell->get();
+}
+
+template<typename Scalar, typename IndexTraits>
+ParallelWellInfo<Scalar>*
+BlackoilWellModelGeneric<Scalar, IndexTraits>::
+findParallelWellInfo(const std::string& wname)
+{
+    // No const_cast needed to share the const overload's lookup: the elements
+    // are unique_ptrs, and constness of the pointer does not carry to the
+    // pointee, so get() already yields a mutable ParallelWellInfo.
     auto pwell = std::lower_bound(this->parallel_well_info_.begin(),
                                   this->parallel_well_info_.end(), wname,
                                   [](const auto& pwInfo, const std::string& name)

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -131,13 +131,9 @@ BlackoilWellModelGeneric(Schedule& schedule,
         }
 
         // Recall: false indicates NOT active!
-        const auto value = std::make_pair(well, true);
-        auto candidate = std::lower_bound(this->parallel_well_info_.begin(),
-                                          this->parallel_well_info_.end(),
-                                          value);
+        const auto* pwInfo = this->findParallelWellInfo(well);
 
-        return (candidate == this->parallel_well_info_.end())
-            || (*candidate != value);
+        return (pwInfo == nullptr) || !pwInfo->hasLocalCells();
     };
 }
 
@@ -221,6 +217,7 @@ initFromRestartFile(const RestartValue& restartValues,
     const auto& config = this->schedule()[report_step].guide_rate();
 
     // wells_ecl_ should only contain wells on this processor.
+    this->registerNewParallelWells(report_step);
     wells_ecl_ = getLocalWells(report_step);
     this->local_parallel_well_info_ = createLocalParallelWellInfo(wells_ecl_);
 
@@ -267,6 +264,7 @@ void BlackoilWellModelGeneric<Scalar, IndexTraits>::
 prepareDeserialize(int report_step, const std::size_t numCells, bool enable_distributed_wells)
 {
     // wells_ecl_ should only contain wells on this processor.
+    this->registerNewParallelWells(report_step);
     wells_ecl_ = getLocalWells(report_step);
     this->local_parallel_well_info_ = createLocalParallelWellInfo(wells_ecl_);
 
@@ -327,15 +325,71 @@ createLocalParallelWellInfo(const std::vector<Well>& wells)
     local_parallel_well_info.reserve(wells.size());
     for (const auto& well : wells)
     {
-        auto wellPair = std::make_pair(well.name(), true);
-        auto pwell = std::lower_bound(parallel_well_info_.begin(),
-                                      parallel_well_info_.end(),
-                                      wellPair);
-        assert(pwell != parallel_well_info_.end() &&
-               *pwell == wellPair);
+        auto* pwell = this->findParallelWellInfo(well.name());
+        if (pwell == nullptr) {
+            OPM_THROW(std::logic_error,
+                      fmt::format("No parallel well information registered "
+                                  "for well {}", well.name()));
+        }
         local_parallel_well_info.push_back(std::ref(*pwell));
     }
     return local_parallel_well_info;
+}
+
+template<typename Scalar, typename IndexTraits>
+ParallelWellInfo<Scalar>*
+BlackoilWellModelGeneric<Scalar, IndexTraits>::
+findParallelWellInfo(const std::string& wname) const
+{
+    auto pwell = std::lower_bound(this->parallel_well_info_.begin(),
+                                  this->parallel_well_info_.end(), wname,
+                                  [](const auto& pwInfo, const std::string& name)
+                                  { return pwInfo->name() < name; });
+
+    return ((pwell == this->parallel_well_info_.end()) ||
+            ((*pwell)->name() != wname))
+        ? nullptr
+        : pwell->get();
+}
+
+template<typename Scalar, typename IndexTraits>
+void BlackoilWellModelGeneric<Scalar, IndexTraits>::
+registerNewParallelWells(const int reportStepIdx)
+{
+    auto added = false;
+
+    for (const auto& wname : this->schedule().wellNames(reportStepIdx)) {
+        if (this->findParallelWellInfo(wname) != nullptr) {
+            continue;
+        }
+
+        const auto& well = this->schedule()[reportStepIdx].wells(wname);
+
+        // A well drilled by an action is not part of the grid partitioning,
+        // so we have to work out here whether it perforates cells on this
+        // rank.
+        const auto hasLocalCells = std::ranges::
+            any_of(well.getConnections(), [this, &well](const Connection& conn)
+            {
+                const auto active_index = well.is_lgr_well()
+                    ? this->compressedIndexForInteriorLGR
+                        (well.get_lgr_well_tag().value(), conn)
+                    : this->compressedIndexForInterior(conn.global_index());
+
+                return active_index >= 0;
+            });
+
+        this->parallel_well_info_.push_back
+            (std::make_unique<ParallelWellInfo<Scalar>>
+             (std::make_pair(wname, hasLocalCells), this->comm_));
+
+        added = true;
+    }
+
+    if (added) {
+        std::ranges::sort(this->parallel_well_info_, {},
+                          [](const auto& pwInfo) { return pwInfo->name(); });
+    }
 }
 
 template<typename Scalar, typename IndexTraits>

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -132,13 +132,9 @@ BlackoilWellModelGeneric(Schedule& schedule,
         }
 
         // Recall: false indicates NOT active!
-        const auto value = std::make_pair(well, true);
-        auto candidate = std::lower_bound(this->parallel_well_info_.begin(),
-                                          this->parallel_well_info_.end(),
-                                          value);
+        const auto* pwInfo = this->findParallelWellInfo(well);
 
-        return (candidate == this->parallel_well_info_.end())
-            || (*candidate != value);
+        return (pwInfo == nullptr) || !pwInfo->hasLocalCells();
     };
 }
 
@@ -222,6 +218,7 @@ initFromRestartFile(const RestartValue& restartValues,
     const auto& config = this->schedule()[report_step].guide_rate();
 
     // wells_ecl_ should only contain wells on this processor.
+    this->registerNewParallelWells(report_step);
     wells_ecl_ = getLocalWells(report_step);
     this->local_parallel_well_info_ = createLocalParallelWellInfo(wells_ecl_);
 
@@ -268,6 +265,7 @@ void BlackoilWellModelGeneric<Scalar, IndexTraits>::
 prepareDeserialize(int report_step, const std::size_t numCells, bool enable_distributed_wells)
 {
     // wells_ecl_ should only contain wells on this processor.
+    this->registerNewParallelWells(report_step);
     wells_ecl_ = getLocalWells(report_step);
     this->local_parallel_well_info_ = createLocalParallelWellInfo(wells_ecl_);
 
@@ -348,15 +346,71 @@ createLocalParallelWellInfo(const std::vector<Well>& wells)
     local_parallel_well_info.reserve(wells.size());
     for (const auto& well : wells)
     {
-        auto wellPair = std::make_pair(well.name(), true);
-        auto pwell = std::lower_bound(parallel_well_info_.begin(),
-                                      parallel_well_info_.end(),
-                                      wellPair);
-        assert(pwell != parallel_well_info_.end() &&
-               *pwell == wellPair);
+        auto* pwell = this->findParallelWellInfo(well.name());
+        if (pwell == nullptr) {
+            OPM_THROW(std::logic_error,
+                      fmt::format("No parallel well information registered "
+                                  "for well {}", well.name()));
+        }
         local_parallel_well_info.push_back(std::ref(*pwell));
     }
     return local_parallel_well_info;
+}
+
+template<typename Scalar, typename IndexTraits>
+ParallelWellInfo<Scalar>*
+BlackoilWellModelGeneric<Scalar, IndexTraits>::
+findParallelWellInfo(const std::string& wname) const
+{
+    auto pwell = std::lower_bound(this->parallel_well_info_.begin(),
+                                  this->parallel_well_info_.end(), wname,
+                                  [](const auto& pwInfo, const std::string& name)
+                                  { return pwInfo->name() < name; });
+
+    return ((pwell == this->parallel_well_info_.end()) ||
+            ((*pwell)->name() != wname))
+        ? nullptr
+        : pwell->get();
+}
+
+template<typename Scalar, typename IndexTraits>
+void BlackoilWellModelGeneric<Scalar, IndexTraits>::
+registerNewParallelWells(const int reportStepIdx)
+{
+    auto added = false;
+
+    for (const auto& wname : this->schedule().wellNames(reportStepIdx)) {
+        if (this->findParallelWellInfo(wname) != nullptr) {
+            continue;
+        }
+
+        const auto& well = this->schedule()[reportStepIdx].wells(wname);
+
+        // A well drilled by an action is not part of the grid partitioning,
+        // so we have to work out here whether it perforates cells on this
+        // rank.
+        const auto hasLocalCells = std::ranges::
+            any_of(well.getConnections(), [this, &well](const Connection& conn)
+            {
+                const auto active_index = well.is_lgr_well()
+                    ? this->compressedIndexForInteriorLGR
+                        (well.get_lgr_well_tag().value(), conn)
+                    : this->compressedIndexForInterior(conn.global_index());
+
+                return active_index >= 0;
+            });
+
+        this->parallel_well_info_.push_back
+            (std::make_unique<ParallelWellInfo<Scalar>>
+             (std::make_pair(wname, hasLocalCells), this->comm_));
+
+        added = true;
+    }
+
+    if (added) {
+        std::ranges::sort(this->parallel_well_info_, {},
+                          [](const auto& pwInfo) { return pwInfo->name(); });
+    }
 }
 
 template<typename Scalar, typename IndexTraits>

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -337,10 +337,29 @@ createLocalParallelWellInfo(const std::vector<Well>& wells)
 }
 
 template<typename Scalar, typename IndexTraits>
-ParallelWellInfo<Scalar>*
+const ParallelWellInfo<Scalar>*
 BlackoilWellModelGeneric<Scalar, IndexTraits>::
 findParallelWellInfo(const std::string& wname) const
 {
+    auto pwell = std::lower_bound(this->parallel_well_info_.begin(),
+                                  this->parallel_well_info_.end(), wname,
+                                  [](const auto& pwInfo, const std::string& name)
+                                  { return pwInfo->name() < name; });
+
+    return ((pwell == this->parallel_well_info_.end()) ||
+            ((*pwell)->name() != wname))
+        ? nullptr
+        : pwell->get();
+}
+
+template<typename Scalar, typename IndexTraits>
+ParallelWellInfo<Scalar>*
+BlackoilWellModelGeneric<Scalar, IndexTraits>::
+findParallelWellInfo(const std::string& wname)
+{
+    // No const_cast needed to share the const overload's lookup: the elements
+    // are unique_ptrs, and constness of the pointer does not carry to the
+    // pointee, so get() already yields a mutable ParallelWellInfo.
     auto pwell = std::lower_bound(this->parallel_well_info_.begin(),
                                   this->parallel_well_info_.end(), wname,
                                   [](const auto& pwInfo, const std::string& name)

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -396,6 +396,27 @@ protected:
     std::vector<std::reference_wrapper<ParallelWellInfo<Scalar>>>
     createLocalParallelWellInfo(const std::vector<Well>& wells);
 
+    /// \brief Look up a well's parallel well information
+    /// \param wname Well name
+    /// \return Pointer to the well's information, or nullptr if the well is
+    ///         not known to the parallel well bookkeeping.
+    ParallelWellInfo<Scalar>* findParallelWellInfo(const std::string& wname) const;
+
+    /// \brief Add parallel well information for wells that entered the model
+    ///        after start-up
+    ///
+    /// The parallel well bookkeeping is built once, from the wells known at
+    /// the end of the schedule.  Wells introduced by WELSPECS inside an
+    /// ACTIONX block are not among those, so they need an entry of their own
+    /// before they can be used.
+    ///
+    /// Collective.  The schedule is replicated on all ranks, so every rank
+    /// visits the same new wells in the same order, which is what the
+    /// communicator split in ParallelWellInfo's constructor requires.
+    ///
+    /// \param reportStepIdx Report step whose well set to register
+    void registerNewParallelWells(int reportStepIdx);
+
     void initializeWellProdIndCalculators();
     void initializeWellPerfData();
 
@@ -547,7 +568,10 @@ protected:
 
     std::vector<int> local_shut_wells_{};
 
-    std::vector<ParallelWellInfo<Scalar>> parallel_well_info_;
+    // Sorted on well name.  Held by pointer so that entries added for wells
+    // that appear mid-run (ACTIONX) do not invalidate references handed out
+    // earlier, e.g. those held by the well container and the well state.
+    std::vector<std::unique_ptr<ParallelWellInfo<Scalar>>> parallel_well_info_;
     std::vector<std::reference_wrapper<ParallelWellInfo<Scalar>>> local_parallel_well_info_;
 
     std::vector<WellProdIndexCalculator<Scalar>> prod_index_calc_;
@@ -618,13 +642,9 @@ private:
     template <typename Predicate>
     bool parallelWellSatisfies(const std::string& wname, Predicate&& p) const
     {
-        const auto pwInfoPos =
-            std::ranges::find_if(this->parallel_well_info_,
-                                 [&wname](const auto& pwInfo)
-                                 { return pwInfo.name() == wname; });
+        const auto* pwInfo = this->findParallelWellInfo(wname);
 
-        return (pwInfoPos != this->parallel_well_info_.end())
-            && p(*pwInfoPos);
+        return (pwInfo != nullptr) && p(*pwInfo);
     }
 
     /// Run caller-defined code for each well owned by current rank

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -400,7 +400,17 @@ protected:
     /// \param wname Well name
     /// \return Pointer to the well's information, or nullptr if the well is
     ///         not known to the parallel well bookkeeping.
-    ParallelWellInfo<Scalar>* findParallelWellInfo(const std::string& wname) const;
+    const ParallelWellInfo<Scalar>* findParallelWellInfo(const std::string& wname) const;
+
+    /// \brief Look up a well's parallel well information for modification
+    ///
+    /// A non-const handle is genuinely needed: initializeWellPerfData() calls
+    /// beginReset(), pushBackEclIndex() and endReset() on the entries that
+    /// createLocalParallelWellInfo() hands it.
+    /// \param wname Well name
+    /// \return Pointer to the well's information, or nullptr if the well is
+    ///         not known to the parallel well bookkeeping.
+    ParallelWellInfo<Scalar>* findParallelWellInfo(const std::string& wname);
 
     /// \brief Add parallel well information for wells that entered the model
     ///        after start-up

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -102,7 +102,9 @@ namespace Opm {
 
             this->parallel_well_info_.reserve(parallel_wells.size());
             for( const auto& name_bool : parallel_wells) {
-                this->parallel_well_info_.emplace_back(name_bool, grid().comm());
+                this->parallel_well_info_.push_back
+                    (std::make_unique<ParallelWellInfo<Scalar>>
+                     (name_bool, grid().comm()));
             }
         }
 
@@ -252,6 +254,11 @@ namespace Opm {
         auto& local_deferredLogger = this->groupStateHelper().deferredLogger();
 
         const auto& comm = this->simulator_.vanguard().grid().comm();
+
+        // Wells drilled by an action are not part of the well set the
+        // parallel well bookkeeping was built from.  Register them before
+        // anything looks them up.  Collective, hence outside the try/catch.
+        this->registerNewParallelWells(reportStepIdx);
 
         // Wells_ecl_ holds this rank's wells, both open and stopped/shut.
         this->wells_ecl_ = this->getLocalWells(reportStepIdx);


### PR DESCRIPTION
Two defects hit by `actionx/ACTIONX_WELSPECS.DATA` (WELSPECS inside an ACTIONX block):

1. **No `ParallelWellInfo` for the new well.** The parallel well bookkeeping is built once from `schedule().getWellsatEnd()`, which does not contain action-created wells. Serial: `createLocalParallelWellInfo` dereferences `end()` → SIGSEGV in `initializeWellPerfData` (the guarding assert is compiled out in release). Parallel: `not_on_process_` reports the well as remote on *every* rank, so it is silently dropped. Fixed by registering missing wells before the local well structure is built; entries are now held by pointer so adding one does not invalidate references handed out earlier.

2. **CPRW coarse system not resized.** It reserves a row per well at creation; the well count then grows and the update path writes past the end. Fixed by rebuilding the solver when the well count changes.

Serial run now completes with the default solver; parallel reaches the existing distributed-well diagnostic and completes with `--allow-distributed-wells=true`.

Note: `udq_actionx/ACTIONX_NE.DATA` still fails, but for an unrelated reason — an OPEN COMPDAT connection in a cell that is not in the simulation grid, at report step 0.