### PR TITLE
Name the cell when the IMPES storage matrix is singular

### DIFF
--- a/opm/simulators/linalg/getQuasiImpesWeights.hpp
+++ b/opm/simulators/linalg/getQuasiImpesWeights.hpp
@@ -20,7 +20,10 @@
 #ifndef OPM_GET_QUASI_IMPES_WEIGHTS_HEADER_INCLUDED
 #define OPM_GET_QUASI_IMPES_WEIGHTS_HEADER_INCLUDED
 
+#include <dune/common/exceptions.hh>
 #include <dune/common/fvector.hh>
+
+#include <fmt/format.h>
 
 #include <opm/grid/utility/ElementChunks.hpp>
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
@@ -28,6 +31,7 @@
 #include <opm/models/parallel/threadmanager.hpp>
 #include <algorithm>
 #include <cmath>
+#include <stdexcept>
 
 #if HAVE_CUDA
 #if USE_HIP
@@ -208,7 +212,35 @@ namespace Amg
                         }
                     }
                 }
-                block_transpose.solve(bweights, rhs);
+                try {
+                    block_transpose.solve(bweights, rhs);
+                }
+                catch (const Dune::FMatrixError&) {
+                    // Rank-deficient storage derivatives: no combination of the
+                    // mass balances has a storage term that depends on pressure
+                    // alone, so there is no weight vector to compute here.
+                    //
+                    // Deliberately no fallback value.  bweights is indexed by
+                    // equation while rhs is indexed by primary variable, so
+                    // substituting rhs would put unit weight on whichever
+                    // equation happens to share the pressure variable's index -
+                    // an arbitrary choice that goes on to make the CPR pressure
+                    // system itself singular.  Name the cell instead, so the
+                    // cause can be found.
+                    const auto globalDofIdx =
+                        localElemCtx.globalSpaceIndex(/*spaceIdx=*/0, /*timeIdx=*/0);
+
+                    throw std::runtime_error {
+                        fmt::format("Singular storage matrix when forming the CPR "
+                                    "pressure weights for cell {} (Cartesian index "
+                                    "{}).  The storage derivatives of that cell are "
+                                    "rank deficient, so the pressure equation cannot "
+                                    "be formed there.",
+                                    globalDofIdx,
+                                    localElemCtx.simulator().vanguard()
+                                        .cartesianIndex(globalDofIdx))
+                    };
+                }
 
                 const double abs_max =
                     *std::ranges::max_element(bweights,


### PR DESCRIPTION
A cell whose storage-derivative matrix is singular makes `getTrueImpesWeights()` throw, and since solver setup is wrapped in `OPM_CATCH_AND_RETHROW_AS_CRITICAL_ERROR` the run dies pointing at the linear-solver JSON, which is not the problem:

```
Original error: getTrueImpesWeights() failed: FMatrixError [luDecomposition]: matrix is singular
Error hint: This is likely due to a faulty linear solver JSON specification.
```

Now:

```
Original error: getTrueImpesWeights() failed: Singular storage matrix when forming the CPR
pressure weights for cell 688 (Cartesian index 688).  The storage derivatives of that cell
are rank deficient, so the pressure equation cannot be formed there.
```

Diagnostic only — it still fails, but says where. Reproduced on `spe1_precsalt/GASCONDENSATE_VAPWAT_PRECSALT`; why that cell is rank deficient is still open.

An earlier version substituted `bweights = rhs` instead of throwing. That was wrong: `bweights` is indexed by equation and `rhs` by primary variable, so it put unit weight on whichever equation shares the pressure variable index — and that fed a singular pressure system into the CPR setup, which is exactly the follow-on failure the first version ran into.

Separately: the "faulty linear solver JSON specification" hint is misleading for every non-configuration failure caught by that macro — worth revisiting, not touched here.