### PR TITLE
janitoring: remove old, unused parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -906,10 +906,6 @@ macro(opm-simulators_targets_hook)
   opm_add_executable(
     TARGET
       flow_comp
-    ONLY_COMPILE
-    ALWAYS_ENABLE
-    DEPENDS
-      opmsimulators
     LIBRARIES
       opmsimulators
     SOURCES


### PR DESCRIPTION
These parameters was for the old opm_add_test macro. They are entirely ignored by opm_add_executable.