### PR TITLE
Hold converged steps to the minimum time step size too

### DIFF
--- a/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
@@ -294,6 +294,7 @@ private:
         double maxGrowth_() const;
         double minTimeStepBeforeClosingWells_() const;
         double minTimeStep_() const;
+        void checkTimeStepCanAdvance_(double new_time_step) const;
         double restartFactor_() const;
         SimulatorReportSingle runSubStep_();
         int solverRestartMax_() const;

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -975,6 +975,7 @@ run()
             }
 
             // set new time step length
+            checkTimeStepCanAdvance_(dt_estimate);
             setTimeStep_(dt_estimate);
 
             report.success.converged = this->substep_timer_.done();
@@ -1058,6 +1059,37 @@ checkTimeStepMaxRestartLimit_(const int restarts) const
         // Use throw directly to prevent file and line
         throw TimeSteppingBreakdown{msg};
     }
+}
+
+template<class TypeTag>
+template<class Solver>
+void
+AdaptiveTimeStepping<TypeTag>::SubStepIteration<Solver>::
+checkTimeStepCanAdvance_(const double new_time_step) const
+{
+    // Both dt floors - the minimum step size and the restart count - sit on
+    // the failure path.  A run whose substeps all converge, but for which the
+    // controller keeps proposing ever smaller steps, consults neither: the
+    // step size shrinks without bound while the elapsed time stands still,
+    // and the run never ends.  Hold the accepted path to the same minimum.
+    if (new_time_step >= minTimeStep_()) {
+        return;
+    }
+
+    const auto msg =
+        fmt::format("Time step control proposed a step of {:.3E} DAYS, below the "
+                    "minimum of {:.3E} DAYS, while every substep converges.  The "
+                    "run is not advancing past {:.6E} DAYS.",
+                    new_time_step / 86400.0,
+                    minTimeStep_() / 86400.0,
+                    this->substep_timer_.simulationTimeElapsed() / 86400.0);
+
+    if (solverVerbose_()) {
+        OpmLog::error(msg);
+    }
+
+    // Use throw directly to prevent file and line
+    throw TimeSteppingBreakdown{msg};
 }
 
 template<class TypeTag>


### PR DESCRIPTION
Both `dt` floors — `--solver-min-time-step` and the restart count — are only consulted when a substep *fails*. A run whose substeps all converge but whose controller keeps proposing smaller steps consults neither: `dt` shrinks without bound, the clock stands still, and the run never finishes and never fails.

`network/NETWORK_MODEL5_STDW_AUTOCHK` does exactly this. Every substep converges with 9 Newton iterations, the network never balances, and `dt` falls past 1e-57 days with the clock frozen at day 143.107 of 152 — past the point where `t + dt == t`, so no number of steps can finish the report step.

Applying the existing minimum on the accepted path stops it after 357 steps with:

```
Time step control proposed a step of 9.872E-13 DAYS, below the minimum of 1.000E-12 DAYS,
while every substep converges.  The run is not advancing past 1.431070E+02 DAYS.
```

The limit is never reached anywhere in the compareECLFiles suite (128 failures before and after, same set — all pre-existing platform diffs on this machine).

Note: reaching this state at all needs [#7263](https://github.com/OPM/opm-simulators/pull/7263)'s deck to get past its abort; on master the deck stops earlier for the unrelated reason described there. This guard is independent and worth having regardless.