### PR TITLE
Name the group and mode in the production target error

### DIFF
--- a/opm/simulators/wells/GroupStateHelper.cpp
+++ b/opm/simulators/wells/GroupStateHelper.cpp
@@ -2112,7 +2112,10 @@ getProductionGroupTargetForMode_(const Group& group,
     }
     default:
         OPM_DEFLOG_THROW(std::logic_error,
-                         "Invalid Group::ProductionCMode in getProductionGroupTargetForMode_",
+                         fmt::format("Invalid Group::ProductionCMode in "
+                                     "getProductionGroupTargetForMode_ for {} cmode: {}",
+                                     group.name(),
+                                     Group::ProductionCMode2String(cmode)),
                          this->deferredLogger());
         return 0.0;
     }


### PR DESCRIPTION
Diagnostic only. `Invalid Group::ProductionCMode in getProductionGroupTargetForMode_` names neither the group nor the mode, so locating the cause needs a debug build. Now matches the injection counterpart:

```
Invalid Group::ProductionCMode in getProductionGroupTargetForMode_ for B1 cmode: NONE
```

Context: this is the abort on `network/NETWORK_MODEL5_STDW_AUTOCHK`. `computeWellGroupThp()` branches on the schedule control mode but reads the target for the group state control mode, and for an auto-choke group those disagree whenever its own limit is momentarily not binding. Both ways of making them agree remove the abort but the run then collapses `dt` to ~1e-14 d at day 143 and never terminates, so I am not proposing a behavioural change here.