### PR TITLE
Output TPSA primary variables in restart files for visualization

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -144,6 +144,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/flow/SimulatorReportBanners.cpp
   opm/simulators/flow/SimulatorSerializer.cpp
   opm/simulators/flow/SolutionContainers.cpp
+  opm/simulators/flow/TpsaContainer.cpp
   opm/simulators/flow/TracerContainer.cpp
   opm/simulators/flow/Transmissibility.cpp
   opm/simulators/flow/ValidationFunctions.cpp
@@ -1071,6 +1072,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/flow/TTagFlowProblemTPSA.hpp
   opm/simulators/flow/TTagFlowProblemGasWater.hpp
   opm/simulators/flow/TTagFlowProblemOnePhase.hpp
+  opm/simulators/flow/TpsaContainer.hpp
   opm/simulators/flow/TracerContainer.hpp
   opm/simulators/flow/TemperatureModel.hpp
   opm/simulators/flow/TracerModel.hpp

--- a/opm/models/tpsa/tpsamodel.hpp
+++ b/opm/models/tpsa/tpsamodel.hpp
@@ -423,6 +423,32 @@ public:
     }
 
     /*!
+    * \brief Output rotation vector
+    *
+    * \param globalIdx Cell index
+    * \returns Rotation vector at grid cell
+    */
+    DimVector rotation(const unsigned globalIdx) const
+    {
+        DimVector rot;
+        for (std::size_t i = 0; i < 3; ++i) {
+            rot[i] = decay<Scalar>(materialState_[globalIdx].rotation(i));
+        }
+        return rot;
+    }
+
+    /*!
+     * \brief Output solid pressure
+     *
+     * \param globalIdx Cell index
+     * \return Solid pressure at grid cell
+     */
+    Scalar solidPressure(const unsigned globalIdx) const
+    {
+        return decay<Scalar>(materialState_[globalIdx].solidPressure());
+    }
+
+    /*!
     * \brief Output (del?)stress tensor
     *
     * \param globalIdx Cell index

--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -418,6 +418,7 @@ assignToSolution(data::Solution& sol)
     }
 
     this->mech_.outputRestart(sol);
+    this->tpsaC_.outputRestart(sol);
     this->extboC_.outputRestart(sol);
 
     if (! this->temperature_.empty())
@@ -909,6 +910,11 @@ doAllocBuffers(const unsigned bufferSize,
 
     if (enableMech_ && eclState_.runspec().mech()) {
         this->mech_.allocate(bufferSize, rstKeywords);
+
+        // TPSA-specific output
+        if (eclState_.runspec().mechSolver().tpsa()) {
+            this->tpsaC_.allocate(bufferSize, rstKeywords);
+        }
     }
 
     if (enableExtbo_) {

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -44,6 +44,7 @@
 #include <opm/simulators/flow/RFTContainer.hpp>
 #include <opm/simulators/flow/RSTConv.hpp>
 #include <opm/simulators/flow/GeochemistryContainer.hpp>
+#include <opm/simulators/flow/TpsaContainer.hpp>
 #include <opm/simulators/flow/TracerContainer.hpp>
 
 #include <opm/simulators/utils/ParallelCommunication.hpp>
@@ -476,6 +477,7 @@ protected:
 
     // buffers for mechanical output
     MechContainer<Scalar> mech_;
+    TpsaContainer<Scalar> tpsaC_;
 
     std::array<ScalarBuffer, numPhases> saturation_;
     std::array<ScalarBuffer, numPhases> invB_;

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -2013,6 +2013,19 @@ private:
                     true
                 );
             }
+            if (this->tpsaC_.allocated()) {
+                this->extractors_.emplace_back(
+                    [&tpsaC = this->tpsaC_,
+                        &model = simulator_.problem().geoMechModel()](const Context& ectx) {
+                        tpsaC.assignRotation(ectx.globalDofIdx,
+                                             model.rotation(ectx.globalDofIdx));
+
+                        tpsaC.assignSolidPressure(ectx.globalDofIdx,
+                                                  model.solidPressure(ectx.globalDofIdx));
+                    },
+                    true
+                );
+            }
         }
     }
 

--- a/opm/simulators/flow/TpsaContainer.cpp
+++ b/opm/simulators/flow/TpsaContainer.cpp
@@ -1,0 +1,128 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#include <config.h>
+
+#include <opm/simulators/flow/TpsaContainer.hpp>
+
+#include <opm/common/utility/Visitor.hpp>
+#include <opm/input/eclipse/Units/UnitSystem.hpp>
+#include <opm/output/data/Solution.hpp>
+
+namespace Opm
+{
+
+template <class Scalar>
+void
+TpsaContainer<Scalar>::
+allocate(const std::size_t bufferSize,
+         std::map<std::string, int>& rstKeywords)
+{
+    this->solidPressure_.resize(bufferSize, 0.0);
+    rstKeywords["SPRES"] = 0;
+
+    std::ranges::for_each(rotation_,
+                          [suffix = 'X', bufferSize, &rstKeywords](auto& v) mutable {
+                              v.resize(bufferSize, 0.0);
+                              rstKeywords[std::string{"ROT"} + suffix++] = 0;
+                          });
+
+    allocated_ = true;
+}
+
+template <class Scalar>
+void
+TpsaContainer<Scalar>::
+assignRotation(const unsigned globalDofIdx,
+               const Dune::FieldVector<Scalar, 3>& rotation)
+{
+    this->rotation_[0][globalDofIdx] = rotation[0];
+    this->rotation_[1][globalDofIdx] = rotation[1];
+    this->rotation_[2][globalDofIdx] = rotation[2];
+}
+
+template <class Scalar>
+void
+TpsaContainer<Scalar>::
+assignSolidPressure(const unsigned globalDofIdx,
+                    const Scalar solidPressure)
+{
+    solidPressure_[globalDofIdx] = solidPressure;
+}
+
+template <class Scalar>
+void
+TpsaContainer<Scalar>::
+outputRestart(data::Solution& sol)
+{
+    if (!allocated_) {
+        return;
+    }
+    using DataEntry = std::tuple<std::string,
+                                 UnitSystem::measure,
+                                 std::variant<std::vector<Scalar>*,
+                                              std::array<std::vector<Scalar>, 3>*> >;
+
+    auto doInsert = [&sol](const std::string& name,
+                           const UnitSystem::measure& measure,
+                           std::vector<Scalar>& entry) {
+        if (!entry.empty()) {
+            sol.insert(name, measure, std::move(entry), data::TargetType::RESTART_OPM_EXTENDED);
+        }
+    };
+
+    const auto solutionVectors = std::array{
+        DataEntry{"SPRES", UnitSystem::measure::pressure, &solidPressure_},
+        DataEntry{"ROT", UnitSystem::measure::pressure, &rotation_},
+    };
+
+    std::ranges::for_each(solutionVectors,
+                          [&doInsert](auto& array) {
+                              std::visit(VisitorOverloadSet{
+                                             [&array, &doInsert](std::vector<Scalar>* v) {
+                                                 doInsert(std::get<0>(array),
+                                                          std::get<1>(array),
+                                                          *v);
+                                             },
+                                             [&array, &doInsert](
+                                             std::array<std::vector<Scalar>, 3>* V) {
+                                                 auto& v = *V;
+                                                 const auto& name = std::get<0>(array);
+                                                 const auto& measure = std::get<1>(array);
+                                                 doInsert(name + "X", measure, v[0]);
+                                                 doInsert(name + "Y", measure, v[1]);
+                                                 doInsert(name + "Z", measure, v[2]);
+                                             },
+                                         },
+                                         std::get<2>(array));
+                          }
+        );
+    allocated_ = false;
+}
+
+template class TpsaContainer<double>;
+
+#if FLOW_INSTANTIATE_FLOAT
+template class TpsaContainer<float>;
+#endif
+
+} // namespace Opm

--- a/opm/simulators/flow/TpsaContainer.hpp
+++ b/opm/simulators/flow/TpsaContainer.hpp
@@ -1,0 +1,73 @@
+/*
+This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::OutputBlackOilModule
+ */
+#ifndef OPM_TPSA_CONTAINER_HPP
+#define OPM_TPSA_CONTAINER_HPP
+
+#include <dune/common/fvector.hh>
+
+#include <array>
+#include <cstddef>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace Opm
+{
+
+namespace data
+{
+    class Solution;
+}
+
+template <typename Scalar>
+class TpsaContainer
+{
+    using ScalarBuffer = std::vector<Scalar>;
+
+public:
+    void allocate(const std::size_t bufferSize,
+                  std::map<std::string, int>& rstKeywords);
+
+    void assignRotation(const unsigned globalDofIdx,
+                        const Dune::FieldVector<Scalar, 3>& rotation);
+
+    void assignSolidPressure(const unsigned globalDofIdx,
+                             const Scalar solidPressure);
+
+    void outputRestart(data::Solution& sol);
+
+    bool allocated() const
+    {
+        return allocated_;
+    }
+
+private:
+    bool allocated_{false};
+    ScalarBuffer solidPressure_;
+    std::array<ScalarBuffer, 3> rotation_;
+}; // class TpsaContainer
+
+} // namespace Opm
+
+#endif //OPM_TPSA_CONTAINER_HPP


### PR DESCRIPTION
Output the TPSA primary variables, rotation and solidPressure, together with the rest of the geomechanics output when --enable-opm-rst-file=true.

Note for documentation: rotation has unit equal to pressure due to its definition in the literature the implementation is based on. For the same reason, solid pressure is actually a kind of effective pressure (=actual_solid_pressure - biotCoeff*delta_pressure), instead of the actual solid pressure term itself.