### PR TITLE
supporting the WELDRAW keyword from the simulator side. 

### DIFF
--- a/opm/simulators/flow/FlowGenericVanguard.cpp
+++ b/opm/simulators/flow/FlowGenericVanguard.cpp
@@ -68,6 +68,7 @@
 #include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>
 #include <opm/input/eclipse/Schedule/Well/NameOrder.hpp>
 #include <opm/input/eclipse/Schedule/Well/WDFAC.hpp>
+#include <opm/input/eclipse/Schedule/Well/WELDRAW.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellBrineProperties.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>

--- a/opm/simulators/utils/ParallelSerialization.cpp
+++ b/opm/simulators/utils/ParallelSerialization.cpp
@@ -50,6 +50,7 @@
 #include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>
 #include <opm/input/eclipse/Schedule/Well/NameOrder.hpp>
 #include <opm/input/eclipse/Schedule/Well/WDFAC.hpp>
+#include <opm/input/eclipse/Schedule/Well/WELDRAW.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellBrineProperties.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>

--- a/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
@@ -280,6 +280,13 @@ partiallySupported()
             },
          },
          {
+            "WELDRAW",
+            {
+               {4,{true, allow_values<std::string> {"NO"}, "WELDRAW(USE_LIMIT): use of the drawdown limit in the well potential calculation is not supported"}}, // USE_LIMIT
+               {5,{true, allow_values<std::string> {"AVG"}, "WELDRAW(GRID_BLOCKS): only the AVG (PI-weighted average drawdown) option is supported"}}, // GRID_BLOCKS
+            },
+         },
+         {
             "WELSPECS",
             {
                {8,{true, allow_values<std::string> {"STD", "NO"}, "WELSPECS(WELNETWK): only the STD and NO options are supported"}}, // INFLOW_EQ

--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -671,7 +671,6 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"WECONT", {true, std::nullopt}},
         {"WELCNTL", {true, std::nullopt}},
         {"WELDEBUG", {true, std::nullopt}},
-        {"WELDRAW", {true, std::nullopt}},
         {"WELEVNT", {true, std::nullopt}},
         {"WELLSTRE", {false, std::nullopt}},
         {"WELMOVEL", {true, std::nullopt}},

--- a/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
@@ -223,9 +223,13 @@ computeWellGroupThp(const double dt, DeferredLogger& local_deferredLogger)
                     auto& ws = well_state.well(well_name);
                     if (group.hasWell(well_name)) {
                         well->setDynamicThpLimit(group_thp);
-                        const Well& well_ecl = well_model_.eclWells()[well->indexOfWell()];
                         const auto inj_controls = Well::InjectionControls(0);
-                        const auto prod_controls = well_ecl.productionControls(summary_state);
+                        // The well equations are solved here to find the group
+                        // THP, so the controls must carry the drawdown limit;
+                        // callers that pass controls explicitly are required to
+                        // have applied it.
+                        const auto prod_controls =
+                            well->productionControlsWithWeldraw(summary_state, ws);
                         well->iterateWellEqWithSwitching(well_model_.simulator(),
                                                          dt,
                                                          inj_controls,

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1688,6 +1688,24 @@ namespace Opm {
         }
         const int episodeIdx = simulator_.episodeIndex();
         const auto& comm = simulator_.vanguard().grid().comm();
+
+        // Convert WELDRAW drawdown limits into maximum production rates.
+        // Like the rate targets of wells under group control, these are
+        // only updated during the first NUPCOL iterations of each timestep
+        // and kept frozen for the remaining iterations.
+        {
+            const auto nupcol = this->schedule()[episodeIdx].nupcol();
+            const auto& iter_ctx = simulator_.problem().iterationContext();
+            if (iter_ctx.withinNupcol(nupcol)) {
+                OPM_BEGIN_PARALLEL_TRY_CATCH()
+                    for (const auto& well : well_container_) {
+                        well->updateWeldrawMaxRate(simulator_, this->wellState(), deferred_logger);
+                    }
+                OPM_END_PARALLEL_TRY_CATCH("BlackoilWellModel: updating WELDRAW rate limits failed: ",
+                                           simulator_.gridView().comm());
+            }
+        }
+
         size_t iter = 0;
         bool changed_well_group = false;
         const Group& fieldGroup = this->schedule().getGroup("FIELD", episodeIdx);

--- a/opm/simulators/wells/GasLiftGroupInfo.cpp
+++ b/opm/simulators/wells/GasLiftGroupInfo.cpp
@@ -27,6 +27,7 @@
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Group/GSatProd.hpp>
 
+#include <opm/simulators/wells/WellInterfaceGeneric.hpp>
 #include <opm/simulators/wells/WellState.hpp>
 
 #include <fmt/format.h>
@@ -545,7 +546,12 @@ getProducerWellRates_(const Well* well, int well_index)
         ? wrate[pu.canonicalToActivePhaseIdx(IndexTraits::waterPhaseIdx)]
         : 0.0;
 
-    const auto controls = well->productionControls(this->summary_state_);
+    // The drawdown limit is a rate target like the others applied below, so
+    // the rates this well contributes to its group must respect it too.
+    auto controls = well->productionControls(this->summary_state_);
+    WellInterfaceGeneric<Scalar, IndexTraits>::
+        applyWeldrawRateLimit(*well, ws.weldraw_max_rate, controls);
+
     Scalar oil_rate = oil_pot;
     Scalar water_rate = water_pot;
     Scalar gas_rate = gas_pot;

--- a/opm/simulators/wells/GasLiftSingleWellGeneric.cpp
+++ b/opm/simulators/wells/GasLiftSingleWellGeneric.cpp
@@ -30,6 +30,7 @@
 #include <opm/simulators/utils/DeferredLogger.hpp>
 #include <opm/simulators/wells/GasLiftWellState.hpp>
 #include <opm/simulators/wells/GroupState.hpp>
+#include <opm/simulators/wells/WellInterfaceGeneric.hpp>
 #include <opm/simulators/wells/WellState.hpp>
 
 #include <fmt/format.h>
@@ -57,7 +58,14 @@ GasLiftSingleWellGeneric(DeferredLogger& deferred_logger,
     , summary_state_ {summary_state}
     , group_info_ {group_info}
     , sync_groups_ {sync_groups}
-    , controls_ {ecl_well_.productionControls(summary_state_)}
+    , controls_ {[&ecl_well, &summary_state, &well_state]() {
+          // Impose the WELDRAW-derived rate cap so that lift gas is not
+          // allocated toward a rate target the drawdown limit will cut.
+          auto controls = ecl_well.productionControls(summary_state);
+          WellInterfaceGeneric<Scalar, IndexTraits>::applyWeldrawRateLimit(
+              ecl_well, well_state.well(ecl_well.name()).weldraw_max_rate, controls);
+          return controls;
+      }()}
     , debug_limit_increase_decrease_ {false}
 {
     this->well_name_ = ecl_well_.name();

--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -75,6 +75,7 @@ serializationTestObject(const ParallelWellInfo<Scalar>& pinfo)
                                                 true, 1.0, {}, 2.0);
     result.perf_data = PerfData<Scalar>::serializationTestObject();
     result.weldraw_max_rate = 3.0;
+    result.weldraw_cmode = WellProducerCMode::LRAT;
 
     return result;
 }
@@ -419,7 +420,8 @@ bool SingleWellState<Scalar, IndexTraits>::operator==(const SingleWellState& rhs
            this->group_target_fallback == rhs.group_target_fallback &&
            this->use_group_target_fallback == rhs.use_group_target_fallback &&
            this->was_shut_before_action_applied == rhs.was_shut_before_action_applied &&
-           this->weldraw_max_rate == rhs.weldraw_max_rate;
+           this->weldraw_max_rate == rhs.weldraw_max_rate &&
+           this->weldraw_cmode == rhs.weldraw_cmode;
 }
 
 template class SingleWellState<double, BlackOilDefaultFluidSystemIndices>;

--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -74,6 +74,7 @@ serializationTestObject(const ParallelWellInfo<Scalar>& pinfo)
     SingleWellState<Scalar, IndexTraits> result("testing", pinfo, PhaseUsageInfo<IndexTraits>{},
                                                 true, 1.0, {}, 2.0);
     result.perf_data = PerfData<Scalar>::serializationTestObject();
+    result.weldraw_max_rate = 3.0;
 
     return result;
 }
@@ -417,7 +418,8 @@ bool SingleWellState<Scalar, IndexTraits>::operator==(const SingleWellState& rhs
            this->group_target == rhs.group_target &&
            this->group_target_fallback == rhs.group_target_fallback &&
            this->use_group_target_fallback == rhs.use_group_target_fallback &&
-           this->was_shut_before_action_applied == rhs.was_shut_before_action_applied;
+           this->was_shut_before_action_applied == rhs.was_shut_before_action_applied &&
+           this->weldraw_max_rate == rhs.weldraw_max_rate;
 }
 
 template class SingleWellState<double, BlackOilDefaultFluidSystemIndices>;

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -91,6 +91,7 @@ public:
         serializer(group_target_fallback);
         serializer(use_group_target_fallback);
         serializer(was_shut_before_action_applied);
+        serializer(weldraw_max_rate);
     }
 
     bool operator==(const SingleWellState&) const;
@@ -130,8 +131,8 @@ public:
         Scalar guiderate_ratio{1.0}; // well to group guide rate ratio for diagnostics
 
         bool operator==(const GroupTarget& other) const {
-            return (group_name == other.group_name 
-                 && target_value == other.target_value 
+            return (group_name == other.group_name
+                 && target_value == other.target_value
                  && production_cmode == other.production_cmode
                  && injection_cmode == other.injection_cmode
                  && guiderate_ratio == other.guiderate_ratio);
@@ -170,6 +171,10 @@ public:
     // if it was SHUT, even the action set the well to OPEN, the data in the well state
     // is not well-defined. We do not use it to overwrite the current well state.
     bool was_shut_before_action_applied {false};
+    // Maximum production rate of the WELDRAW target phase derived from the
+    // well's drawdown limit; updated during the first NUPCOL iterations of
+    // each timestep and unset when no drawdown limit is active.
+    std::optional<Scalar> weldraw_max_rate{};
 
     /// Special purpose method to support dynamically rescaling a well's
     /// CTFs through WELPI.

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -92,6 +92,7 @@ public:
         serializer(use_group_target_fallback);
         serializer(was_shut_before_action_applied);
         serializer(weldraw_max_rate);
+        serializer(weldraw_cmode);
     }
 
     bool operator==(const SingleWellState&) const;
@@ -175,6 +176,10 @@ public:
     // well's drawdown limit; updated during the first NUPCOL iterations of
     // each timestep and unset when no drawdown limit is active.
     std::optional<Scalar> weldraw_max_rate{};
+    // The rate control which carries that limit, set only while the limit is
+    // at least as restrictive as the well's own target for the same phase.
+    // The well is under drawdown control when this is its active control.
+    std::optional<WellProducerCMode> weldraw_cmode{};
 
     /// Special purpose method to support dynamically rescaling a well's
     /// CTFs through WELPI.

--- a/opm/simulators/wells/WellConstraints.cpp
+++ b/opm/simulators/wells/WellConstraints.cpp
@@ -191,7 +191,11 @@ activeProductionConstraint(const SingleWellState<Scalar, IndexTraits>& ws,
                            const std::optional<Well::ProductionControls>& prod_controls) const
 {
     const auto& pu = well_.phaseUsage();
-    const auto controls = prod_controls.has_value() ? prod_controls.value() : well_.wellEcl().productionControls(summaryState);
+    // Controls passed in by the caller already have the WELDRAW limit
+    // applied (or deliberately removed).
+    const auto controls = prod_controls.has_value()
+        ? prod_controls.value()
+        : well_.productionControlsWithWeldraw(summaryState, ws);
     const auto currentControl = ws.production_cmode;
 
     if (controls.hasControl(Well::ProducerCMode::BHP) && currentControl != Well::ProducerCMode::BHP) {

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -257,6 +257,16 @@ public:
                            const GroupStateHelperType& groupStateHelper,
                            WellStateType& well_state) /* const */;
 
+    /// Convert the well's WELDRAW maximum drawdown into a maximum
+    /// production rate for the target phase,
+    ///    Qmax = Dmax * sum_j (Tw_j * M_j),
+    /// and store it in the well state.  Should only be called during the
+    /// first NUPCOL iterations of a timestep; afterwards the stored value
+    /// is kept frozen (like the rate targets of wells under group control).
+    void updateWeldrawMaxRate(const Simulator& simulator,
+                              WellStateType& well_state,
+                              DeferredLogger& deferred_logger) const;
+
     bool updateWellControlAndStatusLocalIteration(const Simulator& simulator,
                                                   const GroupStateHelperType& groupStateHelper,
                                                   const Well::InjectionControls& inj_controls,

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -27,6 +27,7 @@
 
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/Well/FilterCake.hpp>
+#include <opm/input/eclipse/Schedule/Well/WELDRAW.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellBrineProperties.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellFoamProperties.hpp>
@@ -667,13 +668,49 @@ isPressureControlled(const WellState<Scalar, IndexTraits>& well_state) const
 }
 
 template<typename Scalar, typename IndexTraits>
+void WellInterfaceGeneric<Scalar, IndexTraits>::
+applyWeldrawRateLimit(const Well& well_ecl,
+                      const std::optional<Scalar>& weldraw_max_rate,
+                      Well::ProductionControls& controls)
+{
+    if (!weldraw_max_rate.has_value()) {
+        return;
+    }
+
+    const bool gas_target =
+        well_ecl.getWELDRAW().targetPhase() == WELDRAW::TargetPhase::GAS;
+    const auto cmode = gas_target ? Well::ProducerCMode::GRAT
+                                  : Well::ProducerCMode::LRAT;
+    double& rate = gas_target ? controls.gas_rate : controls.liquid_rate;
+
+    // Only ever tighten: an existing target below the drawdown limit stands.
+    const Scalar max_rate = *weldraw_max_rate;
+    if (!controls.hasControl(cmode) || (max_rate < rate)) {
+        rate = max_rate;
+        controls.addControl(cmode);
+    }
+}
+
+template<typename Scalar, typename IndexTraits>
+Well::ProductionControls
+WellInterfaceGeneric<Scalar, IndexTraits>::
+productionControlsWithWeldraw(const SummaryState& summary_state,
+                              const SingleWellState<Scalar, IndexTraits>& ws) const
+{
+    auto controls = this->well_ecl_.productionControls(summary_state);
+    applyWeldrawRateLimit(this->well_ecl_, ws.weldraw_max_rate, controls);
+    return controls;
+}
+
+template<typename Scalar, typename IndexTraits>
 bool WellInterfaceGeneric<Scalar, IndexTraits>::
 wellUnderZeroRateTargetIndividual(const SummaryState& summary_state,
                                   const WellState<Scalar, IndexTraits>& well_state) const
 {
     if (this->isProducer()) { // producers
-        const auto prod_controls = this->well_ecl_.productionControls(summary_state);
-        const auto prod_mode = well_state.well(this->indexOfWell()).production_cmode;
+        const auto& ws = well_state.well(this->indexOfWell());
+        const auto prod_controls = this->productionControlsWithWeldraw(summary_state, ws);
+        const auto prod_mode = ws.production_cmode;
         return wellhelpers::rateControlWithZeroProdTarget(prod_controls, prod_mode);
     } else { // injectors
         const auto inj_controls = this->well_ecl_.injectionControls(summary_state);

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -213,6 +213,23 @@ public:
 
     bool isPressureControlled(const WellStateType& well_state) const;
 
+    /// Impose a WELDRAW-derived maximum production rate as an additional
+    /// LRAT or GRAT constraint on \p controls. No-op when
+    /// \p weldraw_max_rate is unset. Static so that components without a
+    /// well interface (e.g. gas lift optimization) can apply the same limit.
+    static void applyWeldrawRateLimit(const Well& well_ecl,
+                                      const std::optional<Scalar>& weldraw_max_rate,
+                                      Well::ProductionControls& controls);
+
+    /// The well's production controls with the WELDRAW-derived rate limit
+    /// (stored in \p ws.weldraw_max_rate) applied. Constraint checking and
+    /// target computations should obtain controls through this method so
+    /// the drawdown limit cannot be missed; potential calculations use the
+    /// unadjusted Well::productionControls() (WELDRAW item 4 is NO).
+    Well::ProductionControls
+    productionControlsWithWeldraw(const SummaryState& summary_state,
+                                  const SingleWellState<Scalar, IndexTraits>& ws) const;
+
     Scalar wellEfficiencyFactor() const { return well_efficiency_factor_; }
 
     //! \brief Update filter cake multipliers.

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -312,7 +312,11 @@ namespace Opm
 
         // The IPR b-coefficients are the surface-rate coefficients with
         // respect to the drawdown, sum_j Tw_j * mob_j / B_j, summed over the
-        // well's connections (crossflowing connections excluded).
+        // well's connections.  A standard well leaves crossflowing
+        // connections out of that sum while a multisegment well does not, so
+        // the cap of a multisegment well with crossflow is the more lenient
+        // of the two.  The terms are non-negative either way, so this cannot
+        // change the sign of the sum below.
         this->updateIPR(simulator, deferred_logger);
 
         auto phase_coeff = [this](const unsigned phase_idx) -> Scalar {
@@ -338,10 +342,11 @@ namespace Opm
         }
 
         if (!(coeff > 0.0)) {
-            // The target phase cannot flow at any drawdown (phase inactive,
-            // zero mobility, or all connections crossflowing).  Imposing
-            // Qmax = 0 would silently stop the well, so treat the limit as
-            // inactive instead.
+            // The target phase cannot flow at any drawdown, because it is
+            // inactive, because it has no mobility in any connection, or,
+            // for a standard well, because every connection is crossflowing
+            // and hence left out of the sum.  Imposing Qmax = 0 would
+            // silently stop the well, so treat the limit as inactive.
             deferred_logger.warning("WELDRAW_NO_TARGET_PHASE_MOBILITY",
                 fmt::format("Well {}: the WELDRAW target phase ({}) has no "
                             "producible mobility; the drawdown limit is ignored.",

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -298,6 +298,7 @@ namespace Opm
         const auto& weldraw = this->well_ecl_.getWELDRAW();
         if (!weldraw.active()) {
             ws.weldraw_max_rate.reset();
+            ws.weldraw_cmode.reset();
             return;
         }
 
@@ -305,6 +306,7 @@ namespace Opm
         const Scalar max_draw = this->well_ecl_.weldrawMaxDrawdown(summary_state);
         if (!(max_draw > 0.0)) {
             ws.weldraw_max_rate.reset();
+            ws.weldraw_cmode.reset();
             return;
         }
 
@@ -345,10 +347,27 @@ namespace Opm
                             "producible mobility; the drawdown limit is ignored.",
                             this->name(), gas_target ? "GAS" : "LIQ"));
             ws.weldraw_max_rate.reset();
+            ws.weldraw_cmode.reset();
             return;
         }
 
-        ws.weldraw_max_rate = max_draw * coeff;
+        const Scalar max_rate = max_draw * coeff;
+        ws.weldraw_max_rate = max_rate;
+
+        // Remember the rate control the limit is imposed through, but only
+        // while the limit is the more restrictive of the two: a well already
+        // held at a tighter target of its own is not under drawdown control.
+        const auto controls = this->well_ecl_.productionControls(summary_state);
+        const auto cmode = gas_target ? Well::ProducerCMode::GRAT
+                                      : Well::ProducerCMode::LRAT;
+        const Scalar own_target = gas_target ? controls.gas_rate
+                                             : controls.liquid_rate;
+        if (!controls.hasControl(cmode) || (max_rate <= own_target)) {
+            ws.weldraw_cmode = cmode;
+        }
+        else {
+            ws.weldraw_cmode.reset();
+        }
     }
 
     template<typename TypeTag>

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -32,6 +32,7 @@
 
 #include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>
 #include <opm/input/eclipse/Schedule/Well/WDFAC.hpp>
+#include <opm/input/eclipse/Schedule/Well/WELDRAW.hpp>
 
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 
@@ -280,6 +281,74 @@ namespace Opm
         }
 
         return changed;
+    }
+
+    template<typename TypeTag>
+    void
+    WellInterface<TypeTag>::
+    updateWeldrawMaxRate(const Simulator& simulator,
+                         WellStateType& well_state,
+                         DeferredLogger& deferred_logger) const
+    {
+        if (!this->isProducer()) {
+            return;
+        }
+
+        auto& ws = well_state.well(this->index_of_well_);
+        const auto& weldraw = this->well_ecl_.getWELDRAW();
+        if (!weldraw.active()) {
+            ws.weldraw_max_rate.reset();
+            return;
+        }
+
+        const auto& summary_state = simulator.vanguard().summaryState();
+        const Scalar max_draw = this->well_ecl_.weldrawMaxDrawdown(summary_state);
+        if (!(max_draw > 0.0)) {
+            ws.weldraw_max_rate.reset();
+            return;
+        }
+
+        // The IPR b-coefficients are the surface-rate coefficients with
+        // respect to the drawdown, sum_j Tw_j * mob_j / B_j, summed over the
+        // well's connections (crossflowing connections excluded).
+        this->updateIPR(simulator, deferred_logger);
+
+        auto phase_coeff = [this](const unsigned phase_idx) -> Scalar {
+            const unsigned comp_idx = FluidSystem::canonicalToActiveCompIdx(
+                FluidSystem::solventComponentIndex(phase_idx));
+            return this->ipr_b_[comp_idx];
+        };
+
+        Scalar coeff = 0.0;
+        const bool gas_target = (weldraw.targetPhase() == WELDRAW::TargetPhase::GAS);
+        if (gas_target) {
+            if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
+                coeff += phase_coeff(FluidSystem::gasPhaseIdx);
+            }
+        }
+        else {
+            if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
+                coeff += phase_coeff(FluidSystem::oilPhaseIdx);
+            }
+            if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
+                coeff += phase_coeff(FluidSystem::waterPhaseIdx);
+            }
+        }
+
+        if (!(coeff > 0.0)) {
+            // The target phase cannot flow at any drawdown (phase inactive,
+            // zero mobility, or all connections crossflowing).  Imposing
+            // Qmax = 0 would silently stop the well, so treat the limit as
+            // inactive instead.
+            deferred_logger.warning("WELDRAW_NO_TARGET_PHASE_MOBILITY",
+                fmt::format("Well {}: the WELDRAW target phase ({}) has no "
+                            "producible mobility; the drawdown limit is ignored.",
+                            this->name(), gas_target ? "GAS" : "LIQ"));
+            ws.weldraw_max_rate.reset();
+            return;
+        }
+
+        ws.weldraw_max_rate = max_draw * coeff;
     }
 
     template<typename TypeTag>
@@ -570,9 +639,9 @@ namespace Opm
         auto& deferred_logger = groupStateHelper.deferredLogger();
 
         const auto& summary_state = simulator.vanguard().summaryState();
-        const auto inj_controls = this->well_ecl_.isInjector() ? this->well_ecl_.injectionControls(summary_state) : Well::InjectionControls(0);
-        const auto prod_controls = this->well_ecl_.isProducer() ? this->well_ecl_.productionControls(summary_state) : Well::ProductionControls(0);
         const auto& ws = well_state.well(this->indexOfWell());
+        const auto inj_controls = this->well_ecl_.isInjector() ? this->well_ecl_.injectionControls(summary_state) : Well::InjectionControls(0);
+        const auto prod_controls = this->well_ecl_.isProducer() ? this->productionControlsWithWeldraw(summary_state, ws) : Well::ProductionControls(0);
         const auto pmode_orig = ws.production_cmode;
         const auto imode_orig = ws.injection_cmode;
         bool converged = false;
@@ -1021,7 +1090,9 @@ namespace Opm
         OPM_TIMEFUNCTION();
         const auto& summary_state = simulator.vanguard().summaryState();
         const auto inj_controls = this->well_ecl_.isInjector() ? this->well_ecl_.injectionControls(summary_state) : Well::InjectionControls(0);
-        const auto prod_controls = this->well_ecl_.isProducer() ? this->well_ecl_.productionControls(summary_state) : Well::ProductionControls(0);
+        const auto prod_controls = this->well_ecl_.isProducer()
+            ? this->productionControlsWithWeldraw(summary_state, well_state.well(this->index_of_well_))
+            : Well::ProductionControls(0);
         // TODO: the reason to have inj_controls and prod_controls in the arguments, is that we want to change the control used for the well functions
         // TODO: maybe we can use std::optional or pointers to simplify here
         assembleWellEqWithoutIteration(simulator, groupStateHelper, dt, inj_controls, prod_controls, well_state, solving_with_zero_rate);
@@ -1525,7 +1596,7 @@ namespace Opm
         else
         {
             const auto current = ws.production_cmode;
-            const auto& controls = well.productionControls(summaryState);
+            const auto controls = this->productionControlsWithWeldraw(summaryState, ws);
             switch (current) {
             case Well::ProducerCMode::ORAT:
             {

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -653,6 +653,12 @@ report(const int*                            globalCellIdxMap,
             curr.isProducer = ws.producer;
             curr.prod = ws.production_cmode;
             curr.inj  = ws.injection_cmode;
+
+            // A producer whose active control is the one carrying its
+            // converted drawdown limit reports drawdown control instead.
+            curr.drawdownLimited = ws.producer
+                && ws.weldraw_cmode.has_value()
+                && (ws.production_cmode == *ws.weldraw_cmode);
         }
 
         if (const auto& pwinfo = ws.parallel_info.get();

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -1106,6 +1106,63 @@ add_test_compareECLFiles(
 
 add_test_compareECLFiles(
   CASENAME
+    weldraw_01
+  FILENAME
+    WELDRAW-01
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    weldraw
+  TEST_ARGS
+    --enable-tuning=true
+)
+
+add_test_compareECLFiles(
+  CASENAME
+    weldraw_01_msw
+  FILENAME
+    WELDRAW-01-MSW
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    weldraw
+  TEST_ARGS
+    --enable-tuning=true
+)
+
+add_test_compareECLFiles(
+  CASENAME
+    weldraw_02_gas
+  FILENAME
+    WELDRAW-02-GAS
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_blackoil
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    weldraw
+  TEST_ARGS
+    --enable-tuning=true
+)
+
+add_test_compareECLFiles(
+  CASENAME
     gconinje_resv_gas_01
   FILENAME
     GCONINJE_RESV_GAS-01

--- a/tests/TESTWELLMODEL.DATA
+++ b/tests/TESTWELLMODEL.DATA
@@ -58,6 +58,20 @@ WCONPROD
     'PROD1' 'OPEN' 'GRAT' 2* 50000. /
 /
 
+-- Item 3 defaulted, so the target phase follows the WELSPECS preferred
+-- phase of PROD1, which is oil and hence maps to the liquid rate.
+WELDRAW
+    'PROD1' 5.0 2* AVG /
+/
+
+TSTEP
+10 /
+
+-- The same well with the gas rate selected explicitly.
+WELDRAW
+    'PROD1' 5.0 GAS 1* AVG /
+/
+
 TSTEP
 10 /
 

--- a/tests/test_ParallelSerialization.cpp
+++ b/tests/test_ParallelSerialization.cpp
@@ -117,6 +117,7 @@
 #include <opm/input/eclipse/Schedule/Well/WVFPDP.hpp>
 #include <opm/input/eclipse/Schedule/Well/WVFPEXP.hpp>
 #include <opm/input/eclipse/Schedule/Well/WDFAC.hpp>
+#include <opm/input/eclipse/Schedule/Well/WELDRAW.hpp>
 #include <opm/input/eclipse/Schedule/WriteRestartFileEvents.hpp>
 #include <opm/input/eclipse/EclipseState/SimulationConfig/BCConfig.hpp>
 #include <opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.hpp>

--- a/tests/test_wellmodel.cpp
+++ b/tests/test_wellmodel.cpp
@@ -168,6 +168,80 @@ BOOST_AUTO_TEST_CASE(TestStandardWellInput) {
     BOOST_CHECK_THROW( StandardWell( well, pinfo, -1, param, *rateConverter, 0, 3, 3, 0, pdata), std::invalid_argument);
 }
 
+BOOST_AUTO_TEST_CASE(WeldrawRateLimit) {
+    const SetupTest setup_test;
+    const auto& st = *setup_test.summaryState;
+    using PMode = Opm::Well::ProducerCMode;
+
+    // PROD1 at report step 0 has item 3 defaulted, so the limit applies to
+    // the liquid rate; at report step 1 it selects the gas rate.
+    const auto liq_well = setup_test.schedule->getWell("PROD1", 0);
+    const auto gas_well = setup_test.schedule->getWell("PROD1", 1);
+
+    BOOST_CHECK(liq_well.getWELDRAW().active());
+    BOOST_CHECK(gas_well.getWELDRAW().active());
+
+    // Without a rate in the well state the controls are left alone.
+    {
+        auto controls = liq_well.productionControls(st);
+        StandardWell::applyWeldrawRateLimit(liq_well, std::nullopt, controls);
+        BOOST_CHECK(! controls.hasControl(PMode::LRAT));
+    }
+
+    // The well is on GRAT from WCONPROD and has no liquid rate target, so a
+    // liquid drawdown limit introduces one.
+    {
+        auto controls = liq_well.productionControls(st);
+        BOOST_CHECK(! controls.hasControl(PMode::LRAT));
+
+        StandardWell::applyWeldrawRateLimit(liq_well, 1234.0, controls);
+
+        BOOST_CHECK(controls.hasControl(PMode::LRAT));
+        BOOST_CHECK_CLOSE(controls.liquid_rate, 1234.0, 1.0e-10);
+    }
+
+    // A target of the well's own which is tighter than the limit stands.
+    {
+        auto controls = liq_well.productionControls(st);
+        controls.liquid_rate = 100.0;
+        controls.addControl(PMode::LRAT);
+
+        StandardWell::applyWeldrawRateLimit(liq_well, 1234.0, controls);
+
+        BOOST_CHECK_CLOSE(controls.liquid_rate, 100.0, 1.0e-10);
+    }
+
+    // A target of the well's own which is looser than the limit gives way.
+    {
+        auto controls = liq_well.productionControls(st);
+        controls.liquid_rate = 5000.0;
+        controls.addControl(PMode::LRAT);
+
+        StandardWell::applyWeldrawRateLimit(liq_well, 1234.0, controls);
+
+        BOOST_CHECK_CLOSE(controls.liquid_rate, 1234.0, 1.0e-10);
+    }
+
+    // With a gas target phase the limit acts on the gas rate instead, and
+    // the same ordering against the well's own target applies.  WCONPROD
+    // already puts this well on a gas rate target.
+    {
+        auto controls = gas_well.productionControls(st);
+        BOOST_CHECK(controls.hasControl(PMode::GRAT));
+
+        const auto own_target = controls.gas_rate;
+
+        auto tighter = controls;
+        StandardWell::applyWeldrawRateLimit(gas_well, 0.5 * own_target, tighter);
+        BOOST_CHECK_CLOSE(tighter.gas_rate, 0.5 * own_target, 1.0e-10);
+        BOOST_CHECK(! tighter.hasControl(PMode::LRAT));
+
+        auto looser = controls;
+        StandardWell::applyWeldrawRateLimit(gas_well, 2.0 * own_target, looser);
+        BOOST_CHECK_CLOSE(looser.gas_rate, own_target, 1.0e-10);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(TestBehavoir) {
     const SetupTest setup_test;
     const auto& wells_ecl = setup_test.schedule->getWells(setup_test.current_timestep);


### PR DESCRIPTION
Implements the WELDRAW drawdown limit.

The maximum drawdown is converted into a maximum rate for the target phase,

    Qmax = Dmax * sum_j (Tw_j * M_j / B_j)

using the IPR coefficients, and imposed as an additional LRAT or GRAT
constraint. Qmax is updated during the first NUPCOL iterations of each
timestep and held fixed afterwards, as the targets of group controlled wells
are. A well held back by the limit reports drawdown control rather than the
rate control which carries it, and the limit is applied in the gas lift and
network calculations as well as in the well constraints.

Only AVG for item 5 and NO for item 4 are supported; other values are
rejected at deck load.

Keyword parsing and restart handling are in OPM/opm-common#5305.
Test cases in OPM/opm-tests#1571.