### PR TITLE
Throw instead of asserting on a non-positive step and a non-finite change

### DIFF
--- a/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
+++ b/opm/simulators/flow/NonlinearSystemBlackOilReservoir_impl.hpp
@@ -398,8 +398,12 @@ relativeChange() const
                 Scalar tmpSat = saturationsNew[phaseIdx] - saturationsOld[phaseIdx];
                 resultDelta += tmpSat*tmpSat;
                 resultDenom += saturationsNew[phaseIdx]*saturationsNew[phaseIdx];
-                assert(std::isfinite(resultDelta));
-                assert(std::isfinite(resultDenom));
+                // Non-finite here comes from the solution, not from a broken
+                // invariant, so report it instead of vanishing in release.
+                if (!std::isfinite(resultDelta) || !std::isfinite(resultDenom)) {
+                    OPM_THROW(std::runtime_error,
+                              "Non-finite solution change in the convergence measure");
+                }
             }
         }
     }

--- a/opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
+++ b/opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
@@ -21,8 +21,11 @@
 #include "config.h"
 #endif // HAVE_CONFIG_H
 
+#include <opm/common/ErrorMacros.hpp>
+
 #include <algorithm>
 #include <cassert>
+#include <stdexcept>
 #include <cstddef>
 #include <ostream>
 #include <numeric>
@@ -69,7 +72,10 @@ namespace Opm
     {
         ++current_step_;
         current_time_ += dt_;
-        assert(dt_ > 0);
+        if (!(dt_ > 0)) {
+            OPM_THROW(std::runtime_error,
+                      "Time step size is not positive");
+        }
         // store used time step sizes
         steps_.push_back( dt_ );
         return *this;
@@ -81,7 +87,10 @@ namespace Opm
         double remaining = (total_time_ - current_time_);
         // apply max time step if it was set
         dt_ = std::min( dt_estimate, max_time_step_ );
-        assert(dt_ > 0);
+        if (!(dt_ > 0)) {
+            OPM_THROW(std::runtime_error,
+                      "Time step size is not positive");
+        }
         if( remaining > 0 ) {
 
             // set new time step (depending on remaining time)
@@ -91,7 +100,10 @@ namespace Opm
                 if( dt_ > max_time_step_ ) {
                     dt_ = 0.5 * remaining;
                 }
-                assert(dt_ > 0);
+                if (!(dt_ > 0)) {
+                    OPM_THROW(std::runtime_error,
+                              "Time step size is not positive");
+                }
                 return;
             }
 
@@ -100,7 +112,10 @@ namespace Opm
 
             if( 1.5 * dt_ > remaining ) {
                 dt_ = 0.5 * remaining;
-                assert(dt_ > 0);
+                if (!(dt_ > 0)) {
+                    OPM_THROW(std::runtime_error,
+                              "Time step size is not positive");
+                }
                 return;
             }
         }
@@ -114,7 +129,10 @@ namespace Opm
 
     double AdaptiveSimulatorTimer::currentStepLength () const
     {
-      assert(dt_ > 0);
+      if (!(dt_ > 0)) {
+          OPM_THROW(std::runtime_error,
+                    "Time step size is not positive");
+      }
         return dt_;
     }
 


### PR DESCRIPTION
Both conditions come from the run rather than a broken invariant, so they should be reported rather than vanish in a release build:

- **`AdaptiveSimulatorTimer`** — five asserts that the step size is positive. If the controller ever hands over zero, an `NDEBUG` build carries on with it.
- **The convergence measure** — a non-finite solution change is a diverging solution, not a programming error, and it is worth saying so.

Reapplied from #4566, which predates the ebos rename and no longer merges. All the target asserts are still there on master, just in renamed files, so the concern outlived the branch.