### PR TITLE
Set the gravity vector in one place

### DIFF
--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -1616,6 +1616,26 @@ protected:
     }
 
 protected:
+    /*!
+     * \brief Set the gravity vector from the run's configuration.
+     *
+     * Gravity is switched off by the NOGRAV keyword from Frontsim or by
+     * setting EnableGravity to false, else the standard value of the gravity
+     * constant at sea level on earth is used.  The vertical component is
+     * positive, which is the magnitude the equilibration expects.
+     */
+    void initGravity_(const EclipseState& eclState)
+    {
+        this->gravity_ = 0.0;
+
+        if (Parameters::Get<Parameters::EnableGravity>() &&
+            eclState.getInitConfig().hasGravity())
+        {
+            // unit::gravity is 9.80665 m^2/s--i.e., standard measure at Tellus equator.
+            this->gravity_[dim - 1] = unit::gravity;
+        }
+    }
+
     struct PffDofData_
     {
         ConditionalStorage<enableFullyImplicitThermal, Scalar> thermalHalfTransIn;

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -376,16 +376,7 @@ public:
         simulator.setEpisodeIndex(-1);
         simulator.setEpisodeLength(0.0);
 
-        // the "NOGRAV" keyword from Frontsim or setting the EnableGravity to false
-        // disables gravity, else the standard value of the gravity constant at sea level
-        // on earth is used
-        this->gravity_ = 0.0;
-        if (Parameters::Get<Parameters::EnableGravity>() &&
-            eclState.getInitConfig().hasGravity())
-        {
-            // unit::gravity is 9.80665 m^2/s--i.e., standard measure at Tellus equator.
-            this->gravity_[dim - 1] = unit::gravity;
-        }
+        this->initGravity_(eclState);
 
         if (this->enableTuning_) {
             // if support for the TUNING keyword is enabled, we get the initial time

--- a/opm/simulators/flow/FlowProblemComp.hpp
+++ b/opm/simulators/flow/FlowProblemComp.hpp
@@ -167,14 +167,7 @@ public:
         simulator.setEpisodeIndex(-1);
         simulator.setEpisodeLength(0.0);
 
-        // the "NOGRAV" keyword from Frontsim or setting the EnableGravity to false
-        // disables gravity, else the standard value of the gravity constant at sea level
-        // on earth is used
-        this->gravity_ = 0.0;
-        if (Parameters::Get<Parameters::EnableGravity>())
-            this->gravity_[dim - 1] = 9.80665;
-        if (!eclState.getInitConfig().hasGravity())
-            this->gravity_[dim - 1] = 0.0;
+        this->initGravity_(eclState);
 
         if (this->enableTuning_) {
             // if support for the TUNING keyword is enabled, we get the initial time


### PR DESCRIPTION
The black-oil and the compositional problem each spelled out the same rule in finishInit(): gravity is the standard value at sea level unless NOGRAV or EnableGravity=false switches it off. Move it to a helper on the shared FlowProblem base.