### PR TITLE
Make base class destructor virtual.

### DIFF
--- a/opm/models/discretization/common/fvbaseproblem.hh
+++ b/opm/models/discretization/common/fvbaseproblem.hh
@@ -162,6 +162,8 @@ public:
         }
     }
 
+    virtual ~FvBaseProblem() = default;
+
     /*!
      * \brief Registers all available parameters for the problem and
      *        the model.


### PR DESCRIPTION
Fixes a warning seen on some compilers. The problem classes are single-per-program typically so no performance hit.