### PR TITLE
MSW: derive the shut-valve trivial-equation Jacobian entry from the rate

### DIFF
--- a/opm/simulators/wells/MultisegmentWellAssemble.cpp
+++ b/opm/simulators/wells/MultisegmentWellAssemble.cpp
@@ -298,7 +298,7 @@ assemblePressureEq(const int seg,
 template<class FluidSystem, class Indices>
 void MultisegmentWellAssemble<FluidSystem,Indices>::
 assembleTrivialEq(const int seg,
-                  const Scalar value,
+                  const EvalWell& rate,
                   Equations& eqns1) const
 {
     /*
@@ -309,8 +309,8 @@ assembleTrivialEq(const int seg,
         This method does *not* need communication.
     */
     MultisegmentWellEquationAccess<Scalar,IndexTraits,numWellEq,Indices::numEq> eqns(eqns1);
-    eqns.residual()[seg][SPres] = value;
-    eqns.D()[seg][seg][SPres][WQTotal] = 1.;
+    eqns.residual()[seg][SPres] = rate.value();
+    eqns.D()[seg][seg][SPres][WQTotal] = rate.derivative(WQTotal + Indices::numEq);
 }
 
 template<class FluidSystem, class Indices>

--- a/opm/simulators/wells/MultisegmentWellAssemble.hpp
+++ b/opm/simulators/wells/MultisegmentWellAssemble.hpp
@@ -103,8 +103,11 @@ public:
                             Equations& eqns) const;
 
     //! \brief Assembles a trivial equation.
+    //! \details Takes the rate as an Evaluation rather than a value, so the
+    //!          Jacobian entry comes from its derivative. A hard-coded 1 is
+    //!          only correct while the rate primary variable is unscaled.
     void assembleTrivialEq(const int seg,
-                           const Scalar value,
+                           const EvalWell& rate,
                            Equations& eqns) const;
 
     //! \brief Assemble accumulation term.

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -383,7 +383,7 @@ assembleICDPressureEq(const int seg,
        (segment.segmentType() == Segment::SegmentType::VALVE) &&
        (segment.valve().status() == Opm::ICDStatus::SHUT) ) { // we use a zero rate equation to handle SHUT valve
         MultisegmentWellAssemble(baseif_).
-            assembleTrivialEq(seg, this->primary_variables_.eval(seg)[WQTotal].value(), linSys_);
+            assembleTrivialEq(seg, this->primary_variables_.eval(seg)[WQTotal], linSys_);
 
         auto& ws = well_state.well(baseif_.indexOfWell());
         ws.segments.pressure_drop_friction[seg] = 0.;


### PR DESCRIPTION
A SHUT valve segment gets the trivial equation q = 0 in place of its pressure-drop relation, written into the segment pressure row. `assembleTrivialEq` set the residual from the rate but hard-coded the Jacobian entry as `1.`, i.e. dq/dq. That is only right while the rate primary variable is unscaled; with `--well-rate-scaling=s` the primary variable is q/s and the entry must be s. Take it from the rate Evaluation instead, so it is correct by construction. This was the only hard-coded derivative in either well assembler.

Effect: the linear solve returns an increment a factor s too small, `updateNewton` multiplies by s, and the shut segment rate is multiplied by (1-s) every iteration instead of being zeroed.

Reproducing needs a shut valve, which no deck in opm-tests currently has. Take `wsegvalv/BASE_MSW_WSEGVALV.DATA` and set the status of one valve:

    PROD1  14  0.70000  5.589e-5  1* 1* 1* 1* SHUT /

then

    flow BASE_MSW_WSEGVALV.DATA --linear-solver=cprw --well-rate-scaling=4

The shut segment rate reads -3.86e-4, 1.16e-3, -3.48e-3, ... growing by (1-s) = -3 per iteration and reaching 9.96e+131 over the run; with this change it converges to zero in one iteration (max 3.9e-4 over the run). Summary output differs between the two.

Two related observations, not addressed here:
* The convergence check does not escalate this. The SPres branch of `MultisegmentWellEval::getWellConvergence` tests only `isnan`/`isinf`, with no `max_residual_allowed` comparison of the kind the mass-balance and energy branches have, so a finite 1e131 is reported `Severity::Normal` rather than `TooLarge` - no timestep cut, no warning.
* That residual is a rate but is compared against `tolerance_pressure_ms_wells` (0.01 bar), so the trivial equation is never enforced tightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)