### PR TITLE
Transmissibility: say which connection a failed lookup wanted

### DIFF
--- a/opm/simulators/flow/Transmissibility.hpp
+++ b/opm/simulators/flow/Transmissibility.hpp
@@ -278,6 +278,15 @@ protected:
                           const FaceInfo& face,
                           const std::vector<double>& ntg);
 
+    /// Look a connection up, reporting which one is missing rather than
+    /// leaving std::unordered_map::at to say only "key not found".
+    Scalar lookupTrans_(const std::unordered_map<std::uint64_t, Scalar>& map,
+                        unsigned elemIdx1, unsigned elemIdx2,
+                        std::string_view what) const;
+
+    /// Cell index, its Cartesian index, and on a refined grid its level.
+    std::string describeCell_(unsigned elemIdx) const;
+
     std::vector<DimMatrix> permeability_;
     std::vector<Scalar> porosity_;
     std::vector<Scalar> dispersion_;

--- a/opm/simulators/flow/Transmissibility.hpp
+++ b/opm/simulators/flow/Transmissibility.hpp
@@ -39,6 +39,7 @@
 #include <functional>
 #include <map>
 #include <cstdint>
+#include <string>
 #include <unordered_map>
 #include <vector>
 

--- a/opm/simulators/flow/Transmissibility.hpp
+++ b/opm/simulators/flow/Transmissibility.hpp
@@ -287,6 +287,9 @@ protected:
     /// Cell index, its Cartesian index, and on a refined grid its level.
     std::string describeCell_(unsigned elemIdx) const;
 
+    /// Whether the grid has an intersection between the two cells.
+    bool gridJoins_(unsigned elemIdx1, unsigned elemIdx2) const;
+
     std::vector<DimMatrix> permeability_;
     std::vector<Scalar> porosity_;
     std::vector<Scalar> dispersion_;

--- a/opm/simulators/flow/Transmissibility_impl.hpp
+++ b/opm/simulators/flow/Transmissibility_impl.hpp
@@ -119,6 +119,31 @@ Transmissibility(const EclipseState& eclState,
 }
 
 template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>
+bool Transmissibility<Grid,GridView,ElementMapper,CartesianIndexMapper,Scalar>::
+gridJoins_(unsigned elemIdx1, unsigned elemIdx2) const
+{
+    ElementMapper elemMapper(gridView_, Dune::mcmgElementLayout());
+
+    for (const auto& elem : elements(gridView_)) {
+        if (elemMapper.index(elem) != static_cast<int>(elemIdx1)) {
+            continue;
+        }
+
+        for (const auto& intersection : intersections(gridView_, elem)) {
+            if (intersection.neighbor() &&
+                (elemMapper.index(intersection.outside()) == static_cast<int>(elemIdx2)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    return false;
+}
+
+template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>
 std::string Transmissibility<Grid,GridView,ElementMapper,CartesianIndexMapper,Scalar>::
 describeCell_(unsigned elemIdx) const
 {
@@ -176,11 +201,20 @@ lookupTrans_(const std::unordered_map<std::uint64_t, Scalar>& map,
             ((delta % (cartDims[0]*cartDims[1])) == 0) ? "same column, several layers apart (a pinch-out or vertical NNC)"
                                                   : "not Cartesian neighbours (a non-neighbour connection)";
 
+        // Does the grid actually join these two cells? That separates a caller
+        // asking about a connection that does not exist from this calculation
+        // having missed one that does.
+        const auto joined = this->gridJoins_(elemIdx1, elemIdx2);
+
         OPM_THROW(std::out_of_range,
-                  fmt::format("No {} between {} and {}: {}. The model asked for a "
-                              "connection the transmissibility calculation did not "
-                              "produce.",
-                              what, this->describeCell_(elemIdx1), this->describeCell_(elemIdx2), kind));
+                  fmt::format("No {} between {} and {}: {}. {}",
+                              what, this->describeCell_(elemIdx1), this->describeCell_(elemIdx2), kind,
+                              joined
+                              ? "The grid does join them, so the transmissibility "
+                                "calculation skipped a face it should have computed."
+                              : "The grid does not join them either, so the caller asked "
+                                "about a connection that does not exist -- the cell "
+                                "indices it used are not the ones this grid knows."));
     }
 
     return entry->second;

--- a/opm/simulators/flow/Transmissibility_impl.hpp
+++ b/opm/simulators/flow/Transmissibility_impl.hpp
@@ -124,22 +124,33 @@ describeCell_(unsigned elemIdx) const
 {
     auto text = fmt::format("cell {}", elemIdx);
 
-    if (elemIdx < static_cast<unsigned>(gridView_.size(/*codim=*/0))) {
-        text += fmt::format(" (Cartesian {}", cartMapper_.cartesianIndex(elemIdx));
-        if constexpr (requires { grid_.maxLevel(); }) {
-            if (grid_.maxLevel() > 0) {
-                // Which grid the cell belongs to is the first thing worth
-                // knowing here: a pair that spans a refinement boundary, or two
-                // cells refining one coarse cell, is where these lookups go
-                // wrong.
-                const auto& elem = *std::next(elements(gridView_).begin(), elemIdx);
-                text += fmt::format(", level {}", elem.level());
-            }
-        }
-        text += ")";
+    if (elemIdx >= static_cast<unsigned>(gridView_.size(/*codim=*/0))) {
+        return text + " (out of range)";
     }
 
-    return text;
+    const auto cartIdx = cartMapper_.cartesianIndex(elemIdx);
+    std::array<int,dimWorld> ijk{};
+    cartMapper_.cartesianCoordinate(elemIdx, ijk);
+
+    text += fmt::format(" (Cartesian {} = [{},{},{}]", cartIdx, ijk[0], ijk[1], ijk[2]);
+
+    if constexpr (requires { grid_.maxLevel(); }) {
+        if (grid_.maxLevel() > 0) {
+            // Which grid the cell belongs to is the first thing worth knowing:
+            // a pair spanning a refinement boundary, or two cells refining one
+            // coarse cell, is where these lookups go wrong. Found through the
+            // mapper -- iteration order is not index order.
+            ElementMapper elemMapper(gridView_, Dune::mcmgElementLayout());
+            for (const auto& elem : elements(gridView_)) {
+                if (elemMapper.index(elem) == static_cast<int>(elemIdx)) {
+                    text += fmt::format(", level {}", elem.level());
+                    break;
+                }
+            }
+        }
+    }
+
+    return text + ")";
 }
 
 template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>
@@ -151,11 +162,25 @@ lookupTrans_(const std::unordered_map<std::uint64_t, Scalar>& map,
     if (entry == map.end()) {
         // "unordered_map::at: key not found" on its own says nothing about
         // which connection the model asked for.
+        // Whether the pair is Cartesian-adjacent says which kind of connection
+        // went missing: a face the grid should have, or a non-neighbour one.
+        const auto& cartDims = cartMapper_.cartesianDimensions();
+        const auto gc1 = cartMapper_.cartesianIndex(std::min(elemIdx1, elemIdx2));
+        const auto gc2 = cartMapper_.cartesianIndex(std::max(elemIdx1, elemIdx2));
+        const auto delta = gc2 - gc1;
+        const auto kind =
+            (delta == 0)                          ? "same coarse cell (refined siblings)" :
+            (delta == 1)                          ? "neighbours in I" :
+            (delta == cartDims[0])                ? "neighbours in J" :
+            (delta == cartDims[0]*cartDims[1])    ? "neighbours in K" :
+            ((delta % (cartDims[0]*cartDims[1])) == 0) ? "same column, several layers apart (a pinch-out or vertical NNC)"
+                                                  : "not Cartesian neighbours (a non-neighbour connection)";
+
         OPM_THROW(std::out_of_range,
-                  fmt::format("No {} between {} and {}. The model asked for a "
+                  fmt::format("No {} between {} and {}: {}. The model asked for a "
                               "connection the transmissibility calculation did not "
                               "produce.",
-                              what, this->describeCell_(elemIdx1), this->describeCell_(elemIdx2)));
+                              what, this->describeCell_(elemIdx1), this->describeCell_(elemIdx2), kind));
     }
 
     return entry->second;

--- a/opm/simulators/flow/Transmissibility_impl.hpp
+++ b/opm/simulators/flow/Transmissibility_impl.hpp
@@ -55,6 +55,7 @@
 #include <initializer_list>
 #include <sstream>
 #include <stdexcept>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -118,10 +119,53 @@ Transmissibility(const EclipseState& eclState,
 }
 
 template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>
+std::string Transmissibility<Grid,GridView,ElementMapper,CartesianIndexMapper,Scalar>::
+describeCell_(unsigned elemIdx) const
+{
+    auto text = fmt::format("cell {}", elemIdx);
+
+    if (elemIdx < static_cast<unsigned>(gridView_.size(/*codim=*/0))) {
+        text += fmt::format(" (Cartesian {}", cartMapper_.cartesianIndex(elemIdx));
+        if constexpr (requires { grid_.maxLevel(); }) {
+            if (grid_.maxLevel() > 0) {
+                // Which grid the cell belongs to is the first thing worth
+                // knowing here: a pair that spans a refinement boundary, or two
+                // cells refining one coarse cell, is where these lookups go
+                // wrong.
+                const auto& elem = *std::next(elements(gridView_).begin(), elemIdx);
+                text += fmt::format(", level {}", elem.level());
+            }
+        }
+        text += ")";
+    }
+
+    return text;
+}
+
+template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>
+Scalar Transmissibility<Grid,GridView,ElementMapper,CartesianIndexMapper,Scalar>::
+lookupTrans_(const std::unordered_map<std::uint64_t, Scalar>& map,
+             unsigned elemIdx1, unsigned elemIdx2, std::string_view what) const
+{
+    const auto entry = map.find(details::isId(elemIdx1, elemIdx2));
+    if (entry == map.end()) {
+        // "unordered_map::at: key not found" on its own says nothing about
+        // which connection the model asked for.
+        OPM_THROW(std::out_of_range,
+                  fmt::format("No {} between {} and {}. The model asked for a "
+                              "connection the transmissibility calculation did not "
+                              "produce.",
+                              what, this->describeCell_(elemIdx1), this->describeCell_(elemIdx2)));
+    }
+
+    return entry->second;
+}
+
+template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>
 Scalar Transmissibility<Grid,GridView,ElementMapper,CartesianIndexMapper,Scalar>::
 transmissibility(unsigned elemIdx1, unsigned elemIdx2) const
 {
-    return trans_.at(details::isId(elemIdx1, elemIdx2));
+    return this->lookupTrans_(trans_, elemIdx1, elemIdx2, "transmissibility");
 }
 
 template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>
@@ -159,7 +203,7 @@ diffusivity(unsigned elemIdx1, unsigned elemIdx2) const
     if (diffusivity_.empty())
         return 0.0;
 
-    return diffusivity_.at(details::isId(elemIdx1, elemIdx2));
+    return this->lookupTrans_(diffusivity_, elemIdx1, elemIdx2, "diffusivity");
 }
 
 template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>
@@ -169,7 +213,7 @@ dispersivity(unsigned elemIdx1, unsigned elemIdx2) const
     if (dispersivity_.empty())
         return 0.0;
 
-    return dispersivity_.at(details::isId(elemIdx1, elemIdx2));
+    return this->lookupTrans_(dispersivity_, elemIdx1, elemIdx2, "dispersivity");
 }
 
 template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>

--- a/opm/simulators/flow/Transmissibility_impl.hpp
+++ b/opm/simulators/flow/Transmissibility_impl.hpp
@@ -55,6 +55,7 @@
 #include <initializer_list>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 #include <string_view>
 #include <type_traits>
 #include <utility>


### PR DESCRIPTION
`transmissibility()`, `diffusivity()` and `dispersivity()` look their result up with `std::unordered_map::at`, so a missing connection surfaces as `unordered_map::at: key not found` with nothing else — no cells, no indication of what went wrong. Chasing one of those down a full-field model is what prompted this.

The lookup now names both cells with their Cartesian index and IJK, says whether they are Cartesian neighbours or a non-neighbour pair, and checks whether the grid actually joins them — which separates "this calculation skipped a face the grid has" from "the caller asked about a pair the grid never joined, so its indices are not this grid's". The refinement level is appended only when the grid has levels, behind an `if constexpr (requires ...)`, so nothing changes for grids without them.

Error paths only; no behaviour change on a run that works.

Draft: no test. The failure it reports is by construction one that should not happen, so I would welcome a view on whether it is worth constructing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)