### PR TITLE
Fix warnings delete called on non-final x that has virtual functions but non-virtual destructor

### DIFF
--- a/examples/problems/co2injectionflash.hh
+++ b/examples/problems/co2injectionflash.hh
@@ -39,7 +39,7 @@ namespace Opm {
  * problem.
  */
 template <class Scalar, class FluidSystem>
-class Co2InjectionFlash : public Opm::NcpFlash<Scalar, FluidSystem>
+class Co2InjectionFlash final: public Opm::NcpFlash<Scalar, FluidSystem>
 {
     using ParentType = Opm::NcpFlash<Scalar, FluidSystem>;
 

--- a/examples/problems/co2injectionproblem.hh
+++ b/examples/problems/co2injectionproblem.hh
@@ -193,7 +193,7 @@ double Co2InjectionTolerance = 1e-8;
  * hydrostatic pressure is assumed.
  */
 template <class TypeTag>
-class Co2InjectionProblem : public GetPropType<TypeTag, Properties::BaseProblem>
+class Co2InjectionProblem final: public GetPropType<TypeTag, Properties::BaseProblem>
 {
     using ParentType = GetPropType<TypeTag, Properties::BaseProblem>;
 

--- a/examples/problems/co2ptflashproblem.hh
+++ b/examples/problems/co2ptflashproblem.hh
@@ -181,7 +181,7 @@ namespace Opm {
  *
  */
 template <class TypeTag>
-class CO2PTProblem : public GetPropType<TypeTag, Properties::BaseProblem>
+class CO2PTProblem final: public GetPropType<TypeTag, Properties::BaseProblem>
 {
     using ParentType = GetPropType<TypeTag, Properties::BaseProblem>;
 

--- a/examples/problems/cuvetteproblem.hh
+++ b/examples/problems/cuvetteproblem.hh
@@ -145,7 +145,7 @@ namespace Opm {
  * of the domain requires much longer (about 10 days simulated time).
  */
 template <class TypeTag>
-class CuvetteProblem : public GetPropType<TypeTag, Properties::BaseProblem>
+class CuvetteProblem final: public GetPropType<TypeTag, Properties::BaseProblem>
 {
     using ParentType = GetPropType<TypeTag, Properties::BaseProblem>;
 

--- a/examples/problems/diffusionproblem.hh
+++ b/examples/problems/diffusionproblem.hh
@@ -120,7 +120,7 @@ namespace Opm {
  * diffusion.
  */
 template <class TypeTag>
-class DiffusionProblem : public GetPropType<TypeTag, Properties::BaseProblem>
+class DiffusionProblem final: public GetPropType<TypeTag, Properties::BaseProblem>
 {
     using ParentType = GetPropType<TypeTag, Properties::BaseProblem>;
 

--- a/examples/problems/fingerproblem.hh
+++ b/examples/problems/fingerproblem.hh
@@ -159,7 +159,7 @@ namespace Opm {
  * discretization is fine enough.
  */
 template <class TypeTag>
-class FingerProblem : public GetPropType<TypeTag, Properties::BaseProblem>
+class FingerProblem final: public GetPropType<TypeTag, Properties::BaseProblem>
 {
     //!\cond SKIP_THIS
     using ParentType = GetPropType<TypeTag, Properties::BaseProblem>;

--- a/examples/problems/fractureproblem.hh
+++ b/examples/problems/fractureproblem.hh
@@ -197,7 +197,7 @@ namespace Opm {
  * where the pressure is kept constant.
  */
 template <class TypeTag>
-class FractureProblem : public GetPropType<TypeTag, Properties::BaseProblem>
+class FractureProblem final: public GetPropType<TypeTag, Properties::BaseProblem>
 {
     using ParentType = GetPropType<TypeTag, Properties::BaseProblem>;
     using GridView = GetPropType<TypeTag, Properties::GridView>;

--- a/examples/problems/groundwaterproblem.hh
+++ b/examples/problems/groundwaterproblem.hh
@@ -131,7 +131,7 @@ namespace Opm {
  * occupied by a rectangular lens of lower permeability.
  */
 template <class TypeTag>
-class GroundWaterProblem : public GetPropType<TypeTag, Properties::BaseProblem>
+class GroundWaterProblem final: public GetPropType<TypeTag, Properties::BaseProblem>
 {
     using ParentType = GetPropType<TypeTag, Properties::BaseProblem>;
 

--- a/examples/problems/infiltrationproblem.hh
+++ b/examples/problems/infiltrationproblem.hh
@@ -120,7 +120,7 @@ namespace Opm {
  * except for the small infiltration zone in the upper left part.
  */
 template <class TypeTag>
-class InfiltrationProblem : public GetPropType<TypeTag, Properties::BaseProblem>
+class InfiltrationProblem final: public GetPropType<TypeTag, Properties::BaseProblem>
 {
     using ParentType = GetPropType<TypeTag, Properties::BaseProblem>;
 

--- a/examples/problems/lensproblem.hh
+++ b/examples/problems/lensproblem.hh
@@ -173,7 +173,7 @@ namespace Opm {
  * saturation on both sides is zero.
  */
 template <class TypeTag>
-class LensProblem : public GetPropType<TypeTag, Properties::BaseProblem>
+class LensProblem final: public GetPropType<TypeTag, Properties::BaseProblem>
 {
     using ParentType = GetPropType<TypeTag, Properties::BaseProblem>;
 

--- a/examples/problems/obstacleproblem.hh
+++ b/examples/problems/obstacleproblem.hh
@@ -143,7 +143,7 @@ namespace Opm {
  * and the right boundary where a free flow condition is assumed.
  */
 template <class TypeTag>
-class ObstacleProblem : public GetPropType<TypeTag, Properties::BaseProblem>
+class ObstacleProblem final: public GetPropType<TypeTag, Properties::BaseProblem>
 {
     using ParentType = GetPropType<TypeTag, Properties::BaseProblem>;
 

--- a/examples/problems/outflowproblem.hh
+++ b/examples/problems/outflowproblem.hh
@@ -93,7 +93,7 @@ namespace Opm {
  * used.
  */
 template <class TypeTag>
-class OutflowProblem : public GetPropType<TypeTag, Properties::BaseProblem>
+class OutflowProblem final: public GetPropType<TypeTag, Properties::BaseProblem>
 {
     using ParentType = GetPropType<TypeTag, Properties::BaseProblem>;
 

--- a/examples/problems/powerinjectionproblem.hh
+++ b/examples/problems/powerinjectionproblem.hh
@@ -140,7 +140,7 @@ namespace Opm {
  * Systems, University of Stuttgart, 2011
  */
 template <class TypeTag>
-class PowerInjectionProblem : public GetPropType<TypeTag, Properties::BaseProblem>
+class PowerInjectionProblem final: public GetPropType<TypeTag, Properties::BaseProblem>
 {
     using ParentType = GetPropType<TypeTag, Properties::BaseProblem>;
 

--- a/examples/problems/reservoirproblem.hh
+++ b/examples/problems/reservoirproblem.hh
@@ -160,7 +160,7 @@ namespace Opm {
  * the injector wells use a pressure which is 50% above the reservoir pressure.
  */
 template <class TypeTag>
-class ReservoirProblem : public GetPropType<TypeTag, Properties::BaseProblem>
+class ReservoirProblem final: public GetPropType<TypeTag, Properties::BaseProblem>
 {
     using ParentType = GetPropType<TypeTag, Properties::BaseProblem>;
 

--- a/examples/problems/richardslensproblem.hh
+++ b/examples/problems/richardslensproblem.hh
@@ -122,7 +122,7 @@ namespace Opm {
  * instead of a \c DNAPL infiltrates from the top.
  */
 template <class TypeTag>
-class RichardsLensProblem : public GetPropType<TypeTag, Properties::BaseProblem>
+class RichardsLensProblem final: public GetPropType<TypeTag, Properties::BaseProblem>
 {
     using ParentType = GetPropType<TypeTag, Properties::BaseProblem>;
 

--- a/examples/problems/waterairproblem.hh
+++ b/examples/problems/waterairproblem.hh
@@ -165,7 +165,7 @@ namespace Opm {
  * K/m.
  */
 template <class TypeTag >
-class WaterAirProblem : public GetPropType<TypeTag, Properties::BaseProblem>
+class WaterAirProblem final: public GetPropType<TypeTag, Properties::BaseProblem>
 {
     using ParentType = GetPropType<TypeTag, Properties::BaseProblem>;
 


### PR DESCRIPTION
Fixing warnings:
```bash
In file included from /Users/dmar/opm/opm-simulators/examples/waterair_pvs_ni.cpp:30:
In file included from /Users/dmar/opm/opm-simulators/opm/models/common/darcyfluxmodule.hh:33:
In file included from /opt/homebrew/include/dune/common/fmatrix.hh:10:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/iostream:45:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/ios:228:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__locale:28:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/string:654:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/string_view:951:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/algorithm:1865:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/inplace_merge.h:27:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/unique_ptr.h:77:5: warning: 
      delete called on non-final 'Opm::WaterAirProblem<Opm::Properties::TTag::WaterAirProblem>' that has virtual
      functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
   77 |     delete __ptr;
      |     ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/unique_ptr.h:290:7: note: 
      in instantiation of member function
      'std::default_delete<Opm::WaterAirProblem<Opm::Properties::TTag::WaterAirProblem>>::operator()' requested here
  290 |       __deleter_(__tmp);
      |       ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/unique_ptr.h:230:5: note: 
      in instantiation of member function
      'std::unique_ptr<Opm::WaterAirProblem<Opm::Properties::TTag::WaterAirProblem>>::reset' requested here
  230 |     reset(__u.release());
      |     ^
/Users/dmar/opm/opm-simulators/opm/models/utils/simulator.hh:181:22: note: in instantiation of
      member function 'std::unique_ptr<Opm::WaterAirProblem<Opm::Properties::TTag::WaterAirProblem>>::operator='
      requested here
  181 |             problem_ = std::make_unique<Problem>(*this);
      |                      ^
/Users/dmar/opm/opm-simulators/opm/models/utils/simulator.hh:103:11: note: in instantiation of
      member function 'Opm::Simulator<Opm::Properties::TTag::WaterAirProblem>::Simulator' requested here
  103 |         : Simulator(Communication(), verbose)
      |           ^
/Users/dmar/opm/opm-simulators/opm/models/utils/start.hh:323:19: note: in instantiation of member
      function 'Opm::Simulator<Opm::Properties::TTag::WaterAirProblem>::Simulator' requested here
  323 |         Simulator simulator;
      |                   ^
/Users/dmar/opm/opm-simulators/examples/waterair_pvs_ni.cpp:71:17: note: in instantiation of
      function template specialization 'Opm::start<Opm::Properties::TTag::WaterAirProblem>' requested here
   71 |     return Opm::start<ProblemTypeTag>(argc, argv, true);
```