### PR TITLE
WTEST: stamp well closures with the end of the time step

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -895,7 +895,17 @@ namespace Opm {
                     // a timestep without the well in question, after it caused
                     // repeated timestep cuts. It should therefore not be opened,
                     // even if it was new or received new targets this report step.
-                    const bool closed_this_step = (this->wellTestState().lastTestTime(well_name) == simulator_.time());
+                    //
+                    // The time stamp alone cannot establish that, since a shut-in
+                    // decided at the *end* of the previous step carries that
+                    // step's end time, which coincides with the current step's
+                    // start time. Such shut-ins are the ones a new WCON keyword
+                    // may undo, and are exactly what wasDynamicallyShutThisTimeStep()
+                    // reports; mid-step ones from forceShutWellByName() are not
+                    // registered there, so they still block the re-open.
+                    const bool closed_this_step =
+                        (this->wellTestState().lastTestTime(well_name) == simulator_.time()) &&
+                        !this->wasDynamicallyShutThisTimeStep(well_name);
                     // TODO: more checking here, to make sure this standard more specific and complete
                     // maybe there is some WCON keywords will not open the well
                     auto& events = this->wellState().well(w).events;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -695,11 +695,17 @@ namespace Opm {
             local_deferredLogger.warning("WELL_POTENTIAL_CALCULATION_FAILED", msg);
         }
 
-        updateWellTestState(simulationTime, this->wellTestState());
+        // simulationTime is the start of the step that has just been completed,
+        // but a well shut by the economic or physical limit checks below keeps
+        // flowing until its end. Record that instant as the closure time, so
+        // the WTEST re-test countdown starts when the well actually stops.
+        const double closure_time = simulationTime + dt;
+
+        updateWellTestState(closure_time, this->wellTestState());
 
         // check group sales limits at the end of the timestep
         const Group& fieldGroup = this->schedule_.getGroup("FIELD", reportStepIdx);
-        this->checkGEconLimits(fieldGroup, simulationTime,
+        this->checkGEconLimits(fieldGroup, closure_time,
                                simulator_.episodeIndex(), local_deferredLogger);
         this->checkGconsaleLimits(fieldGroup, this->wellState(),
                                   simulator_.episodeIndex(), local_deferredLogger);

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -35,6 +35,7 @@
 
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 
+#include <opm/simulators/wells/EconomicLimitsMessage.hpp>
 #include <opm/simulators/wells/GroupState.hpp>
 #include <opm/simulators/wells/TargetCalculator.hpp>
 #include <opm/simulators/wells/WellBhpThpCalculator.hpp>
@@ -414,7 +415,18 @@ namespace Opm
         OPM_TIMEFUNCTION();
         auto& deferred_logger = groupStateHelper.deferredLogger();
         const auto& group_state = groupStateHelper.groupState();
-        deferred_logger.info(" well " + this->name() + " is being tested");
+        // A well test is run at the start of the time step, so this is also the
+        // instant the well resumes flowing if the test succeeds -- the mirror of
+        // the economic-limit messages, which report when a well stops flowing.
+        const auto& unit_system = simulator.vanguard().eclState().getUnits();
+        const auto start_time = simulator.vanguard().schedule().getStartTime();
+        const auto when =
+            fmt::format("at time {:.2f} {} (date = {})",
+                        unit_system.from_si(UnitSystem::measure::time, simulation_time),
+                        unit_system.name(UnitSystem::measure::time),
+                        economicLimitDateString(start_time, simulation_time));
+
+        deferred_logger.info(fmt::format(" well {} is being tested {}", this->name(), when));
 
         GroupStateHelperType groupStateHelper_copy = groupStateHelper;
         WellStateType well_state_copy = well_state;
@@ -513,8 +525,8 @@ namespace Opm
         if (!welltest_state_temp.well_is_closed(this->name())) {
             well_test_state.open_well(this->name());
 
-            std::string msg = std::string("well ") + this->name() + std::string(" is re-opened");
-            deferred_logger.info(msg);
+            deferred_logger.info(
+                fmt::format("well {} is re-opened {}", this->name(), when));
 
             // also reopen completions
             for (const auto& completion : this->well_ecl_.getCompletions()) {

--- a/opm/simulators/wells/WellTest.cpp
+++ b/opm/simulators/wells/WellTest.cpp
@@ -416,13 +416,18 @@ updateWellTestStateEconomic(const SingleWellState<Scalar, IndexTraits>& ws,
 
         well_test_state.close_well(well_.name(), WellTestConfig::Reason::ECONOMIC, simulation_time);
         if (write_message_to_opmlog) {
-            if (well_.wellEcl().getAutomaticShutIn()) {
-                const std::string msg = std::string("well ") + well_.name() + std::string(" will be shut due to rate economic limit");
-                deferred_logger.info(msg);
-            } else {
-                const std::string msg = std::string("well ") + well_.name() + std::string(" will be stopped due to rate economic limit");
-                deferred_logger.info(msg);
-            }
+            // State when the well stops flowing, as the ratio-limit and CECON
+            // messages below already do. That instant is the end of the time
+            // step the limit was detected on, not its start.
+            const std::string_view action =
+                well_.wellEcl().getAutomaticShutIn() ? "shut" : "stopped";
+            deferred_logger.info(
+                fmt::format("well {} will be {} due to rate economic limit "
+                            "at time {:.2f} {} (date = {})",
+                            well_.name(), action,
+                            unit_system.from_si(UnitSystem::measure::time, simulation_time),
+                            unit_system.name(UnitSystem::measure::time),
+                            economicLimitDateString(start_time, simulation_time)));
         }
         // the well is closed, not need to check other limits
         return;


### PR DESCRIPTION
simulator_.time() is the time at the *start* of the step being closed out, so economic/physical/group shut-ins were recorded one step before the well actually stops flowing. WTEST therefore re-tested wells after interval - dt instead of interval.