### PR TITLE
Singular matrix fix from thermal case running

### DIFF
--- a/opm/simulators/linalg/ISTLSolver.hpp
+++ b/opm/simulators/linalg/ISTLSolver.hpp
@@ -388,7 +388,15 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
                 initPrepare(M,b);
 
                 prepareFlexibleSolver();
-            } OPM_CATCH_AND_RETHROW_AS_CRITICAL_ERROR("This is likely due to a faulty linear solver JSON specification. Check for errors related to missing nodes.");
+            }
+            catch (const Dune::MatrixBlockError&) {
+                // A singular matrix block found while building the
+                // preconditioner is recoverable: rethrow it unchanged so that
+                // the adaptive time stepping can chop the time step instead of
+                // aborting the run.
+                throw;
+            }
+            OPM_CATCH_AND_RETHROW_AS_CRITICAL_ERROR("This is likely due to a faulty linear solver JSON specification. Check for errors related to missing nodes.");
         }
 
 

--- a/opm/simulators/linalg/matrixblock.hh
+++ b/opm/simulators/linalg/matrixblock.hh
@@ -29,6 +29,7 @@
 
 #include <dune/istl/superlu.hh>
 #include <dune/istl/umfpack.hh>
+#include <dune/istl/istlexception.hh>
 #include <dune/istl/matrixutils.hh>
 
 #include <opm/common/Exceptions.hpp>
@@ -65,9 +66,10 @@ static inline void invertMatrix(Dune::FieldMatrix<K,3,3>& matrix)
     Dune::FMatrixHelp::invertMatrix(tmp,matrix);
 }
 
-//! invert 4x4 Matrix without changing the original matrix
+//! Compute the adjugate of a 4x4 matrix and return its determinant.
+//! The inverse of the matrix is the adjugate divided by the determinant.
 template <template<class K> class Matrix, typename K>
-static inline K invertMatrix4(const Matrix<K>& matrix, Matrix<K>& inverse)
+static inline K adjugateMatrix4(const Matrix<K>& matrix, Matrix<K>& inverse)
 {
     inverse[0][0] = matrix[1][1] * matrix[2][2] * matrix[3][3] -
             matrix[1][1] * matrix[2][3] * matrix[3][2] -
@@ -181,17 +183,42 @@ static inline K invertMatrix4(const Matrix<K>& matrix, Matrix<K>& inverse)
             matrix[2][0] * matrix[0][1] * matrix[1][2] -
             matrix[2][0] * matrix[0][2] * matrix[1][1];
 
-    K det = matrix[0][0] * inverse[0][0] + matrix[0][1] * inverse[1][0] +
-            matrix[0][2] * inverse[2][0] + matrix[0][3] * inverse[3][0];
+    return matrix[0][0] * inverse[0][0] + matrix[0][1] * inverse[1][0] +
+           matrix[0][2] * inverse[2][0] + matrix[0][3] * inverse[3][0];
+}
 
-    // return identity for singular or nearly singular matrices.
-    // Note for maintainers: If updating this value, also update the value
-    // in gpuistl/detail/deviceBlockOperations.hpp
+//! invert 4x4 Matrix without changing the original matrix
+//!
+//! The cofactor expansion is used by default. It is branch free and roughly an
+//! order of magnitude faster than a pivoted LU at this size, which matters
+//! because every diagonal block of the ILU decomposition goes through here.
+//!
+//! Its determinant is however the product of the four column scales, so it
+//! underflows for blocks whose residuals are insensitive to some of the
+//! primary variables - a cell in which a phase is absent or immobile - even
+//! though those blocks are perfectly well invertible. Dividing the adjugate by
+//! such a determinant is unreliable, so fall back to Dune's invert(), which
+//! uses Gaussian elimination with partial pivoting and reports a matrix as
+//! singular only when a pivot is exactly zero. Block sizes 5 and above already
+//! use that routine.
+template <template<class K> class Matrix, typename K>
+static inline K invertMatrix4(const Matrix<K>& matrix, Matrix<K>& inverse)
+{
+    const K det = adjugateMatrix4<Matrix, K>(matrix, inverse);
+
     if (std::abs(det) < 1e-40) {
-        inverse = std::numeric_limits<K>::quiet_NaN();
-        throw NumericalProblem("Singular matrix");
-    } else
-      inverse *= 1.0 / det;
+        inverse = matrix;
+        try {
+            inverse.invert();
+        }
+        catch (const Dune::FMatrixError&) {
+            inverse = std::numeric_limits<K>::quiet_NaN();
+            DUNE_THROW(Dune::MatrixBlockError, "Singular matrix block");
+        }
+    }
+    else {
+        inverse *= 1.0 / det;
+    }
 
     return det;
 }

--- a/opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
+++ b/opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
@@ -21,6 +21,8 @@
 #ifndef OPM_DEFERREDLOGGINGERRORHELPERS_HPP
 #define OPM_DEFERREDLOGGINGERRORHELPERS_HPP
 
+#include <dune/istl/istlexception.hh>
+
 #include <opm/common/Exceptions.hpp>
 
 #include <opm/simulators/utils/DeferredLogger.hpp>
@@ -166,6 +168,9 @@ try {
 #define OPM_PARALLEL_CATCH_CLAUSE(obptc_exc_type,          \
                                   obptc_exc_msg)           \
 catch (const Opm::NumericalProblem& e){                    \
+    obptc_exc_type = Opm::ExceptionType::NUMERICAL_ISSUE;  \
+    obptc_exc_msg = e.what();                              \
+} catch (const Dune::MatrixBlockError& e) {                \
     obptc_exc_type = Opm::ExceptionType::NUMERICAL_ISSUE;  \
     obptc_exc_msg = e.what();                              \
 } catch (const std::runtime_error& e) {                    \

--- a/tests/test_invert.cpp
+++ b/tests/test_invert.cpp
@@ -63,5 +63,39 @@ BOOST_AUTO_TEST_CASE(Invert4x4)
 
     // check singular matrix
     BOOST_CHECK_THROW(Opm::detail::invertMatrix4<Opm::detail::FMat4>(matrix_sing, inverse),
-                      Opm::NumericalProblem);
+                      Dune::MatrixBlockError);
+}
+
+BOOST_AUTO_TEST_CASE(Invert4x4WithUnderflowingDeterminant)
+{
+    using BaseType = Dune::FieldMatrix<double, 4, 4>;
+
+    // A well conditioned matrix (condition number about 9.5) scaled such that its
+    // determinant, which is homogeneous of degree one in every row, falls below the
+    // 1e-40 threshold used to decide whether the cofactor determinant can be divided
+    // by. Scaling leaves the matrix just as invertible as it was, so this must be
+    // inverted through the pivoted fallback rather than reported as singular.
+    BaseType matrix;
+    const double base[4][4] = {{2, 1, 0, 0},
+                               {1, 2, 1, 0},
+                               {0, 1, 2, 1},
+                               {0, 0, 1, 2}};
+    for (int i = 0; i < 4; ++i) {
+        for (int j = 0; j < 4; ++j) {
+            matrix[i][j] = base[i][j] * 1e-11;
+        }
+    }
+
+    BaseType inverse;
+    double det = 0.0;
+    BOOST_CHECK_NO_THROW(det = Opm::detail::invertMatrix4<Opm::detail::FMat4>(matrix, inverse));
+    BOOST_CHECK_LT(std::abs(det), 1e-40);
+
+    // the inverse is still accurate even though the determinant underflowed
+    const BaseType product = matrix.rightmultiply(inverse);
+    for (int i = 0; i < 4; ++i) {
+        for (int j = 0; j < 4; ++j) {
+            BOOST_CHECK_SMALL(product[i][j] - (i == j ? 1.0 : 0.0), 1e-12);
+        }
+    }
 }


### PR DESCRIPTION
A thermal run (4 equations per cell) aborted during preconditioner setup with

```
Error rethrown as CriticalError at [.../ISTLSolver.hpp:391].
Original error: Singular matrix
Error hint: This is likely due to a faulty linear solver JSON specification.
```

The hint is misleading — there is nothing wrong with the solver configuration. Two
separate things go wrong: a block that is perfectly invertible is reported as
singular, and that report is then turned into a fatal error instead of a time step
chop.

### 1. `linalg: keep a recoverable ILU setup failure out of CriticalError`

A singular matrix block found while building the preconditioner surfaces as
`Dune::MatrixBlockError`, which `ParallelOverlappingILU0::update()` already catches
and turns into a collective failure, and which `AdaptiveTimeStepping` already handles
by chopping the time step. But `ISTLSolver::prepare()` wrapped every exception into a
`CriticalError`, and that is deliberately not caught by the time stepping — so a
recoverable failure aborted the run.

### 2. `linalg: fall back to a pivoted LU when the 4x4 cofactor determinant underflows`

`|det| < 1e-40` is not a test for singularity, it is a test on scale. The determinant
is homogeneous of degree one in each row and in each column, so scaling a block
scales its determinant while leaving its conditioning untouched. A matrix with
condition number 9.47 is accepted at row scale 1e-10 and rejected at 1e-11,
inverting to 3e-16 in both cases.

The blocks that trip it in practice are cells in which a phase is absent or immobile,
whose residuals are almost insensitive to some of the primary variables. A
representative one, captured from the run:

```
[ -2.810982e-05   3.058127e-24   1.753614e-22  -2.621713e-28 ]
[  3.938012e-05   5.257485e-14   0.000000e+00   0.000000e+00 ]
[ -3.422423e-03   1.139605e-22   1.415303e-20  -9.769569e-27 ]
[  3.096745e-04   6.401928e-13   1.050460e-21   8.215845e-03 ]

determinant             8.739e-41    -> rejected; the cutoff is 1e-40
max |A*inv(A) - I|      1.262e-14    -> using the cofactor inverse itself
```

The old code threw on a block whose own inverse, computed by its own algorithm, is
accurate to 1.3e-14 — the determinant test rejected it before it could be used.

Logging every block the old criterion would reject during a run gives **95 of 95
invertible**, worst `max |A*inv(A) - I|` = 7.0e-12. Across that population (medians
over the 95 blocks, not of any one block) the row magnitudes are 3.7e-6 / 4.4e-6 /
1.1e-4 / 2.0e-3 while the column magnitudes are 1.1e-4 / 7.2e-14 / 8.6e-22 / 2.0e-3;
the per-block spread has a median of 6.0e2 across rows against 2.5e18 across columns.

The cofactor expansion is kept as the fast path, since every diagonal block of the
ILU decomposition goes through it and it is several times cheaper than a pivoted LU
at this size (4.9 ns against 62.3 ns here, gcc `-O3 -march=native`; the ratio is
build dependent). Dune's `invert()` is used only when the determinant is too small to
divide by, and it reports a matrix as singular only when a pivot is exactly zero — as
block sizes 5 and above already do. The determinant return value is unchanged.

Failure is reported as `Dune::MatrixBlockError` rather than `NumericalProblem`, which
is what lets the existing handler in `ParallelOverlappingILU0::update()` do its job
and keeps that file out of this PR entirely. It also improves the diagnostic: since
`MatrixBlockError` derives from `FMatrixError`, Dune's own handler in
`blockILU0Decomposition` re-wraps the exception and attaches the row and column of the
offending block.

### 3. `tests: cover a 4x4 block whose determinant underflows but which is invertible`

A well conditioned matrix (condition number 9.5) scaled by 1e-11, so that its
determinant is 5e-44, must now be inverted through the fallback rather than reported
as singular. The case fails against the previous code, which threw and left the
inverse as NaN.

### Effect

Same deck, 4 MPI ranks, to the same point (day ~210):

| | time steps | Newton its | linearise | linear solve | total |
|---|---|---|---|---|---|
| before | 247 | 543 | 1000.0 s | 423.3 s | 1423.3 s |
| after | 25 | 150 | 221.2 s | 125.5 s | 346.7 s |

Before the change the model reported 299 singular-matrix errors and 256 time step
chops in its first 307 simulated days; after it there are none, no linear solver
stalls are introduced, and fluids in place agree to within the nonlinear solver
tolerance (5e-7 on oil, 8e-7 on gas at days 120 and 212).

### Known trade-off

Dune reports singularity only for an exactly-zero pivot, so a block that is
numerically singular *and* small enough in scale for its roundoff-level determinant
to fall below 1e-40 now returns a large-norm inverse instead of raising a recoverable
error. Constructed example: a rank-3 block scaled by 1e-7 gives a cofactor
determinant of 0, no throw from the LU, and `max |A*inv(A) - I|` of order 1. For an
ILU preconditioner this costs convergence rather than correctness — the Krylov solver
still checks the true residual — and it did not occur in the runs above, but it does
narrow the failure detection. Happy to add a norm-relative guard on the fallback
result if that is preferred.

### Notes

- This is not confined to thermal models. A three-phase standard-well D matrix is 4x4
  in the default configuration (`numWellEq` is initialised to `numPhases + 1`) and
  reaches the same routine via `StandardWellEquations::invert()`. That path is
  unaffected by the change of exception type, because the call in
  `StandardWell_impl.hpp` is wrapped in `catch(...)` and re-raised as
  `NumericalProblem` regardless.
- Not addressed here: `ghost_last_bilu0_decomposition` converts an `FMatrixError`
  into `Dune::ISTLError`, which neither `ParallelOverlappingILU0::update()` nor
  `ISTLSolver::prepare()` catches, so on a parallel run where `interiorSize_ < N` a
  singular block is still fatal. That is pre-existing on master and better handled
  separately.