### PR TITLE
ptflash: keep the derivatives when clamping the composition

### DIFF
--- a/opm/models/ptflash/flashintensivequantities.hh
+++ b/opm/models/ptflash/flashintensivequantities.hh
@@ -135,7 +135,13 @@ public:
 
             Evaluation sumz = 0.0;
             for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
-                z[compIdx] = max(z[compIdx], 1e-8);
+                // Clamp only the value; preserve derivatives. Replacing the Evaluation with
+                // max() when the bound applies removes composition derivatives from a
+                // vanished component's conservation equation and makes the cell Jacobian
+                // block singular.
+                if (z[compIdx] < 1e-8) {
+                    z[compIdx].setValue(1e-8);
+                }
                 sumz += z[compIdx];
             }
             z /= sumz;


### PR DESCRIPTION
Applying max(z, 1e-8) to an AD evaluation replaces it with a constant when the floor applies, removing all composition derivatives. The implicit last mole fraction, 1 - sum(z), can reach the floor in near-pure injection-gas cells, so its conservation equation becomes decoupled from the composition variables. This produces a singular cell Jacobian block and ineffective, heavily limited Newton updates.

Clamp only the value and retain its derivatives. This intentionally uses inconsistent differentiation, but keeps the conservation equation coupled to composition variables so Newton can move the state away from the floor.

This significantly improves the running of many cases that we have.  Although we can do more along this line, but this PR itself is nice to have since it is small and fixes running with small code change, and only improves things. 