### PR TITLE
Rebind writer and linear solver when the grid or matrix object is replaced

### DIFF
--- a/opm/models/io/vtkmultiwriter.hh
+++ b/opm/models/io/vtkmultiwriter.hh
@@ -156,6 +156,13 @@ public:
      * If the grid changes between two calls of beginWrite(), this
      * method _must_ be called before the second beginWrite()!
      */
+
+    void gridViewChanged(const GridView& gridView)
+    {
+        gridView_ = gridView;
+        gridChanged();
+    }
+
     void gridChanged()
     {
         elementMapper_.update(gridView_);
@@ -516,7 +523,7 @@ private:
         managedVectorBuffers_.clear();
     }
 
-    const GridView gridView_;
+    GridView gridView_;
     ElementMapper elementMapper_;
     VertexMapper vertexMapper_;
 

--- a/opm/models/io/vtkmultiwriter.hh
+++ b/opm/models/io/vtkmultiwriter.hh
@@ -157,6 +157,13 @@ public:
      * method _must_ be called before the second beginWrite()!
      */
 
+    /*!
+     * \brief Rebind the writer to a grid view that has been regenerated.
+     *
+     * For writers whose grid is rebuilt during the run rather than merely
+     * refined - opm-flowgeomechanics does this for the fracture grid as it
+     * grows (Fracture.cpp) - the stored view otherwise refers to the old grid.
+     */
     void gridViewChanged(const GridView& gridView)
     {
         gridView_ = gridView;

--- a/opm/simulators/linalg/ISTLSolver.hpp
+++ b/opm/simulators/linalg/ISTLSolver.hpp
@@ -326,6 +326,7 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
         // nothing to clean here
         void eraseMatrix() override
         {
+            matrix_ = nullptr;
         }
 
         void setActiveSolver(const int num) override
@@ -348,9 +349,14 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
         void initPrepare(const Matrix& M, Vector& b)
         {
             const bool firstcall = (matrix_ == nullptr);
+            const bool matrix_changed = &M != matrix_;
+
+            if (matrix_changed) {
+                force_recreate_ = true;
+            }
 
             // update matrix entries for solvers.
-            if (firstcall) {
+            if (firstcall || matrix_changed) {
                 // model will not change the matrix object. Hence simply store a pointer
                 // to the original one with a deleter that does nothing.
                 // Outch! We need to be able to scale the linear system! Hence const_cast
@@ -533,9 +539,15 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
         {
             // Decide if we should recreate the solver or just do
             // a minimal preconditioner update.
+            if (force_recreate_) {
+                force_recreate_ = false; // one-shot trigger set by initPrepare
+                return true;
+            }
+
             if (flexibleSolver_.empty()) {
                 return true;
             }
+
             if (!flexibleSolver_[activeSolverNum_].solver_) {
                 return true;
             }
@@ -685,6 +697,9 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
 
         std::shared_ptr< CommunicationType > comm_;
         std::unique_ptr<ElementChunksType> element_chunks_;
+        // set when initPrepare detects a different matrix object; cleared by
+        // shouldCreateSolver() (hence mutable in an otherwise const query)
+        mutable bool force_recreate_ = false;
     }; // end ISTLSolver
 
 } // namespace Opm

--- a/opm/simulators/linalg/ISTLSolver.hpp
+++ b/opm/simulators/linalg/ISTLSolver.hpp
@@ -323,7 +323,10 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
             element_chunks_ = std::make_unique<ElementChunksType>(simulator_.vanguard().gridView(), Dune::Partitions::all, ThreadManager::maxThreads());
         }
 
-        // nothing to clean here
+        // Drop the cached matrix pointer so initPrepare() sees the next matrix
+        // as a new object.  Callers that rebuild the linear system mid-run rely
+        // on this - opm-flowgeomechanics does it from FlowProblemMech when
+        // fracture connections change.
         void eraseMatrix() override
         {
             matrix_ = nullptr;

--- a/opm/simulators/linalg/ISTLSolver.hpp
+++ b/opm/simulators/linalg/ISTLSolver.hpp
@@ -351,15 +351,14 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
 
         void initPrepare(const Matrix& M, Vector& b)
         {
-            const bool firstcall = (matrix_ == nullptr);
+            // matrix_ starts out null, so this also covers the first call.
             const bool matrix_changed = &M != matrix_;
 
             if (matrix_changed) {
+                // The matrix object is no longer the one the solver was built
+                // for, so the solver has to be rebuilt rather than updated.
                 force_recreate_ = true;
-            }
 
-            // update matrix entries for solvers.
-            if (firstcall || matrix_changed) {
                 // model will not change the matrix object. Hence simply store a pointer
                 // to the original one with a deleter that does nothing.
                 // Outch! We need to be able to scale the linear system! Hence const_cast
@@ -367,12 +366,6 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
 
                 useWellConn_ = Parameters::Get<Parameters::MatrixAddWellContributions>();
                 // setup sparsity pattern for jacobi matrix for preconditioner (only used for openclSolver)
-            } else {
-                // Pointers should not change
-                if ( &M != matrix_ ) {
-                        OPM_THROW(std::logic_error,
-                                  "Matrix objects are expected to be reused when reassembling!");
-                }
             }
             rhs_ = &b;
 


### PR DESCRIPTION
Two small robustness fixes for runs that rebuild the grid or the linear system mid-run (opm-flowgeomechanics does this for a growing fracture grid):

- `vtkmultiwriter`: `gridViewChanged(gridView)` updates the stored view and forwards to `gridChanged()`.
- `ISTLSolver`: `eraseMatrix()` resets the stored matrix pointer, and `initPrepare()` notices when a different matrix object arrives and forces solver recreation.

Inert unless something actually replaces the grid or matrix; SPE1 unchanged.