### PR TITLE
MSW: fix saturated Rv lookup in the segment fluid state

### DIFF
--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -2535,8 +2535,12 @@ namespace Opm
                 case FluidSystem::gasPhaseIdx: {
                     if constexpr (compositionSwitchEnabled) {
                         if (both_oil_gas) {
-                            // starting with saturated rv value
-                            ValueType rv = FluidSystem::saturatedVaporizationFactor(fluid_state, phaseIdx, fluid_state.pvtRegionIndex());
+                            // Starting with the saturated rv value. Note that for the gas phase
+                            // saturatedDissolutionFactor() is the saturated *oil* vaporization
+                            // factor Rv (saturatedVaporizationFactor() would be the saturated
+                            // *water* vaporization factor Rvw, which is zero without vaporized
+                            // water and is not what is needed here).
+                            ValueType rv = FluidSystem::saturatedDissolutionFactor(fluid_state, phaseIdx, fluid_state.pvtRegionIndex());
                             const unsigned oilCompIdx = FluidSystem::canonicalToActiveCompIdx(FluidSystem::oilCompIdx);
                             if (fluid_composition[activeCompIdx] > epsilon) {
                                 const ValueType max_possible_rv = fluid_composition[oilCompIdx] / fluid_composition[activeCompIdx];


### PR DESCRIPTION
saturatedVaporizationFactor() returns the saturated water vaporization factor Rvw for the gas phase, which is zero without vaporized water. The saturated oil vaporization factor Rv is obtained from saturatedDissolutionFactor(), so the segment fluid state carried Rv = 0.