### PR TITLE
Fix gas lift abort on two-phase oil-water runs

### DIFF
--- a/opm/simulators/wells/GasLiftSingleWell_impl.hpp
+++ b/opm/simulators/wells/GasLiftSingleWell_impl.hpp
@@ -211,8 +211,15 @@ setupPhaseVariables_()
     }
     assert(num_phases_ok);
     this->oil_pos_ = FluidSystem::canonicalToActivePhaseIdx(FluidSystem::oilPhaseIdx);
-    this->gas_pos_ = FluidSystem::canonicalToActivePhaseIdx(FluidSystem::gasPhaseIdx);
     this->water_pos_ = FluidSystem::canonicalToActivePhaseIdx(FluidSystem::waterPhaseIdx);
+
+    // In the two-phase oil-water case there is no active gas phase to ask for
+    // an index.  Point gas_pos_ at the first slot of the potentials vector -
+    // which is always sized NUM_PHASES - that computeWellRatesWithBhp() does
+    // not fill, so the gas rate reads as zero, as intended above.
+    this->gas_pos_ = FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)
+        ? static_cast<int>(FluidSystem::canonicalToActivePhaseIdx(FluidSystem::gasPhaseIdx))
+        : static_cast<int>(FluidSystem::numActivePhases());
 }
 
 template<typename TypeTag>


### PR DESCRIPTION
`setupPhaseVariables_()` documents that two-phase oil-water gas lift is supported by leaving the gas entry of the potentials vector at zero — then immediately asks for the active index of the gas phase, which throws `Canonical phase 2 is not active`. The exception escapes `updateWellControlsAndNetworkIteration()` and aborts the run.

The potentials vector is always sized `NUM_PHASES`, so `gas_pos_` now points at the slot `computeWellRatesWithBhp()` leaves untouched.

`gaslift/GASLIFT-01` and `-02` run to completion and do allocate lift gas; the three-phase decks are bit-identical.