### PR TITLE
Add Parallel Support for Region Variable Descriptors

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -187,6 +187,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/utils/DeferredLogger.cpp
   opm/simulators/utils/FullySupportedFlowKeywords.cpp
   opm/simulators/utils/ParallelFileMerger.cpp
+  opm/simulators/utils/ParallelRegionsetVariableDescriptor.cpp
   opm/simulators/utils/ParallelRestart.cpp
   opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
   opm/simulators/utils/PressureAverage.cpp
@@ -1205,6 +1206,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/utils/gatherDeferredLogger.hpp
   opm/simulators/utils/moduleVersion.hpp
   opm/simulators/utils/ParallelCommunication.hpp
+  opm/simulators/utils/ParallelRegionsetVariableDescriptor.hpp
   opm/simulators/utils/ParallelSerialization.hpp
   opm/simulators/utils/readDeck.hpp
   opm/simulators/utils/satfunc/GasPhaseConsistencyChecks.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -188,6 +188,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/utils/DeferredLogger.cpp
   opm/simulators/utils/FullySupportedFlowKeywords.cpp
   opm/simulators/utils/ParallelFileMerger.cpp
+  opm/simulators/utils/ParallelRegionsetVariableDescriptor.cpp
   opm/simulators/utils/ParallelRestart.cpp
   opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
   opm/simulators/utils/PressureAverage.cpp
@@ -1207,6 +1208,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/utils/gatherDeferredLogger.hpp
   opm/simulators/utils/moduleVersion.hpp
   opm/simulators/utils/ParallelCommunication.hpp
+  opm/simulators/utils/ParallelRegionsetVariableDescriptor.hpp
   opm/simulators/utils/ParallelSerialization.hpp
   opm/simulators/utils/readDeck.hpp
   opm/simulators/utils/satfunc/GasPhaseConsistencyChecks.hpp

--- a/opm/simulators/utils/ParallelRegionsetVariableDescriptor.cpp
+++ b/opm/simulators/utils/ParallelRegionsetVariableDescriptor.cpp
@@ -1,0 +1,47 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#include <opm/simulators/utils/ParallelRegionsetVariableDescriptor.hpp>
+
+#include <opm/simulators/utils/ParallelCommunication.hpp>
+
+#include <cassert>
+#include <memory>
+
+Opm::ParallelRegionsetVariableDescriptor::
+ParallelRegionsetVariableDescriptor(const Parallel::Communication& comm)
+    : data::RegionsetVariableDescriptor {}
+    , comm_ { comm }
+{}
+
+std::unique_ptr<Opm::data::RegionsetVariableDescriptor>
+Opm::ParallelRegionsetVariableDescriptor::clone() const
+{
+    return std::make_unique<ParallelRegionsetVariableDescriptor>(*this);
+}
+
+void Opm::ParallelRegionsetVariableDescriptor::communicateGlobalRegsetMaxIDs()
+{
+    assert (this->regsetMaxID_.has_value());
+
+    this->comm_.max(this->regsetMaxID_->data(),
+                    this->regsetMaxID_->size());
+}

--- a/opm/simulators/utils/ParallelRegionsetVariableDescriptor.hpp
+++ b/opm/simulators/utils/ParallelRegionsetVariableDescriptor.hpp
@@ -1,0 +1,118 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_PARALLEL_REGIONSET_VARIABLE_DESCRIPTOR_HPP
+#define OPM_PARALLEL_REGIONSET_VARIABLE_DESCRIPTOR_HPP
+
+#include <opm/output/data/RegionsetVariableDescriptor.hpp>
+
+#include <opm/simulators/utils/ParallelCommunication.hpp>
+
+#include <memory>
+
+/// \file Component to describe a collection of region sets.
+
+namespace Opm {
+
+    /// Basic information about a collection of region sets.
+    ///
+    /// In particular, this class tracks the maximum region ID for each
+    /// region set registered in the collection.  Common region sets in this
+    /// context include the built-in FIPNUM set as well as user defined
+    /// region sets named FIP*, such as FIPABC or FIP_UZ.  There is
+    /// nevertheless nothing that will prevent including a different
+    /// region set such as PVTNUM or KRNUMX in this collection.
+    ///
+    /// The primary use case for this class is assisting in allocating
+    /// region level summary vectors over region sets.  That allocation
+    /// requires knowing the maximum expected region ID for each pertinent
+    /// region set.
+    ///
+    /// Constructing a descriptor object is a multi-step process.
+    ///
+    ///  -# Create the object through the default constructor
+    ///  -# Call member function prepareDescriptorSet() to set the stage for
+    ///     adding new region sets.
+    ///  -# Incorporate one or more region sets through the addRegionSet()
+    ///     overload set.
+    ///  -# Call member function finaliseDescriptorSet() to analyse the data
+    ///     and set up internal data structures.
+    ///
+    /// Once member function finaliseDescriptorSet() has been called, the
+    /// object should be treated as read-only and only its \c const member
+    /// functions should be invoked by client code.  Calling member function
+    /// prepareDescriptorSet() after finaliseDescriptorSet() is allowed, but
+    /// doing so will discard all information collected until that point and
+    /// will require re-registering all pertinent region sets.
+    ///
+    /// This is the parallel implementation of the descriptor class.  It is
+    /// intended to be used in conjunction with the parallel region variable
+    /// values class, and synchronises the maximum region IDs between MPI ranks.
+    class ParallelRegionsetVariableDescriptor : public data::RegionsetVariableDescriptor
+    {
+    public:
+        /// Deleted default constructor.
+        ParallelRegionsetVariableDescriptor() = delete;
+
+        /// Constructor with MPI communication object.
+        ///
+        /// \param[in] comm MPI communication object.  Communication object
+        /// must outlive the descriptor object.
+        explicit ParallelRegionsetVariableDescriptor(const Parallel::Communication& comm);
+
+        /// Destructor.
+        virtual ~ParallelRegionsetVariableDescriptor() = default;
+
+        /// Copy constructor.
+        ParallelRegionsetVariableDescriptor(const ParallelRegionsetVariableDescriptor&) = default;
+
+        /// Move constructor.
+        ParallelRegionsetVariableDescriptor(ParallelRegionsetVariableDescriptor&&) = default;
+
+        /// Assignment operator.
+        ParallelRegionsetVariableDescriptor&
+        operator=(const ParallelRegionsetVariableDescriptor&) = default;
+
+        /// Move-assignment operator.
+        ParallelRegionsetVariableDescriptor&
+        operator=(ParallelRegionsetVariableDescriptor&&) = default;
+
+        /// Create a deep copy of this object.
+        ///
+        /// Intended for when an object holds a pointer to a base class
+        /// and needs to make a copy of the derived class object.
+        ///
+        /// \return A deep copy of this object.
+        std::unique_ptr<data::RegionsetVariableDescriptor> clone() const override;
+
+    protected:
+        /// Exchange maximum region set IDs if needed.
+        ///
+        /// Parallel implementation that exchanges maximum region IDs across
+        /// all ranks.
+        void communicateGlobalRegsetMaxIDs() override;
+
+    private:
+        /// MPI communication object.
+        Parallel::Communication comm_;
+    };
+
+} // namespace Opm
+
+#endif // OPM_PARALLEL_REGIONSET_VARIABLE_DESCRIPTOR_HPP

--- a/opm/simulators/utils/ParallelRegionsetVariableDescriptor.hpp
+++ b/opm/simulators/utils/ParallelRegionsetVariableDescriptor.hpp
@@ -1,0 +1,118 @@
+/*
+  Copyright 2026 Equinor ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_PARALLEL_REGIONSET_VARIABLE_DESCRIPTOR_HPP
+#define OPM_PARALLEL_REGIONSET_VARIABLE_DESCRIPTOR_HPP
+
+#include <opm/output/data/RegionsetVariableDescriptor.hpp>
+
+#include <opm/simulators/utils/ParallelCommunication.hpp>
+
+#include <memory>
+
+/// \file Component to describe a collection of region sets.
+
+namespace Opm {
+
+    /// Basic information about a collection of region sets.
+    ///
+    /// In particular, this class tracks the maximum region ID for each
+    /// region set registered in the collection.  Common region sets in this
+    /// context include the built-in FIPNUM set as well as user defined
+    /// region sets named FIP*, such as FIPABC or FIP_UZ.  There is
+    /// nevertheless nothing that will prevent including a different
+    /// region set such as PVTNUM or KRNUMX in this collection.
+    ///
+    /// The primary use case for this class is assisting in allocating
+    /// region level summary vectors over region sets.  That allocation
+    /// requires knowing the maximum expected region ID for each pertinent
+    /// region set.
+    ///
+    /// Constructing a descriptor object is a multi-step process.
+    ///
+    ///  -# Create the object through the default constructor
+    ///  -# Call member function prepareDescriptorSet() to set the stage for
+    ///     adding new region sets.
+    ///  -# Incorporate one or more region sets through the addRegionSet()
+    ///     overload set.
+    ///  -# Call member function finaliseDescriptorSet() to analyse the data
+    ///     and set up internal data structures.
+    ///
+    /// Once member function finaliseDescriptorSet() has been called, the
+    /// object should be treated as read-only and only its \c const member
+    /// functions should be invoked by client code.  Calling member function
+    /// prepareDescriptorSet() after finaliseDescriptorSet() is allowed, but
+    /// doing so will discard all information collected until that point and
+    /// will require re-registering all pertinent region sets.
+    ///
+    /// This is the parallel implementation of the descriptor class.  It is
+    /// intended to be used in conjunction with the parallel region variable
+    /// values class, and synchronises the maximum region IDs between MPI ranks.
+    class ParallelRegionsetVariableDescriptor : public data::RegionsetVariableDescriptor
+    {
+    public:
+        /// Deleted default constructor.
+        ParallelRegionsetVariableDescriptor() = delete;
+
+        /// Constructor with MPI communication object.
+        ///
+        /// \param[in] comm MPI communication object. Copied into the descriptor;
+        /// the underlying communicator must remain valid for the descriptor's lifetime.
+        explicit ParallelRegionsetVariableDescriptor(const Parallel::Communication& comm);
+
+        /// Destructor.
+        virtual ~ParallelRegionsetVariableDescriptor() = default;
+
+        /// Copy constructor.
+        ParallelRegionsetVariableDescriptor(const ParallelRegionsetVariableDescriptor&) = default;
+
+        /// Move constructor.
+        ParallelRegionsetVariableDescriptor(ParallelRegionsetVariableDescriptor&&) = default;
+
+        /// Assignment operator.
+        ParallelRegionsetVariableDescriptor&
+        operator=(const ParallelRegionsetVariableDescriptor&) = default;
+
+        /// Move-assignment operator.
+        ParallelRegionsetVariableDescriptor&
+        operator=(ParallelRegionsetVariableDescriptor&&) = default;
+
+        /// Create a deep copy of this object.
+        ///
+        /// Intended for when an object holds a pointer to a base class
+        /// and needs to make a copy of the derived class object.
+        ///
+        /// \return A deep copy of this object.
+        std::unique_ptr<data::RegionsetVariableDescriptor> clone() const override;
+
+    protected:
+        /// Exchange maximum region set IDs if needed.
+        ///
+        /// Parallel implementation that exchanges maximum region IDs across
+        /// all ranks.
+        void communicateGlobalRegsetMaxIDs() override;
+
+    private:
+        /// MPI communication object.
+        Parallel::Communication comm_;
+    };
+
+} // namespace Opm
+
+#endif // OPM_PARALLEL_REGIONSET_VARIABLE_DESCRIPTOR_HPP

--- a/parallelUnitTests.cmake
+++ b/parallelUnitTests.cmake
@@ -85,6 +85,28 @@ opm_add_test(test_parallel_wbp_calculation_well_openconns
     2
 )
 
+opm_add_executable(
+  TARGET
+    test_parallel_regionsetvariabledescriptor
+  SOURCES
+    tests/test_parallel_regionsetvariabledescriptor.cpp
+  LIBRARIES
+    opmcommon
+    opmsimulators
+    Boost::unit_test_framework
+)
+
+foreach(NPROC 2 3 4)
+  opm_add_test(test_parallel_regionsetvariabledescriptor_np${NPROC}
+    EXE_TARGET
+      test_parallel_regionsetvariabledescriptor
+    DRIVER_ARGS
+      -n ${NPROC}
+    PROCESSORS
+      ${NPROC}
+  )
+endforeach()
+
 foreach(NPROC 2 3 4)
   opm_add_test(test_rftcontainer_np${NPROC}
     EXE_TARGET

--- a/tests/test_parallel_regionsetvariabledescriptor.cpp
+++ b/tests/test_parallel_regionsetvariabledescriptor.cpp
@@ -1,0 +1,1719 @@
+/*
+  Copyright 2026 Equinor AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#define BOOST_TEST_MODULE TestParallelRegionSetVariableDescriptor
+
+#define BOOST_TEST_NO_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/simulators/utils/ParallelRegionsetVariableDescriptor.hpp>
+
+#include <opm/simulators/utils/ParallelCommunication.hpp>
+
+#include <dune/common/parallel/mpihelper.hh>
+
+#include <array>
+#include <cstddef>
+#include <deque>
+#include <iostream>
+#include <forward_list>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+    struct MPIError
+    {
+        MPIError(std::string_view errstr, const int ec)
+            : errorstring { errstr }
+            , errorcode   { ec }
+        {}
+
+        std::string errorstring;
+        int errorcode;
+    };
+
+    void MPI_err_handler(MPI_Comm*, int* err_code, ...)
+    {
+        std::array<char, MPI_MAX_ERROR_STRING> err_string_vec{'\0'};
+        auto err_length = 0;
+
+        MPI_Error_string(*err_code, err_string_vec.data(), &err_length);
+
+        auto err_string = std::string_view {
+            err_string_vec.data(),
+            static_cast<std::string_view::size_type>(err_length)
+        };
+
+        std::cerr << "An MPI Error ocurred:\n  -> " << err_string << '\n';
+
+        throw MPIError { err_string, *err_code };
+    }
+
+    // Register a throwing error handler to allow for debugging with
+    //
+    //   catch throw
+    //
+    // in GDB.
+    void register_error_handler()
+    {
+        MPI_Errhandler handler{};
+
+        MPI_Comm_create_errhandler(MPI_err_handler, &handler);
+        MPI_Comm_set_errhandler(MPI_COMM_WORLD, handler);
+    }
+
+    class NProc_Is
+    {
+    public:
+        explicit NProc_Is(const int expectNP)
+            : expectNP_ { expectNP }
+        {}
+
+        boost::test_tools::assertion_result
+        operator()(boost::unit_test::test_unit_id) const
+        {
+            auto comm = Opm::Parallel::Communication {
+                Dune::MPIHelper::getCommunicator()
+            };
+
+            if (comm.size() == this->expectNP_) {
+                return true;
+            }
+
+            boost::test_tools::assertion_result response(false);
+            response.message() << "Number of MPI processes ("
+                               << comm.size()
+                               << ") differs from expected "
+                               << this->expectNP_;
+
+            return response;
+        }
+
+    private:
+        int expectNP_{};
+    };
+
+    bool init_unit_test_func()
+    {
+        return true;
+    }
+
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(Single_Regset)
+
+BOOST_AUTO_TEST_SUITE(NProc_2, * boost::unit_test::precondition(NProc_Is{2}))
+
+BOOST_AUTO_TEST_CASE(Empty)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 2);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+    d.addRegionSet(/* maxRegionID = */ 0); // FIELD or similar.
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 2);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* maxRegionID = */ 1); // FIELD or similar.
+    }
+    else {
+        d.addRegionSet(/* maxRegionID = */ 3);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{4});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Common_Max_Declared)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 2);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                   std::array { 1, 1, 1, 2, 2, 0, 1, });
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{4});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Common_Max_Value)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 2);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 1,
+                   std::array { 1, 1, 1, 2, 2, 5, 1, });
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Distinct_Max_Declared)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 2);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 1, 1, 1, });
+    }
+    else {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 2, 0, 1, });
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{4});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Distinct_Max_Value)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 2);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 1, 1, 5, });
+    }
+    else {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 2, 0, 1, });
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // NProc_2
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(NProc_3, * boost::unit_test::precondition(NProc_Is{3}))
+
+BOOST_AUTO_TEST_CASE(Empty)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+    d.addRegionSet(/* maxRegionID = */ 0); // FIELD or similar.
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* maxRegionID = */ 1);
+    }
+    else if (comm.rank() == 1) {
+        d.addRegionSet(/* maxRegionID = */ 3);
+    }
+    else {
+        d.addRegionSet(/* maxRegionID = */ 5);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Common_Max_Declared)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 5,
+                   std::array { 1, 1, 1, 2, 2, 0, 1, });
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Common_Max_Value)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 1,
+                   std::array { 1, 1, 1, 2, 2, 5, 1, });
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Distinct_Max_Declared)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 1, 1, 1, });
+    }
+    else if (comm.rank() == 1) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 2, 0, 1, });
+    }
+    else {
+        d.addRegionSet(/* declaredMaxRegionID = */ 4,
+                       std::array { 3, 2, 1, });
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Distinct_Max_Value)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 1, 1, 5, });
+    }
+    else if (comm.rank() == 1) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 2, 0, 1, });
+    }
+    else {
+        d.addRegionSet(/* declaredMaxRegionID = */ 4,
+                       std::array { 3, 2, 1, });
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // NProc_3
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(NProc_4, * boost::unit_test::precondition(NProc_Is{4}))
+
+BOOST_AUTO_TEST_CASE(Empty)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+    d.addRegionSet(/* maxRegionID = */ 0); // FIELD or similar.
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* maxRegionID = */ 1);
+    }
+    else if (comm.rank() == 1) {
+        d.addRegionSet(/* maxRegionID = */ 3);
+    }
+    else if (comm.rank() == 2) {
+        d.addRegionSet(/* maxRegionID = */ 5);
+    }
+    else {
+        d.addRegionSet(/* maxRegionID = */ 7);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{8});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Common_Max_Declared)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 7,
+                   std::array { 1, 1, 1, 2, 2, 0, 1, });
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{8});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Common_Max_Value)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 1,
+                   std::array { 1, 1, 1, 2, 2, 5, 1, });
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Distinct_Max_Declared)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 1, 1, 1, });
+    }
+    else if (comm.rank() == 1) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 2, 0, 1, });
+    }
+    else if (comm.rank() == 2) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 4,
+                       std::array { 3, 2, 1, });
+    }
+    else {
+        d.addRegionSet(/* declaredMaxRegionID = */ 5,
+                       std::array { 4, 4, 2, });
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Distinct_Max_Value)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 1, 1, 5, });
+    }
+    else if (comm.rank() == 1) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 2, 0, 1, });
+    }
+    else if (comm.rank() == 2) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 4,
+                       std::array { 3, 2, 1, });
+    }
+    else {
+        d.addRegionSet(/* declaredMaxRegionID = */ 4,
+                       std::array { 4, 4, 8, });
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{9});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // NProc_4
+
+BOOST_AUTO_TEST_SUITE_END()     // Single_Regset
+
+// ===========================================================================
+
+BOOST_AUTO_TEST_SUITE(Two_Regsets)
+
+BOOST_AUTO_TEST_SUITE(NProc_2, * boost::unit_test::precondition(NProc_Is{2}))
+
+BOOST_AUTO_TEST_CASE(Single_Region)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor{ comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{1});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor{ comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* maxRegionID = */ 5); // Supports regions 0..5
+    }
+    else {
+        d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+    }
+
+    d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{10});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{6});
+}
+
+BOOST_AUTO_TEST_CASE(Single_Region_Scan_Regions)
+{
+    const auto reg_1 = std::vector { 0, 0, 0, 0, 0, };
+    const auto reg_2 = std::deque { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, };
+
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor{ comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_1);
+    d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_2);
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{1});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_I)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor{ comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 1, 1, 3, };
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{10});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{6});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_II)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor{ comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 2, 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{10});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{4});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_III)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor{ comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 2, 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{8});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{4});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_IV)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor{ comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 17, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 29, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 2, 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 17, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 29, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{48});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{18});
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // NProc_2
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(NProc_3, * boost::unit_test::precondition(NProc_Is{3}))
+
+BOOST_AUTO_TEST_CASE(Empty)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+    d.addRegionSet(/* maxRegionID = */ 0); // FIELD or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // FIELD or similar.
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{1});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* maxRegionID = */ 5); // Supports regions 0..5
+    }
+    else if (comm.rank() == 1) {
+        d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+    }
+    else {
+        d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+    }
+
+    d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{10});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{6});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_I)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_2);
+    }
+    else if (comm.rank() == 1) {
+        const auto reg_1 = std::vector { 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 3, 3, };
+        const auto reg_2 = std::array { 3, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{10});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{6});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_II)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_2);
+    }
+    else if (comm.rank() == 1) {
+        const auto reg_1 = std::vector { 2, 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 3, };
+        const auto reg_2 = std::array { 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{10});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{4});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_III)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_2);
+    }
+    else if (comm.rank() == 1) {
+        const auto reg_1 = std::vector { 2, 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 3, };
+        const auto reg_2 = std::array { 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{8});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{4});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_IV)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 17, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 29, reg_2);
+    }
+    else if (comm.rank() == 1) {
+        const auto reg_1 = std::vector { 2, 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 17, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 29, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 3, };
+        const auto reg_2 = std::array { 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 17, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 29, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{48});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{18});
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // NProc_3
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(NProc_4, * boost::unit_test::precondition(NProc_Is{4}))
+
+BOOST_AUTO_TEST_CASE(Empty)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+    d.addRegionSet(/* maxRegionID = */ 0); // FIELD or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // FIELD or similar.
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{1});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* maxRegionID = */ 5); // Supports regions 0..5
+    }
+    else if (comm.rank() == 1) {
+        d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+    }
+    else if (comm.rank() == 2) {
+        d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+    }
+    else {
+        d.addRegionSet(/* maxRegionID = */ 7); // Supports regions 0..7
+    }
+
+    d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{12});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{8});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_I)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_2);
+    }
+    else if (comm.rank() == 1) {
+        const auto reg_1 = std::vector { 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_2);
+    }
+    else if (comm.rank() == 2) {
+        const auto reg_1 = std::vector { 3, };
+        const auto reg_2 = std::array { 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 4, };
+        const auto reg_2 = std::array { 4, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{11});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{6});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_II)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_2);
+    }
+    else if (comm.rank() == 1) {
+        const auto reg_1 = std::vector { 2, 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_2);
+    }
+    else if (comm.rank() == 2) {
+        const auto reg_1 = std::vector { 3, };
+        const auto reg_2 = std::array { 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 4, };
+        const auto reg_2 = std::array { 4, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{11});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{5});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_III)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_2);
+    }
+    else if (comm.rank() == 1) {
+        const auto reg_1 = std::vector { 2, 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_2);
+    }
+    else if (comm.rank() == 2) {
+        const auto reg_1 = std::vector { 3, };
+        const auto reg_2 = std::array { 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 4, };
+        const auto reg_2 = std::array { 4, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{10});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{5});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_IV)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 17, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 29, reg_2);
+    }
+    else if (comm.rank() == 1) {
+        const auto reg_1 = std::vector { 2, 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 17, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 29, reg_2);
+    }
+    else if (comm.rank() == 2) {
+        const auto reg_1 = std::vector { 3, };
+        const auto reg_2 = std::array { 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 17, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 29, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 4, };
+        const auto reg_2 = std::array { 4, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 17, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 29, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{48});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{18});
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // NProc_4
+
+BOOST_AUTO_TEST_SUITE_END()     // Two_Regsets
+
+// ===========================================================================
+
+BOOST_AUTO_TEST_SUITE(Multiple_Regsets)
+
+BOOST_AUTO_TEST_SUITE(NProc_2, * boost::unit_test::precondition(NProc_Is{2}))
+
+BOOST_AUTO_TEST_CASE(Single_Region)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 2);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{3});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{4});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 2);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* maxRegionID = */ 4); // Supports regions 0..4
+        d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+    }
+    else {
+        d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+        d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+    }
+
+    d.addRegionSet(/* maxRegionID = */ 2); // Supports regions 0..2
+    d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+    d.addRegionSet(/* maxRegionID = */ 0); // Supports regions 0..0
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{15});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{ 0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{ 5});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{ 9});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{12});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{14});
+}
+
+BOOST_AUTO_TEST_CASE(Scan_Regions)
+{
+    const auto reg_1 = std::vector<int> {};
+    const auto reg_2 = std::vector { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, };
+    const auto reg_5 = std::deque { 11, 22, 33, 17, 29, };
+    const auto reg_6 = std::array { 0, 1, 0, 2, 3, 0, 1, };
+
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 2);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */  5, reg_1); // max ID =  5
+    d.addRegionSet(/* declaredMaxRegionID = */ 42, reg_2); // max ID = 42
+
+    if (comm.rank() == 0) {
+        const auto reg_3 = std::vector { 5, 9, 26, };
+        const auto reg_4 = std::forward_list { 0, 0, 0 };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_3); // max ID = 26
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_4); // max ID =  0
+    }
+    else {
+        const auto reg_3 = std::vector { 3, 14, 1, };
+        const auto reg_4 = std::forward_list { 0, 0, 0 };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_3); // max ID = 26
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_4); // max ID =  0
+    }
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 11, reg_5); // max ID = 33
+    d.addRegionSet(/* declaredMaxRegionID = */  5, reg_6); // max ID =  5
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{117});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{  0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{  6});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{ 49});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{ 76});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{ 77});
+    BOOST_CHECK_EQUAL(d.startIndex(5), std::size_t{111});
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // NProc_2
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(NProc_3, * boost::unit_test::precondition(NProc_Is{3}))
+
+BOOST_AUTO_TEST_CASE(Single_Region)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{3});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{4});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* maxRegionID = */ 5); // Supports regions 0..5
+        d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+    }
+    else if (comm.rank() == 1) {
+        d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+        d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+    }
+    else {
+        d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+        d.addRegionSet(/* maxRegionID = */ 7); // Supports regions 0..7
+    }
+
+    d.addRegionSet(/* maxRegionID = */ 2); // Supports regions 0..2
+    d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+    d.addRegionSet(/* maxRegionID = */ 0); // Supports regions 0..0
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{20});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{ 0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{ 6});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{14});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{17});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{19});
+}
+
+BOOST_AUTO_TEST_CASE(Scan_Regions)
+{
+    const auto reg_1 = std::vector<int> {};
+    const auto reg_2 = std::vector { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, };
+    const auto reg_5 = std::deque { 11, 22, 33, 17, 29, };
+    const auto reg_6 = std::array { 0, 1, 0, 2, 3, 0, 1, };
+
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */  5, reg_1); // max ID =  5
+    d.addRegionSet(/* declaredMaxRegionID = */ 42, reg_2); // max ID = 42
+
+    if (comm.rank() == 0) {
+        const auto reg_3 = std::vector { 5, 9, 26, };
+        const auto reg_4 = std::forward_list { 0, 0, 0 };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_3); // max ID = 26
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_4); // max ID =  0
+    }
+    else if (comm.rank() == 1) {
+        const auto reg_3 = std::vector { 3, 14, 1, };
+        const auto reg_4 = std::forward_list { 0, 0, 0 };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_3); // max ID = 26
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_4); // max ID = 26
+    }
+    else {
+        const auto reg_3 = std::vector { 5, 3, 5, };
+        const auto reg_4 = std::forward_list<int> {};
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_3); // max ID = -1
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_4); // max ID = -1
+    }
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 11, reg_5); // max ID = 33
+    d.addRegionSet(/* declaredMaxRegionID = */  5, reg_6); // max ID =  5
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{117});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{  0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{  6});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{ 49});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{ 76});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{ 77});
+    BOOST_CHECK_EQUAL(d.startIndex(5), std::size_t{111});
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // NProc_3
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(NProc_4, * boost::unit_test::precondition(NProc_Is{4}))
+
+BOOST_AUTO_TEST_CASE(Single_Region)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{3});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{4});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* maxRegionID = */ 5); // Supports regions 0..5
+        d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+    }
+    else if (comm.rank() == 1) {
+        d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+        d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+    }
+    else if (comm.rank() == 2) {
+        d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+        d.addRegionSet(/* maxRegionID = */ 7); // Supports regions 0..7
+    }
+    else {
+        d.addRegionSet(/* maxRegionID = */ 7); // Supports regions 0..7
+        d.addRegionSet(/* maxRegionID = */ 9); // Supports regions 0..9
+    }
+
+    d.addRegionSet(/* maxRegionID = */ 2); // Supports regions 0..2
+    d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+    d.addRegionSet(/* maxRegionID = */ 0); // Supports regions 0..0
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{24});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{ 0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{ 8});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{18});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{21});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{23});
+}
+
+BOOST_AUTO_TEST_CASE(Scan_Regions)
+{
+    const auto reg_1 = std::vector<int> {};
+    const auto reg_2 = std::vector { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, };
+    const auto reg_5 = std::deque { 11, 22, 33, 17, 29, };
+    const auto reg_6 = std::array { 0, 1, 0, 2, 3, 0, 1, };
+
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */  5, reg_1); // max ID =  5
+    d.addRegionSet(/* declaredMaxRegionID = */ 42, reg_2); // max ID = 42
+
+    if (comm.rank() == 0) {
+        const auto reg_3 = std::vector { 5, 9, 26, };
+        const auto reg_4 = std::forward_list { 0, 0, 0 };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_3); // max ID = -1
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_4); // max ID = -1
+    }
+    else if (comm.rank() == 1) {
+        const auto reg_3 = std::vector { 3, 14, 1, };
+        const auto reg_4 = std::forward_list { 0, 0, 0 };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_3); // max ID = -1
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_4); // max ID = -1
+    }
+    else if (comm.rank() == 2) {
+        const auto reg_3 = std::vector<int> {};
+        const auto reg_4 = std::forward_list<int> {};
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_3); // max ID = -1
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_4); // max ID = -1
+    }
+    else if (comm.rank() == 3) {
+        const auto reg_3 = std::vector<int> {};
+        const auto reg_4 = std::forward_list<int> {};
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_3); // max ID = -1
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_4); // max ID = -1
+    }
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 11, reg_5); // max ID = 33
+    d.addRegionSet(/* declaredMaxRegionID = */  5, reg_6); // max ID =  5
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{117});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{  0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{  6});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{ 49});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{ 76});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{ 77});
+    BOOST_CHECK_EQUAL(d.startIndex(5), std::size_t{111});
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // NProc_4
+
+BOOST_AUTO_TEST_SUITE_END()     // Multiple_Regsets
+
+// ===========================================================================
+
+int main(int argc, char** argv)
+{
+    Dune::MPIHelper::instance(argc, argv);
+
+    register_error_handler();
+
+    return boost::unit_test::unit_test_main(&init_unit_test_func, argc, argv);
+}

--- a/tests/test_parallel_regionsetvariabledescriptor.cpp
+++ b/tests/test_parallel_regionsetvariabledescriptor.cpp
@@ -1,0 +1,1719 @@
+/*
+  Copyright 2026 Equinor AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#define BOOST_TEST_MODULE TestParallelRegionSetVariableDescriptor
+
+#define BOOST_TEST_NO_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/simulators/utils/ParallelRegionsetVariableDescriptor.hpp>
+
+#include <opm/simulators/utils/ParallelCommunication.hpp>
+
+#include <dune/common/parallel/mpihelper.hh>
+
+#include <array>
+#include <cstddef>
+#include <deque>
+#include <iostream>
+#include <forward_list>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+    struct MPIError
+    {
+        MPIError(std::string_view errstr, const int ec)
+            : errorstring { errstr }
+            , errorcode   { ec }
+        {}
+
+        std::string errorstring;
+        int errorcode;
+    };
+
+    void MPI_err_handler(MPI_Comm*, int* err_code, ...)
+    {
+        std::array<char, MPI_MAX_ERROR_STRING> err_string_vec{'\0'};
+        auto err_length = 0;
+
+        MPI_Error_string(*err_code, err_string_vec.data(), &err_length);
+
+        auto err_string = std::string_view {
+            err_string_vec.data(),
+            static_cast<std::string_view::size_type>(err_length)
+        };
+
+        std::cerr << "An MPI Error occurred:\n  -> " << err_string << '\n';
+
+        throw MPIError { err_string, *err_code };
+    }
+
+    // Register a throwing error handler to allow for debugging with
+    //
+    //   catch throw
+    //
+    // in GDB.
+    void register_error_handler()
+    {
+        MPI_Errhandler handler{};
+
+        MPI_Comm_create_errhandler(MPI_err_handler, &handler);
+        MPI_Comm_set_errhandler(MPI_COMM_WORLD, handler);
+    }
+
+    class NProc_Is
+    {
+    public:
+        explicit NProc_Is(const int expectNP)
+            : expectNP_ { expectNP }
+        {}
+
+        boost::test_tools::assertion_result
+        operator()(boost::unit_test::test_unit_id) const
+        {
+            auto comm = Opm::Parallel::Communication {
+                Dune::MPIHelper::getCommunicator()
+            };
+
+            if (comm.size() == this->expectNP_) {
+                return true;
+            }
+
+            boost::test_tools::assertion_result response(false);
+            response.message() << "Number of MPI processes ("
+                               << comm.size()
+                               << ") differs from expected "
+                               << this->expectNP_;
+
+            return response;
+        }
+
+    private:
+        int expectNP_{};
+    };
+
+    bool init_unit_test_func()
+    {
+        return true;
+    }
+
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(Single_Regset)
+
+BOOST_AUTO_TEST_SUITE(NProc_2, * boost::unit_test::precondition(NProc_Is{2}))
+
+BOOST_AUTO_TEST_CASE(Empty)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 2);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+    d.addRegionSet(/* maxRegionID = */ 0); // FIELD or similar.
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 2);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* maxRegionID = */ 1); // FIELD or similar.
+    }
+    else {
+        d.addRegionSet(/* maxRegionID = */ 3);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{4});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Common_Max_Declared)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 2);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                   std::array { 1, 1, 1, 2, 2, 0, 1, });
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{4});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Common_Max_Value)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 2);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 1,
+                   std::array { 1, 1, 1, 2, 2, 5, 1, });
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Distinct_Max_Declared)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 2);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 1, 1, 1, });
+    }
+    else {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 2, 0, 1, });
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{4});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Distinct_Max_Value)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 2);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 1, 1, 5, });
+    }
+    else {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 2, 0, 1, });
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // NProc_2
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(NProc_3, * boost::unit_test::precondition(NProc_Is{3}))
+
+BOOST_AUTO_TEST_CASE(Empty)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+    d.addRegionSet(/* maxRegionID = */ 0); // FIELD or similar.
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* maxRegionID = */ 1);
+    }
+    else if (comm.rank() == 1) {
+        d.addRegionSet(/* maxRegionID = */ 3);
+    }
+    else {
+        d.addRegionSet(/* maxRegionID = */ 5);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Common_Max_Declared)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 5,
+                   std::array { 1, 1, 1, 2, 2, 0, 1, });
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Common_Max_Value)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 1,
+                   std::array { 1, 1, 1, 2, 2, 5, 1, });
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Distinct_Max_Declared)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 1, 1, 1, });
+    }
+    else if (comm.rank() == 1) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 2, 0, 1, });
+    }
+    else {
+        d.addRegionSet(/* declaredMaxRegionID = */ 4,
+                       std::array { 3, 2, 1, });
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Distinct_Max_Value)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 1, 1, 5, });
+    }
+    else if (comm.rank() == 1) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 2, 0, 1, });
+    }
+    else {
+        d.addRegionSet(/* declaredMaxRegionID = */ 4,
+                       std::array { 3, 2, 1, });
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // NProc_3
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(NProc_4, * boost::unit_test::precondition(NProc_Is{4}))
+
+BOOST_AUTO_TEST_CASE(Empty)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+    d.addRegionSet(/* maxRegionID = */ 0); // FIELD or similar.
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* maxRegionID = */ 1);
+    }
+    else if (comm.rank() == 1) {
+        d.addRegionSet(/* maxRegionID = */ 3);
+    }
+    else if (comm.rank() == 2) {
+        d.addRegionSet(/* maxRegionID = */ 5);
+    }
+    else {
+        d.addRegionSet(/* maxRegionID = */ 7);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{8});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Common_Max_Declared)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 7,
+                   std::array { 1, 1, 1, 2, 2, 0, 1, });
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{8});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Common_Max_Value)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 1,
+                   std::array { 1, 1, 1, 2, 2, 5, 1, });
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Distinct_Max_Declared)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 1, 1, 1, });
+    }
+    else if (comm.rank() == 1) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 2, 0, 1, });
+    }
+    else if (comm.rank() == 2) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 4,
+                       std::array { 3, 2, 1, });
+    }
+    else {
+        d.addRegionSet(/* declaredMaxRegionID = */ 5,
+                       std::array { 4, 4, 2, });
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Distinct_Max_Value)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 1, 1, 5, });
+    }
+    else if (comm.rank() == 1) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 3,
+                       std::array { 2, 0, 1, });
+    }
+    else if (comm.rank() == 2) {
+        d.addRegionSet(/* declaredMaxRegionID = */ 4,
+                       std::array { 3, 2, 1, });
+    }
+    else {
+        d.addRegionSet(/* declaredMaxRegionID = */ 4,
+                       std::array { 4, 4, 8, });
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{9});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // NProc_4
+
+BOOST_AUTO_TEST_SUITE_END()     // Single_Regset
+
+// ===========================================================================
+
+BOOST_AUTO_TEST_SUITE(Two_Regsets)
+
+BOOST_AUTO_TEST_SUITE(NProc_2, * boost::unit_test::precondition(NProc_Is{2}))
+
+BOOST_AUTO_TEST_CASE(Single_Region)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor{ comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{1});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor{ comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* maxRegionID = */ 5); // Supports regions 0..5
+    }
+    else {
+        d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+    }
+
+    d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{10});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{6});
+}
+
+BOOST_AUTO_TEST_CASE(Single_Region_Scan_Regions)
+{
+    const auto reg_1 = std::vector { 0, 0, 0, 0, 0, };
+    const auto reg_2 = std::deque { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, };
+
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor{ comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_1);
+    d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_2);
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{1});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_I)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor{ comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 1, 1, 3, };
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{10});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{6});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_II)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor{ comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 2, 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{10});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{4});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_III)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor{ comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 2, 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{8});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{4});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_IV)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor{ comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 17, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 29, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 2, 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 17, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 29, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{48});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{18});
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // NProc_2
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(NProc_3, * boost::unit_test::precondition(NProc_Is{3}))
+
+BOOST_AUTO_TEST_CASE(Empty)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+    d.addRegionSet(/* maxRegionID = */ 0); // FIELD or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // FIELD or similar.
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{1});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* maxRegionID = */ 5); // Supports regions 0..5
+    }
+    else if (comm.rank() == 1) {
+        d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+    }
+    else {
+        d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+    }
+
+    d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{10});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{6});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_I)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_2);
+    }
+    else if (comm.rank() == 1) {
+        const auto reg_1 = std::vector { 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 3, 3, };
+        const auto reg_2 = std::array { 3, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{10});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{6});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_II)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_2);
+    }
+    else if (comm.rank() == 1) {
+        const auto reg_1 = std::vector { 2, 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 3, };
+        const auto reg_2 = std::array { 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{10});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{4});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_III)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_2);
+    }
+    else if (comm.rank() == 1) {
+        const auto reg_1 = std::vector { 2, 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 3, };
+        const auto reg_2 = std::array { 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{8});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{4});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_IV)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 17, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 29, reg_2);
+    }
+    else if (comm.rank() == 1) {
+        const auto reg_1 = std::vector { 2, 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 17, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 29, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 3, };
+        const auto reg_2 = std::array { 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 17, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 29, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{48});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{18});
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // NProc_3
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(NProc_4, * boost::unit_test::precondition(NProc_Is{4}))
+
+BOOST_AUTO_TEST_CASE(Empty)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+    d.addRegionSet(/* maxRegionID = */ 0); // FIELD or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // FIELD or similar.
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{1});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* maxRegionID = */ 5); // Supports regions 0..5
+    }
+    else if (comm.rank() == 1) {
+        d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+    }
+    else if (comm.rank() == 2) {
+        d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+    }
+    else {
+        d.addRegionSet(/* maxRegionID = */ 7); // Supports regions 0..7
+    }
+
+    d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{12});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{8});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_I)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_2);
+    }
+    else if (comm.rank() == 1) {
+        const auto reg_1 = std::vector { 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_2);
+    }
+    else if (comm.rank() == 2) {
+        const auto reg_1 = std::vector { 3, };
+        const auto reg_2 = std::array { 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 4, };
+        const auto reg_2 = std::array { 4, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{11});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{6});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_II)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_2);
+    }
+    else if (comm.rank() == 1) {
+        const auto reg_1 = std::vector { 2, 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_2);
+    }
+    else if (comm.rank() == 2) {
+        const auto reg_1 = std::vector { 3, };
+        const auto reg_2 = std::array { 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 4, };
+        const auto reg_2 = std::array { 4, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 3, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 5, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{11});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{5});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_III)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_2);
+    }
+    else if (comm.rank() == 1) {
+        const auto reg_1 = std::vector { 2, 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_2);
+    }
+    else if (comm.rank() == 2) {
+        const auto reg_1 = std::vector { 3, };
+        const auto reg_2 = std::array { 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 4, };
+        const auto reg_2 = std::array { 4, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 1, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{10});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{5});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions_Scan_Regions_IV)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        const auto reg_1 = std::vector { 1, 1, 2, };
+        const auto reg_2 = std::array { 1, 1, 2, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 17, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 29, reg_2);
+    }
+    else if (comm.rank() == 1) {
+        const auto reg_1 = std::vector { 2, 2, 1, 1, 3, };
+        const auto reg_2 = std::array { 2, 2, 1, 1, 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 17, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 29, reg_2);
+    }
+    else if (comm.rank() == 2) {
+        const auto reg_1 = std::vector { 3, };
+        const auto reg_2 = std::array { 3, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 17, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 29, reg_2);
+    }
+    else {
+        const auto reg_1 = std::vector { 4, };
+        const auto reg_2 = std::array { 4, };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 17, reg_1);
+        d.addRegionSet(/* declaredMaxRegionID = */ 29, reg_2);
+    }
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{48});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{18});
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // NProc_4
+
+BOOST_AUTO_TEST_SUITE_END()     // Two_Regsets
+
+// ===========================================================================
+
+BOOST_AUTO_TEST_SUITE(Multiple_Regsets)
+
+BOOST_AUTO_TEST_SUITE(NProc_2, * boost::unit_test::precondition(NProc_Is{2}))
+
+BOOST_AUTO_TEST_CASE(Single_Region)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 2);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{3});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{4});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 2);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* maxRegionID = */ 4); // Supports regions 0..4
+        d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+    }
+    else {
+        d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+        d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+    }
+
+    d.addRegionSet(/* maxRegionID = */ 2); // Supports regions 0..2
+    d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+    d.addRegionSet(/* maxRegionID = */ 0); // Supports regions 0..0
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{15});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{ 0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{ 5});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{ 9});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{12});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{14});
+}
+
+BOOST_AUTO_TEST_CASE(Scan_Regions)
+{
+    const auto reg_1 = std::vector<int> {};
+    const auto reg_2 = std::vector { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, };
+    const auto reg_5 = std::deque { 11, 22, 33, 17, 29, };
+    const auto reg_6 = std::array { 0, 1, 0, 2, 3, 0, 1, };
+
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 2);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */  5, reg_1); // max ID =  5
+    d.addRegionSet(/* declaredMaxRegionID = */ 42, reg_2); // max ID = 42
+
+    if (comm.rank() == 0) {
+        const auto reg_3 = std::vector { 5, 9, 26, };
+        const auto reg_4 = std::forward_list { 0, 0, 0 };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_3); // max ID = 26
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_4); // max ID =  0
+    }
+    else {
+        const auto reg_3 = std::vector { 3, 14, 1, };
+        const auto reg_4 = std::forward_list { 0, 0, 0 };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_3); // max ID = 26
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_4); // max ID =  0
+    }
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 11, reg_5); // max ID = 33
+    d.addRegionSet(/* declaredMaxRegionID = */  5, reg_6); // max ID =  5
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{117});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{  0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{  6});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{ 49});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{ 76});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{ 77});
+    BOOST_CHECK_EQUAL(d.startIndex(5), std::size_t{111});
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // NProc_2
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(NProc_3, * boost::unit_test::precondition(NProc_Is{3}))
+
+BOOST_AUTO_TEST_CASE(Single_Region)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{3});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{4});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* maxRegionID = */ 5); // Supports regions 0..5
+        d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+    }
+    else if (comm.rank() == 1) {
+        d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+        d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+    }
+    else {
+        d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+        d.addRegionSet(/* maxRegionID = */ 7); // Supports regions 0..7
+    }
+
+    d.addRegionSet(/* maxRegionID = */ 2); // Supports regions 0..2
+    d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+    d.addRegionSet(/* maxRegionID = */ 0); // Supports regions 0..0
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{20});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{ 0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{ 6});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{14});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{17});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{19});
+}
+
+BOOST_AUTO_TEST_CASE(Scan_Regions)
+{
+    const auto reg_1 = std::vector<int> {};
+    const auto reg_2 = std::vector { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, };
+    const auto reg_5 = std::deque { 11, 22, 33, 17, 29, };
+    const auto reg_6 = std::array { 0, 1, 0, 2, 3, 0, 1, };
+
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 3);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */  5, reg_1); // max ID =  5
+    d.addRegionSet(/* declaredMaxRegionID = */ 42, reg_2); // max ID = 42
+
+    if (comm.rank() == 0) {
+        const auto reg_3 = std::vector { 5, 9, 26, };
+        const auto reg_4 = std::forward_list { 0, 0, 0 };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_3); // max ID = 26
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_4); // max ID =  0
+    }
+    else if (comm.rank() == 1) {
+        const auto reg_3 = std::vector { 3, 14, 1, };
+        const auto reg_4 = std::forward_list { 0, 0, 0 };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_3); // max ID = 26
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_4); // max ID =  0
+    }
+    else {
+        const auto reg_3 = std::vector { 5, 3, 5, };
+        const auto reg_4 = std::forward_list<int> {};
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_3); // max ID = 5
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_4); // max ID = 0
+    }
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 11, reg_5); // max ID = 33
+    d.addRegionSet(/* declaredMaxRegionID = */  5, reg_6); // max ID =  5
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{117});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{  0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{  6});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{ 49});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{ 76});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{ 77});
+    BOOST_CHECK_EQUAL(d.startIndex(5), std::size_t{111});
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // NProc_3
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(NProc_4, * boost::unit_test::precondition(NProc_Is{4}))
+
+BOOST_AUTO_TEST_CASE(Single_Region)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+    d.addRegionSet(/* maxRegionID = */ 0); // "FIELD" or similar.
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{1});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{2});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{3});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{4});
+}
+
+BOOST_AUTO_TEST_CASE(Multiple_Regions)
+{
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    if (comm.rank() == 0) {
+        d.addRegionSet(/* maxRegionID = */ 5); // Supports regions 0..5
+        d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+    }
+    else if (comm.rank() == 1) {
+        d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+        d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+    }
+    else if (comm.rank() == 2) {
+        d.addRegionSet(/* maxRegionID = */ 3); // Supports regions 0..3
+        d.addRegionSet(/* maxRegionID = */ 7); // Supports regions 0..7
+    }
+    else {
+        d.addRegionSet(/* maxRegionID = */ 7); // Supports regions 0..7
+        d.addRegionSet(/* maxRegionID = */ 9); // Supports regions 0..9
+    }
+
+    d.addRegionSet(/* maxRegionID = */ 2); // Supports regions 0..2
+    d.addRegionSet(/* maxRegionID = */ 1); // Supports regions 0..1
+    d.addRegionSet(/* maxRegionID = */ 0); // Supports regions 0..0
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{5});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{24});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{ 0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{ 8});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{18});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{21});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{23});
+}
+
+BOOST_AUTO_TEST_CASE(Scan_Regions)
+{
+    const auto reg_1 = std::vector<int> {};
+    const auto reg_2 = std::vector { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, };
+    const auto reg_5 = std::deque { 11, 22, 33, 17, 29, };
+    const auto reg_6 = std::array { 0, 1, 0, 2, 3, 0, 1, };
+
+    auto comm = Opm::Parallel::Communication {
+        Dune::MPIHelper::getCommunicator()
+    };
+
+    BOOST_REQUIRE_EQUAL(comm.size(), 4);
+
+    auto d = Opm::ParallelRegionsetVariableDescriptor { comm };
+
+    d.prepareDescriptorSet();
+
+    d.addRegionSet(/* declaredMaxRegionID = */  5, reg_1); // max ID =  5
+    d.addRegionSet(/* declaredMaxRegionID = */ 42, reg_2); // max ID = 42
+
+    if (comm.rank() == 0) {
+        const auto reg_3 = std::vector { 5, 9, 26, };
+        const auto reg_4 = std::forward_list { 0, 0, 0 };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_3); // max ID = 26
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_4); // max ID = 0
+    }
+    else if (comm.rank() == 1) {
+        const auto reg_3 = std::vector { 3, 14, 1, };
+        const auto reg_4 = std::forward_list { 0, 0, 0 };
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_3); // max ID = 14
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_4); // max ID = -1
+    }
+    else if (comm.rank() == 2) {
+        const auto reg_3 = std::vector<int> {};
+        const auto reg_4 = std::forward_list<int> {};
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_3); // max ID = -1
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_4); // max ID = -1
+    }
+    else if (comm.rank() == 3) {
+        const auto reg_3 = std::vector<int> {};
+        const auto reg_4 = std::forward_list<int> {};
+
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_3); // max ID = -1
+        d.addRegionSet(/* declaredMaxRegionID = */ 0, reg_4); // max ID = -1
+    }
+
+    d.addRegionSet(/* declaredMaxRegionID = */ 11, reg_5); // max ID = 33
+    d.addRegionSet(/* declaredMaxRegionID = */  5, reg_6); // max ID =  5
+
+    d.finaliseDescriptorSet();
+
+    BOOST_CHECK_EQUAL(d.numRegionSets(), std::size_t{6});
+    BOOST_CHECK_EQUAL(d.numVariableSlots(), std::size_t{117});
+    BOOST_CHECK_EQUAL(d.startIndex(0), std::size_t{  0});
+    BOOST_CHECK_EQUAL(d.startIndex(1), std::size_t{  6});
+    BOOST_CHECK_EQUAL(d.startIndex(2), std::size_t{ 49});
+    BOOST_CHECK_EQUAL(d.startIndex(3), std::size_t{ 76});
+    BOOST_CHECK_EQUAL(d.startIndex(4), std::size_t{ 77});
+    BOOST_CHECK_EQUAL(d.startIndex(5), std::size_t{111});
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // NProc_4
+
+BOOST_AUTO_TEST_SUITE_END()     // Multiple_Regsets
+
+// ===========================================================================
+
+int main(int argc, char** argv)
+{
+    Dune::MPIHelper::instance(argc, argv);
+
+    register_error_handler();
+
+    return boost::unit_test::unit_test_main(&init_unit_test_func, argc, argv);
+}


### PR DESCRIPTION
This PR introduces an MPI-aware version of class
```
Opm::data::RegionsetVariableDescriptor
```
(upstream PR OPM/opm-common#5275). The primary extension to the base class is that this version implements a non-trivial `communicateGlobalRegsetMaxIDs()` member function that calculates maximum region IDs for all region sets across MPI ranks.  The same features and restrictions that apply to the base class also apply to this derived type.