### PR TITLE
Comp well status handling

### DIFF
--- a/flowexperimental/comp/wells/CompWellState_impl.hpp
+++ b/flowexperimental/comp/wells/CompWellState_impl.hpp
@@ -102,7 +102,10 @@ initSingleInjector(const Well& well,
                                     temperature,
                                     conn_data,
                                     false) );
-    ws.update_injector_targets(well, summary_state);
+    ws.status = well.getStatus();
+    if (ws.status != WellStatus::SHUT) {
+        ws.update_injector_targets(well, summary_state);
+    }
 }
 
 template <typename FluidSystem>
@@ -120,7 +123,10 @@ initSingleProducer(const Well& well,
                                     temperature,
                                     conn_data,
                                     true) );
-    ws.update_producer_targets(well, cell_mole_fractions, summary_state);
+    ws.status = well.getStatus();
+    if (ws.status != WellStatus::SHUT) {
+        ws.update_producer_targets(well, cell_mole_fractions, summary_state);
+    }
 }
 
 template <typename FluidSystem>

--- a/flowexperimental/comp/wells/SingleCompWellState.hpp
+++ b/flowexperimental/comp/wells/SingleCompWellState.hpp
@@ -20,9 +20,12 @@
 #ifndef OPM_SINGLE_COMP_WELL_STATE_HPP
 #define OPM_SINGLE_COMP_WELL_STATE_HPP
 
+#include <opm/common/ErrorMacros.hpp>
+
 #include <opm/input/eclipse/Schedule/Well/WellEnums.hpp>
 #include <opm/simulators/wells/PerforationData.hpp>
 
+#include <stdexcept>
 #include <string>
 #include <vector>
 

--- a/flowexperimental/comp/wells/SingleCompWellState_impl.hpp
+++ b/flowexperimental/comp/wells/SingleCompWellState_impl.hpp
@@ -74,11 +74,16 @@ update_injector_targets(const Well& well,
 {
     const auto& inj_controls = well.injectionControls(st);
     const auto& injection_properties = well.getInjectionProperties();
+
+    // Report this the way the black-oil model does in WellAssemble.
+    if (inj_controls.cmode == Well::InjectorCMode::CMODE_UNDEFINED) {
+        OPM_THROW(std::runtime_error,
+                  "Well control must be specified for well " + this->name);
+    }
+
     const auto& inj_composition = injection_properties.gasInjComposition();
 #ifndef NDEBUG
     assert(this->total_molar_fractions.size() == inj_composition.size());
-    const bool cmode_is_undefined = (inj_controls.cmode == Well::InjectorCMode::CMODE_UNDEFINED);
-    assert(!cmode_is_undefined && "control types should be specified");
     const auto injection_type = injection_properties.injectorType;
     const bool is_gas_injecting = (injection_type == InjectorType::GAS);
     assert(is_gas_injecting && "Only gas injection is supported for now");
@@ -120,10 +125,12 @@ update_producer_targets(const Well& well,
                         const SummaryState& st)
 {
     const auto& prod_controls = well.productionControls(st);
-#ifndef NDEBUG
-    const auto cmode_is_undefined = (prod_controls.cmode == Well::ProducerCMode::CMODE_UNDEFINED);
-    assert(!cmode_is_undefined && "control types should be specified");
-#endif
+
+    // Report this the way the black-oil model does in WellAssemble.
+    if (prod_controls.cmode == Well::ProducerCMode::CMODE_UNDEFINED) {
+        OPM_THROW(std::runtime_error,
+                  "Well control must be specified for well " + this->name);
+    }
 
     this->total_molar_fractions = cell_mole_fractions[this->connection_data.ecl_index[0]];
 


### PR DESCRIPTION
It is a temporary fix so that the `flow_comp` can run a reference case that with the following keyword order. 

```
WELSPECS → COMPDAT → TSTEP → WCONINJE → WCONPROD. 
```

