### PR TITLE
Make hybrid solver account for setup time

### DIFF
--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
@@ -422,7 +422,7 @@ solveJacobianSystem(BVector& x)
             linSolver.setResidual(residual);
             perfTimer.start();
             linSolver.solve(x_trial[solver]);
-            times[solver] = perfTimer.stop();
+            times[solver] = setupTimes[solver] + perfTimer.stop();
             perfTimer.reset();
             if (this->terminal_output_) {
                 OpmLog::debug(fmt::format(fmt::runtime("Solver time {}: {}"), solver, times[solver]));


### PR DESCRIPTION
The current formulation disregards the expensive setup of CPRW, favoring it more than necessary. Verified to give improved performance on a small SPE11C realization.