### PR TITLE
Reservoir coupling: Impose master node pressure only where the deck asks for it

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelRescoup.hpp
+++ b/opm/simulators/wells/BlackoilWellModelRescoup.hpp
@@ -242,6 +242,17 @@ private:
     ///   activated slaves and gates the master's own iteration.
     bool masterNetworkHasMasterGroupLeavesForSlave_(std::size_t slave_idx) const;
 
+    /// \brief Slave-side: true iff this slave's own deck put the named group
+    ///   into its own surface network as a fixed-pressure node.
+    ///
+    /// This is the condition under which a master-supplied node pressure may
+    /// be imposed on the group at all: the pressure is the fixed pressure of
+    /// the slave group's node in the *slave's* network, so the deck must have
+    /// declared such a node (GRUPNET item 2, or NODEPROP item 2 for an
+    /// extended network).  A slave that declares no network keeps its wells
+    /// on their WCONPROD THP limits.
+    bool slaveGroupIsFixedPressureNodeInOwnNetwork_(const std::string& group_name) const;
+
     BlackoilWellModel<TypeTag>& well_model_;
     BlackoilWellModelNetwork<TypeTag>& network_;
     Simulator& simulator_;

--- a/opm/simulators/wells/BlackoilWellModelRescoup_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelRescoup_impl.hpp
@@ -182,38 +182,47 @@ receiveMasterGroupNodePressuresFromMaster()
     if (num_pressures > 0) {
         rescoup_slave.receiveMasterGroupNodePressuresFromMaster(num_pressures);
     }
-    // Apply pressures as dynamic THP limits on every producer whose
-    // group has a master-supplied pressure.  Wells in master groups that
-    // are not network leaves are not touched (no entry in the map).
-    // Mirrors the standard local-network apply pattern in
+    // Apply pressures as dynamic THP limits on every producer whose group
+    // has a master-supplied pressure *and* whose group the slave's own deck
+    // placed in its own surface network as a fixed-pressure node.  Wells in
+    // master groups that are not network leaves are not touched either (no
+    // entry in the map).  Mirrors the standard local-network apply pattern in
     // BlackoilWellModelNetworkGeneric::updatePressures(): when the well is
     // currently THP-controlled, also write the new THP into the WellState
     // directly, because setDynamicThpLimit() alone leaves the active
     // control's THP value stale and the subsequent well-solve would
     // converge against the old THP.
     //
-    // TODO (follow-up PR): this THP-direct path is only correct when the
-    // slave has no extended network between its slave group and the wells
-    // (the case exercised here).  When the slave uses an extended network
-    // with the slave group declared as a fixed-pressure node, the master-
-    // supplied pressure should instead be installed as that node's terminal
-    // pressure and the slave's network solver should propagate it down to
-    // the wells.  The plumbing exists -- the solver already reads
+    // The node-pressure exchange is a boundary condition between two
+    // networks: the master's network ends at the master groups, and the
+    // pressure it computes there is the fixed pressure of the corresponding
+    // slave group's node in the *slave's* network.  A slave that declares no
+    // network has no such node, and its wells keep the THP limits from their
+    // own WCONPROD records -- so the messages are still received (the
+    // protocol is unchanged) but nothing is imposed.
+    //
+    // TODO (follow-up PR): when the slave group is a fixed-pressure node with
+    // branches below it, the pressure belongs at the top of the slave's own
+    // network solve rather than directly on the wells; the slave's branches
+    // and their pressure losses then decide the wells' THP limits.  The
+    // plumbing exists -- the solver already reads
     // Network::Node::terminal_pressure() when walking up branches -- but
     // surfacing the master-sent value into the solver needs a runtime
     // override path (e.g. a fixed-pressure override map on
     // BlackoilWellModelNetwork) so we do not mutate the parsed Schedule
-    // network at runtime.  Until then, decks where the slave group is a
-    // fixed-pressure node in the slave's extended network are not handled
-    // correctly.
+    // network at runtime.  Until then the direct write below is exact only
+    // for a slave group that is itself a well group, where there is no
+    // branch between the node and the wells.
     const auto& pressures = rescoup_slave.masterGroupNodePressures();
     if (pressures.empty()) return;
     const auto& summary_state = this->well_model_.summaryState();
     auto& well_state = this->wellState();
     for (auto& well : this->wellContainer()) {
         if (!well->isProducer() || !well->wellEcl().predictionMode()) continue;
-        const auto it = pressures.find(well->wellEcl().groupName());
+        const auto& group_name = well->wellEcl().groupName();
+        const auto it = pressures.find(group_name);
         if (it == pressures.end()) continue;
+        if (!this->slaveGroupIsFixedPressureNodeInOwnNetwork_(group_name)) continue;
         well->setDynamicThpLimit(it->second);
         auto& ws = well_state[well->indexOfWell()];
         if (ws.production_cmode == Well::ProducerCMode::THP) {
@@ -402,6 +411,18 @@ masterNetworkHasMasterGroupLeavesForSlave_(std::size_t slave_idx) const
         }
     }
     return false;
+}
+
+template<typename TypeTag>
+bool
+BlackoilWellModelRescoup<TypeTag>::
+slaveGroupIsFixedPressureNodeInOwnNetwork_(const std::string& group_name) const
+{
+    const int episodeIdx = this->simulator_.episodeIndex();
+    const auto& network = this->schedule()[episodeIdx].network();
+    if (!network.active()) return false;
+    if (!network.has_node(group_name)) return false;
+    return network.node(group_name).terminal_pressure().has_value();
 }
 
 


### PR DESCRIPTION
In a coupled run the master solves its own surface network and sends each slave the nodal pressure of the master group that stands for the slave's group. `BlackoilWellModelRescoup::receiveMasterGroupNodePressuresFromMaster()` currently installs that pressure as a **dynamic THP limit on every producer of the corresponding slave group**, unconditionally, overriding the THP limit the well was given in `WCONPROD`.

That is one step too far. The communicated pressure is a boundary condition **between two networks**: the master's network ends at the master groups, and the pressure computed there is the fixed pressure of the corresponding slave group's node in the *slave's own* network. The slave is then supposed to balance its own network downwards from that pressure, and it is the nodal pressure of the group that actually holds the wells which becomes those wells' THP limit. A slave that declares no network of its own has no such node, so there is nothing for the communicated pressure to overwrite, and its wells should keep the THP limits from their own `WCONPROD` records.

#### What changes

- Adds `slaveGroupIsFixedPressureNodeInOwnNetwork_()`, which asks the **slave's own parsed network** whether the group is present as a fixed-pressure node: the network must be active, contain a node of that name, and that node must carry a terminal pressure (`GRUPNET` item 2, or `NODEPROP` item 2 for an extended network).
- `receiveMasterGroupNodePressuresFromMaster()` consults it before writing a dynamic THP limit. **The messages are still received either way**, so the MPI protocol is unchanged and no send/receive pairing is affected.
- Updates the `TODO` above that code: the remaining unhandled case is a slave group that is a fixed-pressure node **with branches below it**, where the pressure belongs at the top of the slave's own network solve rather than directly on the wells.

#### Effect on `rescoup/rc_m1` in opm-tests

In [`rc_m1`](https://github.com/OPM/opm-tests/blob/master/rescoup/rc_m1/master/RC-01_MAST_PRED.DATA) the master declares an extended network (`BRANPROP`/`NODEPROP`) down to its master groups `B1_M`, `D1_M` and `E1_M`, while neither slave deck declares a network of any kind. So today the master's nodal pressures are imposed on slave wells that the decks never placed in a network.

Comparing the same build with and without this commit, tight coupling (`--rc-network-loose-coupling=false`), all 38 report steps:

- The two `mod2` gas producers `E-1H` and `E-2H` have a 10 bar THP limit in `WCONPROD`. Before the change neither ever gets below **30.1 bar** of wellhead pressure, and each sits exactly on its master group's nodal pressure. After it, neither is ever pinned to the node pressure and both reach their own 10 bar limit.
- `E-2H`, which was effectively shut for the last year of the run, produces again: its cumulative gas rises by **45%**. `E-1H`'s rises by 3.6%.
- The reported well potentials move for the same reason: `WellInterfaceGeneric::onlyKeepBHPandTHPcontrols()` takes its THP target from `getTHPConstraint()`, which prefers the dynamic limit over the deck value. An imposed node pressure therefore also shifted the potentials the slave reports back to the master — which the master uses both for guide rates and for capping each group's target at what its slave says it can deliver.

#### Notes

- For a slave that *does* declare its slave groups as fixed-pressure network nodes, behaviour is unchanged.
- No behavior change outside reservoir coupling: the touched code is in `BlackoilWellModelRescoup`, reached only by a coupling slave.
- This does not make the master's network redundant. Commenting `BRANPROP`/`NODEPROP` out of the `rc_m1` master deck on top of this commit changes the solution substantially — field oil rate by up to 52% at a report step and cumulative field oil by 6%, with the gas sales rate running to 3.9e6 sm3/day instead of 2.4e6 — because the presence of a master network is also what switches on the master/slave network iteration (6,910 flow-rate exchanges over the run versus none).