### PR TITLE
FlowProblem: drop a stray cell-index assignment in updateMaxWaterSaturation_

### DIFF
--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -1358,7 +1358,6 @@ protected:
         if (this->maxWaterSaturation_.empty())
             return false;
 
-        this->maxWaterSaturation_[/*timeIdx=*/1] = this->maxWaterSaturation_[/*timeIdx=*/0];
         this->updateProperty_("FlowProblem::updateMaxWaterSaturation_() failed:",
                               [this](unsigned compressedDofIdx, const IntensiveQuantities& iq)
                               {


### PR DESCRIPTION
`maxWaterSaturation_` is a `std::vector<Scalar>` sized by grid cells and indexed by element index everywhere it is used (`FlowProblem.hpp:1170`, `:1395`, `:1594`, `:1845`, `FlowGenericProblem_impl.hpp:621`). It has no time dimension, so

```cpp
this->maxWaterSaturation_[/*timeIdx=*/1] = this->maxWaterSaturation_[/*timeIdx=*/0];
```

does not shift a time level — it overwrites cell 1's running maximum with cell 0's. The per-cell update that follows only ever raises values, so cell 1 keeps the wrong maximum whenever cell 0 is the larger of the two.

`updateMinPressure_()` is the structural twin on the same ROCKCOMP path and has no such line.

### Effect

Larger than expected. On `spe1/SPE1CASE2_ROCK2DTR`:

| | master | this PR |
|---|---|---|
| Overall Newton iterations | 866 | **583** |
| UNSMRY, UNRST | | differ |
| INIT | | identical |

Corrupting one cell's water-saturation maximum feeds a wrong rock-compaction multiplier into that cell for the rest of the run, and the solver pays for it.

`compareECLFiles_flow+SPE1CASE2_ROCK2DTR` fails on this branch — it is the only failure out of 580 — because the stored reference was generated with the bug present. **The reference needs regenerating** in opm-tests; happy to open that PR if this is agreed.

### Context

Found while auditing #7198. This line is the sole reason that rolling `maxWaterSaturation_` back across a failed timestep changes results: every other quantity in that snapshot is a plain monotone extremum recomputed from the restored solution, hence idempotent, and each measures inert when its restore is removed. This one is not, purely because of this assignment.
