### PR TITLE
Let the classic CPRW contract D for multisegment wells

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -516,6 +516,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_tpsa_localresidual.cpp
   tests/test_tpsa_primaryvariables.cpp
   tests/test_vfpproperties.cpp
+  tests/test_MswCprWellDiagonal.cpp
   tests/test_WellMatrixMerger.cpp
   tests/test_WaterSatfuncConsistencyChecks.cpp
   tests/test_wellmodel.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -515,6 +515,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_tpsa_localresidual.cpp
   tests/test_tpsa_primaryvariables.cpp
   tests/test_vfpproperties.cpp
+  tests/test_MswCprWellDiagonal.cpp
   tests/test_WellMatrixMerger.cpp
   tests/test_WaterSatfuncConsistencyChecks.cpp
   tests/test_wellmodel.cpp

--- a/opm/simulators/linalg/PressureBhpTransferPolicy.hpp
+++ b/opm/simulators/linalg/PressureBhpTransferPolicy.hpp
@@ -201,15 +201,18 @@ namespace Opm
             OPM_TIMEBLOCK(cprwAddWellEquation);
             assert(transpose == false); // not implemented
             const bool use_well_weights = prm_.get<bool>("use_well_weights");
-            // "contract_d" takes the coarse well diagonal from lambda' D(:,bhp)
-            // for every well; "auto" (the default) leaves the multisegment path
-            // on its historical row-sum diagonal. Standard wells contract D
-            // either way, so this only changes multisegment wells.
-            const auto diagonal = prm_.get<std::string>("well_coarse_diagonal", "auto");
-            if (diagonal != "auto" && diagonal != "contract_d") {
+            // How a multisegment well's coarse diagonal is formed: "row_sum"
+            // (the default) keeps the historical minus-the-row-sum diagonal,
+            // "contract_d" takes it from lambda' D(:,bhp) as standard wells
+            // have always done. Standard wells contract D either way, so this
+            // only ever changes multisegment wells. Named after the operation
+            // rather than "auto" so a configuration says which it wants, and
+            // to match the vocabulary of the system solver's own key.
+            const auto diagonal = prm_.get<std::string>("well_coarse_diagonal", "row_sum");
+            if (diagonal != "row_sum" && diagonal != "contract_d") {
                 OPM_THROW(std::invalid_argument,
                           "Unknown well_coarse_diagonal '" + diagonal +
-                          "'. Valid values are 'auto' and 'contract_d'.");
+                          "'. Valid values are 'row_sum' and 'contract_d'.");
             }
             const bool contract_d_diagonal = (diagonal == "contract_d");
             fineOperator.addWellPressureEquations(*coarseLevelMatrix_, weights_,

--- a/opm/simulators/linalg/PressureBhpTransferPolicy.hpp
+++ b/opm/simulators/linalg/PressureBhpTransferPolicy.hpp
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/TimingMacros.hpp>
 
 #include <opm/simulators/linalg/matrixblock.hh>
@@ -199,8 +200,20 @@ namespace Opm
         if (prm_.get<bool>("add_wells")) {
             OPM_TIMEBLOCK(cprwAddWellEquation);
             assert(transpose == false); // not implemented
-            bool use_well_weights = prm_.get<bool>("use_well_weights");
-            fineOperator.addWellPressureEquations(*coarseLevelMatrix_, weights_, use_well_weights);
+            const bool use_well_weights = prm_.get<bool>("use_well_weights");
+            // "contract_d" takes the coarse well diagonal from lambda' D(:,bhp)
+            // for every well; "auto" (the default) leaves the multisegment path
+            // on its historical row-sum diagonal. Standard wells contract D
+            // either way, so this only changes multisegment wells.
+            const auto diagonal = prm_.get<std::string>("well_coarse_diagonal", "auto");
+            if (diagonal != "auto" && diagonal != "contract_d") {
+                OPM_THROW(std::invalid_argument,
+                          "Unknown well_coarse_diagonal '" + diagonal +
+                          "'. Valid values are 'auto' and 'contract_d'.");
+            }
+            const bool contract_d_diagonal = (diagonal == "contract_d");
+            fineOperator.addWellPressureEquations(*coarseLevelMatrix_, weights_,
+                                                  use_well_weights, contract_d_diagonal);
 #ifndef NDEBUG
             std::advance(rowCoarse, fineOperator.getNumberOfExtraEquations());
             assert(rowCoarse == coarseLevelMatrix_->end());

--- a/opm/simulators/linalg/WellOperators.hpp
+++ b/opm/simulators/linalg/WellOperators.hpp
@@ -60,7 +60,8 @@ public:
     using PressureMatrix = Dune::BCRSMatrix<MatrixBlock<field_type, 1, 1>>;
     virtual void addWellPressureEquations(PressureMatrix& jacobian,
                                           const X& weights,
-                                          const bool use_well_weights) const = 0;
+                                          const bool use_well_weights,
+                                          const bool contract_d_diagonal) const = 0;
     virtual void addWellPressureEquationsStruct(PressureMatrix& jacobian) const = 0;
     virtual int getNumberOfExtraEquations() const = 0;
 };
@@ -120,10 +121,11 @@ public:
 
     void addWellPressureEquations(PressureMatrix& jacobian,
                                   const X& weights,
-                                  const bool use_well_weights) const override
+                                  const bool use_well_weights,
+                                  const bool contract_d_diagonal) const override
     {
         OPM_TIMEBLOCK(addWellPressureEquations);
-        wellMod_.addWellPressureEquations(jacobian, weights, use_well_weights);
+        wellMod_.addWellPressureEquations(jacobian, weights, use_well_weights, contract_d_diagonal);
     }
 
     void addWellPressureEquationsStruct(PressureMatrix& jacobian) const override
@@ -197,12 +199,14 @@ public:
 
     void addWellPressureEquations(PressureMatrix& jacobian,
                                   const X& weights,
-                                  const bool use_well_weights) const override
+                                  const bool use_well_weights,
+                                  const bool contract_d_diagonal) const override
     {
         OPM_TIMEBLOCK(addWellPressureEquations);
         this->wellMod_.addWellPressureEquationsDomain(jacobian,
                                                       weights,
                                                       use_well_weights,
+                                                      contract_d_diagonal,
                                                       domainIndex_);
     }
 
@@ -264,10 +268,11 @@ public:
 
     void addWellPressureEquations(PressureMatrix& jacobian,
                                   const X& weights,
-                                  const bool use_well_weights) const
+                                  const bool use_well_weights,
+                                  const bool contract_d_diagonal) const
     {
         OPM_TIMEBLOCK(addWellPressureEquations);
-        wellOper_.addWellPressureEquations(jacobian, weights, use_well_weights);
+        wellOper_.addWellPressureEquations(jacobian, weights, use_well_weights, contract_d_diagonal);
     }
 
     void addWellPressureEquationsStruct(PressureMatrix& jacobian) const
@@ -359,10 +364,11 @@ public:
 
     void addWellPressureEquations(PressureMatrix& jacobian,
                                   const X& weights,
-                                  const bool use_well_weights) const
+                                  const bool use_well_weights,
+                                  const bool contract_d_diagonal) const
     {
         OPM_TIMEBLOCK(addWellPressureEquations);
-        wellOper_.addWellPressureEquations(jacobian, weights, use_well_weights);
+        wellOper_.addWellPressureEquations(jacobian, weights, use_well_weights, contract_d_diagonal);
     }
 
     void addWellPressureEquationsStruct(PressureMatrix& jacobian) const

--- a/opm/simulators/linalg/setupPropertyTree.cpp
+++ b/opm/simulators/linalg/setupPropertyTree.cpp
@@ -327,10 +327,10 @@ setupCPRW(const std::string& /*conf*/, const FlowLinearSolverParameters& p)
     prm.put("preconditioner.type", "cprw"s);
     prm.put("preconditioner.use_well_weights", "false"s);
     prm.put("preconditioner.add_wells", "true"s);
-    // "auto" keeps the historical coarse well diagonal: contract D for standard
-    // wells, minus the row sum for multisegment wells. "contract_d" contracts D
-    // for both, which keeps the segment-to-segment coupling.
-    prm.put("preconditioner.well_coarse_diagonal", "auto"s);
+    // Coarse well diagonal for multisegment wells: "row_sum" is the historical
+    // minus-the-row-sum, "contract_d" contracts D and so keeps the
+    // segment-to-segment coupling. Standard wells contract D either way.
+    prm.put("preconditioner.well_coarse_diagonal", "row_sum"s);
     prm.put("preconditioner.weight_type", "trueimpes"s);
     prm.put("preconditioner.pre_smooth", 0);
     prm.put("preconditioner.post_smooth", 1);

--- a/opm/simulators/linalg/setupPropertyTree.cpp
+++ b/opm/simulators/linalg/setupPropertyTree.cpp
@@ -327,6 +327,10 @@ setupCPRW(const std::string& /*conf*/, const FlowLinearSolverParameters& p)
     prm.put("preconditioner.type", "cprw"s);
     prm.put("preconditioner.use_well_weights", "false"s);
     prm.put("preconditioner.add_wells", "true"s);
+    // "auto" keeps the historical coarse well diagonal: contract D for standard
+    // wells, minus the row sum for multisegment wells. "contract_d" contracts D
+    // for both, which keeps the segment-to-segment coupling.
+    prm.put("preconditioner.well_coarse_diagonal", "auto"s);
     prm.put("preconditioner.weight_type", "trueimpes"s);
     prm.put("preconditioner.pre_smooth", 0);
     prm.put("preconditioner.post_smooth", 1);

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -304,11 +304,13 @@ template<class Scalar> class WellContributions;
 
             void addWellPressureEquations(PressureMatrix& jacobian,
                                           const BVector& weights,
-                                          const bool use_well_weights) const;
+                                          const bool use_well_weights,
+                                          const bool contract_d_diagonal) const;
             void addWellPressureEquationsStruct(PressureMatrix& jacobian) const;
             void addWellPressureEquationsDomain(PressureMatrix& jacobian,
                                                 const BVector& weights,
                                                 const bool use_well_weights,
+                                                const bool contract_d_diagonal,
                                                 const int domainIndex) const
             {
                 if (!nldd_) {
@@ -317,6 +319,7 @@ template<class Scalar> class WellContributions;
                 return nldd_->addWellPressureEquations(jacobian,
                                                        weights,
                                                        use_well_weights,
+                                                       contract_d_diagonal,
                                                        domainIndex);
             }
 

--- a/opm/simulators/wells/BlackoilWellModelNldd.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNldd.hpp
@@ -98,6 +98,7 @@ public:
     void addWellPressureEquations(PressureMatrix& jacobian,
                                   const BVector& weights,
                                   const bool use_well_weights,
+                                  const bool contract_d_diagonal,
                                   const int domainIndex) const;
 
     // prototype for assemble function for ASPIN solveLocal()

--- a/opm/simulators/wells/BlackoilWellModelNldd_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNldd_impl.hpp
@@ -122,6 +122,7 @@ BlackoilWellModelNldd<TypeTag>::
 addWellPressureEquations(PressureMatrix& /*jacobian*/,
                          const BVector& /*weights*/,
                          const bool /*use_well_weights*/,
+                         const bool /*contract_d_diagonal*/,
                          const int /*domainIndex*/) const
 {
     throw std::logic_error("CPRW is not yet implemented for NLDD subdomains");

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1500,7 +1500,8 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     addWellPressureEquations(PressureMatrix& jacobian,
                              const BVector& weights,
-                             const bool use_well_weights) const
+                             const bool use_well_weights,
+                             const bool contract_d_diagonal) const
     {
         int nw = this->numLocalWellsEnd();
         int rdofs = local_num_cells_;
@@ -1514,6 +1515,7 @@ namespace Opm {
                                            weights,
                                            pressureVarIndex,
                                            use_well_weights,
+                                           contract_d_diagonal,
                                            this->wellState());
         }
     }

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1484,7 +1484,8 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     addWellPressureEquations(PressureMatrix& jacobian,
                              const BVector& weights,
-                             const bool use_well_weights) const
+                             const bool use_well_weights,
+                             const bool contract_d_diagonal) const
     {
         int nw = this->numLocalWellsEnd();
         int rdofs = local_num_cells_;
@@ -1498,6 +1499,7 @@ namespace Opm {
                                            weights,
                                            pressureVarIndex,
                                            use_well_weights,
+                                           contract_d_diagonal,
                                            this->wellState());
         }
     }

--- a/opm/simulators/wells/MSWellHelpers.hpp
+++ b/opm/simulators/wells/MSWellHelpers.hpp
@@ -25,6 +25,9 @@
 
 #include <dune/istl/matrix.hh>
 
+#include <cmath>
+#include <cstddef>
+
 namespace Dune {
 template<class Matrix> class UMFPack;
 }
@@ -75,6 +78,39 @@ namespace mswellhelpers
     VectorType
     applyUMFPack(Dune::UMFPack<MatrixType>& linsolver,
                  VectorType x);
+
+    /// Coarse CPRW diagonal for a multisegment well: lambda' D(:,p), summed
+    /// over every segment row and every column of D.
+    ///
+    /// This is the Galerkin diagonal for a prolongation that spreads the well's
+    /// single coarse unknown over all of its segment pressures, which is the
+    /// prolongation the coarse column already assumes. Unlike the row-sum
+    /// convention it keeps the segment-to-segment coupling D carries, which is
+    /// most of a well once there is one segment per connection.
+    ///
+    /// \param D                  the well's diagonal block, segment rows by segment columns
+    /// \param lambda             well weights, one per conservation equation
+    /// \param pressureColumn     the segment-pressure column of a D block
+    ///
+    /// Returns 1 if the contraction cancels exactly, since a zero would make
+    /// the coarse pressure system singular.
+    template <class DiagMatWell, class WellWeight>
+    typename DiagMatWell::field_type
+    contractCprWellDiagonal(const DiagMatWell& D,
+                            const WellWeight& lambda,
+                            const int pressureColumn)
+    {
+        using Scalar = typename DiagMatWell::field_type;
+        Scalar diag = 0.0;
+        for (std::size_t row = 0; row < D.N(); ++row) {
+            for (auto col = D[row].begin(), end = D[row].end(); col != end; ++col) {
+                for (std::size_t i = 0; i < lambda.size(); ++i) {
+                    diag += lambda[i] * (*col)[i][pressureColumn];
+                }
+            }
+        }
+        return (std::abs(diag) > 0.0) ? diag : Scalar{1.0};
+    }
 
 
 

--- a/opm/simulators/wells/MSWellHelpers.hpp
+++ b/opm/simulators/wells/MSWellHelpers.hpp
@@ -96,9 +96,10 @@ namespace mswellhelpers
     /// Returns 1 if the contraction cancels exactly, since a zero would make
     /// the coarse pressure system singular.
     ///
-    /// Keep in sync with the inline D-loop in
-    /// SystemCprwPressureStage::assembleCoarseMatrix: same contraction, over
-    /// merged blocks rather than a Dune BCRSMatrix.
+    /// SystemCprwPressureStage::assembleCoarseMatrix runs the same inner
+    /// kernel over its merged matrix, but distributes into a whole coarse row
+    /// with per-block weights instead of accumulating one well's D into a
+    /// single scalar, so the two are not one function.
     template <class DiagMatWell, class WellWeight>
     typename DiagMatWell::field_type
     contractCprWellDiagonal(const DiagMatWell& D,

--- a/opm/simulators/wells/MSWellHelpers.hpp
+++ b/opm/simulators/wells/MSWellHelpers.hpp
@@ -26,6 +26,7 @@
 #include <dune/istl/matrix.hh>
 
 #include <cmath>
+#include <cassert>
 #include <cstddef>
 
 namespace Dune {
@@ -94,6 +95,10 @@ namespace mswellhelpers
     ///
     /// Returns 1 if the contraction cancels exactly, since a zero would make
     /// the coarse pressure system singular.
+    ///
+    /// Keep in sync with the inline D-loop in
+    /// SystemCprwPressureStage::assembleCoarseMatrix: same contraction, over
+    /// merged blocks rather than a Dune BCRSMatrix.
     template <class DiagMatWell, class WellWeight>
     typename DiagMatWell::field_type
     contractCprWellDiagonal(const DiagMatWell& D,
@@ -101,6 +106,13 @@ namespace mswellhelpers
                             const int pressureColumn)
     {
         using Scalar = typename DiagMatWell::field_type;
+        using Block = typename DiagMatWell::block_type;
+
+        // lambda indexes the conservation-equation rows of a D block, so the
+        // weights must not outrun them.  Catches a future reordering of the
+        // well primary variables that puts something else in the first rows.
+        assert(lambda.size() <= static_cast<std::size_t>(Block::rows));
+
         Scalar diag = 0.0;
         for (std::size_t row = 0; row < D.N(); ++row) {
             for (auto col = D[row].begin(), end = D[row].end(); col != end; ++col) {

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -175,6 +175,7 @@ namespace Opm {
                                       const BVector& x,
                                       const int pressureVarIndex,
                                       const bool use_well_weights,
+                                      const bool contract_d_diagonal,
                                       const WellStateType& well_state) const override;
 
         std::vector<Scalar>

--- a/opm/simulators/wells/MultisegmentWellEquations.cpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.cpp
@@ -373,6 +373,7 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
                          const BVector& weights,
                          const int pressureVarIndex,
                          const bool /*use_well_weights*/,
+                         const bool contract_d_diagonal,
                          const WellInterfaceGeneric<Scalar, IndexTraits>& well,
                          const int seg_pressure_var_ind,
                          const WellState<Scalar, IndexTraits>& well_state) const
@@ -438,6 +439,14 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
             }
         }
 
+        // Standard wells have always contracted D for the coarse diagonal;
+        // only this path was left on the row sum.
+        if (contract_d_diagonal) {
+            diag_ell = mswellhelpers::contractCprWellDiagonal(duneD_,
+                                                              well_weight,
+                                                              seg_pressure_var_ind);
+        }
+
 #define EXTRA_DEBUG_MSW 0
 #if EXTRA_DEBUG_MSW
         if (diag_ell <= 0.0) {
@@ -473,6 +482,7 @@ sumDistributed(Parallel::Communication comm)
         extractCPRPressureMatrix(Dune::BCRSMatrix<MatrixBlock<T,1,1>>&,                        \
                                  const MultisegmentWellEquations<T,BlackOilDefaultFluidSystemIndices,numWellEq,numEq>::BVector&, \
                                  const int,                                                    \
+                                 const bool,                                                   \
                                  const bool,                                                   \
                                  const WellInterfaceGeneric<T,BlackOilDefaultFluidSystemIndices>&,                               \
                                  const int,                                                    \

--- a/opm/simulators/wells/MultisegmentWellEquations.hpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.hpp
@@ -122,6 +122,7 @@ public:
                                   const BVector& weights,
                                   const int pressureVarIndex,
                                   const bool /*use_well_weights*/,
+                                  const bool contract_d_diagonal,
                                   const WellInterfaceGeneric<Scalar, IndexTraits>& well,
                                   const int seg_pressure_var_ind,
                                   const WellState<Scalar, IndexTraits>& well_state) const;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -908,6 +908,7 @@ namespace Opm
                              const BVector& weights,
                              const int pressureVarIndex,
                              const bool use_well_weights,
+                             const bool contract_d_diagonal,
                              const WellStateType& well_state) const
     {
         if (this->number_of_local_perforations_ == 0) {
@@ -919,6 +920,7 @@ namespace Opm
                                                weights,
                                                pressureVarIndex,
                                                use_well_weights,
+                                               contract_d_diagonal,
                                                *this,
                                                this->SPres,
                                                well_state);

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -181,6 +181,7 @@ namespace Opm
                                       const BVector& x,
                                       const int pressureVarIndex,
                                       const bool use_well_weights,
+                                      const bool contract_d_diagonal,
                                       const WellStateType& well_state) const override;
 
         // iterate well equations with the specified control until converged

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -287,6 +287,7 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
                          const BVector& weights,
                          const int pressureVarIndex,
                          const bool use_well_weights,
+                         const bool /*contract_d_diagonal*/, // a standard well always contracts D
                          const WellInterfaceGeneric<Scalar, IndexTraits>& well,
                          const int bhp_var_index,
                          const WellState<Scalar, IndexTraits>& well_state) const
@@ -425,6 +426,7 @@ sumDistributed(Parallel::Communication comm)
         extractCPRPressureMatrix(Dune::BCRSMatrix<MatrixBlock<T,1,1>>&,               \
                                  const typename StandardWellEquations<T,BlackOilDefaultFluidSystemIndices,N>::BVector&, \
                                  const int,                                           \
+                                 const bool,                                          \
                                  const bool,                                          \
                                  const WellInterfaceGeneric<T,BlackOilDefaultFluidSystemIndices>&,                      \
                                  const int,                                           \

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -113,6 +113,7 @@ public:
                                   const BVector& weights,
                                   const int pressureVarIndex,
                                   const bool use_well_weights,
+                                  const bool contract_d_diagonal,
                                   const WellInterfaceGeneric<Scalar, IndexTraits>& well,
                                   const int bhp_var_index,
                                   const WellState<Scalar, IndexTraits>& well_state) const;

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1987,12 +1987,14 @@ namespace Opm
                                                     const BVector& weights,
                                                     const int pressureVarIndex,
                                                     const bool use_well_weights,
+                                                    const bool contract_d_diagonal,
                                                     const WellStateType& well_state) const
     {
         this->linSys_.extractCPRPressureMatrix(jacobian,
                                                weights,
                                                pressureVarIndex,
                                                use_well_weights,
+                                               contract_d_diagonal,
                                                *this,
                                                Bhp,
                                                well_state);

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -284,6 +284,7 @@ public:
                                           const BVector& x,
                                           const int pressureVarIndex,
                                           const bool use_well_weights,
+                                          const bool contract_d_diagonal,
                                           const WellStateType& well_state) const = 0;
 
     void addCellRates(std::map<int, RateVector>& cellRates_) const;

--- a/tests/test_MswCprWellDiagonal.cpp
+++ b/tests/test_MswCprWellDiagonal.cpp
@@ -1,0 +1,103 @@
+/*
+  Copyright Equinor ASA 2026
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <config.h>
+#define BOOST_TEST_MODULE OPM_test_MswCprWellDiagonal
+#include <boost/test/unit_test.hpp>
+
+#include <opm/simulators/wells/MSWellHelpers.hpp>
+
+#include <dune/common/fmatrix.hh>
+#include <dune/common/fvector.hh>
+#include <dune/istl/bcrsmatrix.hh>
+
+#include <cstddef>
+
+namespace {
+
+using Scalar = double;
+constexpr int numWellEq = 4; // three conservation equations plus segment pressure
+constexpr int pressureColumn = numWellEq - 1;
+
+using Block = Dune::FieldMatrix<Scalar, numWellEq, numWellEq>;
+using DiagMatWell = Dune::BCRSMatrix<Block>;
+using WellWeight = Dune::FieldVector<Scalar, 3>;
+
+// Two segments, each with an entry on the other: the tridiagonal pattern an
+// inlet/outlet pair produces. Only the pressure column is filled, since that is
+// all the contraction reads.
+DiagMatWell makeD(const Scalar d00, const Scalar d01,
+                  const Scalar d10, const Scalar d11)
+{
+    DiagMatWell D(2, 2, 4, DiagMatWell::row_wise);
+    for (auto row = D.createbegin(); row != D.createend(); ++row) {
+        row.insert(0);
+        row.insert(1);
+    }
+    D = 0.0;
+    // Put the same value on every conservation row, so the contraction against
+    // a weight vector is just (sum of weights) times that value.
+    for (int i = 0; i < 3; ++i) {
+        D[0][0][i][pressureColumn] = d00;
+        D[0][1][i][pressureColumn] = d01;
+        D[1][0][i][pressureColumn] = d10;
+        D[1][1][i][pressureColumn] = d11;
+    }
+    return D;
+}
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_CASE(ContractionSumsEveryBlockOfD)
+{
+    const auto D = makeD(2.0, -0.5, -0.25, 3.0);
+    const WellWeight lambda {0.5, 0.25, 0.125};
+    const Scalar weightSum = 0.5 + 0.25 + 0.125;
+
+    const auto diag = Opm::mswellhelpers::contractCprWellDiagonal(D, lambda, pressureColumn);
+
+    // (2.0 - 0.5 - 0.25 + 3.0) * sum(lambda)
+    BOOST_CHECK_CLOSE(diag, 4.25 * weightSum, 1e-12);
+}
+
+BOOST_AUTO_TEST_CASE(OffDiagonalSegmentCouplingIsKept)
+{
+    // Same diagonal, different segment-to-segment coupling. The row-sum
+    // convention never reads D at all and cannot tell these two apart; the
+    // contraction must.
+    const WellWeight lambda {1.0, 1.0, 1.0};
+    const auto weak = Opm::mswellhelpers::contractCprWellDiagonal(makeD(2.0, 0.0, 0.0, 3.0),
+                                                                  lambda, pressureColumn);
+    const auto strong = Opm::mswellhelpers::contractCprWellDiagonal(makeD(2.0, -0.5, -0.25, 3.0),
+                                                                    lambda, pressureColumn);
+
+    BOOST_CHECK_CLOSE(weak, 5.0 * 3.0, 1e-12);
+    BOOST_CHECK_CLOSE(strong, 4.25 * 3.0, 1e-12);
+    BOOST_CHECK_LT(strong, weak);
+}
+
+BOOST_AUTO_TEST_CASE(ExactCancellationIsRegularised)
+{
+    // A zero here would make the coarse pressure system singular.
+    const auto D = makeD(2.0, -1.0, -1.0, 0.0);
+    const WellWeight lambda {1.0, 1.0, 1.0};
+
+    const auto diag = Opm::mswellhelpers::contractCprWellDiagonal(D, lambda, pressureColumn);
+
+    BOOST_CHECK_EQUAL(diag, 1.0);
+}


### PR DESCRIPTION
Standard wells build their coarse CPRW diagonal by contracting D
(`StandardWellEquations` reads `duneD_[0][0]`). Multisegment wells instead use
minus the row sum of the contracted reservoir entries, which never reads D and so
drops every segment-to-segment coupling — most of the well once there is one
segment per connection.

`preconditioner.well_coarse_diagonal = contract_d` makes the multisegment path
contract D as well. Default `auto` is today's behaviour, so nothing changes unless
asked for. Contracting D is also the Galerkin diagonal for the prolongation the
coarse column already assumes: one coarse value spread over the well's segment
pressures.

The flag is threaded next to `use_well_weights`. The contraction is
`mswellhelpers::contractCprWellDiagonal`, unit tested in `test_MswCprWellDiagonal`;
it returns 1 on exact cancellation, since a zero would make the coarse pressure
system singular.

Full Norne with `--convert-to-multisegment-well=per-connection`, linear iterations:

| | linear iterations |
|---|---|
| `cprw` | 2716 |
| `cprw`, `well_coarse_diagonal = contract_d` | **2646** |

Standard wells are byte-identical either way, as they must be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Note on the `well_coarse_diagonal` config key

This PR's classic path (`PressureBhpTransferPolicy`) accepts `{auto, contract_d}` and defaults to `auto`; #7278's system path accepts `{auto, contract_d, row_sum}` and defaults to `contract_d`. Same key name, different valid set and different default — each preserving its own historical behaviour, which is why they differ. Recorded here so that if the two paths are ever unified, the divergence is a known decision rather than a surprise.
