### PR TITLE
EclWriter: forward dynamically created well connections to EclipseIO

### DIFF
--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -212,7 +212,7 @@ public:
 
     void recordNewDynamicWellConns(const DynamicConns& newConns)
     {
-        if ((this->rank_ == 0) && (this->eclIO_ != nullptr)) {
+        if (this->collectOnIORank_.isIORank() && (this->eclIO_ != nullptr)) {
             this->eclIO_->recordNewDynamicWellConns(newConns);
         }
     }

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -60,6 +60,7 @@
 
 #include <boost/date_time/posix_time/posix_time.hpp>
 
+#include <algorithm>
 #include <cstddef>
 #include <functional>
 #include <limits>
@@ -144,6 +145,9 @@ class EclWriter : public EclGenericWriter<GetPropType<TypeTag, Properties::Grid>
 
 public:
 
+    using DynamicConns =
+        std::vector<std::pair<std::string, std::vector<std::size_t>>>;
+
     static void registerParameters()
     {
         OutputModule::registerParameters();
@@ -204,6 +208,13 @@ public:
     const EquilGrid& globalGrid() const
     {
         return simulator_.vanguard().equilGrid();
+    }
+
+    void recordNewDynamicWellConns(const DynamicConns& newConns)
+    {
+        if ((this->rank_ == 0) && (this->eclIO_ != nullptr)) {
+            this->eclIO_->recordNewDynamicWellConns(newConns);
+        }
     }
 
     /*!


### PR DESCRIPTION
`recordNewDynamicWellConns()` hands well name plus zero-based Cartesian cell ids for dynamically created connections to the output layer on the I/O rank, so the summary engine can instantiate connection-level vectors for them.

The receiving side already exists in opm-common (`Summary::recordNewDynamicWellConns`); this is only the simulator-side forwarding. Nothing upstream calls it yet — it is needed by a fracture model that creates connections during the run, which lives out of tree.

12 lines, inert without such a caller.
