### PR TITLE
Rename BCProp to BCState

### DIFF
--- a/opm/models/blackoil/blackoillocalresidualtpfa.hh
+++ b/opm/models/blackoil/blackoillocalresidualtpfa.hh
@@ -29,7 +29,7 @@
 #define EWOMS_BLACK_OIL_LOCAL_TPFA_RESIDUAL_HH
 
 #include <opm/input/eclipse/EclipseState/Grid/FaceDir.hpp>
-#include <opm/input/eclipse/Schedule/BCProp.hpp>
+#include <opm/input/eclipse/Schedule/BCState.hpp>
 
 #include <opm/material/common/ConditionalStorage.hpp>
 #include <opm/material/common/MathToolbox.hpp>

--- a/opm/models/discretization/common/tpfalinearizer.hh
+++ b/opm/models/discretization/common/tpfalinearizer.hh
@@ -40,7 +40,7 @@
 #include <opm/material/common/ConditionalStorage.hpp>
 
 #include <opm/input/eclipse/EclipseState/Grid/FaceDir.hpp>
-#include <opm/input/eclipse/Schedule/BCProp.hpp>
+#include <opm/input/eclipse/Schedule/BCState.hpp>
 
 #include <opm/models/blackoil/blackoilproperties.hh>
 #include <opm/models/common/multiphasebaseproperties.hh>

--- a/opm/models/discretization/common/tpfalinearizerstructs.hh
+++ b/opm/models/discretization/common/tpfalinearizerstructs.hh
@@ -26,7 +26,7 @@
 
 #include <opm/common/Exceptions.hpp>
 #include <opm/grid/utility/SparseTable.hpp>
-#include <opm/input/eclipse/Schedule/BCProp.hpp>
+#include <opm/input/eclipse/Schedule/BCState.hpp>
 
 #include <opm/common/utility/gpuistl_if_available.hpp>
 #include <opm/common/utility/pointerArithmetic.hpp>

--- a/opm/models/discretization/common/tpsalinearizer.hpp
+++ b/opm/models/discretization/common/tpsalinearizer.hpp
@@ -31,7 +31,7 @@
 
 #include <opm/grid/utility/SparseTable.hpp>
 
-#include <opm/input/eclipse/Schedule/BCProp.hpp>
+#include <opm/input/eclipse/Schedule/BCState.hpp>
 
 #include <opm/material/materialstates/MaterialStateTPSA.hpp>
 

--- a/opm/models/tpsa/elasticitylocalresidualtpsa.hpp
+++ b/opm/models/tpsa/elasticitylocalresidualtpsa.hpp
@@ -27,7 +27,7 @@
 
 #include <dune/common/fvector.hh>
 
-#include <opm/input/eclipse/Schedule/BCProp.hpp>
+#include <opm/input/eclipse/Schedule/BCState.hpp>
 
 #include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/materialstates/MaterialStateTPSA.hpp>
@@ -213,7 +213,7 @@ public:
     }
 
     /*!
-    * \brief Calculate boundary conditions in TPSA formulation given by BCCON/BCPROP
+    * \brief Calculate boundary conditions in TPSA formulation given by BCCON/BCMECH
     *
     * \param bndryTerm Boundary term vector
     * \param materialState Material state container

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -1232,10 +1232,10 @@ public:
         if (bcindex_(dir)[globalSpaceIdx] == 0) {
             return { BCType::NONE, RateVector(0.0) };
         }
-        if (schedule[this->episodeIndex()].bcprop.size() == 0) {
+        if (schedule[this->episodeIndex()].bcstate.size() == 0) {
             return { BCType::NONE, RateVector(0.0) };
         }
-        const auto& bc = schedule[this->episodeIndex()].bcprop[bcindex_(dir)[globalSpaceIdx]];
+        const auto& bc = schedule[this->episodeIndex()].bcstate[bcindex_(dir)[globalSpaceIdx]];
         if (bc.bctype!=BCType::RATE) {
             return { bc.bctype, RateVector(0.0) };
         }
@@ -1891,15 +1891,15 @@ protected:
         }
     };
 
-    virtual void handleSolventBC(const BCProp::BCFace&, RateVector&) const = 0;
+    virtual void handleSolventBC(const BCState::BCFace&, RateVector&) const = 0;
 
-    virtual void handlePolymerBC(const BCProp::BCFace&, RateVector&) const = 0;
+    virtual void handlePolymerBC(const BCState::BCFace&, RateVector&) const = 0;
 
-    virtual void handleMicrBC(const BCProp::BCFace&, RateVector&) const = 0;
+    virtual void handleMicrBC(const BCState::BCFace&, RateVector&) const = 0;
 
-    virtual void handleOxygBC(const BCProp::BCFace&, RateVector&) const = 0;
+    virtual void handleOxygBC(const BCState::BCFace&, RateVector&) const = 0;
 
-    virtual void handleUreaBC(const BCProp::BCFace&, RateVector&) const = 0;
+    virtual void handleUreaBC(const BCState::BCFace&, RateVector&) const = 0;
 
     BCData<int> bcindex_;
     bool nonTrivialBoundaryConditions_ = false;

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -793,8 +793,8 @@ public:
     InitialFluidState boundaryFluidState(unsigned globalDofIdx, const int directionId) const
     {
         OPM_TIMEBLOCK_LOCAL(boundaryFluidState, Subsystem::Assembly);
-        const auto& bcprop = this->simulator().vanguard().schedule()[this->episodeIndex()].bcprop;
-        if (bcprop.size() > 0) {
+        const auto& bcstate = this->simulator().vanguard().schedule()[this->episodeIndex()].bcstate;
+        if (bcstate.size() > 0) {
             FaceDir::DirEnum dir = FaceDir::FromIntersectionIndex(directionId);
 
             // index == 0: no boundary conditions for this
@@ -802,7 +802,7 @@ public:
             if (this->bcindex_(dir)[globalDofIdx] == 0)
                 return initialFluidStates_[globalDofIdx];
 
-            const auto& bc = bcprop[this->bcindex_(dir)[globalDofIdx]];
+            const auto& bc = bcstate[this->bcindex_(dir)[globalDofIdx]];
             if (bc.bctype == BCType::DIRICHLET )
             {
                 InitialFluidState fluidState;
@@ -1605,7 +1605,7 @@ protected:
 
     }
 
-    void handleSolventBC(const BCProp::BCFace& bc, RateVector& rate) const override
+    void handleSolventBC(const BCState::BCFace& bc, RateVector& rate) const override
     {
         if constexpr (!enableSolvent)
             throw std::logic_error("solvent is disabled and you're trying to add solvent to BC");
@@ -1613,7 +1613,7 @@ protected:
         rate[Indices::solventSaturationIdx] = bc.rate;
     }
 
-    void handlePolymerBC(const BCProp::BCFace& bc, RateVector& rate) const override
+    void handlePolymerBC(const BCState::BCFace& bc, RateVector& rate) const override
     {
         if constexpr (!enablePolymer)
             throw std::logic_error("polymer is disabled and you're trying to add polymer to BC");
@@ -1621,7 +1621,7 @@ protected:
         rate[Indices::polymerConcentrationIdx] = bc.rate;
     }
 
-    void handleMicrBC(const BCProp::BCFace& bc, RateVector& rate) const override
+    void handleMicrBC(const BCState::BCFace& bc, RateVector& rate) const override
     {
         if constexpr (!enableMICP)
             throw std::logic_error("MICP is disabled and you're trying to add microbes to BC");
@@ -1629,7 +1629,7 @@ protected:
         rate[Indices::microbialConcentrationIdx] = bc.rate;
     }
 
-    void handleOxygBC(const BCProp::BCFace& bc, RateVector& rate) const override
+    void handleOxygBC(const BCState::BCFace& bc, RateVector& rate) const override
     {
         if constexpr (!enableMICP)
             throw std::logic_error("MICP is disabled and you're trying to add oxygen to BC");
@@ -1637,7 +1637,7 @@ protected:
         rate[Indices::oxygenConcentrationIdx] = bc.rate;
     }
 
-    void handleUreaBC(const BCProp::BCFace& bc, RateVector& rate) const override
+    void handleUreaBC(const BCState::BCFace& bc, RateVector& rate) const override
     {
         if constexpr (!enableMICP)
             throw std::logic_error("MICP is disabled and you're trying to add urea to BC");

--- a/opm/simulators/flow/FlowProblemComp.hpp
+++ b/opm/simulators/flow/FlowProblemComp.hpp
@@ -601,27 +601,27 @@ protected:
 
 private:
 
-    void handleSolventBC(const BCProp::BCFace& /* bc */, RateVector& /* rate */) const override
+    void handleSolventBC(const BCState::BCFace& /* bc */, RateVector& /* rate */) const override
     {
         throw std::logic_error("solvent is disabled for compositional modeling and you're trying to add solvent to BC");
     }
 
-    void handlePolymerBC(const BCProp::BCFace& /* bc */, RateVector& /* rate */) const override
+    void handlePolymerBC(const BCState::BCFace& /* bc */, RateVector& /* rate */) const override
     {
         throw std::logic_error("polymer is disabled for compositional modeling and you're trying to add polymer to BC");
     }
 
-    void handleMicrBC(const BCProp::BCFace& /* bc */, RateVector& /* rate */) const override
+    void handleMicrBC(const BCState::BCFace& /* bc */, RateVector& /* rate */) const override
     {
         throw std::logic_error("MICP is disabled for compositional modeling and you're trying to add microbes to BC");
     }
 
-    void handleOxygBC(const BCProp::BCFace& /* bc */, RateVector& /* rate */) const override
+    void handleOxygBC(const BCState::BCFace& /* bc */, RateVector& /* rate */) const override
     {
         throw std::logic_error("MICP is disabled for compositional modeling and you're trying to add oxygen to BC");
     }
 
-    void handleUreaBC(const BCProp::BCFace& /* bc */, RateVector& /* rate */) const override
+    void handleUreaBC(const BCState::BCFace& /* bc */, RateVector& /* rate */) const override
     {
         throw std::logic_error("MICP is disabled for compositional modeling and you're trying to add urea to BC");
     }

--- a/opm/simulators/flow/FlowProblemTPSA.hpp
+++ b/opm/simulators/flow/FlowProblemTPSA.hpp
@@ -280,20 +280,22 @@ public:
     std::pair<BCMECHType, Dune::FieldVector<Evaluation, 3>>
     mechBoundaryCondition(const unsigned int globalSpaceIdx, const int directionId)
     {
-        // Default boundary conditions if BCCON/BCPROP not defined
+        // Default boundary conditions if BCCON/BCMECH not defined
         if (!this->nonTrivialBoundaryConditions()) {
             return { BCMECHType::NONE, Dune::FieldVector<Evaluation, 3>{0.0, 0.0, 0.0} };
         }
 
-        // Default for BCPROP index = 0 or no BCPROP defined at current episode
+        // Default for BCMECH index = 0 or no BCMECH defined at current episode
         FaceDir::DirEnum dir = FaceDir::FromIntersectionIndex(directionId);
         const auto& schedule = this->simulator().vanguard().schedule();
-        if (this->bcindex_(dir)[globalSpaceIdx] == 0 || schedule[this->episodeIndex()].bcprop.size() == 0) {
-            return { BCMECHType::NONE, Dune::FieldVector<Evaluation, 3>{0.0, 0.0, 0.0} };
+        if (this->bcindex_(dir)[globalSpaceIdx] == 0
+            || schedule[this->episodeIndex()].bcstate.size() == 0) {
+            return {BCMECHType::NONE, Dune::FieldVector<Evaluation, 3>{0.0, 0.0, 0.0} };
         }
 
         // Get current BC
-        const auto& bc = schedule[this->episodeIndex()].bcprop[this->bcindex_(dir)[globalSpaceIdx]];
+        const auto& bc =
+            schedule[this->episodeIndex()].bcstate[this->bcindex_(dir)[globalSpaceIdx]];
         if (bc.bcmechtype == BCMECHType::FREE) {
             return { BCMECHType::FREE, Dune::FieldVector<Evaluation, 3>{0.0, 0.0, 0.0} };
         }

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -1676,6 +1676,7 @@ add_test_compareECLFiles(
 set(_tpsa_cases
   TPSA_LAGGED
   TPSA_FIXEDSTRESS
+  TPSA_BC
 )
 
 add_multiple_tests(

--- a/tests/test_tpsa_localresidual.cpp
+++ b/tests/test_tpsa_localresidual.cpp
@@ -26,7 +26,7 @@
 
 #include <dune/common/fvector.hh>
 
-#include <opm/input/eclipse/Schedule/BCProp.hpp>
+#include <opm/input/eclipse/Schedule/BCState.hpp>
 
 #include <opm/material/materialstates/MaterialStateTPSA.hpp>
 


### PR DESCRIPTION
Downstream of https://github.com/OPM/opm-common/pull/5295, where the BCProp class has been renamed to BCState, due to introduction of the BCMECH keyword.