### PR TITLE
do not set a default flux module

### DIFF
--- a/examples/co2_ptflash_ecfv.cpp
+++ b/examples/co2_ptflash_ecfv.cpp
@@ -32,33 +32,35 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/StreamLog.hpp>
 
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/utils/start.hh>
+
 #include "problems/co2ptflashproblem.hh"
 
 #include <iostream>
 #include <memory>
 
-
 namespace Opm::Properties {
 
 namespace TTag {
-    struct CO2PTEcfvProblem {
-    using InheritsFrom = std::tuple<CO2PTBaseProblem, FlashModel>;
-};
+
+struct CO2PTEcfvProblem
+{ using InheritsFrom = std::tuple<CO2PTBaseProblem, FlashModel>; };
+
 }
 
 template <class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::CO2PTEcfvProblem>
-{
-    using type = TTag::EcfvDiscretization;
-};
+{ using type = TTag::EcfvDiscretization; };
 
 template <class TypeTag>
 struct LocalLinearizerSplice<TypeTag, TTag::CO2PTEcfvProblem>
-{
-    using type = TTag::AutoDiffLocalLinearizer;
-};
+{ using type = TTag::AutoDiffLocalLinearizer; };
 
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::CO2PTEcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/co2injection_flash_ecfv.cpp
+++ b/examples/co2injection_flash_ecfv.cpp
@@ -32,10 +32,12 @@
 #include <opm/material/common/quad.hpp>
 #endif
 
+#include <opm/models/common/darcyfluxmodule.hh>
+#include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
+#include <opm/models/flash/flashmodel.hh>
 #include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
-#include <opm/models/flash/flashmodel.hh>
-#include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
+
 #include "problems/co2injectionflash.hh"
 #include "problems/co2injectionproblem.hh"
 
@@ -63,6 +65,12 @@ template<class TypeTag>
 struct FlashSolver<TypeTag, TTag::Co2InjectionFlashEcfvProblem>
 { using type = Opm::Co2InjectionFlash<GetPropType<TypeTag, Properties::Scalar>,
                                       GetPropType<TypeTag, Properties::FluidSystem>>; };
+
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::Co2InjectionFlashEcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 // the flash model has serious problems with the numerical
 // precision. if quadruple precision math is available, we use it,

--- a/examples/co2injection_flash_ni_ecfv.cpp
+++ b/examples/co2injection_flash_ni_ecfv.cpp
@@ -31,10 +31,12 @@
 // this must be included before the vanguard
 #include <opm/material/common/quad.hpp>
 
+#include <opm/models/common/darcyfluxmodule.hh>
+#include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
+#include <opm/models/flash/flashmodel.hh>
 #include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
-#include <opm/models/flash/flashmodel.hh>
-#include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
+
 #include "problems/co2injectionflash.hh"
 #include "problems/co2injectionproblem.hh"
 
@@ -63,8 +65,13 @@ struct LocalLinearizerSplice<TypeTag, TTag::Co2InjectionFlashNiEcfvProblem>
 // use the CO2 injection problem adapted flash solver
 template<class TypeTag>
 struct FlashSolver<TypeTag, TTag::Co2InjectionFlashNiEcfvProblem>
-{ using type = Opm::Co2InjectionFlash<GetPropType<TypeTag, Properties::Scalar>,
-                                      GetPropType<TypeTag, Properties::FluidSystem>>; };
+{ using type = Co2InjectionFlash<GetPropType<TypeTag, Properties::Scalar>,
+                                 GetPropType<TypeTag, Properties::FluidSystem>>; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::Co2InjectionFlashNiEcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 // the flash model has serious problems with the numerical
 // precision. if quadruple precision math is available, we use it,

--- a/examples/co2injection_flash_ni_vcfv.cpp
+++ b/examples/co2injection_flash_ni_vcfv.cpp
@@ -31,10 +31,12 @@
 // this must be included before the vanguard
 #include <opm/material/common/quad.hpp>
 
+#include <opm/models/common/darcyfluxmodule.hh>
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
+#include <opm/models/flash/flashmodel.hh>
 #include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
-#include <opm/models/flash/flashmodel.hh>
-#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
+
 #include "problems/co2injectionflash.hh"
 #include "problems/co2injectionproblem.hh"
 
@@ -59,8 +61,14 @@ struct EnableEnergy<TypeTag, TTag::Co2InjectionFlashNiVcfvProblem>
 // use the CO2 injection problem adapted flash solver
 template<class TypeTag>
 struct FlashSolver<TypeTag, TTag::Co2InjectionFlashNiVcfvProblem>
-{ using type = Opm::Co2InjectionFlash<GetPropType<TypeTag, Properties::Scalar>,
-                                      GetPropType<TypeTag, Properties::FluidSystem>>; };
+{ using type = Co2InjectionFlash<GetPropType<TypeTag, Properties::Scalar>,
+                                 GetPropType<TypeTag, Properties::FluidSystem>>; };
+
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::Co2InjectionFlashNiVcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 // the flash model has serious problems with the numerical
 // precision. if quadruple precision math is available, we use it,

--- a/examples/co2injection_flash_vcfv.cpp
+++ b/examples/co2injection_flash_vcfv.cpp
@@ -32,10 +32,12 @@
 #include <opm/material/common/quad.hpp>
 #endif
 
+#include <opm/models/common/darcyfluxmodule.hh>
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
+#include <opm/models/flash/flashmodel.hh>
 #include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
-#include <opm/models/flash/flashmodel.hh>
-#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
+
 #include "problems/co2injectionflash.hh"
 #include "problems/co2injectionproblem.hh"
 
@@ -55,8 +57,13 @@ struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionFlashVcfvProblem>
 // use the flash solver adapted to the CO2 injection problem
 template<class TypeTag>
 struct FlashSolver<TypeTag, TTag::Co2InjectionFlashVcfvProblem>
-{ using type = Opm::Co2InjectionFlash<GetPropType<TypeTag, Properties::Scalar>,
-                                      GetPropType<TypeTag, Properties::FluidSystem>>; };
+{ using type = Co2InjectionFlash<GetPropType<TypeTag, Properties::Scalar>,
+                                 GetPropType<TypeTag, Properties::FluidSystem>>; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::Co2InjectionFlashVcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 // the flash model has serious problems with the numerical
 // precision. if quadruple precision math is available, we use it,

--- a/examples/co2injection_immiscible_ecfv.cpp
+++ b/examples/co2injection_immiscible_ecfv.cpp
@@ -28,10 +28,11 @@
  */
 #include "config.h"
 
+#include <opm/models/common/darcyfluxmodule.hh>
+#include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
+#include <opm/models/immiscible/immisciblemodel.hh>
 #include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
-#include <opm/models/immiscible/immisciblemodel.hh>
-#include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
 
 #include "problems/co2injectionproblem.hh"
 
@@ -47,6 +48,11 @@ struct Co2InjectionImmiscibleEcfvProblem
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionImmiscibleEcfvProblem>
 { using type = TTag::EcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::Co2InjectionImmiscibleEcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/co2injection_immiscible_ni_ecfv.cpp
+++ b/examples/co2injection_immiscible_ni_ecfv.cpp
@@ -28,10 +28,12 @@
  */
 #include "config.h"
 
+#include <opm/models/common/darcyfluxmodule.hh>
+#include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
+#include <opm/models/immiscible/immisciblemodel.hh>
 #include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
-#include <opm/models/immiscible/immisciblemodel.hh>
-#include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
+
 #include "problems/co2injectionproblem.hh"
 
 namespace Opm::Properties {
@@ -55,6 +57,11 @@ struct EnableEnergy<TypeTag, TTag::Co2InjectionImmiscibleNiEcfvProblem>
 template<class TypeTag>
 struct LocalLinearizerSplice<TypeTag, TTag::Co2InjectionImmiscibleNiEcfvProblem>
 { using type = TTag::AutoDiffLocalLinearizer; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::Co2InjectionImmiscibleNiEcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/co2injection_immiscible_ni_vcfv.cpp
+++ b/examples/co2injection_immiscible_ni_vcfv.cpp
@@ -28,10 +28,12 @@
  */
 #include "config.h"
 
+#include <opm/models/common/darcyfluxmodule.hh>
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
+#include <opm/models/immiscible/immisciblemodel.hh>
 #include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
-#include <opm/models/immiscible/immisciblemodel.hh>
-#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
+
 #include "problems/co2injectionproblem.hh"
 
 namespace Opm::Properties {
@@ -50,6 +52,11 @@ struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionImmiscibleNiVcfvPr
 template<class TypeTag>
 struct EnableEnergy<TypeTag, TTag::Co2InjectionImmiscibleNiVcfvProblem>
 { static constexpr bool value = true; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::Co2InjectionImmiscibleNiVcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/co2injection_immiscible_vcfv.cpp
+++ b/examples/co2injection_immiscible_vcfv.cpp
@@ -28,10 +28,11 @@
  */
 #include "config.h"
 
+#include <opm/models/common/darcyfluxmodule.hh>
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
+#include <opm/models/immiscible/immisciblemodel.hh>
 #include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
-#include <opm/models/immiscible/immisciblemodel.hh>
-#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 
 #include "problems/co2injectionproblem.hh"
 
@@ -47,6 +48,11 @@ struct Co2InjectionImmiscibleVcfvProblem
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionImmiscibleVcfvProblem>
 { using type = TTag::VcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::Co2InjectionImmiscibleVcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/co2injection_ncp_ecfv.cpp
+++ b/examples/co2injection_ncp_ecfv.cpp
@@ -28,10 +28,12 @@
  */
 #include "config.h"
 
-#include <opm/models/io/dgfvanguard.hh>
-#include <opm/models/utils/start.hh>
-#include <opm/models/ncp/ncpmodel.hh>
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
+#include <opm/models/io/dgfvanguard.hh>
+#include <opm/models/ncp/ncpmodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include "problems/co2injectionproblem.hh"
 
 namespace Opm::Properties {
@@ -47,6 +49,11 @@ struct Co2InjectionNcpEcfvProblem
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionNcpEcfvProblem>
 { using type = TTag::EcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::Co2InjectionNcpEcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/co2injection_ncp_ni_ecfv.cpp
+++ b/examples/co2injection_ncp_ni_ecfv.cpp
@@ -28,10 +28,12 @@
  */
 #include "config.h"
 
-#include <opm/models/io/dgfvanguard.hh>
-#include <opm/models/utils/start.hh>
-#include <opm/models/ncp/ncpmodel.hh>
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
+#include <opm/models/io/dgfvanguard.hh>
+#include <opm/models/ncp/ncpmodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include "problems/co2injectionproblem.hh"
 
 namespace Opm::Properties {
@@ -56,6 +58,11 @@ struct EnableEnergy<TypeTag, TTag::Co2InjectionNcpNiEcfvProblem>
 template<class TypeTag>
 struct LocalLinearizerSplice<TypeTag, TTag::Co2InjectionNcpNiEcfvProblem>
 { using type = TTag::AutoDiffLocalLinearizer; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::Co2InjectionNcpNiEcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/co2injection_ncp_ni_vcfv.cpp
+++ b/examples/co2injection_ncp_ni_vcfv.cpp
@@ -28,10 +28,12 @@
  */
 #include "config.h"
 
-#include <opm/models/io/dgfvanguard.hh>
-#include <opm/models/utils/start.hh>
-#include <opm/models/ncp/ncpmodel.hh>
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
+#include <opm/models/io/dgfvanguard.hh>
+#include <opm/models/ncp/ncpmodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include "problems/co2injectionproblem.hh"
 
 namespace Opm::Properties {
@@ -50,6 +52,11 @@ struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionNcpNiVcfvProblem>
 template<class TypeTag>
 struct EnableEnergy<TypeTag, TTag::Co2InjectionNcpNiVcfvProblem>
 { static constexpr bool value = true; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::Co2InjectionNcpNiVcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/co2injection_ncp_vcfv.cpp
+++ b/examples/co2injection_ncp_vcfv.cpp
@@ -28,10 +28,11 @@
  */
 #include "config.h"
 
-#include <opm/models/io/dgfvanguard.hh>
-#include <opm/models/utils/start.hh>
-#include <opm/models/ncp/ncpmodel.hh>
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
+#include <opm/models/io/dgfvanguard.hh>
+#include <opm/models/ncp/ncpmodel.hh>
+#include <opm/models/utils/start.hh>
 
 #include "problems/co2injectionproblem.hh"
 
@@ -48,6 +49,11 @@ struct Co2InjectionNcpVcfvProblem
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionNcpVcfvProblem>
 { using type = TTag::VcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::Co2InjectionNcpVcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/co2injection_pvs_ecfv.cpp
+++ b/examples/co2injection_pvs_ecfv.cpp
@@ -28,10 +28,12 @@
  */
 #include "config.h"
 
-#include <opm/models/io/dgfvanguard.hh>
-#include <opm/models/utils/start.hh>
-#include <opm/models/pvs/pvsmodel.hh>
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
+#include <opm/models/io/dgfvanguard.hh>
+#include <opm/models/pvs/pvsmodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include "problems/co2injectionproblem.hh"
 
 namespace Opm::Properties {
@@ -47,6 +49,11 @@ struct Co2InjectionPvsEcfvProblem
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionPvsEcfvProblem>
 { using type = TTag::EcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::Co2InjectionPvsEcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/co2injection_pvs_ni_ecfv.cpp
+++ b/examples/co2injection_pvs_ni_ecfv.cpp
@@ -28,10 +28,12 @@
  */
 #include "config.h"
 
-#include <opm/models/io/dgfvanguard.hh>
-#include <opm/models/utils/start.hh>
-#include <opm/models/pvs/pvsmodel.hh>
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
+#include <opm/models/io/dgfvanguard.hh>
+#include <opm/models/pvs/pvsmodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include "problems/co2injectionproblem.hh"
 
 namespace Opm::Properties {
@@ -55,6 +57,11 @@ struct EnableEnergy<TypeTag, TTag::Co2InjectionPvsNiEcfvProblem>
 template<class TypeTag>
 struct LocalLinearizerSplice<TypeTag, TTag::Co2InjectionPvsNiEcfvProblem>
 { using type = TTag::AutoDiffLocalLinearizer; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::Co2InjectionPvsNiEcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/co2injection_pvs_ni_vcfv.cpp
+++ b/examples/co2injection_pvs_ni_vcfv.cpp
@@ -28,10 +28,12 @@
  */
 #include "config.h"
 
-#include <opm/models/io/dgfvanguard.hh>
-#include <opm/models/utils/start.hh>
-#include <opm/models/pvs/pvsmodel.hh>
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
+#include <opm/models/io/dgfvanguard.hh>
+#include <opm/models/pvs/pvsmodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include "problems/co2injectionproblem.hh"
 
 namespace Opm::Properties {
@@ -51,6 +53,11 @@ struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionPvsNiVcfvProblem>
 template<class TypeTag>
 struct EnableEnergy<TypeTag, TTag::Co2InjectionPvsNiVcfvProblem>
 { static constexpr bool value = true; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::Co2InjectionPvsNiVcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/co2injection_pvs_vcfv.cpp
+++ b/examples/co2injection_pvs_vcfv.cpp
@@ -28,10 +28,11 @@
  */
 #include "config.h"
 
-#include <opm/models/io/dgfvanguard.hh>
-#include <opm/models/utils/start.hh>
-#include <opm/models/pvs/pvsmodel.hh>
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
+#include <opm/models/io/dgfvanguard.hh>
+#include <opm/models/pvs/pvsmodel.hh>
+#include <opm/models/utils/start.hh>
 
 #include "problems/co2injectionproblem.hh"
 
@@ -48,6 +49,11 @@ struct Co2InjectionPvsVcfvProblem
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::Co2InjectionPvsVcfvProblem>
 { using type = TTag::VcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::Co2InjectionPvsVcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/cuvette_pvs.cpp
+++ b/examples/cuvette_pvs.cpp
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/pvs/pvsmodel.hh>
@@ -49,6 +50,11 @@ struct CuvetteProblem
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::CuvetteProblem>
 { using type = TTag::VcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::CuvetteProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/diffusion_flash.cpp
+++ b/examples/diffusion_flash.cpp
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/flash/flashmodel.hh>
 #include <opm/models/utils/start.hh>
@@ -49,6 +50,11 @@ struct DiffusionProblem
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::DiffusionProblem>
 { using type = TTag::VcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::DiffusionProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/diffusion_ncp.cpp
+++ b/examples/diffusion_ncp.cpp
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/ncp/ncpmodel.hh>
 #include <opm/models/utils/start.hh>
@@ -49,6 +50,11 @@ struct DiffusionProblem
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::DiffusionProblem>
 { using type = TTag::VcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::DiffusionProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/diffusion_pvs.cpp
+++ b/examples/diffusion_pvs.cpp
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/pvs/pvsmodel.hh>
 #include <opm/models/utils/start.hh>
@@ -49,6 +50,11 @@ struct DiffusionProblem
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::DiffusionProblem>
 { using type = TTag::VcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::DiffusionProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/finger_immiscible_ecfv.cpp
+++ b/examples/finger_immiscible_ecfv.cpp
@@ -27,9 +27,11 @@
  */
 #include "config.h"
 
-#include <opm/models/utils/start.hh>
-#include <opm/models/immiscible/immisciblemodel.hh>
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
+#include <opm/models/immiscible/immisciblemodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
 
 #include "problems/fingerproblem.hh"
@@ -38,10 +40,20 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct FingerProblemEcfv { using InheritsFrom = std::tuple<FingerBaseProblem, ImmiscibleTwoPhaseModel>; };
+
+struct FingerProblemEcfv
+{ using InheritsFrom = std::tuple<FingerBaseProblem, ImmiscibleTwoPhaseModel>; };
+
 } // end namespace TTag
+
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::FingerProblemEcfv> { using type = TTag::EcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::FingerProblemEcfv>
+{ using type = TTag::EcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::FingerProblemEcfv>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/finger_immiscible_vcfv.cpp
+++ b/examples/finger_immiscible_vcfv.cpp
@@ -27,9 +27,11 @@
  */
 #include "config.h"
 
-#include <opm/models/utils/start.hh>
-#include <opm/models/immiscible/immisciblemodel.hh>
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
+#include <opm/models/immiscible/immisciblemodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
 
 #include "problems/fingerproblem.hh"
@@ -38,10 +40,20 @@ namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct FingerProblemVcfv { using InheritsFrom = std::tuple<FingerBaseProblem, ImmiscibleTwoPhaseModel>; };
+
+struct FingerProblemVcfv
+{ using InheritsFrom = std::tuple<FingerBaseProblem, ImmiscibleTwoPhaseModel>; };
+
 } // end namespace TTag
+
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::FingerProblemVcfv> { using type = TTag::VcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::FingerProblemVcfv>
+{ using type = TTag::VcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::FingerProblemVcfv>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/groundwater_immiscible.cpp
+++ b/examples/groundwater_immiscible.cpp
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>
 #include <opm/models/io/dgfvanguard.hh>
@@ -48,6 +49,11 @@ struct GroundWaterProblem
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::GroundWaterProblem>
 { using type = TTag::VcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::GroundWaterProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/infiltration_pvs.cpp
+++ b/examples/infiltration_pvs.cpp
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/pvs/pvsmodel.hh>
@@ -48,6 +49,11 @@ struct InfiltrationProblem
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::InfiltrationProblem>
 { using type = TTag::VcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::InfiltrationProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/lens_immiscible_ecfv_ad.hh
+++ b/examples/lens_immiscible_ecfv_ad.hh
@@ -29,28 +29,41 @@
 #ifndef EWOMS_LENS_IMMISCIBLE_ECFV_AD_HH
 #define EWOMS_LENS_IMMISCIBLE_ECFV_AD_HH
 
-#include <opm/models/immiscible/immisciblemodel.hh>
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
+#include <opm/models/immiscible/immisciblemodel.hh>
+
 #include "problems/lensproblem.hh"
 
 namespace Opm::Properties {
 
 // Create new type tags
 namespace TTag {
-struct LensProblemEcfvAd { using InheritsFrom = std::tuple<LensBaseProblem, ImmiscibleTwoPhaseModel>; };
+
+struct LensProblemEcfvAd
+{ using InheritsFrom = std::tuple<LensBaseProblem, ImmiscibleTwoPhaseModel>; };
+
 } // end namespace TTag
 
 // use the element centered finite volume spatial discretization
 template<class TypeTag>
-struct SpatialDiscretizationSplice<TypeTag, TTag::LensProblemEcfvAd> { using type = TTag::EcfvDiscretization; };
+struct SpatialDiscretizationSplice<TypeTag, TTag::LensProblemEcfvAd>
+{ using type = TTag::EcfvDiscretization; };
 
 // use automatic differentiation for this simulator
 template<class TypeTag>
-struct LocalLinearizerSplice<TypeTag, TTag::LensProblemEcfvAd> { using type = TTag::AutoDiffLocalLinearizer; };
+struct LocalLinearizerSplice<TypeTag, TTag::LensProblemEcfvAd>
+{ using type = TTag::AutoDiffLocalLinearizer; };
 
 // this problem works fine if the linear solver uses single precision scalars
 template<class TypeTag>
-struct LinearSolverScalar<TypeTag, TTag::LensProblemEcfvAd> { using type = float; };
+struct LinearSolverScalar<TypeTag, TTag::LensProblemEcfvAd>
+{ using type = float; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::LensProblemEcfvAd>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/lens_immiscible_vcfv_ad.cpp
+++ b/examples/lens_immiscible_vcfv_ad.cpp
@@ -28,6 +28,7 @@
  */
 #include "config.h"
 
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>
 #include <opm/models/utils/start.hh>
@@ -55,6 +56,11 @@ struct LocalLinearizerSplice<TypeTag, TTag::LensProblemVcfvAd>
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::LensProblemVcfvAd>
 { using type = TTag::VcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::LensProblemVcfvAd>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 // use linear finite element gradients if dune-localfunctions is available
 #if HAVE_DUNE_LOCALFUNCTIONS

--- a/examples/lens_immiscible_vcfv_fd.cpp
+++ b/examples/lens_immiscible_vcfv_fd.cpp
@@ -28,6 +28,7 @@
  */
 #include "config.h"
 
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>
 #include <opm/models/utils/start.hh>
@@ -55,6 +56,11 @@ struct LocalLinearizerSplice<TypeTag, TTag::LensProblemVcfvFd>
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::LensProblemVcfvFd>
 { using type = TTag::VcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::LensProblemVcfvFd>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 // use linear finite element gradients if dune-localfunctions is available
 #if HAVE_DUNE_LOCALFUNCTIONS

--- a/examples/lens_richards_ecfv.cpp
+++ b/examples/lens_richards_ecfv.cpp
@@ -27,9 +27,11 @@
  */
 #include "config.h"
 
+#include <opm/models/common/darcyfluxmodule.hh>
+#include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
 #include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
-#include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
 
 #include "problems/richardslensproblem.hh"
@@ -51,6 +53,11 @@ struct SpatialDiscretizationSplice<TypeTag, TTag::RichardsLensEcfvProblem>
 template<class TypeTag>
 struct LocalLinearizerSplice<TypeTag, TTag::RichardsLensEcfvProblem>
 { using type = TTag::AutoDiffLocalLinearizer; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::RichardsLensEcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/lens_richards_vcfv.cpp
+++ b/examples/lens_richards_vcfv.cpp
@@ -27,9 +27,11 @@
  */
 #include "config.h"
 
+#include <opm/models/common/darcyfluxmodule.hh>
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
-#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
 
 #include "problems/richardslensproblem.hh"
@@ -47,6 +49,11 @@ struct RichardsLensVcfvProblem
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::RichardsLensVcfvProblem>
 { using type = TTag::VcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::RichardsLensVcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/obstacle_immiscible.cpp
+++ b/examples/obstacle_immiscible.cpp
@@ -28,6 +28,7 @@
  */
 #include "config.h"
 
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>
 #include <opm/models/io/dgfvanguard.hh>
@@ -50,6 +51,11 @@ struct ObstacleProblem
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::ObstacleProblem>
 { using type = TTag::VcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::ObstacleProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/obstacle_ncp.cpp
+++ b/examples/obstacle_ncp.cpp
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/ncp/ncpmodel.hh>
@@ -50,6 +51,11 @@ struct ObstacleProblem
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::ObstacleProblem>
 { using type = TTag::VcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::ObstacleProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/obstacle_pvs.cpp
+++ b/examples/obstacle_pvs.cpp
@@ -29,6 +29,7 @@
  */
 #include "config.h"
 
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/pvs/pvsmodel.hh>
@@ -52,6 +53,11 @@ struct ObstacleProblem
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::ObstacleProblem>
 { using type = TTag::VcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::ObstacleProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/outflow_pvs.cpp
+++ b/examples/outflow_pvs.cpp
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/pvs/pvsmodel.hh>
@@ -50,6 +51,11 @@ struct OutflowProblem
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::OutflowProblem>
 { using type = TTag::VcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::OutflowProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/powerinjection_darcy_ad.cpp
+++ b/examples/powerinjection_darcy_ad.cpp
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>
 #include <opm/models/utils/start.hh>
@@ -46,7 +47,7 @@ struct PowerInjectionDarcyAdProblem
 
 template<class TypeTag>
 struct FluxModule<TypeTag, TTag::PowerInjectionDarcyAdProblem>
-{ using type = Opm::DarcyFluxModule<TypeTag>; };
+{ using type = DarcyFluxModule<TypeTag>; };
 
 template<class TypeTag>
 struct LocalLinearizerSplice<TypeTag, TTag::PowerInjectionDarcyAdProblem>

--- a/examples/powerinjection_forchheimer_ad.cpp
+++ b/examples/powerinjection_forchheimer_ad.cpp
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/common/forchheimerfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>
 #include <opm/models/utils/start.hh>
@@ -46,7 +47,7 @@ struct PowerInjectionForchheimerAdProblem
 
 template<class TypeTag>
 struct FluxModule<TypeTag, TTag::PowerInjectionForchheimerAdProblem>
-{ using type = Opm::ForchheimerFluxModule<TypeTag>; };
+{ using type = ForchheimerFluxModule<TypeTag>; };
 
 template<class TypeTag>
 struct LocalLinearizerSplice<TypeTag, TTag::PowerInjectionForchheimerAdProblem>

--- a/examples/powerinjection_forchheimer_fd.cpp
+++ b/examples/powerinjection_forchheimer_fd.cpp
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/common/forchheimerfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>
 #include <opm/models/utils/start.hh>
@@ -46,7 +47,7 @@ struct PowerInjectionForchheimerFdProblem
 
 template<class TypeTag>
 struct FluxModule<TypeTag, TTag::PowerInjectionForchheimerFdProblem>
-{ using type = Opm::ForchheimerFluxModule<TypeTag>; };
+{ using type = ForchheimerFluxModule<TypeTag>; };
 
 template<class TypeTag>
 struct LocalLinearizerSplice<TypeTag, TTag::PowerInjectionForchheimerFdProblem>

--- a/examples/problems/fractureproblem.hh
+++ b/examples/problems/fractureproblem.hh
@@ -48,6 +48,7 @@
 #include <opm/material/components/SimpleH2O.hpp>
 #include <opm/material/components/Dnapl.hpp>
 
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretefracture/discretefracturemodel.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/io/dgfvanguard.hh>
@@ -168,6 +169,11 @@ struct EnableConstraints<TypeTag, TTag::FractureProblem>
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::FractureProblem>
 { using type = TTag::VcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::FractureProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/problems/powerinjectionproblem.hh
+++ b/examples/problems/powerinjectionproblem.hh
@@ -37,6 +37,7 @@
 #include <opm/material/components/SimpleH2O.hpp>
 #include <opm/material/components/Air.hpp>
 
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/common/fvbaseadlocallinearizer.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>
 #include <opm/models/io/cubegridvanguard.hh>

--- a/examples/reservoir_blackoil_ecfv.cpp
+++ b/examples/reservoir_blackoil_ecfv.cpp
@@ -28,11 +28,13 @@
  */
 #include "config.h"
 
-#include <opm/models/io/dgfvanguard.hh>
-#include <opm/models/utils/start.hh>
 #include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+#include <opm/models/blackoil/blackoildarcyfluxmodule.hh>
 #include <opm/models/blackoil/blackoilmodel.hh>
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
+#include <opm/models/io/dgfvanguard.hh>
+#include <opm/models/utils/start.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
 
 #include "problems/reservoirproblem.hh"
@@ -56,6 +58,12 @@ struct SpatialDiscretizationSplice<TypeTag, TTag::ReservoirBlackOilEcfvProblem>
 template<class TypeTag>
 struct LocalLinearizerSplice<TypeTag, TTag::ReservoirBlackOilEcfvProblem>
 { using type = TTag::AutoDiffLocalLinearizer; };
+
+//! Use the the velocity module which is aware of the black-oil specific model extensions
+//! (i.e., the polymer and solvent extensions)
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::ReservoirBlackOilEcfvProblem>
+{ using type = BlackOilDarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/reservoir_blackoil_vcfv.cpp
+++ b/examples/reservoir_blackoil_vcfv.cpp
@@ -27,10 +27,12 @@
  */
 #include "config.h"
 
+#include <opm/models/blackoil/blackoilmodel.hh>
+#include <opm/models/blackoil/blackoildarcyfluxmodule.hh>
+#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/utils/start.hh>
-#include <opm/models/blackoil/blackoilmodel.hh>
-#include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
 
 #include "problems/reservoirproblem.hh"
@@ -49,6 +51,12 @@ struct ReservoirBlackOilVcfvProblem
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::ReservoirBlackOilVcfvProblem>
 { using type = TTag::VcfvDiscretization; };
+
+//! Use the the velocity module which is aware of the black-oil specific model extensions
+//! (i.e., the polymer and solvent extensions)
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::ReservoirBlackOilVcfvProblem>
+{ using type = BlackOilDarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/reservoir_ncp_ecfv.cpp
+++ b/examples/reservoir_ncp_ecfv.cpp
@@ -27,10 +27,12 @@
  */
 #include "config.h"
 
-#include <opm/models/io/dgfvanguard.hh>
-#include <opm/models/utils/start.hh>
-#include <opm/models/ncp/ncpmodel.hh>
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
+#include <opm/models/io/dgfvanguard.hh>
+#include <opm/models/ncp/ncpmodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
 
 #include "problems/reservoirproblem.hh"
@@ -54,6 +56,10 @@ struct SpatialDiscretizationSplice<TypeTag, TTag::ReservoirNcpEcfvProblem>
 template<class TypeTag>
 struct LocalLinearizerSplice<TypeTag, TTag::ReservoirNcpEcfvProblem>
 { using type = TTag::AutoDiffLocalLinearizer; };
+
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::ReservoirNcpEcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/examples/reservoir_ncp_vcfv.cpp
+++ b/examples/reservoir_ncp_vcfv.cpp
@@ -28,10 +28,12 @@
  */
 #include "config.h"
 
-#include <opm/models/io/dgfvanguard.hh>
-#include <opm/models/utils/start.hh>
-#include <opm/models/ncp/ncpmodel.hh>
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
+#include <opm/models/io/dgfvanguard.hh>
+#include <opm/models/ncp/ncpmodel.hh>
+#include <opm/models/utils/start.hh>
+
 #include <opm/simulators/linalg/parallelbicgstabbackend.hh>
 
 #include "problems/reservoirproblem.hh"
@@ -50,6 +52,10 @@ struct ReservoirNcpVcfvProblem
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::ReservoirNcpVcfvProblem>
 { using type = TTag::VcfvDiscretization; };
+
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::ReservoirNcpVcfvProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 // reduce the base epsilon for the finite difference method to 10^-11. for some reason
 // the simulator converges better with this. (TODO: use automatic differentiation?)

--- a/examples/tutorial1problem.hh
+++ b/examples/tutorial1problem.hh
@@ -29,6 +29,7 @@
 #define EWOMS_TUTORIAL1_PROBLEM_HH /*@\label{tutorial1:guardian2}@*/
 
 // The numerical model
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/immiscible/immisciblemodel.hh>
 
 // The spatial discretization (VCFV == Vertex-Centered Finite Volumes)
@@ -69,6 +70,10 @@ struct Tutorial1Problem { using InheritsFrom = std::tuple<ImmiscibleTwoPhaseMode
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::Tutorial1Problem>
 { using type = TTag::VcfvDiscretization; }; /*@\label{tutorial1:set-spatial-discretization}@*/
+
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::Tutorial1Problem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 // Set the "Problem" property
 template<class TypeTag>

--- a/examples/waterair_pvs_ni.cpp
+++ b/examples/waterair_pvs_ni.cpp
@@ -27,6 +27,7 @@
  */
 #include "config.h"
 
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/vcfv/vcfvdiscretization.hh>
 #include <opm/models/io/dgfvanguard.hh>
 #include <opm/models/pvs/pvsmodel.hh>
@@ -50,6 +51,11 @@ struct EnableEnergy<TypeTag, TTag::WaterAirProblem>
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::WaterAirProblem>
 { using type = TTag::VcfvDiscretization; };
+
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag>
+struct FluxModule<TypeTag, TTag::WaterAirProblem>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 } // namespace Opm::Properties
 

--- a/flowexperimental/comp/flow_comp.hpp
+++ b/flowexperimental/comp/flow_comp.hpp
@@ -22,6 +22,7 @@
 #include <opm/material/constraintsolvers/PTFlash.hpp>
 #include <opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp>
 
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/common/baseauxiliarymodule.hh>
 #include <opm/models/nonlinear/newtonmethod.hh>
 #include <opm/models/ptflash/flashmodel.hh>

--- a/flowexperimental/comp/flow_comp.hpp
+++ b/flowexperimental/comp/flow_comp.hpp
@@ -19,8 +19,6 @@
 #ifndef FLOW_COMP_HPP
 #define FLOW_COMP_HPP
 
-#include <memory>
-
 #include <opm/material/constraintsolvers/PTFlash.hpp>
 #include <opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp>
 
@@ -148,6 +146,10 @@ struct TracerModel<TypeTag, TTag::FlowCompProblem<NumComp, EnableWater>> {
     using type = EmptyModel<TypeTag>;
 };
 
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag, int NumComp, bool EnableWater>
+struct FluxModule<TypeTag, TTag::FlowCompProblem<NumComp, EnableWater>>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 template <class TypeTag, int NumComp, bool EnableWater>
 struct FlashSolver<TypeTag, TTag::FlowCompProblem<NumComp, EnableWater>> {
@@ -159,7 +161,6 @@ private:
 public:
     using type = Opm::PTFlash<Scalar, FluidSystem>;
 };
-
 
 template <class TypeTag, class MyTypeTag>
 struct NumComp { using type = UndefinedProperty; };

--- a/flowexperimental/comp/flowexp_comp.hpp
+++ b/flowexperimental/comp/flowexp_comp.hpp
@@ -131,6 +131,10 @@ struct TracerModel<TypeTag, TTag::FlowExpCompProblem<NumComp, EnableWater>> {
     using type = EmptyModel<TypeTag>;
 };
 
+//! Use the Darcy relation to determine the phase velocity
+template<class TypeTag, int NumComp, bool EnableWater>
+struct FluxModule<TypeTag, TTag::FlowExpCompProblem<NumComp, EnableWater>>
+{ using type = DarcyFluxModule<TypeTag>; };
 
 template <class TypeTag, int NumComp, bool EnableWater>
 struct FlashSolver<TypeTag, TTag::FlowExpCompProblem<NumComp, EnableWater>> {

--- a/flowexperimental/comp/flowexp_comp.hpp
+++ b/flowexperimental/comp/flowexp_comp.hpp
@@ -22,6 +22,7 @@
 #include <opm/material/constraintsolvers/PTFlash.hpp>
 #include <opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp>
 
+#include <opm/models/common/darcyfluxmodule.hh>
 #include <opm/models/discretization/common/baseauxiliarymodule.hh>
 #include <opm/models/ptflash/flashmodel.hh>
 

--- a/opm/models/blackoil/blackoilmodel.hh
+++ b/opm/models/blackoil/blackoilmodel.hh
@@ -34,7 +34,6 @@
 
 #include <opm/models/blackoil/blackoilmodules.hpp>
 #include <opm/models/blackoil/blackoilboundaryratevector.hh>
-#include <opm/models/blackoil/blackoildarcyfluxmodule.hh>
 #include <opm/models/blackoil/blackoilextensivequantities.hh>
 #include <opm/models/blackoil/blackoilvariableandequationindices.hh>
 #include <opm/models/blackoil/blackoilintensivequantities.hh>
@@ -126,12 +125,6 @@ struct IntensiveQuantities<TypeTag, TTag::BlackOilModel>
 template<class TypeTag>
 struct ExtensiveQuantities<TypeTag, TTag::BlackOilModel>
 { using type = BlackOilExtensiveQuantities<TypeTag>; };
-
-//! Use the the velocity module which is aware of the black-oil specific model extensions
-//! (i.e., the polymer and solvent extensions)
-template<class TypeTag>
-struct FluxModule<TypeTag, TTag::BlackOilModel>
-{ using type = BlackOilDarcyFluxModule<TypeTag>; };
 
 //! The indices required by the model
 template<class TypeTag>

--- a/opm/models/common/multiphasebasemodel.hh
+++ b/opm/models/common/multiphasebasemodel.hh
@@ -36,7 +36,6 @@
 #include <opm/material/thermal/NullSolidEnergyLaw.hpp>
 #include <opm/material/thermal/NullThermalConductionLaw.hpp>
 
-#include <opm/models/common/flux.hh>
 #include <opm/models/common/multiphasebaseextensivequantities.hh>
 #include <opm/models/common/multiphasebaseparameters.hh>
 #include <opm/models/common/multiphasebaseproblem.hh>
@@ -101,11 +100,6 @@ struct NumComponents<TypeTag, TTag::MultiPhaseBaseModel>
 template<class TypeTag>
 struct BaseProblem<TypeTag, TTag::MultiPhaseBaseModel>
 { using type = MultiPhaseBaseProblem<TypeTag>; };
-
-//! By default, use the Darcy relation to determine the phase velocity
-template<class TypeTag>
-struct FluxModule<TypeTag, TTag::MultiPhaseBaseModel>
-{ using type = DarcyFluxModule<TypeTag>; };
 
 /*!
  * \brief Set the material law to the null law by default.

--- a/opm/simulators/flow/FlowProblemComp.hpp
+++ b/opm/simulators/flow/FlowProblemComp.hpp
@@ -43,8 +43,6 @@
 
 #include <algorithm>
 #include <functional>
-#include <set>
-#include <string>
 #include <vector>
 
 namespace Opm {


### PR DESCRIPTION
Continuing https://github.com/OPM/opm-simulators/pull/7272, avoid pulling in the darcyfluxmodule unless used.

touch darcyfluxmodule.hh
| Status | Build | Link |
| :--- | :--- | :--- |
| **Old** | 169| 244 |
| **New** | 96 | 57 |

touch blackoildarcyfluxmodule.hh
| Status | Build | Link |
| :--- | :--- | :--- |
| **Old** | 118 | 244 |
| **New** | 2 | 2 |

While unrelated as such, it touches the same lines creating conflicts, so keeping this as draft instead of doing the rebase dance.