### PR TITLE
do not set a default discretization

### DIFF
--- a/examples/cuvette_pvs.cpp
+++ b/examples/cuvette_pvs.cpp
@@ -27,9 +27,11 @@
  */
 #include "config.h"
 
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/io/dgfvanguard.hh>
-#include <opm/models/utils/start.hh>
 #include <opm/models/pvs/pvsmodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
 
 #include "problems/cuvetteproblem.hh"
@@ -42,6 +44,11 @@ struct CuvetteProblem
 { using InheritsFrom = std::tuple<CuvetteBaseProblem, PvsModel>; };
 
 } // end namespace TTag
+
+//! We use a vertex centered finite volume method
+template<class TypeTag>
+struct SpatialDiscretizationSplice<TypeTag, TTag::CuvetteProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/examples/diffusion_flash.cpp
+++ b/examples/diffusion_flash.cpp
@@ -27,17 +27,28 @@
  */
 #include "config.h"
 
-#include <opm/models/utils/start.hh>
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/flash/flashmodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
+
 #include "problems/diffusionproblem.hh"
 
 namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct DiffusionProblem { using InheritsFrom = std::tuple<DiffusionBaseProblem, FlashModel>; };
+
+struct DiffusionProblem
+{ using InheritsFrom = std::tuple<DiffusionBaseProblem, FlashModel>; };
+
 } // end namespace TTag
+
+//! We use a vertex centered finite volume method
+template<class TypeTag>
+struct SpatialDiscretizationSplice<TypeTag, TTag::DiffusionProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/examples/diffusion_ncp.cpp
+++ b/examples/diffusion_ncp.cpp
@@ -27,8 +27,10 @@
  */
 #include "config.h"
 
-#include <opm/models/utils/start.hh>
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/ncp/ncpmodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
 
 #include "problems/diffusionproblem.hh"
@@ -37,8 +39,16 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct DiffusionProblem { using InheritsFrom = std::tuple<DiffusionBaseProblem, NcpModel>; };
+
+struct DiffusionProblem
+{ using InheritsFrom = std::tuple<DiffusionBaseProblem, NcpModel>; };
+
 } // end namespace TTag
+
+//! We use a vertex centered finite volume method
+template<class TypeTag>
+struct SpatialDiscretizationSplice<TypeTag, TTag::DiffusionProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/examples/diffusion_pvs.cpp
+++ b/examples/diffusion_pvs.cpp
@@ -27,17 +27,28 @@
  */
 #include "config.h"
 
-#include <opm/models/utils/start.hh>
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/pvs/pvsmodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
+
 #include "problems/diffusionproblem.hh"
 
 namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct DiffusionProblem { using InheritsFrom = std::tuple<DiffusionBaseProblem, PvsModel>; };
+
+struct DiffusionProblem
+{ using InheritsFrom = std::tuple<DiffusionBaseProblem, PvsModel>; };
+
 } // end namespace TTag
+
+//! We use a vertex centered finite volume method
+template<class TypeTag>
+struct SpatialDiscretizationSplice<TypeTag, TTag::DiffusionProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/examples/fracture_discretefracture.cpp
+++ b/examples/fracture_discretefracture.cpp
@@ -28,6 +28,7 @@
 #include "config.h"
 
 #include <opm/models/utils/start.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
 
 #include "problems/fractureproblem.hh"

--- a/examples/groundwater_immiscible.cpp
+++ b/examples/groundwater_immiscible.cpp
@@ -27,9 +27,11 @@
  */
 #include "config.h"
 
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
+#include <opm/models/immiscible/immisciblemodel.hh>
 #include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
-#include <opm/models/immiscible/immisciblemodel.hh>
+
 #include "problems/groundwaterproblem.hh"
 
 namespace Opm::Properties {
@@ -41,6 +43,11 @@ struct GroundWaterProblem
 { using InheritsFrom = std::tuple<GroundWaterBaseProblem, ImmiscibleSinglePhaseModel>; };
 
 } // end namespace TTag
+
+//! We use a vertex centered finite volume method
+template<class TypeTag>
+struct SpatialDiscretizationSplice<TypeTag, TTag::GroundWaterProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/examples/infiltration_pvs.cpp
+++ b/examples/infiltration_pvs.cpp
@@ -27,10 +27,13 @@
  */
 #include "config.h"
 
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/io/dgfvanguard.hh>
-#include <opm/models/utils/start.hh>
 #include <opm/models/pvs/pvsmodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
+
 #include "problems/infiltrationproblem.hh"
 
 namespace Opm::Properties {
@@ -40,6 +43,11 @@ namespace TTag {
 struct InfiltrationProblem
 { using InheritsFrom = std::tuple<InfiltrationBaseProblem, PvsModel>; };
 } // end namespace TTag
+
+//! We use a vertex centered finite volume method
+template<class TypeTag>
+struct SpatialDiscretizationSplice<TypeTag, TTag::InfiltrationProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/examples/lens_immiscible_vcfv_ad.cpp
+++ b/examples/lens_immiscible_vcfv_ad.cpp
@@ -28,8 +28,10 @@
  */
 #include "config.h"
 
-#include <opm/models/utils/start.hh>
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
 
 #include "problems/lensproblem.hh"
@@ -38,17 +40,27 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct LensProblemVcfvAd { using InheritsFrom = std::tuple<LensBaseProblem, ImmiscibleTwoPhaseModel>; };
+
+struct LensProblemVcfvAd
+{ using InheritsFrom = std::tuple<LensBaseProblem, ImmiscibleTwoPhaseModel>; };
+
 } // end namespace TTag
 
 // use automatic differentiation for this simulator
 template<class TypeTag>
-struct LocalLinearizerSplice<TypeTag, TTag::LensProblemVcfvAd> { using type = TTag::AutoDiffLocalLinearizer; };
+struct LocalLinearizerSplice<TypeTag, TTag::LensProblemVcfvAd>
+{ using type = TTag::AutoDiffLocalLinearizer; };
+
+//! We use a vertex centered finite volume method
+template<class TypeTag>
+struct SpatialDiscretizationSplice<TypeTag, TTag::LensProblemVcfvAd>
+{ using type = TTag::VcfvDiscretization; };
 
 // use linear finite element gradients if dune-localfunctions is available
 #if HAVE_DUNE_LOCALFUNCTIONS
 template<class TypeTag>
-struct UseP1FiniteElementGradients<TypeTag, TTag::LensProblemVcfvAd> { static constexpr bool value = true; };
+struct UseP1FiniteElementGradients<TypeTag, TTag::LensProblemVcfvAd>
+{ static constexpr bool value = true; };
 #endif
 
 } // namespace Opm::Properties

--- a/examples/lens_immiscible_vcfv_fd.cpp
+++ b/examples/lens_immiscible_vcfv_fd.cpp
@@ -28,8 +28,10 @@
  */
 #include "config.h"
 
-#include <opm/models/utils/start.hh>
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
 
 #include "problems/lensproblem.hh"
@@ -38,17 +40,27 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct LensProblemVcfvFd { using InheritsFrom = std::tuple<LensBaseProblem, ImmiscibleTwoPhaseModel>; };
+
+struct LensProblemVcfvFd
+{ using InheritsFrom = std::tuple<LensBaseProblem, ImmiscibleTwoPhaseModel>; };
+
 } // end namespace TTag
 
 // use the finite difference methodfor this simulator
 template<class TypeTag>
-struct LocalLinearizerSplice<TypeTag, TTag::LensProblemVcfvFd> { using type = TTag::FiniteDifferenceLocalLinearizer; };
+struct LocalLinearizerSplice<TypeTag, TTag::LensProblemVcfvFd>
+{ using type = TTag::FiniteDifferenceLocalLinearizer; };
+
+//! We use a vertex centered finite volume method
+template<class TypeTag>
+struct SpatialDiscretizationSplice<TypeTag, TTag::LensProblemVcfvFd>
+{ using type = TTag::VcfvDiscretization; };
 
 // use linear finite element gradients if dune-localfunctions is available
 #if HAVE_DUNE_LOCALFUNCTIONS
 template<class TypeTag>
-struct UseP1FiniteElementGradients<TypeTag, TTag::LensProblemVcfvFd> { static constexpr bool value = true; };
+struct UseP1FiniteElementGradients<TypeTag, TTag::LensProblemVcfvFd>
+{ static constexpr bool value = true; };
 #endif
 
 } // namespace Opm::Properties

--- a/examples/obstacle_immiscible.cpp
+++ b/examples/obstacle_immiscible.cpp
@@ -28,10 +28,13 @@
  */
 #include "config.h"
 
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
+#include <opm/models/immiscible/immisciblemodel.hh>
 #include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
-#include <opm/models/immiscible/immisciblemodel.hh>
+
 #include "problems/obstacleproblem.hh"
 
 namespace Opm::Properties {
@@ -42,6 +45,11 @@ struct ObstacleProblem
 { using InheritsFrom = std::tuple<ObstacleBaseProblem, ImmiscibleModel>; };
 
 } // end namespace TTag
+
+//! We use a vertex centered finite volume method
+template<class TypeTag>
+struct SpatialDiscretizationSplice<TypeTag, TTag::ObstacleProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/examples/obstacle_ncp.cpp
+++ b/examples/obstacle_ncp.cpp
@@ -27,9 +27,11 @@
  */
 #include "config.h"
 
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/io/dgfvanguard.hh>
-#include <opm/models/utils/start.hh>
 #include <opm/models/ncp/ncpmodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
 
 #include "problems/obstacleproblem.hh"
@@ -43,6 +45,11 @@ struct ObstacleProblem
 { using InheritsFrom = std::tuple<ObstacleBaseProblem, NcpModel>; };
 
 } // end namespace TTag
+
+//! We use a vertex centered finite volume method
+template<class TypeTag>
+struct SpatialDiscretizationSplice<TypeTag, TTag::ObstacleProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/examples/obstacle_pvs.cpp
+++ b/examples/obstacle_pvs.cpp
@@ -29,9 +29,11 @@
  */
 #include "config.h"
 
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/io/dgfvanguard.hh>
-#include <opm/models/utils/start.hh>
 #include <opm/models/pvs/pvsmodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
 
 #include "problems/obstacleproblem.hh"
@@ -45,6 +47,11 @@ struct ObstacleProblem
 { using InheritsFrom = std::tuple<ObstacleBaseProblem, PvsModel>; };
 
 } // end namespace TTag
+
+//! We use a vertex centered finite volume method
+template<class TypeTag>
+struct SpatialDiscretizationSplice<TypeTag, TTag::ObstacleProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/examples/outflow_pvs.cpp
+++ b/examples/outflow_pvs.cpp
@@ -27,9 +27,11 @@
  */
 #include "config.h"
 
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/io/dgfvanguard.hh>
-#include <opm/models/utils/start.hh>
 #include <opm/models/pvs/pvsmodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
 
 #include "problems/outflowproblem.hh"
@@ -43,6 +45,11 @@ struct OutflowProblem
 { using InheritsFrom = std::tuple<OutflowBaseProblem, PvsModel>; };
 
 } // end namespace TTag
+
+//! We use a vertex centered finite volume method
+template<class TypeTag>
+struct SpatialDiscretizationSplice<TypeTag, TTag::OutflowProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/examples/powerinjection_darcy_ad.cpp
+++ b/examples/powerinjection_darcy_ad.cpp
@@ -27,9 +27,12 @@
  */
 #include "config.h"
 
-#include <opm/models/utils/start.hh>
-#include <opm/simulators/linalg/parallelbicgstabbackend.hh>
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>
+#include <opm/models/utils/start.hh>
+
+#include <opm/simulators/linalg/parallelbicgstabbackend.hh>
+
 #include "problems/powerinjectionproblem.hh"
 
 namespace Opm::Properties {
@@ -42,9 +45,17 @@ struct PowerInjectionDarcyAdProblem
 } // namespace TTag
 
 template<class TypeTag>
-struct FluxModule<TypeTag, TTag::PowerInjectionDarcyAdProblem> { using type = Opm::DarcyFluxModule<TypeTag>; };
+struct FluxModule<TypeTag, TTag::PowerInjectionDarcyAdProblem>
+{ using type = Opm::DarcyFluxModule<TypeTag>; };
+
 template<class TypeTag>
-struct LocalLinearizerSplice<TypeTag, TTag::PowerInjectionDarcyAdProblem> { using type = TTag::AutoDiffLocalLinearizer; };
+struct LocalLinearizerSplice<TypeTag, TTag::PowerInjectionDarcyAdProblem>
+{ using type = TTag::AutoDiffLocalLinearizer; };
+
+//! We use a vertex centered finite volume method
+template<class TypeTag>
+struct SpatialDiscretizationSplice<TypeTag, TTag::PowerInjectionDarcyAdProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/examples/powerinjection_darcy_fd.cpp
+++ b/examples/powerinjection_darcy_fd.cpp
@@ -27,9 +27,12 @@
  */
 #include "config.h"
 
-#include <opm/models/utils/start.hh>
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
+
 #include "problems/powerinjectionproblem.hh"
 
 namespace Opm::Properties {
@@ -42,9 +45,17 @@ struct PowerInjectionDarcyFdProblem
 } // namespace TTag
 
 template<class TypeTag>
-struct FluxModule<TypeTag, TTag::PowerInjectionDarcyFdProblem> { using type = Opm::DarcyFluxModule<TypeTag>; };
+struct FluxModule<TypeTag, TTag::PowerInjectionDarcyFdProblem>
+{ using type = Opm::DarcyFluxModule<TypeTag>; };
+
 template<class TypeTag>
-struct LocalLinearizerSplice<TypeTag, TTag::PowerInjectionDarcyFdProblem> { using type = TTag::FiniteDifferenceLocalLinearizer; };
+struct LocalLinearizerSplice<TypeTag, TTag::PowerInjectionDarcyFdProblem>
+{ using type = TTag::FiniteDifferenceLocalLinearizer; };
+
+//! We use a vertex centered finite volume method
+template<class TypeTag>
+struct SpatialDiscretizationSplice<TypeTag, TTag::PowerInjectionDarcyFdProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/examples/powerinjection_forchheimer_ad.cpp
+++ b/examples/powerinjection_forchheimer_ad.cpp
@@ -27,9 +27,12 @@
  */
 #include "config.h"
 
-#include <opm/models/utils/start.hh>
-#include <opm/simulators/linalg/parallelbicgstabbackend.hh>
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>
+#include <opm/models/utils/start.hh>
+
+#include <opm/simulators/linalg/parallelbicgstabbackend.hh>
+
 #include "problems/powerinjectionproblem.hh"
 
 namespace Opm::Properties {
@@ -42,9 +45,17 @@ struct PowerInjectionForchheimerAdProblem
 } // namespace TTag
 
 template<class TypeTag>
-struct FluxModule<TypeTag, TTag::PowerInjectionForchheimerAdProblem> { using type = Opm::ForchheimerFluxModule<TypeTag>; };
+struct FluxModule<TypeTag, TTag::PowerInjectionForchheimerAdProblem>
+{ using type = Opm::ForchheimerFluxModule<TypeTag>; };
+
 template<class TypeTag>
-struct LocalLinearizerSplice<TypeTag, TTag::PowerInjectionForchheimerAdProblem> { using type = TTag::AutoDiffLocalLinearizer; };
+struct LocalLinearizerSplice<TypeTag, TTag::PowerInjectionForchheimerAdProblem>
+{ using type = TTag::AutoDiffLocalLinearizer; };
+
+//! We use a vertex centered finite volume method
+template<class TypeTag>
+struct SpatialDiscretizationSplice<TypeTag, TTag::PowerInjectionForchheimerAdProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/examples/powerinjection_forchheimer_fd.cpp
+++ b/examples/powerinjection_forchheimer_fd.cpp
@@ -27,9 +27,12 @@
  */
 #include "config.h"
 
-#include <opm/models/utils/start.hh>
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
+
 #include "problems/powerinjectionproblem.hh"
 
 namespace Opm::Properties {
@@ -42,9 +45,17 @@ struct PowerInjectionForchheimerFdProblem
 } // namespace TTag
 
 template<class TypeTag>
-struct FluxModule<TypeTag, TTag::PowerInjectionForchheimerFdProblem> { using type = Opm::ForchheimerFluxModule<TypeTag>; };
+struct FluxModule<TypeTag, TTag::PowerInjectionForchheimerFdProblem>
+{ using type = Opm::ForchheimerFluxModule<TypeTag>; };
+
 template<class TypeTag>
-struct LocalLinearizerSplice<TypeTag, TTag::PowerInjectionForchheimerFdProblem> { using type = TTag::FiniteDifferenceLocalLinearizer; };
+struct LocalLinearizerSplice<TypeTag, TTag::PowerInjectionForchheimerFdProblem>
+{ using type = TTag::FiniteDifferenceLocalLinearizer; };
+
+//! We use a vertex centered finite volume method
+template<class TypeTag>
+struct SpatialDiscretizationSplice<TypeTag, TTag::PowerInjectionForchheimerFdProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/examples/problems/fractureproblem.hh
+++ b/examples/problems/fractureproblem.hh
@@ -37,9 +37,6 @@
 #error "dune-alugrid not found!"
 #endif
 
-#include <opm/models/discretefracture/discretefracturemodel.hh>
-#include <opm/models/io/dgfvanguard.hh>
-
 #include <opm/material/fluidmatrixinteractions/RegularizedBrooksCorey.hpp>
 #include <opm/material/fluidmatrixinteractions/RegularizedVanGenuchten.hpp>
 #include <opm/material/fluidmatrixinteractions/LinearMaterial.hpp>
@@ -50,6 +47,10 @@
 #include <opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp>
 #include <opm/material/components/SimpleH2O.hpp>
 #include <opm/material/components/Dnapl.hpp>
+
+#include <opm/models/discretefracture/discretefracturemodel.hh>
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
+#include <opm/models/io/dgfvanguard.hh>
 
 #include <dune/common/version.hh>
 #include <dune/common/fmatrix.hh>
@@ -69,7 +70,10 @@ namespace Opm::Properties {
 // Create a type tag for the problem
 // Create new type tags
 namespace TTag {
-struct FractureProblem { using InheritsFrom = std::tuple<DiscreteFractureModel>; };
+
+struct FractureProblem
+{ using InheritsFrom = std::tuple<DiscreteFractureModel>; };
+
 } // end namespace TTag
 
 // Set the grid type
@@ -79,11 +83,13 @@ struct Grid<TypeTag, TTag::FractureProblem>
 
 // Set the Vanguard property
 template<class TypeTag>
-struct Vanguard<TypeTag, TTag::FractureProblem> { using type = Opm::DgfVanguard<TypeTag>; };
+struct Vanguard<TypeTag, TTag::FractureProblem>
+{ using type = Opm::DgfVanguard<TypeTag>; };
 
 // Set the problem property
 template<class TypeTag>
-struct Problem<TypeTag, TTag::FractureProblem> { using type = Opm::FractureProblem<TypeTag>; };
+struct Problem<TypeTag, TTag::FractureProblem>
+{ using type = Opm::FractureProblem<TypeTag>; };
 
 // Set the wetting phase
 template<class TypeTag>
@@ -132,7 +138,8 @@ public:
 
 // Enable the energy equation
 template<class TypeTag>
-struct EnableEnergy<TypeTag, TTag::FractureProblem> { static constexpr bool value = true; };
+struct EnableEnergy<TypeTag, TTag::FractureProblem>
+{ static constexpr bool value = true; };
 
 // Set the thermal conduction law
 template<class TypeTag>
@@ -154,7 +161,13 @@ struct SolidEnergyLaw<TypeTag, TTag::FractureProblem>
 
 // For this problem, we use constraints to specify the left boundary
 template<class TypeTag>
-struct EnableConstraints<TypeTag, TTag::FractureProblem> { static constexpr bool value = true; };
+struct EnableConstraints<TypeTag, TTag::FractureProblem>
+{ static constexpr bool value = true; };
+
+//! We use a vertex centered finite volume method
+template<class TypeTag>
+struct SpatialDiscretizationSplice<TypeTag, TTag::FractureProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 
@@ -658,6 +671,7 @@ private:
     Scalar temperature_;
     Scalar eps_;
 };
+
 } // namespace Opm
 
 #endif // EWOMS_FRACTURE_PROBLEM_HH

--- a/examples/problems/powerinjectionproblem.hh
+++ b/examples/problems/powerinjectionproblem.hh
@@ -28,9 +28,6 @@
 #ifndef EWOMS_POWER_INJECTION_PROBLEM_HH
 #define EWOMS_POWER_INJECTION_PROBLEM_HH
 
-#include <opm/models/immiscible/immisciblemodel.hh>
-#include <opm/models/io/cubegridvanguard.hh>
-
 #include <opm/material/fluidmatrixinteractions/RegularizedVanGenuchten.hpp>
 #include <opm/material/fluidmatrixinteractions/LinearMaterial.hpp>
 #include <opm/material/fluidmatrixinteractions/EffToAbsLaw.hpp>
@@ -39,6 +36,10 @@
 #include <opm/material/fluidstates/ImmiscibleFluidState.hpp>
 #include <opm/material/components/SimpleH2O.hpp>
 #include <opm/material/components/Air.hpp>
+
+#include <opm/models/discretization/common/fvbaseadlocallinearizer.hh>
+#include <opm/models/immiscible/immisciblemodel.hh>
+#include <opm/models/io/cubegridvanguard.hh>
 
 #include <dune/grid/yaspgrid.hh>
 
@@ -64,15 +65,18 @@ struct PowerInjectionBaseProblem {};
 
 // Set the grid implementation to be used
 template<class TypeTag>
-struct Grid<TypeTag, TTag::PowerInjectionBaseProblem> { using type = Dune::YaspGrid</*dim=*/1>; };
+struct Grid<TypeTag, TTag::PowerInjectionBaseProblem>
+{ using type = Dune::YaspGrid</*dim=*/1>; };
 
 // set the Vanguard property
 template<class TypeTag>
-struct Vanguard<TypeTag, TTag::PowerInjectionBaseProblem> { using type = Opm::CubeGridVanguard<TypeTag>; };
+struct Vanguard<TypeTag, TTag::PowerInjectionBaseProblem>
+{ using type = Opm::CubeGridVanguard<TypeTag>; };
 
 // Set the problem property
 template<class TypeTag>
-struct Problem<TypeTag, TTag::PowerInjectionBaseProblem> { using type = Opm::PowerInjectionProblem<TypeTag>; };
+struct Problem<TypeTag, TTag::PowerInjectionBaseProblem>
+{ using type = Opm::PowerInjectionProblem<TypeTag>; };
 
 // Set the wetting phase
 template<class TypeTag>

--- a/examples/waterair_pvs_ni.cpp
+++ b/examples/waterair_pvs_ni.cpp
@@ -27,9 +27,11 @@
  */
 #include "config.h"
 
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/io/dgfvanguard.hh>
-#include <opm/models/utils/start.hh>
 #include <opm/models/pvs/pvsmodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include "problems/waterairproblem.hh"
 
 namespace Opm::Properties {
@@ -43,6 +45,11 @@ struct WaterAirProblem
 template<class TypeTag>
 struct EnableEnergy<TypeTag, TTag::WaterAirProblem>
 { static constexpr bool value = true; };
+
+//! We use a vertex centered finite volume method
+template<class TypeTag>
+struct SpatialDiscretizationSplice<TypeTag, TTag::WaterAirProblem>
+{ using type = TTag::VcfvDiscretization; };
 
 } // namespace Opm::Properties
 

--- a/opm/models/common/multiphasebasemodel.hh
+++ b/opm/models/common/multiphasebasemodel.hh
@@ -37,12 +37,11 @@
 #include <opm/material/thermal/NullThermalConductionLaw.hpp>
 
 #include <opm/models/common/flux.hh>
-#include <opm/models/common/multiphasebaseparameters.hh>
-#include <opm/models/common/multiphasebaseproperties.hh>
-#include <opm/models/common/multiphasebaseproblem.hh>
 #include <opm/models/common/multiphasebaseextensivequantities.hh>
-
-#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
+#include <opm/models/common/multiphasebaseparameters.hh>
+#include <opm/models/common/multiphasebaseproblem.hh>
+#include <opm/models/common/multiphasebaseproperties.hh>
+#include <opm/models/parallel/threadedentityiterator.hh>
 
 #include <opm/models/io/vtkmultiphasemodule.hpp>
 #include <opm/models/io/vtktemperaturemodule.hpp>
@@ -75,13 +74,6 @@ struct Splices<TypeTag, TTag::MultiPhaseBaseModel>
                                               TTag::MultiPhaseBaseModel,
                                               Properties::SpatialDiscretizationSplice>>;
 };
-
-//! Set the default spatial discretization
-//!
-//! We use a vertex centered finite volume method by default
-template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::MultiPhaseBaseModel>
-{ using type = TTag::VcfvDiscretization; };
 
 //! set the number of equations to the number of phases
 template<class TypeTag>


### PR DESCRIPTION
this way we avoid pulling vcfv code into TUs where ecfv is used, avoiding unnecessary parsing of about 2k LOC and lots of spurious rebuilds.

touch vcfvdiscretization.hh
| Status | Build | Link |
| :--- | :--- | :--- |
| **Old** | 170 | 244 |
| **New** | 33 | 33 |