### PR TITLE
tests: field totals must not change when part of the grid is refined

### DIFF
--- a/comparisonTests.cmake
+++ b/comparisonTests.cmake
@@ -31,3 +31,37 @@ add_test_compareSeparateECLFiles(
   MPI_PROCS
     1
 )
+
+# Refining part of the grid must not change the field totals.  The two decks are
+# identical but for the CARFIN block, so any difference in FPR/FOIP/FGIP/FWIP/
+# FRPV/FHPV means the region arrays or the in-place sums are not mapped onto the
+# leaf grid correctly.  The tolerance sits an order of magnitude above the
+# discretisation drift between the two grids (~1.3e-4 by the end of the run) and
+# an order below the ~1.4e-2 error it is there to catch.
+set(lgr_rel_tol 1e-3)
+add_test_compareSeparateECLFiles(
+  CASENAME
+    lgr_field_totals_invariant_under_refinement
+  DIR1
+    lgr
+  FILENAME1
+    SPE1CASE1_CARFIN1-3DCORNERPOINT_XYZ
+  DIR2
+    lgr
+  FILENAME2
+    SPE1CASE1_CARFIN1-3DCORNERPOINT_XYZ_NOLGR
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${lgr_rel_tol}
+  IGNORE_EXTRA_KW
+    BOTH
+  MPI_PROCS
+    1
+  TEST_ARGS
+    --parsing-strictness=low
+)


### PR DESCRIPTION
Adds a comparison test asserting that refining part of the grid does not change the field totals. The two decks are identical but for the `CARFIN` block, so they are compared against each other — no reference data, and the test states the property directly rather than freezing whatever numbers we happen to produce today.

**Stacked, and red until the rest lands:**
- needs the twin deck from OPM/opm-tests#1558
- needs #7245 (on master all cell-based output is zero once an LGR is present — FIP *and* block quantities)
- needs #7244 (without it the refined cells are dropped from the sums, ~1.4%)

With all three:

| | refined | unrefined |
|---|---|---|
| FPR | 4992.268066 | 4992.268066 |
| FOIP | 8.513534e+07 | 8.513534e+07 |
| FRPV | 1.832981e+08 | 1.832981e+08 |

`REL_TOL` is 1e-3 — an order of magnitude above the discretisation drift between the two grids (~1.3e-4 at the end of the run) and an order below the ~1.4e-2 error it catches.

Motivation: no LGR deck in opm-tests requests region FIP today, and only one requests FPR, so nothing in CI noticed that LGR output had stopped working.
