### PR TITLE
Reservoir coupling: do not compare group targets of different rate types

### DIFF
--- a/opm/simulators/wells/GroupConstraintCalculator.cpp
+++ b/opm/simulators/wells/GroupConstraintCalculator.cpp
@@ -597,6 +597,9 @@ calculateGroupConstraint()
     // NOTE: Injection targets for VREP, RESV, and REIN modes are always sent as RATE
     //   control mode to the slave, see
     //   RescoupConstraintsCalculator.cpp::calculateSlaveGroupConstraints_()
+    // bottom_group_current_rate_available is a positive magnitude for producers (the sign is
+    // normalized at the source in getBottomGroupCurrentRateAvailable_()), so it is directly
+    // comparable to the positive full_target.
     if (bottom_group_current_rate_available > TARGET_RATE_TOLERANCE) {  // > 1e-12
         const auto toplevel_control_mode = this->getToplevelControlMode_();
         if ((bottom_group_current_rate_available > full_target)) {
@@ -721,9 +724,16 @@ getBottomGroupCurrentRateAvailable_() const
     }
     else {
         const auto& tcalc = std::get<TargetCalculator>(this->target_calculator_);
-        return tcalc.calcModeRateFromRates(
+        const Scalar avail = tcalc.calcModeRateFromRates(
             this->groupStateHelper().getGroupRatesAvailableForHigherLevelControl(group, /*is_injector=*/false)
         );
+        // Source-level sign fix: getGroupRatesAvailableForHigherLevelControl() returns producer
+        // rates in the signed (negative) convention. Negate to a positive magnitude so the value
+        // is consistent with the (positive) top-level target everywhere it is used in
+        // calculateGroupConstraint() -- both the reduction add-back and the overshoot
+        // comparison/scaling. Mirrors the non-coupled path in GroupStateHelper.cpp, which uses
+        // current_rate_available = -tcalc.calcModeRateFromRates(rates) for producers.
+        return -avail;
     }
 }
 

--- a/opm/simulators/wells/GroupConstraintCalculator.cpp
+++ b/opm/simulators/wells/GroupConstraintCalculator.cpp
@@ -276,10 +276,13 @@ calculateGroupConstraint()
     const auto efficiency_factor = group.getGroupEfficiencyFactor();
     auto constraint = this->calculateGroupConstraintRecursive_(this->parentGroup(group), efficiency_factor);
     if (constraint.has_value()) {
-        // TODO: We could probably switch the group to FLD control mode now. However, this call is coming
-        //    from beginTimeStep() in BlackoilWellModel_impl.hpp, but the regular higher constraints
-        //    checks (for all groups, not just the master group) will first be done during the assemble() step,
-        //    at which point the group should be switched to FLD control mode if necessary.
+        // NOTE: The group is not switched to FLD control mode here, and it does not need to be:
+        //    the constraint is re-derived from the top of the hierarchy on every call, so a group
+        //    left under an individual rate mode still follows its parent's target.  Do not expect
+        //    the regular higher-level constraint checks during assemble() to correct the mode
+        //    either -- they switch a group to FLD only when its rate violates its share of the
+        //    parent's target, so a group holding a share larger than it can produce is never
+        //    switched by them.
         return constraint;
     }
     // If a higher level constraint was not found or not violated, use the group's own constraint.

--- a/opm/simulators/wells/GroupConstraintCalculator.cpp
+++ b/opm/simulators/wells/GroupConstraintCalculator.cpp
@@ -628,12 +628,12 @@ calculateGroupConstraint()
     // Return the more restrictive of the top-level distributed target and the
     // bottom group's own target. This prevents the slave group from overshooting the
     // top-level budget.
-    auto bottom_constraint = this->getGroupConstraintNoGuideRate_(this->bottom_group_);
-    if (!bottom_constraint.has_value()) {
-        // The bottom group has no own constraint (e.g. production cmode NONE or FLD).
-        // Check if the bottom group has a limit defined for the top-level control mode
-        // (e.g. an ORAT limit in GCONPROD even though the active cmode is NONE).
-        const auto toplevel_control_mode = this->getToplevelControlMode_();
+    const auto toplevel_control_mode = this->getToplevelControlMode_();
+    // The top-level target, capped by the bottom group's own limit for the top-level
+    // control mode if it defines one.  Used whenever the bottom group's own target
+    // cannot be compared with the top-level one (it has none, or it is a target for a
+    // different rate type).
+    auto toplevel_target_capped_by_own_limit = [&]() {
         Scalar capped_target = full_target;
         if (this->isProductionConstraint()) {
             const auto* prod_cmode = std::get_if<Group::ProductionCMode>(&toplevel_control_mode);
@@ -645,9 +645,25 @@ calculateGroupConstraint()
             }
         }
         return ConstraintInfo{capped_target, toplevel_control_mode};
+    };
+    auto bottom_constraint = this->getGroupConstraintNoGuideRate_(this->bottom_group_);
+    if (!bottom_constraint.has_value()) {
+        // The bottom group has no own constraint (e.g. production cmode NONE or FLD).
+        // Check if the bottom group has a limit defined for the top-level control mode
+        // (e.g. an ORAT limit in GCONPROD even though the active cmode is NONE).
+        return toplevel_target_capped_by_own_limit();
+    }
+    if (bottom_constraint->cmode != toplevel_control_mode) {
+        // The two targets are rates of different phases -- comparing them numerically is
+        // meaningless, and picking the smaller number is not "more restrictive": an oil
+        // rate is always a smaller number than a gas rate.  This happens when a superior
+        // group switches control mode (an oil-controlled field becoming gas-controlled,
+        // say) while the bottom group still carries a target for the old mode.  The
+        // top-level target is the one that reflects the current constraint, so use it,
+        // capped by the bottom group's own limit for that same mode if it has one.
+        return toplevel_target_capped_by_own_limit();
     }
     if (full_target < bottom_constraint->constraint) {
-        const auto toplevel_control_mode = this->getToplevelControlMode_();
         return ConstraintInfo{full_target, toplevel_control_mode};
     }
     return bottom_constraint;


### PR DESCRIPTION
~~Stacked on top of #7203 and #7340.~~ The three commits of this PR are in `GroupConstraintCalculator.cpp`, related to `calculateGroupConstraint()`, which is what gives a master group its target: it distributes the nearest controlling ancestor's target down the hierarchy by guide-rate fractions and then reconciles the result with the group's own `GCONPROD` target.

#### The problem

The reconciliation at the end of that function returns "the more restrictive of the top-level distributed target and the bottom group's own target" by comparing the two numerically. That is only meaningful when both are targets for the **same rate type**. When a superior group switches control mode — an oil-controlled field becoming gas-controlled under a `GCONSALE` limit, say — while the master group still carries a target for the old mode, the comparison is an oil rate against a gas rate. An oil rate is always the smaller number, so the stale own target always wins and the group stops following its parent for the rest of the run.

Two exits earlier in the same function should have caught this before the comparison is reached: one for a group producing above its share, one for a group under `FLD` control. Both sit behind `if (bottom_group_current_rate_available > TARGET_RATE_TOLERANCE)`, and `getBottomGroupCurrentRateAvailable_()` returns the signed producer rate — negative — so for a producer master group that guard never passes and both exits are unreachable.

#### The commits

- **`Normalize the producer rate sign in the group constraint calculator`** — negate the producer rate at its source so it is a positive magnitude, consistent with the positive top-level target everywhere `calculateGroupConstraint()` uses it, both in the reduction add-back and in the overshoot comparison. This mirrors the non-coupled path in `GroupStateHelper.cpp`, which already uses `-tcalc.calcModeRateFromRates(rates)` for producers. It makes the two exits above reachable again.
- **`Do not compare group targets for different rate types`** — when the bottom group's own target is for a different rate type than the top-level target, use the top-level target, capped by the bottom group's own limit for **that same** rate type if it defines one. That capping already existed for a bottom group with no own target at all; it is now a small local helper shared by both paths.
- **`Explain what a master group's control mode does and does not decide`** — comment only. The note above that fallback claimed the higher-level constraint checks during `assemble()` would switch a master group to `FLD` "if necessary"; they only do so when the group's rate violates its share, so a group holding a share larger than it can produce is never switched by them — and with the two fixes above it does not need to be.

#### Effect on `rescoup/rc_m1` in opm-tests

In [`rc_m1`](https://github.com/OPM/opm-tests/blob/master/rescoup/rc_m1/master/RC-01_MAST_PRED.DATA) the field's gas handling is `GCONINJE FIELD GAS REIN` with a 4.0e6 sm3/day ceiling plus `GCONSALE FIELD 1.0E6 1.05E6 0.99E6 RATE`, so the field gas production the deck implies is 1.0e6 sales + 0.2e6 consumption + 4.0e6 reinjection = **5.2e6 sm3/day**. Late in 2020 the sales limit moves the field to `GRAT`, and this is where the defect bites: master group `D1_M` is left holding an **oil** target equal to its own `GCONPROD` limit of 9,200 sm3/day, and keeps it for the remaining year.

Field gas production rate over the run, master against this branch — the grey curve settles on the 5.2e6 sm3/day the deck implies, while master keeps climbing to 6.7e6:

<img width="1029" height="945" alt="image" src="https://github.com/user-attachments/assets/520abded-ace6-407a-ad1f-6560f8aa7aa9" />

#### Notes

- `GroupConstraintCalculator` is included only by `RescoupConstraintsCalculator`, so nothing outside reservoir coupling is affected.
- The sign fix changes results on its own — it takes the mean 2021 field gas rate part of the way down — but it does not close the gap by itself, because the exit it unlocks only rescues a group whose rate already exceeds its share. A group with spare capacity still reaches the comparison at the tail. The two commits are kept separate for that reason.
- ~~Stacked on #7203 and #7340; draft mode until those merge.~~

