### PR TITLE
Only the end-of-stream sentinel may stop the convergence output thread

### DIFF
--- a/opm/simulators/flow/ExtraConvergenceOutputThread.cpp
+++ b/opm/simulators/flow/ExtraConvergenceOutputThread.cpp
@@ -327,24 +327,43 @@ writeIterInfo(const std::vector<ConvergenceReportQueue::OutputRequest>& requests
     }
 
     if (! this->haveOutputIterHeader_) {
-        std::tie(this->firstColSize_, this->colSize_) =
-            writeConvergenceHeader(this->infoIter_.value(),
-                                   this->getPhaseName_,
-                                   requests.front());
-        this->haveOutputIterHeader_ = true;
+        // The header layout needs an actual convergence report to derive
+        // the metric columns.  A request may legitimately carry none --
+        // the end-of-stream sentinel does not, and neither does a step
+        // that aborted before its first convergence check -- so search
+        // for the first request that has one instead of blindly using
+        // requests.front(), which dereferenced the empty sentinel when a
+        // run failed before completing any report step.
+        auto headerReq = std::find_if(requests.begin(), requests.end(),
+                                      [](const auto& request)
+                                      { return ! request.reports.empty(); });
+        if (headerReq != requests.end()) {
+            std::tie(this->firstColSize_, this->colSize_) =
+                writeConvergenceHeader(this->infoIter_.value(),
+                                       this->getPhaseName_,
+                                       *headerReq);
+            this->haveOutputIterHeader_ = true;
+        }
     }
 
     for (const auto& request : requests) {
+        if (request.isFinal) {
+            // End-of-stream sentinel from signalLastOutputRequest().  An
+            // ordinary request with an empty 'reports' vector must NOT
+            // stop the thread -- it merely has nothing to write.
+            this->finalRequestWritten_ = true;
+            break;
+        }
+
+        if (request.reports.empty() || ! this->haveOutputIterHeader_) {
+            continue;
+        }
+
         writeConvergenceRequest(this->infoIter_.value(),
                                 this->convertTime_,
                                 this->firstColSize_,
                                 this->colSize_,
                                 request);
-
-        if (request.reports.empty()) {
-            this->finalRequestWritten_ = true;
-            break;
-        }
     }
 
     this->infoIter_.value().flush();
@@ -376,8 +395,10 @@ void Opm::ConvergenceReportQueue::enqueue(std::vector<OutputRequest>&& requests)
 
 void Opm::ConvergenceReportQueue::signalLastOutputRequest()
 {
-    // Empty request signals end of production.
-    this->enqueue(std::vector<OutputRequest>(1));
+    // Explicitly flagged sentinel request signals end of production.
+    auto sentinel = std::vector<OutputRequest>(1);
+    sentinel.front().isFinal = true;
+    this->enqueue(std::move(sentinel));
 }
 
 // ---------------------------------------------------------------------------

--- a/opm/simulators/flow/ExtraConvergenceOutputThread.cpp
+++ b/opm/simulators/flow/ExtraConvergenceOutputThread.cpp
@@ -323,24 +323,37 @@ writeIterInfo(const std::vector<ConvergenceReportQueue::OutputRequest>& requests
         return;
     }
 
+    if (! this->haveOutputIterHeader_) {
+        // The header layout needs an actual convergence report to derive
+        // the metric columns.  A request may legitimately carry none --
+        // the end-of-stream sentinel does not, and neither does a step
+        // that aborted before its first convergence check -- so search
+        // for the first request that has one instead of blindly using
+        // requests.front(), which dereferenced the empty sentinel when a
+        // run failed before completing any report step.
+        auto headerReq = std::find_if(requests.begin(), requests.end(),
+                                      [](const auto& request)
+                                      { return ! request.reports.empty(); });
+        if (headerReq != requests.end()) {
+            std::tie(this->firstColSize_, this->colSize_) =
+                writeConvergenceHeader(this->infoIter_.value(),
+                                       this->getPhaseName_,
+                                       *headerReq);
+            this->haveOutputIterHeader_ = true;
+        }
+    }
+
     for (const auto& request : requests) {
-        if (request.reports.empty()) {
-            // Empty request signals end of production.  Must be detected
-            // before the header is written, since forming the header needs a
-            // convergence report to name the metric columns.  A run that
-            // fails before completing a single non-linear iteration - e.g.,
-            // one that chops its way to the minimum time step - sends this
-            // sentinel as its very first request.
+        if (request.isFinal) {
+            // End-of-stream sentinel from signalLastOutputRequest().  An
+            // ordinary request with an empty 'reports' vector must NOT
+            // stop the thread -- it merely has nothing to write.
             this->finalRequestWritten_ = true;
             break;
         }
 
-        if (! this->haveOutputIterHeader_) {
-            std::tie(this->firstColSize_, this->colSize_) =
-                writeConvergenceHeader(this->infoIter_.value(),
-                                       this->getPhaseName_,
-                                       request);
-            this->haveOutputIterHeader_ = true;
+        if (request.reports.empty() || ! this->haveOutputIterHeader_) {
+            continue;
         }
 
         writeConvergenceRequest(this->infoIter_.value(),
@@ -379,8 +392,10 @@ void Opm::ConvergenceReportQueue::enqueue(std::vector<OutputRequest>&& requests)
 
 void Opm::ConvergenceReportQueue::signalLastOutputRequest()
 {
-    // Empty request signals end of production.
-    this->enqueue(std::vector<OutputRequest>(1));
+    // Explicitly flagged sentinel request signals end of production.
+    auto sentinel = std::vector<OutputRequest>(1);
+    sentinel.front().isFinal = true;
+    this->enqueue(std::move(sentinel));
 }
 
 // ---------------------------------------------------------------------------

--- a/opm/simulators/flow/ExtraConvergenceOutputThread.hpp
+++ b/opm/simulators/flow/ExtraConvergenceOutputThread.hpp
@@ -71,6 +71,13 @@ public:
         /// Convergence metrics for each non-linear ieration in the \c
         /// currentStep.
         std::vector<ConvergenceReport> reports{};
+
+        /// Whether this request is the end-of-stream sentinel enqueued by
+        /// signalLastOutputRequest().  Only the sentinel may terminate the
+        /// output thread.  An ordinary request whose \c reports happens to
+        /// be empty (e.g., a step that aborted before any convergence
+        /// check) must not be mistaken for the sentinel.
+        bool isFinal{false};
     };
 
     /// Push sequence of output requests, typically all substeps whether

--- a/opm/simulators/flow/SimulatorConvergenceOutput.cpp
+++ b/opm/simulators/flow/SimulatorConvergenceOutput.cpp
@@ -105,6 +105,10 @@ void SimulatorConvergenceOutput::endThread()
 
     this->convergenceOutputQueue_->signalLastOutputRequest();
     this->convergenceOutputThread_->join();
+
+    // Make repeated calls no-ops so that both the explicit shutdown path
+    // and the destructor may call endThread() safely.
+    this->convergenceOutputThread_.reset();
 }
 
 } // namespace Opm

--- a/opm/simulators/flow/SimulatorConvergenceOutput.cpp
+++ b/opm/simulators/flow/SimulatorConvergenceOutput.cpp
@@ -107,6 +107,10 @@ void SimulatorConvergenceOutput::endThread()
 
     this->convergenceOutputQueue_->signalLastOutputRequest();
     this->convergenceOutputThread_->join();
+
+    // Make repeated calls no-ops so that both the explicit shutdown path
+    // and the destructor may call endThread() safely.
+    this->convergenceOutputThread_.reset();
 }
 
 } // namespace Opm

--- a/opm/simulators/flow/SimulatorConvergenceOutput.hpp
+++ b/opm/simulators/flow/SimulatorConvergenceOutput.hpp
@@ -43,6 +43,14 @@ namespace Opm {
 class SimulatorConvergenceOutput
 {
 public:
+    /// Ensure the output thread is joined even if the owning simulator's
+    /// normal shutdown path is bypassed, e.g. when an exception unwinds
+    /// the stack after a simulation failure.  endThread() is idempotent.
+    ~SimulatorConvergenceOutput()
+    {
+        this->endThread();
+    }
+
     /// Start convergence output thread.
     ///
     /// Thread starts only if explicitly requested in runtime user options.

--- a/opm/simulators/flow/SimulatorFullyImplicit_impl.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicit_impl.hpp
@@ -77,6 +77,19 @@ template<class TypeTag>
 SimulatorFullyImplicit<TypeTag>::
 ~SimulatorFullyImplicit()
 {
+    // Flush any convergence reports that were never written because the
+    // run terminated before completing its report step -- exactly the
+    // failed runs whose convergence history is most valuable.  write() is
+    // idempotent for already-reported steps and a no-op when convergence
+    // output is not active.
+    if (this->solver_ != nullptr) {
+        try {
+            this->convergence_output_.write(this->solver_->model().stepReports());
+        } catch (...) {
+            // Never let diagnostics output escape a destructor.
+        }
+    }
+
     // Safe to call on all ranks, not just the I/O rank.
     convergence_output_.endThread();
 }


### PR DESCRIPTION
#7257 has landed since this was opened and fixes the segfault it originally targeted. What is left is the semantics underneath that crash.

`OutputRequest` used "reports is empty" as the shutdown sentinel, but `SimulatorConvergenceOutput::write()` builds one request per `StepReport` — so a step that aborted before its first convergence check produces an ordinary request with no reports, indistinguishable from the sentinel. The writer thread then stops for the rest of the run. This makes the sentinel an explicit `isFinal` flag, lays the header out from the first request that actually carries a report, and skips report-less requests instead of dereferencing them. `endThread()` is idempotent and a destructor backstops it.

Checked on current master: `wconprod/WCONPROD-01.DATA` with `--output-extra-convergence-info=steps,iterations` exits cleanly, and its INFOITER is empty **both with and without this PR** — that run never completes a step, so there is nothing to write. The "zero-byte INFOITER" claim in the original description does not hold; INFOITER is flushed incrementally as steps complete. I have left that out.
