### PR TITLE
fvbasediscretization: do not let exceptions escape the OpenMP block in invalidateAndUpdateIntensiveQuantities. 

### DIFF
--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -67,8 +67,10 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <exception>
 #include <list>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <sstream>
 #include <string>
@@ -726,49 +728,86 @@ public:
     {
         invalidateIntensiveQuantitiesCache(timeIdx);
 
+        // exceptions must not escape the parallel block below (that calls
+        // std::terminate()); tuck any exception away and rethrow it after the
+        // block, so that e.g. a failed flash in the property evaluation leads
+        // to a time step chop instead of an abort
+        std::mutex exceptionLock;
+        std::exception_ptr exceptionPtr = nullptr;
+
         // loop over all elements...
         ThreadedEntityIterator<GridView, /*codim=*/0> threadedElemIt(gridView_);
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
         {
-            ElementContext elemCtx(simulator_);
-            ElementIterator elemIt = threadedElemIt.beginParallel();
-            for (; !threadedElemIt.isFinished(elemIt); elemIt = threadedElemIt.increment()) {
-                const Element& elem = *elemIt;
-                elemCtx.updatePrimaryStencil(elem);
-                elemCtx.updatePrimaryIntensiveQuantities(timeIdx);
+            try {
+                ElementContext elemCtx(simulator_);
+                for (ElementIterator elemIt = threadedElemIt.beginParallel();
+                     !threadedElemIt.isFinished(elemIt);
+                     elemIt = threadedElemIt.increment())
+                {
+                    const Element& elem = *elemIt;
+                    elemCtx.updatePrimaryStencil(elem);
+                    elemCtx.updatePrimaryIntensiveQuantities(timeIdx);
+                }
             }
+            catch (...) {
+                std::lock_guard<std::mutex> take(exceptionLock);
+                exceptionPtr = std::current_exception();
+                threadedElemIt.setFinished();
+            }
+        }
+
+        if (exceptionPtr) {
+            std::rethrow_exception(exceptionPtr);
         }
     }
 
     template <class GridViewType>
     void invalidateAndUpdateIntensiveQuantities(unsigned timeIdx, const GridViewType& gridView) const
     {
+        // see the overload above for why exceptions are bridged out of the
+        // parallel block like this
+        std::mutex exceptionLock;
+        std::exception_ptr exceptionPtr = nullptr;
+
         // loop over all elements...
         ThreadedEntityIterator<GridViewType, /*codim=*/0> threadedElemIt(gridView);
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
         {
-
-            ElementContext elemCtx(simulator_);
-            auto elemIt = threadedElemIt.beginParallel();
-            for (; !threadedElemIt.isFinished(elemIt); elemIt = threadedElemIt.increment()) {
-                if (elemIt->partitionType() != Dune::InteriorEntity) {
-                    continue;
+            try {
+                ElementContext elemCtx(simulator_);
+                for (auto elemIt = threadedElemIt.beginParallel();
+                     !threadedElemIt.isFinished(elemIt);
+                     elemIt = threadedElemIt.increment())
+                {
+                    if (elemIt->partitionType() != Dune::InteriorEntity) {
+                        continue;
+                    }
+                    const Element& elem = *elemIt;
+                    elemCtx.updatePrimaryStencil(elem);
+                    // Mark cache for this element as invalid.
+                    const std::size_t numPrimaryDof = elemCtx.numPrimaryDof(timeIdx);
+                    for (unsigned dofIdx = 0; dofIdx < numPrimaryDof; ++dofIdx) {
+                        const unsigned globalIndex = elemCtx.globalSpaceIndex(dofIdx, timeIdx);
+                        setIntensiveQuantitiesCacheEntryValidity(globalIndex, timeIdx, false);
+                    }
+                    // Update for this element.
+                    elemCtx.updatePrimaryIntensiveQuantities(timeIdx);
                 }
-                const Element& elem = *elemIt;
-                elemCtx.updatePrimaryStencil(elem);
-                // Mark cache for this element as invalid.
-                const std::size_t numPrimaryDof = elemCtx.numPrimaryDof(timeIdx);
-                for (unsigned dofIdx = 0; dofIdx < numPrimaryDof; ++dofIdx) {
-                    const unsigned globalIndex = elemCtx.globalSpaceIndex(dofIdx, timeIdx);
-                    setIntensiveQuantitiesCacheEntryValidity(globalIndex, timeIdx, false);
-                }
-                // Update for this element.
-                elemCtx.updatePrimaryIntensiveQuantities(timeIdx);
             }
+            catch (...) {
+                std::lock_guard<std::mutex> take(exceptionLock);
+                exceptionPtr = std::current_exception();
+                threadedElemIt.setFinished();
+            }
+        }
+
+        if (exceptionPtr) {
+            std::rethrow_exception(exceptionPtr);
         }
     }
 


### PR DESCRIPTION
Both overloads of invalidateAndUpdateIntensiveQuantities update the intensive quantities inside an OpenMP parallel block. An exception thrown there cannot propagate out of the parallel region: the C++ runtime calls std::terminate() and the whole simulation aborts instead of retrying with a smaller time step.

This was found with compositional runs, where the property evaluation includes a flash: on a hard state the flash solver can fail to converge and throw, and a single such cell was enough to kill the entire run, even though the failure is exactly the kind the time stepping recovers from by chopping. Any other throwing property evaluation (e.g. a table-range violation) hits the same problem.

Following the pattern already used in FvBaseLinearizer, the exception is captured into a std::exception_ptr (under a mutex, since any thread can throw), the threaded iteration is wound down via setFinished(), and the exception is rethrown after the parallel block. From there the usual recovery applies, so a failed flash now leads to a time step chop instead of an abort.

No behavior change when nothing throws.