### PR TITLE
pvs: get rid of faulty gcc analytics

### DIFF
--- a/opm/models/pvs/pvsintensivequantities.hh
+++ b/opm/models/pvs/pvsintensivequantities.hh
@@ -72,13 +72,13 @@ class PvsIntensiveQuantities
     using GridView = GetPropType<TypeTag, Properties::GridView>;
     using FluxModule = GetPropType<TypeTag, Properties::FluxModule>;
 
-    enum { switch0Idx = Indices::switch0Idx };
-    enum { pressure0Idx = Indices::pressure0Idx };
-    enum { numPhases = getPropValue<TypeTag, Properties::NumPhases>() };
-    enum { numComponents = getPropValue<TypeTag, Properties::NumComponents>() };
+    static constexpr int switch0Idx = Indices::switch0Idx;
+    static constexpr int pressure0Idx = Indices::pressure0Idx;
+    static constexpr int numPhases = getPropValue<TypeTag, Properties::NumPhases>();
+    static constexpr int numComponents = getPropValue<TypeTag, Properties::NumComponents>();
     static constexpr bool enableDiffusion = getPropValue<TypeTag, Properties::EnableDiffusion>();
     static constexpr bool enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>();
-    enum { dimWorld = GridView::dimensionworld };
+    static constexpr int dimWorld = GridView::dimensionworld;
 
     using Toolbox = MathToolbox<Evaluation>;
     using MiscibleMultiPhaseComposition = ::Opm::MiscibleMultiPhaseComposition<Scalar, FluidSystem, Evaluation>;

--- a/opm/models/pvs/pvsintensivequantities.hh
+++ b/opm/models/pvs/pvsintensivequantities.hh
@@ -197,10 +197,14 @@ public:
                 }
             }
 
-            for (; auxIdx < numAuxConstraints; ++auxIdx, ++switchIdx) {
-                const unsigned compIdx = numPhases - numNonPresentPhases + auxIdx;
-                auxConstraints[auxIdx].set(lowestPresentPhaseIdx, compIdx,
-                                           priVars.makeEvaluation(switch0Idx + switchIdx, timeIdx));
+            // only reachable when numComponents > numPhases; constexpr guard prevents
+            // false -Warray-bounds on instantiations where the two are equal
+            if constexpr (numComponents > numPhases) {
+                for (; auxIdx < numAuxConstraints; ++auxIdx, ++switchIdx) {
+                    const unsigned compIdx = numPhases - numNonPresentPhases + auxIdx;
+                    auxConstraints[auxIdx].set(lowestPresentPhaseIdx, compIdx,
+                                               priVars.makeEvaluation(switch0Idx + switchIdx, timeIdx));
+                }
             }
 
             // both phases are present, i.e. phase compositions are a result of the the


### PR DESCRIPTION
Finally got around to throwing this problem to an agent.

This is a proper replacement for https://github.com/OPM/opm-simulators/pull/6904

Requires https://github.com/OPM/opm-common/pull/5289 as else warnings from there now trigger.