### PR TITLE
Network well without vfp

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -78,6 +78,7 @@
 #endif
 
 #include <algorithm>
+#include <cmath>
 #include <cassert>
 #include <functional>
 #include <iterator>
@@ -241,6 +242,41 @@ initFromRestartFile(const RestartValue& restartValues,
                         handle_ms_well,
                         this->wellState(),
                         this->groupState());
+
+    // Reconstruct the retained network THP limit, which the restart file does
+    // not carry. A well is attached to the network when its group is a network
+    // node, and detached once it is not, for instance after WELSPECS moved it
+    // to a non-network group. Attached wells recover their limit from the
+    // restored node pressures; a detached well must recover it from itself: a
+    // THP-controlled well enforces its limit as ws.thp, so the restart THP is
+    // that limit, unless it matches the schedule limit. In that case the well
+    // runs on its own limit and seeding would freeze it against later (UDA)
+    // updates. A limit that was inactive when the restart was written, e.g. on
+    // a rate-controlled well, cannot be recovered. A well without a VFP table
+    // cannot be put under THP control, so nothing is reconstructed for it.
+    // The network.active() test asks whether the deck defines a network at
+    // all; without it a restart would put ordinary THP wells in network-free
+    // decks on the dynamic-THP-limit path.
+    if (const auto& network = this->schedule()[report_step].network(); network.active()) {
+        for (const auto& well : wells_ecl_) {
+            if (!well.isProducer() || !well.predictionMode() ||
+                well.vfp_table_number() <= 0 ||
+                network.has_node(well.groupName()))
+            {
+                continue;
+            }
+            auto& ws = this->wellState().well(well.name());
+            if (ws.production_cmode != Well::ProducerCMode::THP || !(ws.thp > 0.0)) {
+                continue;
+            }
+            const Scalar schedule_limit = well.productionControls(summaryState_).thp_limit;
+            // Relative tolerance for the unit round-trip through the restart file.
+            const Scalar tol = 1e-7 * std::max(std::abs(ws.thp), std::abs(schedule_limit));
+            if (std::abs(ws.thp - schedule_limit) > tol) {
+                ws.network_thp_limit = ws.thp;
+            }
+        }
+    }
 
     if (config.has_model()) {
         BlackoilWellModelRestart(*this).
@@ -912,8 +948,9 @@ updateEclWells(const int timeStepIdx,
     this->updateEclWellsConstraints(timeStepIdx, sim_update, st);
 
     // Re-specifying THP or VFP controls in ACTIONX cancels a retained
-    // network-imposed limit, even if the value is unchanged and the well is
-    // therefore absent from affected_wells.
+    // network-imposed limit, even if the value is unchanged. At a report step
+    // the same change arrives as WELL_THP_UPDATE and is handled in
+    // WellState::init().
     for (const auto& wname : sim_update.thp_respecified_wells) {
         if (const auto well_index = this->wellState().index(wname)) {
             this->wellState().well(*well_index).network_thp_limit.reset();

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -911,6 +911,21 @@ updateEclWells(const int timeStepIdx,
 {
     this->updateEclWellsConstraints(timeStepIdx, sim_update, st);
 
+    // Re-specifying THP or VFP controls in ACTIONX cancels a retained
+    // network-imposed limit, even if the value is unchanged and the well is
+    // therefore absent from affected_wells.
+    for (const auto& wname : sim_update.thp_respecified_wells) {
+        if (const auto well_index = this->wellState().index(wname)) {
+            this->wellState().well(*well_index).network_thp_limit.reset();
+        }
+        auto well_it = std::ranges::find_if(this->well_container_generic_,
+                                            [&wname](const auto* well)
+                                            { return well->name() == wname; });
+        if (well_it != this->well_container_generic_.end()) {
+            (*well_it)->setDynamicThpLimit(std::nullopt);
+        }
+    }
+
     if (! sim_update.well_structure_changed &&
         ! this->wellStructureChangedDynamically_)
     {

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
@@ -245,7 +245,7 @@ updatePressures(const int reportStepIdx,
             && well->wellEcl().vfp_table_number() > 0) {
             const auto it = node_pressures_.find(well->wellEcl().groupName());
             if (it != node_pressures_.end()) {
-                // The well belongs to a group with has a network pressure constraint,
+                // The well belongs to a group that has a network pressure constraint;
                 // set the dynamic THP constraint of the well accordingly.
                 this->imposeWellThpLimit(*well, it->second);
                 SingleWellState<Scalar, IndexTraits>& ws = well_model_.wellState()[well->indexOfWell()];
@@ -319,8 +319,23 @@ assignNodeAndBranchValues(std::map<std::string, data::NodeData>& nodevalues,
 
 template<typename Scalar, typename IndexTraits>
 void BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
-initialize(const int /*report_step*/)
+initialize(const int report_step)
 {
+    // Discard pressures for nodes that are absent from the current network.
+    // Retained per-well limits are kept because they can outlive the network.
+    const auto& network = well_model_.schedule()[report_step].network();
+    if (!network.active()) {
+        this->node_pressures_.clear();
+        this->last_valid_node_pressures_.clear();
+    }
+    else {
+        const auto is_stale = [&network](const auto& node_pressure)
+        { return !network.has_node(node_pressure.first); };
+
+        std::erase_if(this->node_pressures_, is_stale);
+        std::erase_if(this->last_valid_node_pressures_, is_stale);
+    }
+
     // Retained THP limits can outlive network activity, so initialize every well.
     for (auto& well : well_model_.genericWells()) {
         initializeWell(*well);

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
@@ -243,8 +243,7 @@ updatePressures(const int reportStepIdx,
             if (it != node_pressures_.end()) {
                 // The well belongs to a group with has a network pressure constraint,
                 // set the dynamic THP constraint of the well accordingly.
-                const Scalar new_limit = it->second;
-                well->setDynamicThpLimit(new_limit);
+                this->imposeWellThpLimit(*well, it->second);
                 SingleWellState<Scalar, IndexTraits>& ws = well_model_.wellState()[well->indexOfWell()];
                 const bool thp_is_limit = ws.production_cmode == Well::ProducerCMode::THP;
                 // TODO: not sure why the thp is NOT updated properly elsewhere
@@ -316,13 +315,11 @@ assignNodeAndBranchValues(std::map<std::string, data::NodeData>& nodevalues,
 
 template<typename Scalar, typename IndexTraits>
 void BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
-initialize(const int report_step)
+initialize(const int /*report_step*/)
 {
-    const auto& network = well_model_.schedule()[report_step].network();
-    if (network.active() && !node_pressures_.empty()) {
-        for (auto& well : well_model_.genericWells()) {
-            initializeWell(*well);
-        }
+    // Retained THP limits can outlive network activity, so initialize every well.
+    for (auto& well : well_model_.genericWells()) {
+        initializeWell(*well);
     }
 }
 
@@ -330,17 +327,30 @@ template<typename Scalar, typename IndexTraits>
 void BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
 initializeWell(WellInterfaceGeneric<Scalar,IndexTraits>& well)
 {
-    // Producers only, since we so far only support the
-    // "extended" network model (properties defined by
-    // BRANPROP and NODEPROP) which only applies to producers.
-    if (well.isProducer() && !node_pressures_.empty()) {
-        const auto it = this->node_pressures_.find(well.wellEcl().groupName());
-        if (it != this->node_pressures_.end()) {
-            // The well belongs to a group which has a network nodal pressure,
-            // set the dynamic THP constraint based on the network nodal pressure
-            well.setDynamicThpLimit(it->second);
+    // Extended networks defined by BRANPROP and NODEPROP currently apply only
+    // to producers.
+    if (!well.isProducer()) {
+        return;
+    }
+    const auto it = this->node_pressures_.find(well.wellEcl().groupName());
+    if (it != this->node_pressures_.end()) {
+        // Apply and retain the network node pressure as the dynamic THP limit.
+        this->imposeWellThpLimit(well, it->second);
+    } else {
+        // Reapply a retained limit after network detachment or well reconstruction.
+        const auto& ws = well_model_.wellState().well(well.indexOfWell());
+        if (ws.network_thp_limit.has_value()) {
+            well.setDynamicThpLimit(*ws.network_thp_limit);
         }
     }
+}
+
+template<typename Scalar, typename IndexTraits>
+void BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
+imposeWellThpLimit(WellInterfaceGeneric<Scalar,IndexTraits>& well, const Scalar limit)
+{
+    well.setDynamicThpLimit(limit);
+    well_model_.wellState().well(well.indexOfWell()).network_thp_limit = limit;
 }
 
 template <typename Scalar, typename IndexTraits>

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
@@ -238,7 +238,11 @@ updatePressures(const int reportStepIdx,
         // Producers only, since we so far only support the
         // "extended" network model (properties defined by
         // BRANPROP and NODEPROP) which only applies to producers.
-        if (well->isProducer() && well->wellEcl().predictionMode()) {
+        // The network cannot put a well without a VFP table under THP
+        // control, so no THP limit is imposed on such a well, while its
+        // rates still contribute to the network flows.
+        if (well->isProducer() && well->wellEcl().predictionMode()
+            && well->wellEcl().vfp_table_number() > 0) {
             const auto it = node_pressures_.find(well->wellEcl().groupName());
             if (it != node_pressures_.end()) {
                 // The well belongs to a group with has a network pressure constraint,
@@ -328,8 +332,10 @@ void BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
 initializeWell(WellInterfaceGeneric<Scalar,IndexTraits>& well)
 {
     // Extended networks defined by BRANPROP and NODEPROP currently apply only
-    // to producers.
-    if (!well.isProducer()) {
+    // to producers. The network cannot put a well without a VFP table under
+    // THP control, so no THP limit is imposed on or retained for such a well,
+    // while its rates still contribute to the network flows.
+    if (!well.isProducer() || well.wellEcl().vfp_table_number() <= 0) {
         return;
     }
     const auto it = this->node_pressures_.find(well.wellEcl().groupName());

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.hpp
@@ -126,6 +126,11 @@ protected:
                      const int reportStepIdx,
                      const Parallel::Communication& comm) const;
 
+    //! \brief Apply a network THP limit and retain it across well
+    //! reconstruction or network detachment.
+    void imposeWellThpLimit(WellInterfaceGeneric<Scalar,IndexTraits>& well,
+                            const Scalar limit);
+
 
     bool active_{false};
     BlackoilWellModelGeneric<Scalar,IndexTraits>& well_model_;

--- a/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
@@ -222,7 +222,11 @@ computeWellGroupThp(const double dt, DeferredLogger& local_deferredLogger)
                     std::string well_name = well->name();
                     auto& ws = well_state.well(well_name);
                     if (group.hasWell(well_name)) {
-                        well->setDynamicThpLimit(group_thp);
+                        // A well without a VFP table cannot be put under THP
+                        // control, so the common THP is not imposed on it.
+                        if (well->wellEcl().vfp_table_number() > 0) {
+                            well->setDynamicThpLimit(group_thp);
+                        }
                         const auto inj_controls = Well::InjectionControls(0);
                         // The well equations are solved here to find the group
                         // THP, so the controls must carry the drawdown limit;
@@ -344,7 +348,10 @@ computeWellGroupThp(const double dt, DeferredLogger& local_deferredLogger)
                 if (well->isInjector() || !well->wellEcl().predictionMode())
                     continue;
 
-                if (group.hasWell(well_name)) {
+                // As above: a well without a VFP table cannot be put under THP
+                // control, so the auto-choke group THP is not imposed on it.
+                if (group.hasWell(well_name)
+                    && well->wellEcl().vfp_table_number() > 0) {
                     well->setDynamicThpLimit(well_group_thp);
                 }
                 const auto& ws = well_model_.wellState().well(well->indexOfWell());

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -602,10 +602,7 @@ namespace Opm {
                 well->setPrevSurfaceRates(this->wellState(), this->prevWellState());
             }
 
-            const auto& network = this->schedule()[timeStepIdx].network();
-            if (network.active()) {
-                this->network_.initializeWell(*well);
-            }
+            this->network_.initializeWell(*well);
             try {
                 using GLiftEclWells = typename GasLiftGroupInfo<Scalar, IndexTraits>::GLiftEclWells;
                 GLiftEclWells ecl_well_map;

--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -75,6 +75,7 @@ serializationTestObject(const ParallelWellInfo<Scalar>& pinfo)
     result.perf_data = PerfData<Scalar>::serializationTestObject();
     result.weldraw_max_rate = 3.0;
     result.weldraw_cmode = WellProducerCMode::LRAT;
+    result.network_thp_limit = 4.0;
 
     return result;
 }
@@ -395,6 +396,7 @@ bool SingleWellState<Scalar, IndexTraits>::operator==(const SingleWellState& rhs
            this->producer == rhs.producer &&
            this->bhp == rhs.bhp &&
            this->thp == rhs.thp &&
+           this->network_thp_limit == rhs.network_thp_limit &&
            this->pressure_first_connection == rhs.pressure_first_connection &&
            this->temperature == rhs.temperature &&
            this->phase_mixing_rates == rhs.phase_mixing_rates &&

--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -53,7 +53,6 @@ SingleWellState(const std::string& name_,
     , reservoir_rates(pu.numActivePhases())
     , prev_surface_rates(pu.numActivePhases())
     , perf_data(perf_input.size(), !is_producer, pu.numActivePhases())
-    , trivial_group_target(false)
     , use_group_target_fallback(false)
 {
     for (std::size_t perf = 0; perf < perf_input.size(); perf++) {
@@ -409,7 +408,6 @@ bool SingleWellState<Scalar, IndexTraits>::operator==(const SingleWellState& rhs
            this->frac_rate == rhs.frac_rate &&
            this->perf_data == rhs.perf_data &&
            this->filtrate_conc == rhs.filtrate_conc &&
-           this->trivial_group_target == rhs.trivial_group_target &&
            this->segments == rhs.segments &&
            this->events == rhs.events &&
            this->injection_cmode == rhs.injection_cmode &&

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -65,6 +65,7 @@ public:
         serializer(producer);
         serializer(bhp);
         serializer(thp);
+        serializer(network_thp_limit);
         serializer(pressure_first_connection);
         serializer(temperature);
         serializer(energy_rate);
@@ -104,6 +105,9 @@ public:
     PhaseUsageInfo<IndexTraits> pu;
     Scalar bhp{0};
     Scalar thp{0};
+    // Network-imposed THP limit retained until the schedule re-specifies the
+    // well's THP limit or VFP table.
+    std::optional<Scalar> network_thp_limit;
     Scalar pressure_first_connection{0};
 
     // thermal related

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -78,7 +78,6 @@ public:
         serializer(reservoir_rates);
         serializer(prev_surface_rates);
         serializer(frac_rate);
-        serializer(trivial_group_target);
         serializer(segments);
         serializer(events);
         serializer(injection_cmode);
@@ -158,7 +157,6 @@ public:
     std::vector<Scalar> prev_surface_rates;
     Scalar frac_rate{0.0};
     PerfData<Scalar> perf_data;
-    bool trivial_group_target;
     std::optional<GroupTarget> group_target;
     std::optional<GroupTarget> group_target_fallback;
     bool use_group_target_fallback;

--- a/opm/simulators/wells/WellConstraints.cpp
+++ b/opm/simulators/wells/WellConstraints.cpp
@@ -296,9 +296,14 @@ activeProductionConstraint(const SingleWellState<Scalar, IndexTraits>& ws,
     if (well_.wellHasTHPConstraints(summaryState) && currentControl != Well::ProducerCMode::THP) {
         const auto& thp = well_.getTHPConstraint(summaryState);
         Scalar current_thp = ws.thp;
-        // For trivial group targets (for instance caused by NETV) we dont want to flip to THP control.
-        const bool dont_check = (currentControl == Well::ProducerCMode::GRUP && ws.trivial_group_target);
-        if (thp > current_thp && !dont_check) {
+        // Wells with a trivial (zero) group rate target are handled before
+        // this check is reached (updateWellControl and the local-iteration
+        // switching both return early for them based on the freshly evaluated
+        // group target), so the THP limit is checked unconditionally here.
+        // Note that the stored ws.trivial_group_target is only updated when a
+        // well switches control and may be stale; using it here could keep a
+        // well flowing with a THP below the network nodal pressure.
+        if (thp > current_thp) {
             // If WVFPEXP item 4 is set to YES1 or YES2
             // switching to THP is prevented if the well will
             // produce at a higher rate with THP control

--- a/opm/simulators/wells/WellConstraints.cpp
+++ b/opm/simulators/wells/WellConstraints.cpp
@@ -296,13 +296,11 @@ activeProductionConstraint(const SingleWellState<Scalar, IndexTraits>& ws,
     if (well_.wellHasTHPConstraints(summaryState) && currentControl != Well::ProducerCMode::THP) {
         const auto& thp = well_.getTHPConstraint(summaryState);
         Scalar current_thp = ws.thp;
-        // Wells with a trivial (zero) group rate target are handled before
-        // this check is reached (updateWellControl and the local-iteration
-        // switching both return early for them based on the freshly evaluated
-        // group target), so the THP limit is checked unconditionally here.
-        // Note that the stored ws.trivial_group_target is only updated when a
-        // well switches control and may be stale; using it here could keep a
-        // well flowing with a THP below the network nodal pressure.
+        // Wells under a zero group rate target are handled before this check
+        // is reached: stoppedOrZeroRateTarget() in updateWellControl() and
+        // wellUnderZeroRateTarget() in the local-iteration switching both
+        // return early for them. The THP limit is checked unconditionally
+        // here.
         if (thp > current_thp) {
             // If WVFPEXP item 4 is set to YES1 or YES2
             // switching to THP is prevented if the well will

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -331,7 +331,10 @@ wellHasTHPConstraints(const SummaryState& summaryState) const
     }
 
     if (dynamic_thp_limit_) {
-        return true;
+        // An imposed limit cannot be evaluated without a VFP table. A THP
+        // limit from the deck is left alone, so that the missing table is
+        // still reported.
+        return this->wellEcl().vfp_table_number() > 0;
     }
 
     return WellBhpThpCalculator(*this).wellHasTHPConstraints(summaryState);

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1828,11 +1828,6 @@ namespace Opm
                     for (int p = 0; p<np; ++p) {
                         ws.surface_rates[p] *= scale;
                     }
-                    ws.trivial_group_target = false;
-                } else {
-                    // If group target is trivial we dont want to flip to other controls. To avoid oscillation we store
-                    // this information in the well state and explicitly check for this condition when evaluating well controls.
-                    ws.trivial_group_target = true;
                 }
                 break;
             }

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -393,6 +393,8 @@ init(const std::vector<Scalar>& cellPressures,
 
             // Preserve the retained limit across time steps and shut periods
             // unless the schedule explicitly re-specifies THP or VFP controls.
+            // ACTIONX raises no event here, it is handled from
+            // thp_respecified_wells in BlackoilWellModelGeneric::updateEclWells().
             if (prev_well.network_thp_limit.has_value() &&
                 new_well.producer == prev_well.producer && new_well.producer &&
                 !new_well.events.hasEvent(ScheduleEvents::WELL_THP_UPDATE))

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -391,6 +391,15 @@ init(const std::vector<Scalar>& cellPressures,
             auto& new_well = this->well(w);
             new_well.init_timestep(prev_well);
 
+            // Preserve the retained limit across time steps and shut periods
+            // unless the schedule explicitly re-specifies THP or VFP controls.
+            if (prev_well.network_thp_limit.has_value() &&
+                new_well.producer == prev_well.producer && new_well.producer &&
+                !new_well.events.hasEvent(ScheduleEvents::WELL_THP_UPDATE))
+            {
+                new_well.network_thp_limit = prev_well.network_thp_limit;
+            }
+
             if (prev_well.status == Well::Status::SHUT || prev_well.was_shut_before_action_applied) {
                 // Well was shut in previous state, do not use its values.
                 continue;

--- a/tests/test_wellstate.cpp
+++ b/tests/test_wellstate.cpp
@@ -157,7 +157,8 @@ namespace {
 
     Opm::WellState<double, IndexTraits>
     buildWellState(const Setup& setup, const std::size_t timeStep,
-                   std::vector<Opm::ParallelWellInfo<double>>& pinfos)
+                   std::vector<Opm::ParallelWellInfo<double>>& pinfos,
+                   const WellState* prevState = nullptr)
     {
         auto state  = WellState{setup.pu};
 
@@ -186,7 +187,7 @@ namespace {
 
         state.init(cpress, ctemp, setup.sched,
                    wells, ppinfos,
-                   timeStep, nullptr, setup.well_perf_data, setup.st,
+                   timeStep, prevState, setup.well_perf_data, setup.st,
                    false /*enableDistributedWells*/);
 
         state.initWellStateMSWell(setup.sched.getWells(timeStep),
@@ -240,6 +241,87 @@ WCONPROD
 /
 WCONINJE
   'INJ' 'WATER' 'OPEN' 'RATE' 100 1* 200 /
+/
+
+END
+)");
+    }
+
+
+    Opm::Deck makeRetainedThpLimitDeck()
+    {
+        return Opm::Parser{}.parseString(R"(
+RUNSPEC
+OIL
+WATER
+GAS
+METRIC
+DIMENS
+    2 1 1 /
+
+START
+  1 JAN 2000 /
+
+GRID
+DXV
+  2*100 /
+DYV
+  1*100 /
+DZV
+  1*10 /
+DEPTHZ
+  6*1000 /
+PORO
+  2*0.20 /
+PERMX
+  2*100 /
+PERMY
+  2*100 /
+PERMZ
+  2*20 /
+
+SCHEDULE
+VFPPROD
+-- table, datum, flo, wfr, gfr, pressure, alq, unit, table_vals
+  1 1000.0 LIQ WCT GOR THP ' ' METRIC BHP /
+  1.0 /
+  0.0 1.0 /
+  0.0 /
+  0.0 /
+  0.0 /
+  1 1 1 1 0.0 /
+  2 1 1 1 1.0 /
+
+WELSPECS
+  'PROD' 'G' 1 1 1000 'OIL' /
+/
+COMPDAT
+  'PROD' 1 1 1 1 'OPEN' 1* 100 0.1 /
+/
+WCONPROD
+  'PROD' 'OPEN' 'ORAT' 100 4* 100 25.0 1 /
+/
+
+DATES     -- 1: nothing is re-specified
+  1 FEB 2000 /
+/
+
+DATES     -- 2
+  1 MAR 2000 /
+/
+WELTARG   -- a target that is neither the THP limit nor the VFP table
+  'PROD' ORAT 90 /
+/
+
+DATES     -- 3
+  1 APR 2000 /
+/
+WELTARG   -- re-specifies the THP limit
+  'PROD' THP 30 /
+/
+
+DATES     -- 4
+  1 MAY 2000 /
 /
 
 END
@@ -498,6 +580,38 @@ BOOST_AUTO_TEST_CASE(RSCONST_InjectionWellDoesNotSynthesizeGas)
     const auto& rates = rpt.at("INJ").rates;
     BOOST_CHECK(!rates.has(Opm::data::Rates::opt::gas));
     BOOST_CHECK(!rates.has(Opm::data::Rates::opt::dissolved_gas));
+}
+
+// ---------------------------------------------------------------------
+
+// A network-imposed THP limit is retained in the well state so that it stays
+// in force after the well leaves the network, where nothing recomputes it.
+// It is dropped only when the schedule re-specifies the THP limit or the VFP
+// table, which is the sole way a deck can get rid of it again.
+BOOST_AUTO_TEST_CASE(RetainedNetworkThpLimit)
+{
+    const auto setup = Setup { makeRetainedThpLimitDeck() };
+    const auto limit = 50.0*Opm::unit::barsa;
+
+    auto pinfos = std::vector<std::vector<Opm::ParallelWellInfo<double>>>(4);
+
+    // The network imposed a THP limit on the well at the first step.
+    auto imposed = buildWellState(setup, 0, pinfos[0]);
+    imposed.well("PROD").network_thp_limit = limit;
+
+    // Nothing is re-specified, the limit stays in force.
+    const auto kept = buildWellState(setup, 1, pinfos[1], &imposed);
+    BOOST_REQUIRE(kept.well("PROD").network_thp_limit.has_value());
+    BOOST_CHECK_CLOSE(*kept.well("PROD").network_thp_limit, limit, 1.0e-10);
+
+    // A target that is neither the THP limit nor the VFP table leaves it alone.
+    const auto other_target = buildWellState(setup, 2, pinfos[2], &kept);
+    BOOST_REQUIRE(other_target.well("PROD").network_thp_limit.has_value());
+    BOOST_CHECK_CLOSE(*other_target.well("PROD").network_thp_limit, limit, 1.0e-10);
+
+    // Re-specifying the THP limit drops it, the well reverts to the deck limit.
+    const auto respecified = buildWellState(setup, 3, pinfos[3], &other_target);
+    BOOST_CHECK(!respecified.well("PROD").network_thp_limit.has_value());
 }
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
A well can be attached to a production network without a VFP curve specified for it. OPM Flow aborts the run with Nonexistent VFP table 0 referenced, which is not a helpful message. This PR makes that case run, and fixes a second problem for wells attached to a network.

A well whose THP limit and VFP table are defaulted (WCONPROD items 10 and 11) is no longer treated as THP-constrained when the network imposes a limit on it, so it stays on its remaining controls while its rates still enter the network pressure calculation. A THP limit entered in the deck is left alone, so a missing VFP table is still reported there. The same eligibility rule is applied wherever a network THP limit is imposed or retained: the extended network, auto-choke groups, and the reconstruction at restart.

A well that leaves the network — for instance moved to a non-network group by WELSPECS — now keeps the THP limit last imposed by network balancing until the schedule re-specifies its THP limit or VFP table, instead of silently reverting to the static limit from the deck. The limit is stored in SingleWellState, so it also survives shut periods and is reconstructed at restart. Node pressures left over from an earlier network are dropped at the start of a report step, so they are not imposed as if they had just been balanced. A unit test covers the retention and its cancellation.

Also removes the trivial_group_target veto in activeProductionConstraint(), which skipped the switch to THP control for GRUP-controlled wells. The flag is only rewritten when a well switches control, so it could go stale and block the very switch that would refresh it, letting network wells produce with a THP below the pressure of the node they feed. Both call paths already return early for wells whose freshly evaluated group target is zero, so the veto could only act on stale information; the flag itself is now unused and removed.

Depends on OPM/opm-common#5298 (WELL_THP_UPDATE event and SimulatorUpdate::thp_respecified_wells), which is what detects re-specification even when the entered values are unchanged.


