### PR TITLE
Do not lose precision in Parameters::SetDefault

### DIFF
--- a/opm/models/utils/parametersystem.hpp
+++ b/opm/models/utils/parametersystem.hpp
@@ -36,6 +36,7 @@
 
 #include <cstring>
 #include <functional>
+#include <limits>
 #include <set>
 #include <sstream>
 #include <string>
@@ -216,6 +217,11 @@ void SetDefault(decltype(Param::value) new_value)
 {
     const std::string paramName = detail::getParamName<Param>();
     std::ostringstream oss;
+    // full precision: the default stream setting of 6 significant digits
+    // silently corrupts values on the text round trip
+    if constexpr (std::is_floating_point_v<decltype(Param::value)>) {
+        oss.precision(std::numeric_limits<decltype(Param::value)>::max_digits10);
+    }
     oss << new_value;
     detail::SetDefault_(paramName, oss.str());
 }

--- a/tests/test_parametersystem.cpp
+++ b/tests/test_parametersystem.cpp
@@ -181,3 +181,26 @@ SimpleParamInt="10"
 SimpleParamString="foo"
 )"));
 }
+
+namespace {
+
+struct PrecisionFixture
+{
+    PrecisionFixture()
+    {
+        Opm::Parameters::reset();
+        Opm::Parameters::Register<Opm::Parameters::SimpleParamDouble>("Simple double parameter");
+        // 2^23 + 2^-2: exactly representable, but needs 9 significant digits,
+        // so it does not survive a round trip through 6-digit text.
+        Opm::Parameters::SetDefault<Opm::Parameters::SimpleParamDouble>(8388608.25);
+        Opm::Parameters::endRegistration();
+    }
+};
+
+}
+
+BOOST_FIXTURE_TEST_CASE(SetDefaultKeepsPrecision, PrecisionFixture)
+{
+    BOOST_CHECK_EQUAL(Opm::Parameters::Get<Opm::Parameters::SimpleParamDouble>(),
+                      8388608.25);
+}


### PR DESCRIPTION
SetDefault serializes the value through text at the stream default of 6 significant digits, so SetDefault(8388608.0) is stored as 8.38861e+06 and read back as 8388610. Serialize floating-point values at max_digits10 so the round trip is exact. Command-line values were never affected. Found via a unit test that set a well-scaling default of 2^23; the added test fails without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)