### PR TITLE
bugfix when creating GpuSeqILU0 from GPU matrix

### DIFF
--- a/opm/simulators/linalg/gpuistl/GpuSeqILU0.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuSeqILU0.hpp
@@ -187,17 +187,14 @@ template <typename T, typename std::enable_if_t<is_gpu_matrix_v<T>, int>>
 GpuSeqILU0<M, X, Y, l>::GpuSeqILU0(const M& A, field_type w)
     : m_underlyingMatrix(A)
     , m_w(w)
-    , m_LU(A.getNonZeroValues().data(),
-           A.getRowIndices().data(),
-           A.getColumnIndices().data(),
-           A.nonzeroes(),
-           A.blockSize(),
-           A.N())
+    , m_LU(A.getRowIndices(), A.getColumnIndices(), A.blockSize())
     , m_temporaryStorage(m_LU.N() * m_LU.blockSize())
     , m_descriptionL(detail::createLowerDiagonalDescription())
     , m_descriptionU(detail::createUpperDiagonalDescription())
     , m_cuSparseHandle(detail::CuSparseHandle::getInstance())
 {
+    m_LU.updateNonzeroValues(A);
+
     // Some sanity check
     OPM_ERROR_IF(A.N() != m_LU.N(),
                  fmt::format("CuSparse matrix not same size as DUNE matrix. {} vs {}.", m_LU.N(), A.N()));

--- a/opm/simulators/linalg/gpuistl/GpuVector.cpp
+++ b/opm/simulators/linalg/gpuistl/GpuVector.cpp
@@ -26,6 +26,7 @@
 #include <opm/simulators/linalg/gpuistl/detail/cublas_wrapper.hpp>
 #include <opm/simulators/linalg/gpuistl/detail/gpu_constants.hpp>
 #include <opm/simulators/linalg/gpuistl/detail/gpu_safe_call.hpp>
+#include <opm/simulators/linalg/gpuistl/detail/is_gpu_pointer.hpp>
 #include <opm/simulators/linalg/gpuistl/detail/vector_operations.hpp>
 
 namespace Opm::gpuistl
@@ -49,6 +50,9 @@ template <class T>
 GpuVector<T>::GpuVector(const T* dataOnHost, const size_t numberOfElements)
     : GpuVector(numberOfElements)
 {
+    if (detail::isGPUPointer(dataOnHost)) {
+        OPM_THROW(std::invalid_argument, "dataOnHost is a GPU pointer, use copy constructor instead");
+    }
 
     OPM_GPU_SAFE_CALL(cudaMemcpy(
         m_dataOnDevice, dataOnHost, detail::to_size_t(m_numberOfElements) * sizeof(T), cudaMemcpyHostToDevice));

--- a/tests/gpuistl/test_GpuVector.cpp
+++ b/tests/gpuistl/test_GpuVector.cpp
@@ -64,6 +64,13 @@ BOOST_AUTO_TEST_CASE(TestCopyFromHostConstructor)
     BOOST_CHECK_EQUAL_COLLECTIONS(buffer.begin(), buffer.end(), data.begin(), data.end());
 }
 
+BOOST_AUTO_TEST_CASE(TestCopyFromHostConstructorWithGPUPointer)
+{
+    std::vector<double> data {{1, 2, 3, 4, 5, 6, 7}};
+    auto vectorOnGPU = Opm::gpuistl::GpuVector<double>(data.data(), data.size());
+    BOOST_CHECK_THROW(Opm::gpuistl::GpuVector<double>(vectorOnGPU.data(), data.size()), std::invalid_argument);
+}
+
 
 BOOST_AUTO_TEST_CASE(TestCopyFromHostFunction)
 {


### PR DESCRIPTION
The unit test `test_preconditioner_factory_gpu` failed with the error
```
417: unknown location(0): fatal error: in "TestMatrixAdapter": memory access violation at address: 0x7fa240e21c28: invalid permissions
```

The direct cause was that a GpuSparseMatrix was tried created by passing device pointers instead of host pointers. 
These device pointers was passed on to the `GpuVector` constructor `GpuVector(const T* dataOnHost, const size_t numberOfElements)`, which (somewhat surprisingly) successfully carried out a host to device `cudaMemcpy`.
When the matrix constructor later tried to verify that the last element of `rowIndices` (the pointer to device, not host, memory) was the same as `numberOfNonzeroBlocks`, device memory was treated as host memory causing the above error.

The bug was related to the constructor of a `GpuSeqILU0` object using a GPU matrix as input (see my diff in GpuSeqILU0.hpp).
* Old implementation: Building `GpuSparseMatrix` by passing device pointers into the constructor that expected host pointers.
* Fix: Use the `GpuSparseMatrix` constructor that takes `GpuVector`s as input instead.



### Relevant question: Why didn't `cudeMemcpy` from host to device notice that the data it copied from was a device pointer?

My LLM claims (which sounds plausible):

> Why cudaMemcpy often does not complain
> `cudaMemcpyHostToDevice` does not mean “I will CPU-dereference src like memcpy.” It means “perform a copy; I claim the direction is host→device.”
> 
> On modern CUDA with Unified Virtual Addressing (UVA) (basically all current GPUs/toolkits you care about):
> 
> * Host and device pointers live in one address space and are distinguishable by value.
> * The runtime can (and often does) look up pointer attributes for src and dst.
> * If both are valid CUDA-known pointers, it can still perform a correct transfer even when kind is wrong — e.g. treat it as device→device under the hood.


The proposed check in the constructor `GpuVector(const T* dataOnHost, const size_t numberOfElements)`
to throw an exception if `dataOnHost` points to device memory instead of host memory would have made debugging the failing test easier.

Such checks should be made before all `cudaMemcpy` calls. I will add those in a separate PR, along with some refactoring of `GpuVector` to hold a `GpuBuffer` to reduce code duplication.


