### PR TITLE
Fix RK4IVP dense-output evaluation at the span end

### DIFF
--- a/opm/simulators/flow/equil/InitStateEquil_impl.hpp
+++ b/opm/simulators/flow/equil/InitStateEquil_impl.hpp
@@ -152,7 +152,7 @@ std::pair<Scalar,Scalar> cellCenterXY(const Element& element)
     static constexpr int yCoord = Element::dimension - 2;
     Scalar yy = 0.0;
     Scalar xx = 0.0;
-        
+
 
     const Geometry& geometry = element.geometry();
     const int corners = geometry.corners();
@@ -282,7 +282,7 @@ Scalar calculateTrueVerticalDepth(Scalar z, Scalar x, Scalar y,
                                 const std::array<Scalar, 3>& referencePoint)
 {
     // For True Vertical Depth calculation:
-    // TVD = reference_depth + (z - reference_z) * cos(dipAngle) 
+    // TVD = reference_depth + (z - reference_z) * cos(dipAngle)
     //       + lateral_distance * sin(dipAngle) * cos(azimuth_difference)
 
     // Calculate lateral displacement from reference point
@@ -357,11 +357,14 @@ operator()(const Scalar x) const
     // (Hermite interpolation)
     const Scalar h = stepsize();
     int i = (x - span_[0]) / h;
-    const Scalar t = (x - (span_[0] + i*h)) / h;
 
     // Crude handling of evaluation point outside "span_";
     if (i  <  0) { i = 0;      }
     if (N_ <= i) { i = N_ - 1; }
+
+    // Relative to the interval actually used, so that a point at the end of
+    // the span lands on t = 1 of the final interval rather than t = 0.
+    const Scalar t = (x - (span_[0] + i*h)) / h;
 
     const Scalar y0 = y_[i], y1 = y_[i + 1];
     const Scalar f0 = f_[i], f1 = f_[i + 1];


### PR DESCRIPTION
`RK4IVP::operator()` derived the Hermite interpolation parameter `t` from the
*unclamped* interval index, then clamped the index afterwards. When the two
disagree — which happens exactly at the end of the integration span — the
interpolation is evaluated on one interval using a parameter measured from a
different one, and the result is one integration step early.

### The arithmetic

A column from 2000 m to 2100 m with `N = 4` steps, so `h = 25` m, hydrostatic
gradient 0.1 bar/m, starting at 200 bar. The integrator stores

```
y = [200.0, 202.5, 205.0, 207.5, 210.0]   at 2000, 2025, 2050, 2075, 2100
```

Evaluating at `x = 2100`, i.e. exactly the end of the span:

| | index | parameter | result |
|---|---|---|---|
| before | `i = (2100-2000)/25 = 4`, clamped to `3` | `t = (2100 - (2000 + 4*25))/25 = 0` | Hermite at `t=0` → `y[3]` = **207.5** |
| after | clamp first: `i = 3` | `t = (2100 - (2000 + 3*25))/25 = 1` | Hermite at `t=1` → `y[4]` = **210.0** |

The correct value is 210.0. The old path is short by exactly one step,
`rho*g*h = 2.5` bar. In a real run `h = span / NumPressurePointsEquil`, so the
error is small but systematic, and it lands on the contact pressure.

### Why this is reached on ordinary decks

Black-oil equilibration deliberately widens the integration span to include the
EQUIL contacts (`InitStateEquil_impl.hpp`, `vspan[0] = min(vspan[0], min(zgoc,
zwoc))`). Any region whose contact sits at the edge of its cell extent is
therefore evaluated exactly at the span end. `opm-tests/model2/0_BASE_MODEL2` is
one such deck — its EQUIL datum depth and gas-oil contact are both 2561.59 m.

Measured on that deck (2794 cells, 40 report steps). Cell pressures are
unchanged at initialization; what moves is the contact pressure, and with it the
capillary-determined saturations, which then propagate:

| array | initial state | after 40 report steps |
|---|---|---|
| `PRESSURE` | unchanged | 0.230 max abs, all cells |
| `SWAT` | 1.40e-03 (1074 cells) | 3.34e-02 |
| `SGAS` | 4.85e-05 (312 cells) | 4.75e-02 |
| `RS` | unchanged | 10.47 |

As a side effect, a depth *outside* the span now extrapolates from the end
interval instead of interpolating within it at an unrelated parameter value,
which is also closer to the true profile.

### Regression results

**This changes equilibrated saturations and therefore the stored reference
results.** 70 `compareECLFiles_flow+*` cases were affected when this rode along
in another PR: https://ci.opm-project.org/job/opm-simulators-PR-builder/10373/

The baselines in `opm-tests` need regenerating; that, rather than the one-line
change, is what this PR is really asking for.