### PR TITLE
Use depth from eclGrid instead of recomputing it. 

### DIFF
--- a/opm/simulators/flow/CpGridVanguard.hpp
+++ b/opm/simulators/flow/CpGridVanguard.hpp
@@ -255,12 +255,15 @@ public:
 
         this->updateGridView_();
         this->updateCartesianToCompressedMapping_();
-        this->updateCellDepths_();
         this->updateCellThickness_();
 
 #if HAVE_MPI
         this->distributeFieldProps_(this->eclState());
 #endif
+
+        // Must be done after the field properties have been distributed, since the
+        // DEPTH property is needed on all ranks to honour DEPTH in the EDIT section.
+        this->updateCellDepths_();
     }
 
     /*!

--- a/opm/simulators/flow/FlowBaseVanguard.hpp
+++ b/opm/simulators/flow/FlowBaseVanguard.hpp
@@ -363,10 +363,13 @@ protected:
         ElementMapper elemMapper(this->gridView(), Dune::mcmgElementLayout());
 
         const auto num_aqu_cells = this->allAquiferCells();
+        const auto* depthEdits = this->editedCellDepths_(numCells);
 
-        for(const auto& element : elements(this->gridView())) {
+        for (const auto& element : elements(this->gridView())) {
             const unsigned int elemIdx = elemMapper.index(element);
-            cellCenterDepth_[elemIdx] = cellCenterDepth(element);
+            cellCenterDepth_[elemIdx] = depthEdits != nullptr
+                ? (*depthEdits)[elemIdx]
+                : cellCenterDepth(element);
 
             if (!num_aqu_cells.empty()) {
                 const unsigned int global_index = cartesianIndex(elemIdx);
@@ -377,6 +380,38 @@ protected:
                 }
             }
         }
+    }
+
+    /*!
+     * \brief Cell depths from a DEPTH assignment in the EDIT section, or nullptr.
+     *
+     * The DEPTH field property is used rather than EclipseGrid::getCellDepth() because
+     * the input grid is only available on the root process. Whether DEPTH was edited is
+     * likewise only known on the root process, so the flag has to be communicated to
+     * keep all ranks on the same branch.
+     */
+    const std::vector<double>* editedCellDepths_(const int numCells) const
+    {
+        const auto& comm = this->gridView().comm();
+
+        int depthEdited = (comm.rank() == 0)
+            && this->eclState().globalFieldProps().depth_edited();
+        depthEdited = comm.max(depthEdited);
+
+        if (!depthEdited) {
+            return nullptr;
+        }
+
+        const auto& depth = this->eclState().fieldProps().get_double("DEPTH");
+
+        // The field properties are given on the level zero grid, so they cannot be
+        // indexed by leaf element index when the grid has been refined.
+        if (static_cast<int>(depth.size()) != numCells) {
+            throw std::runtime_error("DEPTH assigned in the EDIT section is not "
+                                      "supported in combination with LGR");
+        }
+
+        return &depth;
     }
     void updateCellThickness_()
     {
@@ -395,7 +430,6 @@ protected:
     }
 
 private:
-    // computed from averaging cell corner depths
     Scalar cellCenterDepth(const Element& element) const
     {
         typedef typename Element::Geometry Geometry;
@@ -404,10 +438,10 @@ private:
 
         const Geometry& geometry = element.geometry();
         const int corners = geometry.corners();
-        for (int i=0; i < corners; ++i)
+        for (int i = 0; i < corners; ++i)
             zz += geometry.corner(i)[zCoord];
 
-        return zz/Scalar(corners);
+        return zz / Scalar(corners);
     }
 
     Scalar computeCellThickness(const typename GridView::template Codim<0>::Entity& element) const


### PR DESCRIPTION
Note, this makes it possible to use DEPTH set in the EDIT section

Follow up on. 
https://github.com/OPM/opm-common/pull/5181

Note 2: I had to use the DEPTH array directly, rather than just the depth from eclgrid, to make it work in parallel.  