### PR TITLE
Keep the zero-trans overlap and the deck in mechanical runs

### DIFF
--- a/opm/simulators/flow/GenericCpGridVanguard.cpp
+++ b/opm/simulators/flow/GenericCpGridVanguard.cpp
@@ -222,9 +222,13 @@ doLoadBalance_(const Dune::EdgeWeightMethod             edgeWeightsMethod,
             : std::vector<Well>{};
 
         const auto& possibleFutureConnections = schedule.getPossibleFutureConnections();
+                // Mechanics couples cells across zero-transmissibility faces,
+                // so the overlap layer must not be pruned by transmissibility
+                // in mechanical runs (same reasoning as for thermal runs).
                 const bool useTransToFilterOverlap =
                         !(eclState1.getSimulationConfig().isThermal() ||
-                            eclState1.getSimulationConfig().isTemp());
+                            eclState1.getSimulationConfig().isTemp() ||
+                            eclState1.runspec().mech());
         // Distribute the grid and switch to the distributed view.
         if (mpiSize > 1) {
             this->distributeGrid(edgeWeightsMethod, ownersFirst,

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -323,9 +323,7 @@ protected:
                            Parameters::Get<Parameters::ParsingStrictness>(),
                            Parameters::Get<Parameters::ActionParsingStrictness>(),
                            Parameters::Get<Parameters::InputSkipMode>(),
-                           // Geomechanics needs the full deck retained (fracture
-                           // seeds and mech keywords are read during the run).
-                           keepKeywords || getPropValue<PreTypeTag, Properties::EnableMech>(),
+                           keepKeywords,
                            getNumThreads(),
                            Parameters::Get<Parameters::EclOutputInterval>(),
                            Parameters::Get<Parameters::Slave>(),

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -323,7 +323,9 @@ protected:
                            Parameters::Get<Parameters::ParsingStrictness>(),
                            Parameters::Get<Parameters::ActionParsingStrictness>(),
                            Parameters::Get<Parameters::InputSkipMode>(),
-                           keepKeywords,
+                           // Geomechanics needs the full deck retained (fracture
+                           // seeds and mech keywords are read during the run).
+                           keepKeywords || getPropValue<PreTypeTag, Properties::EnableMech>(),
                            getNumThreads(),
                            Parameters::Get<Parameters::EclOutputInterval>(),
                            Parameters::Get<Parameters::Slave>(),

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -383,17 +383,24 @@ namespace {
             eclipseState = createEclipseState(comm, deck);
         }
 
+        // A fracture model reads its seeds out of the deck during the run, not
+        // only at setup, so a FRAC run has to retain the Schedule keywords
+        // whatever the general setting says.  Decided here rather than by the
+        // caller because it needs the parsed RUNSPEC.
+        const auto keepScheduleKeywords =
+            keepKeywords || eclipseState->runspec().frac();
+
         if (eclipseState->getInitConfig().restartRequested()) {
             loadObjectsFromRestart(deck, parser, *parseContext,
                                    initFromRestart, outputInterval,
-                                   lowActionParsingStrictness, keepKeywords,
+                                   lowActionParsingStrictness, keepScheduleKeywords,
                                    *eclipseState, std::move(python),
                                    schedule, udqState, actionState, wtestState,
                                    errorGuard);
         }
         else {
             createNonRestartDynamicObjects(deck, *eclipseState, *parseContext,
-                                           lowActionParsingStrictness, keepKeywords,
+                                           lowActionParsingStrictness, keepScheduleKeywords,
                                            std::move(python),
                                            schedule, udqState, actionState, wtestState,
                                            errorGuard, slaveMode);


### PR DESCRIPTION
Two one-line conditions, both gated on `runspec.mech()`:

- **`GenericCpGridVanguard`** stops pruning the overlap layer by transmissibility in mechanical runs. Mechanics couples cells across zero-transmissibility faces, so pruning by transmissibility drops cells the mechanical stencil needs. This is the same reasoning upstream already applies to thermal and temperature runs, added to the same condition.
- **`Main`** retains the deck when mechanics is enabled, because fracture seeds and mechanics keywords are read during the run rather than only at setup.

No effect on a run without `MECH`. 8 lines total.
