### PR TITLE
Require a positive sample count in the equilibration pressure integation

### DIFF
--- a/opm/simulators/flow/FlowGenericProblem_impl.hpp
+++ b/opm/simulators/flow/FlowGenericProblem_impl.hpp
@@ -81,9 +81,25 @@ FlowGenericProblem(const EclipseState& eclState,
     // 2. EQLDIMS item 2.  Default value from
     //    opm-common/opm/input/eclipse/share/keywords/000_Eclipse100/E/EQLDIMS
 
-    numPressurePointsEquil_ = Parameters::IsSet<Parameters::NumPressurePointsEquil>()
-        ? Parameters::Get<Parameters::NumPressurePointsEquil>()
-        : eclState.getTableManager().getEqldims().getNumDepthNodesP();
+    if (Parameters::IsSet<Parameters::NumPressurePointsEquil>()) {
+        numPressurePointsEquil_ = Parameters::Get<Parameters::NumPressurePointsEquil>();
+        if (numPressurePointsEquil_ < 1) {
+            throw std::invalid_argument {
+                fmt::format("--num-pressure-points-equil must be at least 1, "
+                            "but {} was given.", numPressurePointsEquil_)
+            };
+        }
+    }
+    else {
+        numPressurePointsEquil_ = eclState.getTableManager().getEqldims().getNumDepthNodesP();
+        if (numPressurePointsEquil_ < 1) {
+            throw std::invalid_argument {
+                fmt::format("EQLDIMS item 2, the number of depth nodes in the "
+                            "equilibration pressure tables, must be at least 1, "
+                            "but {} was given.", numPressurePointsEquil_)
+            };
+        }
+    }
 
     explicitRockCompaction_ = Parameters::Get<Parameters::ExplicitRockCompaction>();
 }

--- a/opm/simulators/flow/equil/InitStateEquil_impl.hpp
+++ b/opm/simulators/flow/equil/InitStateEquil_impl.hpp
@@ -323,6 +323,11 @@ RK4IVP<Scalar,RHS>::RK4IVP(const RHS& f,
     : N_(N)
     , span_(span)
 {
+    // stepsize() divides by N_ and operator() evaluates interval N_ - 1.  A
+    // non-positive sample count is rejected when the value is loaded in
+    // FlowGenericProblem, where its source is known.
+    assert(N >= 1);
+
     const Scalar h = stepsize();
     const Scalar h2 = h / 2;
     const Scalar h6 = h / 6;


### PR DESCRIPTION

RK4IVP divides by the sample count and evaluates interval N - 1, so a zero from EQLDIMS item 2 or --num-pressure-points-equil was a division by zero instead of an input error.

It is raised by the copilot in https://github.com/OPM/opm-simulators/pull/7306

<img width="1029" height="600" alt="image" src="https://github.com/user-attachments/assets/f51ba401-ab5c-4203-bd9d-ead4bc07657a" />
