### PR TITLE
TPSA restructure (1/3): New matrix/vector framework

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -175,6 +175,8 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/linalg/system/SystemPreconditioner.cpp
   opm/simulators/linalg/system/SystemPreconditionerFactory.cpp
   opm/simulators/linalg/system/WellMatrixMerger.cpp
+  opm/simulators/linalg/tpsa/TpsaMatrix.cpp
+  opm/simulators/linalg/tpsa/TpsaVector.cpp
   opm/simulators/linalg/TPSALinearSolverParameters.cpp
   opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
   opm/simulators/timestepping/AdaptiveTimeStepping.cpp
@@ -518,6 +520,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_timer.cpp
   tests/test_tpsa_face_properties.cpp
   tests/test_tpsa_localresidual.cpp
+  tests/test_tpsa_matrix.cpp
   tests/test_tpsa_primaryvariables.cpp
   tests/test_vfpproperties.cpp
   tests/test_WellMatrixMerger.cpp
@@ -1133,6 +1136,9 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/linalg/system/SystemTypes.hpp
   opm/simulators/linalg/system/WellMatrixMerger.hpp
   opm/simulators/linalg/ISTLSolverTPSA.hpp
+  opm/simulators/linalg/tpsa/TpsaMatrix.hpp
+  opm/simulators/linalg/tpsa/TpsaTypes.hpp
+  opm/simulators/linalg/tpsa/TpsaVector.hpp
   opm/simulators/linalg/istlpreconditionerwrappers.hh
   opm/simulators/linalg/istlsolverwrappers.hh
   opm/simulators/linalg/istlsparsematrixadapter.hh

--- a/opm/simulators/linalg/tpsa/TpsaMatrix.cpp
+++ b/opm/simulators/linalg/tpsa/TpsaMatrix.cpp
@@ -1,0 +1,236 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2025 NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+#include <config.h>
+
+#include <opm/simulators/linalg/tpsa/TpsaMatrix.hpp>
+
+#include <opm/common/ErrorMacros.hpp>
+
+#include <algorithm>
+
+namespace Opm::Linear
+{
+
+//
+// TpsaBlockRef implementation
+//
+template <class Scalar>
+TpsaBlockRef<Scalar>&
+TpsaBlockRef<Scalar>::operator+=(const MatrixBlock& b)
+{
+    apply_([](Scalar& stored, const Scalar& dense) {
+               stored += dense;
+           },
+           b);
+
+    return *this;
+}
+
+template <class Scalar>
+TpsaBlockRef<Scalar>&
+TpsaBlockRef<Scalar>::operator=(const MatrixBlock& b)
+{
+    apply_([](Scalar& stored, const Scalar& dense) {
+               stored = dense;
+           },
+           b);
+
+    return *this;
+}
+
+template <class Scalar>
+TpsaBlockRef<Scalar>&
+TpsaBlockRef<Scalar>::operator=(Scalar value)
+{
+    const MatrixBlock b(value);
+
+    return *this = b;
+}
+
+template <class Scalar>
+void
+TpsaBlockRef<Scalar>::gather(MatrixBlock& b) const
+{
+    b = Scalar(0.0);
+    apply_([](Scalar& stored, Scalar& dense) {
+               dense = stored;
+           },
+           b);
+}
+
+//
+// TpsaMatrix implementation
+//
+template <class Scalar>
+void
+TpsaMatrix<Scalar>::clear()
+{
+    // Return early, if called before reserve()
+    if (nnz_ == 0) {
+        return;
+    }
+
+    // Note: base_ points to start entry of sub-matrix thus suitable to use with std::fill_n
+    forEachSubMatrixWithIndex_([&](auto& subMatrix, std::size_t subIdx) {
+        std::fill_n(base_[subIdx], nnz_ * blockScalars_(subMatrix), Scalar(0.0));
+    });
+}
+
+template <class Scalar>
+void
+TpsaMatrix<Scalar>::clearRow(const std::size_t row, const Scalar diag)
+{
+    const MatrixBlock zeroBlock(Scalar(0.0));
+
+    MatrixBlock diagBlock(Scalar(0.0));
+    for (int eqIdx = 0; eqIdx < numTpsaEq; ++eqIdx) {
+        diagBlock[eqIdx][eqIdx] = diag;
+    }
+
+    for (std::size_t k = rowStart_[row]; k < rowStart_[row + 1]; ++k) {
+        BlockAddress(*this, k) = (colIdx_[k] == row) ? diagBlock : zeroBlock;
+    }
+}
+
+template <class Scalar>
+void
+TpsaMatrix<Scalar>::makeOverlapRowsInvalid(const std::vector<int>& overlapRows)
+{
+    for (const int row : overlapRows) {
+        clearRow(static_cast<std::size_t>(row), Scalar(1.0));
+    }
+}
+
+template <class Scalar>
+void
+TpsaMatrix<Scalar>::scaleFields(const std::array<Scalar, numTpsaFields>& rowFac,
+                                const std::array<Scalar, numTpsaFields>& colFac)
+{
+    // Return early, if called before reserve()
+    if (nnz_ == 0) {
+        return;
+    }
+
+    forEachSubMatrixWithIndex_([&](auto& subMatrix, std::size_t subIdx) {
+        const auto [rowField, colField] = subMatrixFields_[subIdx];
+        const Scalar factor = rowFac[rowField] * colFac[colField];
+        if (factor == Scalar(1.0)) {
+            return;
+        }
+
+        Scalar* values = base_[subIdx];
+        const std::size_t numValues = nnz_ * blockScalars_(subMatrix);
+        for (std::size_t k = 0; k < numValues; ++k) {
+            values[k] *= factor;
+        }
+    });
+}
+
+template <class Scalar>
+void
+TpsaMatrix<Scalar>::cacheValueArrays_()
+{
+    forEachSubMatrixWithIndex_([&](auto& subMatrix, std::size_t subIdx) {
+        const std::size_t stride = blockScalars_(subMatrix);
+        Scalar* base = nullptr;
+        std::size_t k = 0;
+
+        for (auto rowIt = subMatrix.begin(); rowIt != subMatrix.end(); ++rowIt) {
+            for (auto colIt = rowIt->begin(); colIt != rowIt->end(); ++colIt, ++k) {
+                Scalar* entry = &(*colIt)[0][0];
+                if (k == 0) {
+                    base = entry;
+                }
+
+                if (entry != base + k * stride || colIt.index() != colIdx_[k]) {
+                    OPM_THROW(std::logic_error,
+                              "TPSA: sub-matrix storage is not the contiguous, pattern-ordered "
+                              "layout needed in TpsaMatrix");
+                }
+            }
+        }
+
+        if (k != nnz_) {
+            OPM_THROW(std::logic_error,
+                      "TPSA: sub-matrix has an unexpected number of nonzeroes");
+        }
+
+        base_[subIdx] = base;
+    });
+}
+
+template <class Scalar>
+void
+TpsaMatrix<Scalar>::setMatrixView_()
+{
+    view_.M11_00 = &dd00_;
+    view_.M12_00 = &dr0_;
+    view_.M13_00 = &dsp0_;
+
+    view_.M11_11 = &dd11_;
+    view_.M12_10 = &dr1_;
+    view_.M13_10 = &dsp1_;
+
+    view_.M11_22 = &dd22_;
+    view_.M12_20 = &dr2_;
+    view_.M13_20 = &dsp2_;
+
+    view_.M21_00 = &rd0_;
+    view_.M21_01 = &rd1_;
+    view_.M21_02 = &rd2_;
+    view_.M22 = &rr_;
+    view_.M23 = &rsp_;
+
+    view_.M31_00 = &spd0_;
+    view_.M31_01 = &spd1_;
+    view_.M31_02 = &spd2_;
+    view_.M32 = &spr_;
+    view_.M33 = &spsp_;
+}
+
+template <class Scalar>
+std::size_t
+TpsaMatrix<Scalar>::flatIndex_(std::size_t rowIdx, std::size_t colIdx) const
+{
+    const auto begin = colIdx_.begin() + rowStart_[rowIdx];
+    const auto end = colIdx_.begin() + rowStart_[rowIdx + 1];
+    const auto it = std::lower_bound(begin, end, static_cast<unsigned>(colIdx));
+    if (it == end || *it != static_cast<unsigned>(colIdx)) {
+        OPM_THROW(std::logic_error,
+                  "TPSA: requested a matrix block outside the sparsity pattern");
+    }
+
+    return rowStart_[rowIdx] + static_cast<std::size_t>(it - begin);
+}
+
+template class TpsaBlockRef<double>;
+template class TpsaMatrix<double>;
+
+#if FLOW_INSTANTIATE_FLOAT
+template class TpsaBlockRef<float>;
+template class TpsaMatrix<float>;
+#endif
+
+} // namespace Opm::Linear

--- a/opm/simulators/linalg/tpsa/TpsaMatrix.hpp
+++ b/opm/simulators/linalg/tpsa/TpsaMatrix.hpp
@@ -1,0 +1,792 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2025 NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+#ifndef OPM_TPSA_MATRIX_HPP
+#define OPM_TPSA_MATRIX_HPP
+
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/simulators/linalg/matrixblock.hh>
+#include <opm/simulators/linalg/tpsa/TpsaTypes.hpp>
+
+#include <array>
+#include <cstddef>
+#include <numeric>
+#include <ranges>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace Opm::Linear
+{
+
+template <class Scalar>
+class TpsaMatrix;
+
+/*!
+ * \brief Handle on one block of the TPSA matrix
+ *
+ * Wrapper around MatrixBlock to handle the distribution of incoming 7x7 dense block to the TPSA
+ * sub-matrix fields.
+ *
+ * \tparam Scalar Field type of the matrix entries.
+ */
+template <class Scalar>
+class TpsaBlockRef
+{
+public:
+    using MatrixBlock = Opm::MatrixBlock<Scalar, numTpsaEq, numTpsaEq>;
+
+    //! \brief Construct a handle that does not refer to any block.
+    TpsaBlockRef() = default;
+
+    /*!
+     * \brief Construct a handle on one block of a TPSA matrix.
+     *
+     * \param[in] matrix Matrix owning the block
+     * \param[in] flatIdx Flat index of the block within the shared sparsity pattern, as
+     *                    returned by TpsaMatrix::flatIndex_().
+     */
+    TpsaBlockRef(const TpsaMatrix<Scalar>& matrix, std::size_t flatIdx)
+        : matrix_(&matrix)
+        , k_(flatIdx)
+    {
+    }
+
+    /*!
+     * \brief Dereference the handle, so that it can be used where a pointer to a block is
+     *        expected.
+     *
+     * \return Reference to this handle itself.
+     */
+    TpsaBlockRef& operator*()
+    {
+        return *this;
+    }
+
+    /*!
+     * \brief Scatter a dense 7x7 contribution into the sub-matrices.
+     *
+     * \param[in] b Dense block whose entries are added to the stored entries.
+     *
+     * \return Reference to this handle.
+     */
+    TpsaBlockRef& operator+=(const MatrixBlock& b);
+
+    /*!
+     * \brief Overwrite the stored entries with a dense 7x7 block.
+     *
+     * \param[in] b Dense block the stored entries are copied from.
+     *
+     * \return Reference to this handle.
+     */
+    TpsaBlockRef& operator=(const MatrixBlock& b);
+
+    /*!
+     * \brief Set every stored entry of this block to a scalar.
+     *
+     * \param[in] value Value assigned to all stored entries of the block.
+     *
+     * \return Reference to this handle.
+     */
+    TpsaBlockRef& operator=(Scalar value);
+
+    /*!
+     * \brief Gather the stored entries into a dense 7x7 block.
+     *
+     * \param[out] b Dense block the stored entries are written to. Fully overwritten.
+     */
+    void gather(MatrixBlock& b) const;
+
+private:
+    /*!
+     * \brief Run an operation over every stored entry of this block, paired with the
+     *        corresponding entry of a dense 7x7 block.
+     *
+     * Templated on the block type so that the same index map serves both the scattering
+     * (const block) and the gathering (mutable block) direction.
+     *
+     * \tparam Op Callable invoked as op(storedEntry, denseEntry).
+     * \tparam Block Dense block type, const for scattering and mutable for gathering.
+     *
+     * \param[in] op Operation applied to each (stored, dense) entry pair.
+     * \param[in,out] b Dense block that supplies or receives the entries, depending on \p op.
+     */
+    template <class Op, class Block>
+    void apply_(Op op, Block& b) const;
+
+    const TpsaMatrix<Scalar>* matrix_{nullptr};
+    std::size_t k_{0};
+};
+
+/*!
+ * \brief TPSA matrix for linear elasticity.
+ *
+ * This is the equivalent as IstlSparseMatrixAdapter class is for flow linearizations.
+*  The TPSA linearizer still provides dense 7x7 blocks, but internally in the class the entries go
+*  into 19 sub-matrices. Displacement-displacement sub-matrix have been divided up in 1x1 fields
+*  for the Hypre BoomerAMG preconditioner.
+*  Overview of sub-matrix fields:
+ *
+ *     field 0: u_x            (1 dof)
+ *     field 1: u_y            (1 dof)
+ *     field 2: u_z            (1 dof)
+ *     field 3: rot_x/y/z      (3 dofs)
+ *     field 4: p_solid        (1 dof)
+ *
+ * Note that, displacement-displacement off-diagonals are zero in linear elasticity
+ *
+ * \tparam Scalar Field type of the matrix entries.
+ */
+template <class Scalar>
+class TpsaMatrix
+{
+    friend class TpsaBlockRef<Scalar>;
+
+public:
+    //! \brief What the linear solver operates on.
+    using IstlMatrix = TpsaMatrixView<Scalar>;
+
+    //! \brief Dense local block the linearizer accumulates into.
+    using MatrixBlock = Opm::MatrixBlock<Scalar, numTpsaEq, numTpsaEq>;
+
+    //! \brief What blockAddress() returns.
+    using BlockAddress = TpsaBlockRef<Scalar>;
+
+    //! \brief Field type of the matrix entries.
+    using field_type = Scalar;
+
+    /*!
+     * \brief Construct a matrix of the given block dimensions.
+     *
+     * No storage is allocated here; call reserve() with the sparsity pattern first.
+     *
+     * \param[in] rows Number of block rows, i.e. degrees of freedom.
+     * \param[in] columns Number of block columns, i.e. degrees of freedom.
+     */
+    TpsaMatrix(std::size_t rows, std::size_t columns)
+        : rows_(rows)
+        , columns_(columns)
+    {
+    }
+
+    /*!
+     * \brief Construct a square matrix sized from a simulator's degrees of freedom.
+     *
+     * \tparam Simulator Simulator type exposing model().numTotalDof().
+     *
+     * \param[in] simulator Simulator the number of degrees of freedom is taken from. Only
+     *                      read during construction.
+     */
+    template <class Simulator>
+    explicit TpsaMatrix(const Simulator& simulator)
+        : TpsaMatrix(simulator.model().numTotalDof(), simulator.model().numTotalDof())
+    {
+    }
+
+    // The cached value-array base pointers and the sub-matrix view point into
+    // this object, so it must not be copied or moved.
+    TpsaMatrix(const TpsaMatrix&) = delete;
+
+    TpsaMatrix(TpsaMatrix&&) = delete;
+
+    TpsaMatrix& operator=(const TpsaMatrix&) = delete;
+
+    TpsaMatrix& operator=(TpsaMatrix&&) = delete;
+
+    /*!
+     * \brief Allocate all sub-matrices from a common sparsity pattern.
+     *
+     * Also flattens the pattern, caches the value-array base pointer of every sub-matrix and
+     * sets up the solver view. Must be called before any block is accessed.
+     *
+     * \tparam Set Ordered container of column indices, e.g. std::set<unsigned>.
+     *
+     * \param[in] sparsityPattern One entry per block row, holding that row's column indices
+     *                            in ascending order.
+     */
+    template <class Set>
+    void reserve(const std::vector<Set>& sparsityPattern)
+    {
+        if (sparsityPattern.size() != rows_) {
+            OPM_THROW(std::logic_error,
+                      "TPSA: sparsity pattern does not match the number of matrix rows");
+        }
+
+        // Flatten the pattern once; the column indices of a std::set are
+        // already ascending, which is the order BCRSMatrix stores them in.
+        rowStart_.resize(rows_ + 1);
+        rowStart_[0] = 0;
+        const auto sizes = sparsityPattern
+            | std::views::transform([](const auto& a) { return a.size(); });
+        std::partial_sum(sizes.begin(), sizes.end(), rowStart_.begin() + 1);
+        nnz_ = rowStart_[rows_];
+
+        colIdx_.clear();
+        colIdx_.reserve(nnz_);
+        for (std::size_t row = 0; row < rows_; ++row) {
+            colIdx_.insert(colIdx_.end(),
+                           sparsityPattern[row].begin(),
+                           sparsityPattern[row].end());
+        }
+
+        forEachSubMatrix_([&](auto& subMatrix) {
+            reserveSubMatrix_(subMatrix, sparsityPattern);
+        });
+
+        // Initialize base_ pointer to sub-matrices and set up TpsaMatrixView
+        cacheValueArrays_();
+        setMatrixView_();
+    }
+
+    /*!
+     * \brief Handle on the block at (rowIdx, colIdx).
+     *
+     * Only called while the sparsity pattern is set up, so the linear scan over
+     * the row is not on any hot path.
+     *
+     * \param[in] rowIdx Block row index.
+     * \param[in] colIdx Block column index.
+     *
+     * \return Handle on the requested block.
+     *
+     * \throw std::logic_error If the block is not part of the sparsity pattern.
+     */
+    BlockAddress blockAddress(const std::size_t rowIdx, const std::size_t colIdx) const
+    {
+        return BlockAddress(*this, flatIndex_(rowIdx, colIdx));
+    }
+
+    /*!
+     * \brief Set all matrix entries to zero.
+     *
+     * Does nothing when called before reserve().
+     */
+    void clear();
+
+    /*!
+     * \brief Set the given row to zero, except for the main diagonal.
+     *
+     * The main diagonal of the block on the diagonal is set to \p diag. Written
+     * as dense blocks so that the field split is applied by TpsaBlockRef, i.e. by
+     * the same index map assembly goes through, rather than by a second
+     * description of which slots are field-diagonal.
+     *
+     * \param[in] row Block row to clear.
+     * \param[in] diag Value put on the main diagonal of the diagonal block.
+     */
+    void clearRow(const std::size_t row, const Scalar diag = 1.0);
+
+    /*!
+     * \brief Zero out the overlap rows and put the identity on their diagonal.
+     *
+     * \param[in] overlapRows Block rows that are not owned by this process.
+     */
+    void makeOverlapRowsInvalid(const std::vector<int>& overlapRows);
+
+    /*!
+     * \brief Scale the system by one factor per field: A <- D_row * A * D_col.
+     *
+     * Every sub-matrix couples exactly one field row to one field column, so a
+     * field scaling is a single factor per sub-matrix and can be applied to the
+     * flat value arrays without walking the sparsity pattern.
+     *
+     * \param[in] rowFac Row (equation) factor of each field.
+     * \param[in] colFac Column (unknown) factor of each field.
+     *
+     * \note Scales in place, so it must be called once per assembly. Does nothing when called
+     *       before reserve().
+     */
+    void scaleFields(const std::array<Scalar, numTpsaFields>& rowFac,
+                     const std::array<Scalar, numTpsaFields>& colFac);
+
+    /*!
+     * \brief Fill \p value with the stored entries of the given block.
+     *
+     * The displacement-displacement off-diagonals are not stored and come back as zero.
+     *
+     * \param[in] rowIdx Block row index.
+     * \param[in] colIdx Block column index.
+     * \param[out] value Dense block the entries are written to. Fully overwritten.
+     */
+    void block(const std::size_t rowIdx, const std::size_t colIdx, MatrixBlock& value) const
+    {
+        blockAddress(rowIdx, colIdx).gather(value);
+    }
+
+    /*!
+     * \brief Overwrite the given block with a dense 7x7 block.
+     *
+     * \param[in] rowIdx Block row index.
+     * \param[in] colIdx Block column index.
+     * \param[in] value Dense block the stored entries are copied from. Its
+     *                  displacement-displacement off-diagonals are ignored.
+     */
+    void setBlock(const std::size_t rowIdx, const std::size_t colIdx, const MatrixBlock& value)
+    {
+        blockAddress(rowIdx, colIdx) = value;
+    }
+
+    /*!
+     * \brief Add a dense 7x7 block to the given block.
+     *
+     * \param[in] rowIdx Block row index.
+     * \param[in] colIdx Block column index.
+     * \param[in] value Dense block added to the stored entries. Its
+     *                  displacement-displacement off-diagonals are ignored.
+     */
+    void addToBlock(const std::size_t rowIdx, const std::size_t colIdx, const MatrixBlock& value)
+    {
+        blockAddress(rowIdx, colIdx) += value;
+    }
+
+    //! \brief No local caching, so nothing to commit.
+    void commit()
+    {
+    }
+
+    //! \brief The structure is already solver-ready after reserve().
+    void finalize()
+    {
+    }
+
+    /*!
+     * \brief The sub-matrix view the linear solver operates on.
+     *
+     * Only valid after reserve(); the view points into this object.
+     *
+     * \return Reference to the 5x5 view over the sub-matrices.
+     */
+    IstlMatrix& istlMatrix()
+    {
+        return view_;
+    }
+
+    //! \copydoc istlMatrix()
+    const IstlMatrix& istlMatrix() const
+    {
+        return view_;
+    }
+
+    /*!
+     * \brief Number of block rows.
+     *
+     * \return Number of block rows of the matrix.
+     */
+    std::size_t rows() const
+    {
+        return rows_;
+    }
+
+    /*!
+     * \brief Number of block columns.
+     *
+     * \return Number of block columns of the matrix.
+     */
+    std::size_t cols() const
+    {
+        return columns_;
+    }
+
+    //! \copydoc rows()
+    std::size_t N() const
+    {
+        return rows_;
+    }
+
+    //! \copydoc cols()
+    std::size_t M() const
+    {
+        return columns_;
+    }
+
+    /*!
+     * \brief Number of nonzero blocks in the shared sparsity pattern.
+     *
+     * \return Number of nonzero blocks, or zero before reserve() has been called.
+     */
+    std::size_t nonzeroes() const
+    {
+        return nnz_;
+    }
+
+    // Sub-matrix accessors.  dd00/dd11/dd22 and spsp are the scalar blocks Hypre
+    // can precondition.
+
+    /*!
+     * \brief Access the u_x-u_x sub-matrix.
+     *
+     * \return Reference to the sub-matrix. Only meaningful after reserve().
+     */
+    DispDispMatrix00T<Scalar>& dd00()
+    {
+        return dd00_;
+    }
+
+    /*!
+     * \brief Access the u_y-u_y sub-matrix.
+     *
+     * \return Reference to the sub-matrix. Only meaningful after reserve().
+     */
+    DispDispMatrix11T<Scalar>& dd11()
+    {
+        return dd11_;
+    }
+
+    /*!
+     * \brief Access the u_z-u_z sub-matrix.
+     *
+     * \return Reference to the sub-matrix. Only meaningful after reserve().
+     */
+    DispDispMatrix22T<Scalar>& dd22()
+    {
+        return dd22_;
+    }
+
+    /*!
+     * \brief Access the rotation-rotation sub-matrix.
+     *
+     * \return Reference to the sub-matrix. Only meaningful after reserve().
+     */
+    RotRotMatrixT<Scalar>& rr()
+    {
+        return rr_;
+    }
+
+    /*!
+     * \brief Access the solid pressure-solid pressure sub-matrix.
+     *
+     * \return Reference to the sub-matrix. Only meaningful after reserve().
+     */
+    SPresSPresMatrixT<Scalar>& spsp()
+    {
+        return spsp_;
+    }
+
+    //! \copydoc dd00()
+    const DispDispMatrix00T<Scalar>& dd00() const
+    {
+        return dd00_;
+    }
+
+    //! \copydoc dd11()
+    const DispDispMatrix11T<Scalar>& dd11() const
+    {
+        return dd11_;
+    }
+
+    //! \copydoc dd22()
+    const DispDispMatrix22T<Scalar>& dd22() const
+    {
+        return dd22_;
+    }
+
+    //! \copydoc rr()
+    const RotRotMatrixT<Scalar>& rr() const
+    {
+        return rr_;
+    }
+
+    //! \copydoc spsp()
+    const SPresSPresMatrixT<Scalar>& spsp() const
+    {
+        return spsp_;
+    }
+
+private:
+    /*!
+     * \brief Slots in the base_ array, one per sub-matrix.
+     *
+     * The order must match the tuple returned by subMatrices_().
+     */
+    enum SubMatrixIdx : std::size_t
+    {
+        DD00 = 0, DD11, DD22,
+        DR0, DR1, DR2,
+        DSP0, DSP1, DSP2,
+        RD0, RD1, RD2,
+        RR, RSP,
+        SPD0, SPD1, SPD2,
+        SPR, SPSP,
+        numSubMatrices
+    };
+
+    /*!
+     * \brief The (field row, field column) each sub-matrix couples.
+     *
+     * The order must match the SubMatrixIdx slots above, i.e. the tuple returned
+     * by subMatrices_().
+     */
+    static constexpr std::array<std::pair<std::size_t, std::size_t>, numSubMatrices>
+    subMatrixFields_ {{
+        {0, 0}, {1, 1}, {2, 2},   // DD00, DD11, DD22
+        {0, 3}, {1, 3}, {2, 3},   // DR0,  DR1,  DR2
+        {0, 4}, {1, 4}, {2, 4},   // DSP0, DSP1, DSP2
+        {3, 0}, {3, 1}, {3, 2},   // RD0,  RD1,  RD2
+        {3, 3}, {3, 4},           // RR,   RSP
+        {4, 0}, {4, 1}, {4, 2},   // SPD0, SPD1, SPD2
+        {4, 3}, {4, 4}            // SPR,  SPSP
+    }};
+
+    /*!
+     * \brief Scalars per block of a sub-matrix, i.e. the stride of its flat
+     *        value array.
+     *
+     * Read off the sub-matrix' own block type, so there is no parallel table to
+     * keep in step with the slot order.
+     *
+     * \tparam SubMatrix Sub-matrix type whose block_type carries the block dimensions.
+     *
+     * \param[in] (unnamed) Sub-matrix the stride is read from. Only its type is used.
+     *
+     * \return Number of scalars per block of that sub-matrix.
+     */
+    template <class SubMatrix>
+    static constexpr std::size_t blockScalars_(const SubMatrix&)
+    {
+        using Block = typename SubMatrix::block_type;
+
+        return static_cast<std::size_t>(Block::rows) * static_cast<std::size_t>(Block::cols);
+    }
+
+    /*!
+     * \brief All sub-matrices in slot order.
+     *
+     * \return Tuple of references to the sub-matrices, ordered as in SubMatrixIdx.
+     */
+    auto subMatrices_()
+    {
+        return std::tie(dd00_,
+                        dd11_,
+                        dd22_,
+                        dr0_,
+                        dr1_,
+                        dr2_,
+                        dsp0_,
+                        dsp1_,
+                        dsp2_,
+                        rd0_,
+                        rd1_,
+                        rd2_,
+                        rr_,
+                        rsp_,
+                        spd0_,
+                        spd1_,
+                        spd2_,
+                        spr_,
+                        spsp_);
+    }
+
+    /*!
+     * \brief Apply an operation to every sub-matrix.
+     *
+     * \tparam Op Callable invoked as op(subMatrix).
+     *
+     * \param[in] op Operation applied to each sub-matrix in slot order.
+     */
+    template <class Op>
+    void forEachSubMatrix_(Op op)
+    {
+        std::apply([&op](auto&... subMatrix) {
+                       (op(subMatrix), ...);
+                   },
+                   subMatrices_());
+    }
+
+    /*!
+     * \brief Apply an operation to every sub-matrix together with its slot index.
+     *
+     * \tparam Op Callable invoked as op(subMatrix, subIdx).
+     *
+     * \param[in] op Operation applied to each sub-matrix and its SubMatrixIdx slot, in slot
+     *               order.
+     */
+    template <class Op>
+    void forEachSubMatrixWithIndex_(Op op)
+    {
+        std::apply([&op, subIdx = std::size_t{0}](auto&... subMatrix) mutable {
+                       (op(subMatrix, subIdx++), ...);
+                   },
+                   subMatrices_());
+    }
+
+    /*!
+     * \brief Build one sub-matrix from the shared sparsity pattern.
+     *
+     * All entries are zero afterwards.
+     *
+     * \tparam SubMatrix BCRSMatrix type of the sub-matrix.
+     * \tparam Set Ordered container of column indices.
+     *
+     * \param[out] subMatrix Sub-matrix that is sized and given its sparsity pattern.
+     * \param[in] sparsityPattern One entry per block row, holding that row's column indices
+     *                            in ascending order.
+     */
+    template <class SubMatrix, class Set>
+    void reserveSubMatrix_(SubMatrix& subMatrix, const std::vector<Set>& sparsityPattern)
+    {
+        subMatrix.setBuildMode(SubMatrix::random);
+        subMatrix.setSize(rows_, columns_);
+
+        for (std::size_t row = 0; row < rows_; ++row) {
+            subMatrix.setrowsize(row, sparsityPattern[row].size());
+        }
+        subMatrix.endrowsizes();
+
+        for (std::size_t row = 0; row < rows_; ++row) {
+            for (const auto& col : sparsityPattern[row]) {
+                subMatrix.addindex(row, col);
+            }
+        }
+        // Note: all entries in subMatrix are Scalar(0.0) by default construction in endindices()
+        subMatrix.endindices();
+    }
+
+    /*!
+     * \brief Cache the base pointer of every sub-matrix' value array.
+     *
+     * Also verifies that the k-th nonzero really is at `base + k*stride` in
+     * every sub-matrix, i.e. that the sub-matrices share both the pattern and
+     * the storage order.  Everything else in this class rests on that.
+     */
+    void cacheValueArrays_();
+
+    //! \brief Point the solver view at the sub-matrices owned by this object.
+    void setMatrixView_();
+
+    /*!
+     * \brief Look up the flat index of a block in the shared sparsity pattern.
+     *
+     * \param[in] rowIdx Block row index.
+     * \param[in] colIdx Block column index.
+     *
+     * \return Flat index of the block, counting nonzeroes row by row.
+     */
+    std::size_t flatIndex_(std::size_t rowIdx, std::size_t colIdx) const;
+
+    std::size_t rows_{0};
+    std::size_t columns_{0};
+    std::size_t nnz_{0};
+
+    // Flattened sparsity pattern, shared by all sub-matrices.
+    std::vector<std::size_t> rowStart_{};
+    std::vector<unsigned> colIdx_{};
+
+    // Base pointers into the sub-matrices' contiguous value arrays.
+    std::array<Scalar*, numSubMatrices> base_{};
+
+    DispDispMatrix00T<Scalar> dd00_{};
+    DispDispMatrix11T<Scalar> dd11_{};
+    DispDispMatrix22T<Scalar> dd22_{};
+
+    DispRotMatrix0T<Scalar> dr0_{};
+    DispRotMatrix1T<Scalar> dr1_{};
+    DispRotMatrix2T<Scalar> dr2_{};
+
+    DispSPresMatrix0T<Scalar> dsp0_{};
+    DispSPresMatrix1T<Scalar> dsp1_{};
+    DispSPresMatrix2T<Scalar> dsp2_{};
+
+    RotDispMatrix0T<Scalar> rd0_{};
+    RotDispMatrix1T<Scalar> rd1_{};
+    RotDispMatrix2T<Scalar> rd2_{};
+
+    RotRotMatrixT<Scalar> rr_{};
+    RotSPresMatrixT<Scalar> rsp_{};
+
+    SPresDispMatrix0T<Scalar> spd0_{};
+    SPresDispMatrix1T<Scalar> spd1_{};
+    SPresDispMatrix2T<Scalar> spd2_{};
+
+    SPresRotMatrixT<Scalar> spr_{};
+
+    SPresSPresMatrixT<Scalar> spsp_{};
+
+    IstlMatrix view_{};
+};
+
+//
+// TpsaBlockRef implementation
+//
+template <class Scalar>
+template <class Op, class Block>
+void
+TpsaBlockRef<Scalar>::apply_(Op op, Block& b) const
+{
+    using Matrix = TpsaMatrix<Scalar>;
+    const auto& base = matrix_->base_;
+    const std::size_t k = k_;
+
+    // Displacement-displacement (diagonal components only)
+    op(base[Matrix::DD00][k], b[0][0]);
+    op(base[Matrix::DD11][k], b[1][1]);
+    op(base[Matrix::DD22][k], b[2][2]);
+
+    // Displacement-rotation: three 1x3 blocks
+    for (int j = 0; j < numRotDofs; ++j) {
+        op(base[Matrix::DR0][3 * k + j], b[0][3 + j]);
+        op(base[Matrix::DR1][3 * k + j], b[1][3 + j]);
+        op(base[Matrix::DR2][3 * k + j], b[2][3 + j]);
+    }
+
+    // Displacement-solid pressure: three 1x1 blocks
+    op(base[Matrix::DSP0][k], b[0][6]);
+    op(base[Matrix::DSP1][k], b[1][6]);
+    op(base[Matrix::DSP2][k], b[2][6]);
+
+    // Rotation-displacement: three 3x1 blocks
+    for (int i = 0; i < numRotDofs; ++i) {
+        op(base[Matrix::RD0][3 * k + i], b[3 + i][0]);
+        op(base[Matrix::RD1][3 * k + i], b[3 + i][1]);
+        op(base[Matrix::RD2][3 * k + i], b[3 + i][2]);
+    }
+
+    // Rotation-rotation: one 3x3 block
+    for (int i = 0; i < numRotDofs; ++i) {
+        for (int j = 0; j < numRotDofs; ++j) {
+            op(base[Matrix::RR][9 * k + 3 * i + j], b[3 + i][3 + j]);
+        }
+    }
+
+    // Rotation-solid pressure: one 3x1 block
+    for (int i = 0; i < numRotDofs; ++i) {
+        op(base[Matrix::RSP][3 * k + i], b[3 + i][6]);
+    }
+
+    // Solid pressure-displacement: three 1x1 blocks
+    op(base[Matrix::SPD0][k], b[6][0]);
+    op(base[Matrix::SPD1][k], b[6][1]);
+    op(base[Matrix::SPD2][k], b[6][2]);
+
+    // Solid pressure-rotation: one 1x3 block
+    for (int j = 0; j < numRotDofs; ++j) {
+        op(base[Matrix::SPR][3 * k + j], b[6][3 + j]);
+    }
+
+    // Solid pressure-solid pressure: one 1x1 block
+    op(base[Matrix::SPSP][k], b[6][6]);
+}
+
+} // namespace Opm::Linear
+
+#endif // OPM_TPSA_MATRIX_HPP

--- a/opm/simulators/linalg/tpsa/TpsaTypes.hpp
+++ b/opm/simulators/linalg/tpsa/TpsaTypes.hpp
@@ -1,0 +1,603 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2025 NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+#ifndef OPM_TPSA_TYPES_HPP
+#define OPM_TPSA_TYPES_HPP
+
+#include <opm/simulators/linalg/matrixblock.hh>
+
+#include <dune/common/fvector.hh>
+#include <dune/common/indices.hh>
+#include <dune/istl/bcrsmatrix.hh>
+#include <dune/istl/bvector.hh>
+#include <dune/istl/multitypeblockvector.hh>
+
+#include <cstddef>
+
+namespace Opm::Linear {
+
+//! \brief Number of dofs of each field.
+inline constexpr int numDispDofs = 1;
+inline constexpr int numRotDofs = 3;
+inline constexpr int numSolidPresDofs = 1;
+
+//! \brief Number of fields the TPSA system is split into.
+inline constexpr int numTpsaFields = 5;
+
+//! \brief Total number of TPSA equations per cell.
+inline constexpr int numTpsaEq = 3 * numDispDofs + numRotDofs + numSolidPresDofs;
+
+//
+// Sub-matrix types
+//
+// Diagonal blocks
+template <typename Scalar>
+using DispDispMatrix00T = Dune::BCRSMatrix<MatrixBlock<Scalar, numDispDofs, numDispDofs>>;
+template <typename Scalar>
+using DispDispMatrix11T = Dune::BCRSMatrix<MatrixBlock<Scalar, numDispDofs, numDispDofs>>;
+template <typename Scalar>
+using DispDispMatrix22T = Dune::BCRSMatrix<MatrixBlock<Scalar, numDispDofs, numDispDofs>>;
+template <typename Scalar>
+using RotRotMatrixT = Dune::BCRSMatrix<MatrixBlock<Scalar, numRotDofs, numRotDofs>>;
+template <typename Scalar>
+using SPresSPresMatrixT = Dune::BCRSMatrix<MatrixBlock<Scalar, numSolidPresDofs, numSolidPresDofs>>;
+
+// Displacement-rotation and displacement-solid pressure
+template <typename Scalar>
+using DispRotMatrix0T = Dune::BCRSMatrix<MatrixBlock<Scalar, numDispDofs, numRotDofs>>;
+template <typename Scalar>
+using DispRotMatrix1T = DispRotMatrix0T<Scalar>;
+template <typename Scalar>
+using DispRotMatrix2T = DispRotMatrix0T<Scalar>;
+template <typename Scalar>
+using DispSPresMatrix0T = Dune::BCRSMatrix<MatrixBlock<Scalar, numDispDofs, numSolidPresDofs>>;
+template <typename Scalar>
+using DispSPresMatrix1T = DispSPresMatrix0T<Scalar>;
+template <typename Scalar>
+using DispSPresMatrix2T = DispSPresMatrix0T<Scalar>;
+
+// Rotation-displacement and rotation-solid pressure
+template <typename Scalar>
+using RotDispMatrix0T = Dune::BCRSMatrix<MatrixBlock<Scalar, numRotDofs, numDispDofs>>;
+template <typename Scalar>
+using RotDispMatrix1T = RotDispMatrix0T<Scalar>;
+template <typename Scalar>
+using RotDispMatrix2T = RotDispMatrix0T<Scalar>;
+template <typename Scalar>
+using RotSPresMatrixT = Dune::BCRSMatrix<MatrixBlock<Scalar, numRotDofs, numSolidPresDofs>>;
+
+// Solid pressure-displacement and solid pressure-rotation
+template <typename Scalar>
+using SPresDispMatrix0T = Dune::BCRSMatrix<MatrixBlock<Scalar, numSolidPresDofs, numDispDofs>>;
+template <typename Scalar>
+using SPresDispMatrix1T = SPresDispMatrix0T<Scalar>;
+template <typename Scalar>
+using SPresDispMatrix2T = SPresDispMatrix0T<Scalar>;
+template <typename Scalar>
+using SPresRotMatrixT = Dune::BCRSMatrix<MatrixBlock<Scalar, numSolidPresDofs, numRotDofs>>;
+
+//
+// Sub-vector types
+//
+template <typename Scalar>
+using DispVector0T = Dune::BlockVector<Dune::FieldVector<Scalar, numDispDofs>>;
+template <typename Scalar>
+using DispVector1T = DispVector0T<Scalar>;
+template <typename Scalar>
+using DispVector2T = DispVector0T<Scalar>;
+template <typename Scalar>
+using RotVectorT = Dune::BlockVector<Dune::FieldVector<Scalar, numRotDofs>>;
+template <typename Scalar>
+using SPresVectorT = Dune::BlockVector<Dune::FieldVector<Scalar, numSolidPresDofs>>;
+
+//! \brief The vector the Krylov solver and the preconditioner operate on.
+template <typename Scalar>
+using TpsaMultiVector = Dune::MultiTypeBlockVector<DispVector0T<Scalar>,
+                                                   DispVector1T<Scalar>,
+                                                   DispVector2T<Scalar>,
+                                                   RotVectorT<Scalar>,
+                                                   SPresVectorT<Scalar>>;
+
+template <typename Scalar> struct TpsaMatrixRow0;
+template <typename Scalar> struct TpsaMatrixRow1;
+template <typename Scalar> struct TpsaMatrixRow2;
+template <typename Scalar> struct TpsaMatrixRow3;
+template <typename Scalar> struct TpsaMatrixRow4;
+
+/*!
+ * \brief Lightweight, non-owning 5x5 view over the sub-matrices owned by TpsaMatrix. Provides
+ * the operator interface used by Dune solvers plus sub-matrix block access
+ *
+ * \tparam Scalar Field type of the matrix entries.
+ */
+template <typename Scalar>
+class TpsaMatrixView
+{
+public:
+    using size_type = std::size_t;
+    using field_type = Scalar;
+    using block_type = typename RotRotMatrixT<Scalar>::block_type;
+
+    // Row 0: u_x
+    const DispDispMatrix00T<Scalar>* M11_00 = nullptr;
+    const DispRotMatrix0T<Scalar>* M12_00 = nullptr;
+    const DispSPresMatrix0T<Scalar>* M13_00 = nullptr;
+
+    // Row 1: u_y
+    const DispDispMatrix11T<Scalar>* M11_11 = nullptr;
+    const DispRotMatrix1T<Scalar>* M12_10 = nullptr;
+    const DispSPresMatrix1T<Scalar>* M13_10 = nullptr;
+
+    // Row 2: u_z
+    const DispDispMatrix22T<Scalar>* M11_22 = nullptr;
+    const DispRotMatrix2T<Scalar>* M12_20 = nullptr;
+    const DispSPresMatrix2T<Scalar>* M13_20 = nullptr;
+
+    // Row 3: rotation
+    const RotDispMatrix0T<Scalar>* M21_00 = nullptr;
+    const RotDispMatrix1T<Scalar>* M21_01 = nullptr;
+    const RotDispMatrix2T<Scalar>* M21_02 = nullptr;
+    const RotRotMatrixT<Scalar>* M22 = nullptr;
+    const RotSPresMatrixT<Scalar>* M23 = nullptr;
+
+    // Row 4: solid pressure
+    const SPresDispMatrix0T<Scalar>* M31_00 = nullptr;
+    const SPresDispMatrix1T<Scalar>* M31_01 = nullptr;
+    const SPresDispMatrix2T<Scalar>* M31_02 = nullptr;
+    const SPresRotMatrixT<Scalar>* M32 = nullptr;
+    const SPresSPresMatrixT<Scalar>* M33 = nullptr;
+
+    /*!
+     * \brief Sub-block access, S[_i][_j]: returns a proxy for the requested block row.
+     *
+     * \param[in] (unnamed) Compile-time block row index, one of Dune::Indices::_0 ... _4.
+     *
+     * \return Row proxy referencing the sub-matrices of that block row.
+     */
+    TpsaMatrixRow0<Scalar> operator[](Dune::index_constant<0>) const;
+    //! \copydoc operator[](Dune::index_constant<0>) const
+    TpsaMatrixRow1<Scalar> operator[](Dune::index_constant<1>) const;
+    //! \copydoc operator[](Dune::index_constant<0>) const
+    TpsaMatrixRow2<Scalar> operator[](Dune::index_constant<2>) const;
+    //! \copydoc operator[](Dune::index_constant<0>) const
+    TpsaMatrixRow3<Scalar> operator[](Dune::index_constant<3>) const;
+    //! \copydoc operator[](Dune::index_constant<0>) const
+    TpsaMatrixRow4<Scalar> operator[](Dune::index_constant<4>) const;
+
+    /*!
+     * \brief Matrix-vector product
+     *
+     * \param[in] x Multi-vector to multiply with
+     * \param[out] y Result multi-vector
+     */
+    void mv(const TpsaMultiVector<Scalar>& x, TpsaMultiVector<Scalar>& y) const
+    {
+        using namespace Dune::Indices;
+        M11_00->mv(x[_0], y[_0]);
+        M12_00->umv(x[_3], y[_0]);
+        M13_00->umv(x[_4], y[_0]);
+
+        M11_11->mv(x[_1], y[_1]);
+        M12_10->umv(x[_3], y[_1]);
+        M13_10->umv(x[_4], y[_1]);
+
+        M11_22->mv(x[_2], y[_2]);
+        M12_20->umv(x[_3], y[_2]);
+        M13_20->umv(x[_4], y[_2]);
+
+        M21_00->mv(x[_0], y[_3]);
+        M21_01->umv(x[_1], y[_3]);
+        M21_02->umv(x[_2], y[_3]);
+        M22->umv(x[_3], y[_3]);
+        M23->umv(x[_4], y[_3]);
+
+        M31_00->mv(x[_0], y[_4]);
+        M31_01->umv(x[_1], y[_4]);
+        M31_02->umv(x[_2], y[_4]);
+        M32->umv(x[_3], y[_4]);
+        M33->umv(x[_4], y[_4]);
+    }
+
+    /*!
+     * \brief Accumulating matrix-vector product
+     *
+     * \param[in] x Multi-vector to multiply with
+     * \param[in,out] y Multi-vector the product is added to
+     */
+    void umv(const TpsaMultiVector<Scalar>& x, TpsaMultiVector<Scalar>& y) const
+    {
+        using namespace Dune::Indices;
+        M11_00->umv(x[_0], y[_0]);
+        M12_00->umv(x[_3], y[_0]);
+        M13_00->umv(x[_4], y[_0]);
+
+        M11_11->umv(x[_1], y[_1]);
+        M12_10->umv(x[_3], y[_1]);
+        M13_10->umv(x[_4], y[_1]);
+
+        M11_22->umv(x[_2], y[_2]);
+        M12_20->umv(x[_3], y[_2]);
+        M13_20->umv(x[_4], y[_2]);
+
+        M21_00->umv(x[_0], y[_3]);
+        M21_01->umv(x[_1], y[_3]);
+        M21_02->umv(x[_2], y[_3]);
+        M22->umv(x[_3], y[_3]);
+        M23->umv(x[_4], y[_3]);
+
+        M31_00->umv(x[_0], y[_4]);
+        M31_01->umv(x[_1], y[_4]);
+        M31_02->umv(x[_2], y[_4]);
+        M32->umv(x[_3], y[_4]);
+        M33->umv(x[_4], y[_4]);
+    }
+
+    /*!
+     * \brief Scaled accumulating matrix-vector product
+     *
+     * \param[in] alpha Scalar the product is scaled by
+     * \param[in] x Multi-vector to multiply with
+     * \param[in,out] y Multi-vector the scaled product is added to
+     */
+    void usmv(field_type alpha, const TpsaMultiVector<Scalar>& x, TpsaMultiVector<Scalar>& y) const
+    {
+        using namespace Dune::Indices;
+        M11_00->usmv(alpha, x[_0], y[_0]);
+        M12_00->usmv(alpha, x[_3], y[_0]);
+        M13_00->usmv(alpha, x[_4], y[_0]);
+
+        M11_11->usmv(alpha, x[_1], y[_1]);
+        M12_10->usmv(alpha, x[_3], y[_1]);
+        M13_10->usmv(alpha, x[_4], y[_1]);
+
+        M11_22->usmv(alpha, x[_2], y[_2]);
+        M12_20->usmv(alpha, x[_3], y[_2]);
+        M13_20->usmv(alpha, x[_4], y[_2]);
+
+        M21_00->usmv(alpha, x[_0], y[_3]);
+        M21_01->usmv(alpha, x[_1], y[_3]);
+        M21_02->usmv(alpha, x[_2], y[_3]);
+        M22->usmv(alpha, x[_3], y[_3]);
+        M23->usmv(alpha, x[_4], y[_3]);
+
+        M31_00->usmv(alpha, x[_0], y[_4]);
+        M31_01->usmv(alpha, x[_1], y[_4]);
+        M31_02->usmv(alpha, x[_2], y[_4]);
+        M32->usmv(alpha, x[_3], y[_4]);
+        M33->usmv(alpha, x[_4], y[_4]);
+    }
+
+    /*!
+     * \brief Number of block rows of the view.
+     *
+     * \return Number of fields the TPSA system is split into.
+     */
+    static constexpr size_type N()
+    {
+        return numTpsaFields;
+    }
+
+    /*!
+     * \brief Number of block columns of the view.
+     *
+     * \return Number of fields the TPSA system is split into.
+     */
+    static constexpr size_type M()
+    {
+        return numTpsaFields;
+    }
+};  // class TpsaMatrixView
+
+// Row proxies for S[row][col].  Only the stored couplings have an overload.
+
+/*!
+ * \brief Proxy for block row 0 (u_x) of TpsaMatrixView.
+ *
+ * \tparam Scalar Field type of the matrix entries.
+ */
+template <typename Scalar>
+struct TpsaMatrixRow0
+{
+    const DispDispMatrix00T<Scalar>& M11_00;
+    const DispRotMatrix0T<Scalar>& M12_00;
+    const DispSPresMatrix0T<Scalar>& M13_00;
+
+    /*!
+     * \brief Access one sub-matrix of this block row.
+     *
+     * \param[in] (unnamed) Compile-time block column index. Only the columns coupled to
+     *                      u_x have an overload.
+     *
+     * \return Reference to the sub-matrix at that block column.
+     */
+    const DispDispMatrix00T<Scalar>& operator[](Dune::index_constant<0>) const
+    {
+        return M11_00;
+    }
+
+    //! \copydoc operator[]
+    const DispRotMatrix0T<Scalar>& operator[](Dune::index_constant<3>) const
+    {
+        return M12_00;
+    }
+
+    //! \copydoc operator[]
+    const DispSPresMatrix0T<Scalar>& operator[](Dune::index_constant<4>) const
+    {
+        return M13_00;
+    }
+};
+
+/*!
+ * \brief Proxy for block row 1 (u_y) of TpsaMatrixView.
+ *
+ * \tparam Scalar Field type of the matrix entries.
+ */
+template <typename Scalar>
+struct TpsaMatrixRow1
+{
+    const DispDispMatrix11T<Scalar>& M11_11;
+    const DispRotMatrix1T<Scalar>& M12_10;
+    const DispSPresMatrix1T<Scalar>& M13_10;
+
+    /*!
+     * \brief Access one sub-matrix of this block row.
+     *
+     * \param[in] (unnamed) Compile-time block column index. Only the columns coupled to
+     *                      u_y have an overload.
+     *
+     * \return Reference to the sub-matrix at that block column.
+     */
+    const DispDispMatrix11T<Scalar>& operator[](Dune::index_constant<1>) const
+    {
+        return M11_11;
+    }
+
+    //! \copydoc operator[]
+    const DispRotMatrix1T<Scalar>& operator[](Dune::index_constant<3>) const
+    {
+        return M12_10;
+    }
+
+    //! \copydoc operator[]
+    const DispSPresMatrix1T<Scalar>& operator[](Dune::index_constant<4>) const
+    {
+        return M13_10;
+    }
+};
+
+/*!
+ * \brief Proxy for block row 2 (u_z) of TpsaMatrixView.
+ *
+ * \tparam Scalar Field type of the matrix entries.
+ */
+template <typename Scalar>
+struct TpsaMatrixRow2
+{
+    const DispDispMatrix22T<Scalar>& M11_22;
+    const DispRotMatrix2T<Scalar>& M12_20;
+    const DispSPresMatrix2T<Scalar>& M13_20;
+
+    /*!
+     * \brief Access one sub-matrix of this block row.
+     *
+     * \param[in] (unnamed) Compile-time block column index. Only the columns coupled to
+     *                      u_z have an overload.
+     *
+     * \return Reference to the sub-matrix at that block column.
+     */
+    const DispDispMatrix22T<Scalar>& operator[](Dune::index_constant<2>) const
+    {
+        return M11_22;
+    }
+
+    //! \copydoc operator[]
+    const DispRotMatrix2T<Scalar>& operator[](Dune::index_constant<3>) const
+    {
+        return M12_20;
+    }
+
+    //! \copydoc operator[]
+    const DispSPresMatrix2T<Scalar>& operator[](Dune::index_constant<4>) const
+    {
+        return M13_20;
+    }
+};
+
+/*!
+ * \brief Proxy for block row 3 (rotation) of TpsaMatrixView.
+ *
+ * \tparam Scalar Field type of the matrix entries.
+ */
+template <typename Scalar>
+struct TpsaMatrixRow3
+{
+    const RotDispMatrix0T<Scalar>& M21_00;
+    const RotDispMatrix1T<Scalar>& M21_01;
+    const RotDispMatrix2T<Scalar>& M21_02;
+    const RotRotMatrixT<Scalar>& M22;
+    const RotSPresMatrixT<Scalar>& M23;
+
+    /*!
+     * \brief Access one sub-matrix of this block row.
+     *
+     * \param[in] (unnamed) Compile-time block column index. Only the columns coupled to
+     *                      the rotation field have an overload.
+     *
+     * \return Reference to the sub-matrix at that block column.
+     */
+    const RotDispMatrix0T<Scalar>& operator[](Dune::index_constant<0>) const
+    {
+        return M21_00;
+    }
+
+    //! \copydoc operator[]
+    const RotDispMatrix1T<Scalar>& operator[](Dune::index_constant<1>) const
+    {
+        return M21_01;
+    }
+
+    //! \copydoc operator[]
+    const RotDispMatrix2T<Scalar>& operator[](Dune::index_constant<2>) const
+    {
+        return M21_02;
+    }
+
+    //! \copydoc operator[]
+    const RotRotMatrixT<Scalar>& operator[](Dune::index_constant<3>) const
+    {
+        return M22;
+    }
+
+    //! \copydoc operator[]
+    const RotSPresMatrixT<Scalar>& operator[](Dune::index_constant<4>) const
+    {
+        return M23;
+    }
+};
+
+/*!
+ * \brief Proxy for block row 4 (solid pressure) of TpsaMatrixView.
+ *
+ * \tparam Scalar Field type of the matrix entries.
+ */
+template <typename Scalar>
+struct TpsaMatrixRow4
+{
+    const SPresDispMatrix0T<Scalar>& M31_00;
+    const SPresDispMatrix1T<Scalar>& M31_01;
+    const SPresDispMatrix2T<Scalar>& M31_02;
+    const SPresRotMatrixT<Scalar>& M32;
+    const SPresSPresMatrixT<Scalar>& M33;
+
+    /*!
+     * \brief Access one sub-matrix of this block row.
+     *
+     * \param[in] (unnamed) Compile-time block column index. Only the columns coupled to
+     *                      the solid pressure field have an overload.
+     *
+     * \return Reference to the sub-matrix at that block column.
+     */
+    const SPresDispMatrix0T<Scalar>& operator[](Dune::index_constant<0>) const
+    {
+        return M31_00;
+    }
+
+    //! \copydoc operator[]
+    const SPresDispMatrix1T<Scalar>& operator[](Dune::index_constant<1>) const
+    {
+        return M31_01;
+    }
+
+    //! \copydoc operator[]
+    const SPresDispMatrix2T<Scalar>& operator[](Dune::index_constant<2>) const
+    {
+        return M31_02;
+    }
+
+    //! \copydoc operator[]
+    const SPresRotMatrixT<Scalar>& operator[](Dune::index_constant<3>) const
+    {
+        return M32;
+    }
+
+    //! \copydoc operator[]
+    const SPresSPresMatrixT<Scalar>& operator[](Dune::index_constant<4>) const
+    {
+        return M33;
+    }
+};
+
+template <typename Scalar>
+TpsaMatrixRow0<Scalar>
+TpsaMatrixView<Scalar>::operator[](Dune::index_constant<0>) const
+{
+    return {*M11_00, *M12_00, *M13_00};
+}
+
+template <typename Scalar>
+TpsaMatrixRow1<Scalar>
+TpsaMatrixView<Scalar>::operator[](Dune::index_constant<1>) const
+{
+    return {*M11_11, *M12_10, *M13_10};
+}
+
+template <typename Scalar>
+TpsaMatrixRow2<Scalar>
+TpsaMatrixView<Scalar>::operator[](Dune::index_constant<2>) const
+{
+    return {*M11_22, *M12_20, *M13_20};
+}
+
+template <typename Scalar>
+TpsaMatrixRow3<Scalar>
+TpsaMatrixView<Scalar>::operator[](Dune::index_constant<3>) const
+{
+    return {*M21_00, *M21_01, *M21_02, *M22, *M23};
+}
+
+template <typename Scalar>
+TpsaMatrixRow4<Scalar>
+TpsaMatrixView<Scalar>::operator[](Dune::index_constant<4>) const
+{
+    return {*M31_00, *M31_01, *M31_02, *M32, *M33};
+}
+
+} // namespace Opm::Linear
+
+namespace Dune {
+
+// Dune::MultiTypeBlockVector needs the field traits of its components to form
+// scalar products and norms.
+template<>
+struct FieldTraits<BlockVector<FieldVector<double, 3>>>
+{
+    using field_type = double;
+    using real_type = double;
+};
+
+template<>
+struct FieldTraits<BlockVector<FieldVector<float, 3>>>
+{
+    using field_type = float;
+    using real_type = float;
+};
+
+template<>
+struct FieldTraits<BlockVector<FieldVector<double, 1>>>
+{
+    using field_type = double;
+    using real_type = double;
+};
+
+template<>
+struct FieldTraits<BlockVector<FieldVector<float, 1>>>
+{
+    using field_type = float;
+    using real_type = float;
+};
+
+} // namespace Dune
+
+#endif // OPM_TPSA_TYPES_HPP

--- a/opm/simulators/linalg/tpsa/TpsaVector.cpp
+++ b/opm/simulators/linalg/tpsa/TpsaVector.cpp
@@ -1,0 +1,271 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2025 NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+#include <config.h>
+
+#include <opm/simulators/linalg/tpsa/TpsaVector.hpp>
+
+#include <dune/common/hybridutilities.hh>
+#include <dune/common/indices.hh>
+
+#include <algorithm>
+
+namespace Opm::Linear
+{
+
+//
+// TpsaVector<ScalarT>::EntryProxy implementation
+//
+template <class ScalarT>
+TpsaVector<ScalarT>::EntryProxy::operator EqVector() const
+{
+    EqVector res;
+    for (std::size_t eqIdx = 0; eqIdx < numTpsaEq; ++eqIdx) {
+        res[eqIdx] = at_(eqIdx);
+    }
+
+    return res;
+}
+
+template <class ScalarT>
+typename TpsaVector<ScalarT>::EntryProxy&
+TpsaVector<ScalarT>::EntryProxy::operator=(Scalar value)
+{
+    for (std::size_t eqIdx = 0; eqIdx < numTpsaEq; ++eqIdx) {
+        at_(eqIdx) = value;
+    }
+
+    return *this;
+}
+
+template <class ScalarT>
+typename TpsaVector<ScalarT>::EntryProxy&
+TpsaVector<ScalarT>::EntryProxy::operator=(const EqVector& value)
+{
+    for (std::size_t eqIdx = 0; eqIdx < numTpsaEq; ++eqIdx) {
+        at_(eqIdx) = value[eqIdx];
+    }
+
+    return *this;
+}
+
+template <class ScalarT>
+typename TpsaVector<ScalarT>::EntryProxy&
+TpsaVector<ScalarT>::EntryProxy::operator=(const EntryProxy& other)
+{
+    return *this = static_cast<EqVector>(other);
+}
+
+template <class ScalarT>
+typename TpsaVector<ScalarT>::EntryProxy&
+TpsaVector<ScalarT>::EntryProxy::operator+=(const EqVector& value)
+{
+    for (std::size_t eqIdx = 0; eqIdx < numTpsaEq; ++eqIdx) {
+        at_(eqIdx) += value[eqIdx];
+    }
+
+    return *this;
+}
+
+template <class ScalarT>
+typename TpsaVector<ScalarT>::EntryProxy&
+TpsaVector<ScalarT>::EntryProxy::operator-=(const EqVector& value)
+{
+    for (std::size_t eqIdx = 0; eqIdx < numTpsaEq; ++eqIdx) {
+        at_(eqIdx) -= value[eqIdx];
+    }
+
+    return *this;
+}
+
+template <class ScalarT>
+typename TpsaVector<ScalarT>::EntryProxy&
+TpsaVector<ScalarT>::EntryProxy::operator*=(Scalar factor)
+{
+    for (std::size_t eqIdx = 0; eqIdx < numTpsaEq; ++eqIdx) {
+        at_(eqIdx) *= factor;
+    }
+
+    return *this;
+}
+
+template <class ScalarT>
+ScalarT&
+TpsaVector<ScalarT>::EntryProxy::at_(std::size_t eqIdx) const
+{
+    using namespace Dune::Indices;
+    switch (eqIdx) {
+    case 0:
+        return (*v_)[_0][i_][0];
+    case 1:
+        return (*v_)[_1][i_][0];
+    case 2:
+        return (*v_)[_2][i_][0];
+    case 3:
+        return (*v_)[_3][i_][0];
+    case 4:
+        return (*v_)[_3][i_][1];
+    case 5:
+        return (*v_)[_3][i_][2];
+    default:
+        return (*v_)[_4][i_][0];
+    }
+}
+
+//
+// TpsaVector<ScalarT> implementation
+//
+template <class ScalarT>
+void
+TpsaVector<ScalarT>::resize(std::size_t numDof)
+{
+    using namespace Dune::Indices;
+    Dune::Hybrid::forEach(Dune::range(Dune::index_constant<numTpsaFields>{}),
+                          [&](auto fieldIdx) {
+                              v_[fieldIdx].resize(numDof);
+                          });
+    size_ = numDof;
+}
+
+template <class ScalarT>
+TpsaVector<ScalarT>&
+TpsaVector<ScalarT>::operator=(Scalar value)
+{
+    Dune::Hybrid::forEach(Dune::range(Dune::index_constant<numTpsaFields>{}),
+                          [&](auto fieldIdx) {
+                              v_[fieldIdx] = value;
+                          });
+
+    return *this;
+}
+
+template <class ScalarT>
+TpsaVector<ScalarT>&
+TpsaVector<ScalarT>::operator+=(const TpsaVector& other)
+{
+    Dune::Hybrid::forEach(Dune::range(Dune::index_constant<numTpsaFields>{}),
+                          [&](auto fieldIdx) {
+                              v_[fieldIdx] += other.v_[fieldIdx];
+                          });
+
+    return *this;
+}
+
+template <class ScalarT>
+TpsaVector<ScalarT>&
+TpsaVector<ScalarT>::operator-=(const TpsaVector& other)
+{
+    Dune::Hybrid::forEach(Dune::range(Dune::index_constant<numTpsaFields>{}),
+                          [&](auto fieldIdx) {
+                              v_[fieldIdx] -= other.v_[fieldIdx];
+                          });
+
+    return *this;
+}
+
+template <class ScalarT>
+TpsaVector<ScalarT>&
+TpsaVector<ScalarT>::operator*=(Scalar factor)
+{
+    Dune::Hybrid::forEach(Dune::range(Dune::index_constant<numTpsaFields>{}),
+                          [&](auto fieldIdx) {
+                              v_[fieldIdx] *= factor;
+                          });
+
+    return *this;
+}
+
+template <class ScalarT>
+void
+TpsaVector<ScalarT>::scaleFields(const std::array<Scalar, numTpsaFields>& factors)
+{
+    Dune::Hybrid::forEach(Dune::range(Dune::index_constant<numTpsaFields>{}),
+                          [&](auto fieldIdx) {
+                              v_[fieldIdx] *= factors[fieldIdx];
+                          });
+}
+
+template <class ScalarT>
+ScalarT
+TpsaVector<ScalarT>::one_norm() const
+{
+    Scalar norm = 0.0;
+    Dune::Hybrid::forEach(Dune::range(Dune::index_constant<numTpsaFields>{}),
+                          [&](auto fieldIdx) {
+                              norm += v_[fieldIdx].one_norm();
+                          });
+
+    return norm;
+}
+
+template <class ScalarT>
+ScalarT
+TpsaVector<ScalarT>::two_norm2() const
+{
+    Scalar norm = 0.0;
+    Dune::Hybrid::forEach(Dune::range(Dune::index_constant<numTpsaFields>{}),
+                          [&](auto fieldIdx) {
+                              norm += v_[fieldIdx].two_norm2();
+                          });
+
+    return norm;
+}
+
+template <class ScalarT>
+ScalarT
+TpsaVector<ScalarT>::infinity_norm() const
+{
+    Scalar norm = 0.0;
+    Dune::Hybrid::forEach(Dune::range(Dune::index_constant<numTpsaFields>{}),
+                          [&](auto fieldIdx) {
+                              norm = std::max(norm, v_[fieldIdx].infinity_norm());
+                          });
+
+    return norm;
+}
+
+template <class ScalarT>
+typename TpsaVector<ScalarT>::EqVector
+TpsaVector<ScalarT>::operator[](std::size_t dofIdx) const
+{
+    using namespace Dune::Indices;
+    EqVector res;
+    res[0] = v_[_0][dofIdx][0];
+    res[1] = v_[_1][dofIdx][0];
+    res[2] = v_[_2][dofIdx][0];
+    res[3] = v_[_3][dofIdx][0];
+    res[4] = v_[_3][dofIdx][1];
+    res[5] = v_[_3][dofIdx][2];
+    res[6] = v_[_4][dofIdx][0];
+
+    return res;
+}
+
+template class TpsaVector<double>;
+
+#if FLOW_INSTANTIATE_FLOAT
+template class TpsaVector<float>;
+#endif
+
+} // namespace Opm::Linear

--- a/opm/simulators/linalg/tpsa/TpsaVector.hpp
+++ b/opm/simulators/linalg/tpsa/TpsaVector.hpp
@@ -1,0 +1,361 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2025 NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+#ifndef OPM_TPSA_VECTOR_HPP
+#define OPM_TPSA_VECTOR_HPP
+
+#include <opm/simulators/linalg/tpsa/TpsaTypes.hpp>
+
+#include <dune/common/fvector.hh>
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+
+namespace Opm::Linear
+{
+
+/*!
+ * \brief Vector type for TPSA linear elasticity
+ *
+ * Companion to TpsaMatrix class. This is a wrapper around Dune::MultiTypeBlockVector type to
+ * distribute a 7x1 dense vector to sub-vector fields corresponding to the sub-matrix fields in
+ * TpsaMatrix
+ *
+ * \tparam ScalarT Field type of the vector entries.
+ */
+template <class ScalarT>
+class TpsaVector
+{
+public:
+    //! \brief Field type of the vector entries.
+    using Scalar = ScalarT;
+
+    //! \copydoc Scalar
+    using field_type = ScalarT;
+
+    //! \brief Dense block holding the seven equations of a single cell.
+    using EqVector = Dune::FieldVector<Scalar, numTpsaEq>;
+
+    //! \copydoc EqVector
+    using block_type = EqVector;
+
+    //! \brief What the linear solver operates on.
+    using IstlVector = TpsaMultiVector<Scalar>;
+
+    //! \brief Type used for sizes and indices.
+    using size_type = std::size_t;
+
+    /*!
+     * \brief Mutable reference to the seven equations of a single cell.
+     *
+     * Reads and writes are scattered over the five sub-vectors.
+     */
+    class EntryProxy
+    {
+    public:
+        /*!
+         * \brief Construct a handle on the equations of one cell.
+         *
+         * \param[in] v Multi-type vector holding the sub-vectors. Must outlive the proxy,
+         *              which only stores a pointer to it.
+         * \param[in] dofIdx Index of the cell the proxy refers to.
+         */
+        EntryProxy(IstlVector& v, std::size_t dofIdx)
+            : v_(&v)
+            , i_(dofIdx)
+        {
+        }
+
+        /*!
+         * \brief Number of equations the proxy exposes.
+         *
+         * \return Number of TPSA equations per cell.
+         */
+        static constexpr std::size_t size()
+        {
+            return numTpsaEq;
+        }
+
+        /*!
+         * \brief Access one equation of the cell.
+         *
+         * \param[in] eqIdx Equation index in [0, numTpsaEq)
+         *
+         * \return Reference to the entry in the sub-vector it belongs to.
+         */
+        Scalar& operator[](std::size_t eqIdx)
+        {
+            return at_(eqIdx);
+        }
+
+        /*!
+         * \brief Read one equation of the cell.
+         *
+         * \param[in] eqIdx Equation index in [0, numTpsaEq)
+         *
+         * \return Value of the entry.
+         */
+        Scalar operator[](std::size_t eqIdx) const
+        {
+            return at_(eqIdx);
+        }
+
+        /*!
+         * \brief Gathers to an EqVector block vector
+         *
+         * \warning This function requires an explicit return type EqVector, contrary to
+         * "auto b = v[i]" which returns a EntryProxy type
+         *
+         * \return The seven equations of the cell, gathered into a dense block.
+         */
+        operator EqVector() const;
+
+        /*!
+         * \brief Set all seven equations of the cell to a scalar.
+         *
+         * \param[in] value Value assigned to every equation.
+         *
+         * \return Reference to this proxy.
+         */
+        EntryProxy& operator=(Scalar value);
+
+        /*!
+         * \brief Scatter a dense 7x1 block into the sub-vectors.
+         *
+         * \param[in] value Dense block the entries are copied from.
+         *
+         * \return Reference to this proxy.
+         */
+        EntryProxy& operator=(const EqVector& value);
+
+        /*!
+         * \brief Copy the equations of one cell to another.
+         *
+         * \param[in] other Proxy the entries are copied from.
+         *
+         * \return Reference to this proxy.
+         */
+        EntryProxy& operator=(const EntryProxy& other);
+
+        /*!
+         * \brief Add a dense 7x1 block to the equations of the cell.
+         *
+         * \param[in] value Dense block added to the stored entries.
+         *
+         * \return Reference to this proxy.
+         */
+        EntryProxy& operator+=(const EqVector& value);
+
+        /*!
+         * \brief Subtract a dense 7x1 block from the equations of the cell.
+         *
+         * \param[in] value Dense block subtracted from the stored entries.
+         *
+         * \return Reference to this proxy.
+         */
+        EntryProxy& operator-=(const EqVector& value);
+
+        /*!
+         * \brief Scale all seven equations of the cell.
+         *
+         * \param[in] factor Factor the stored entries are multiplied by.
+         *
+         * \return Reference to this proxy.
+         */
+        EntryProxy& operator*=(Scalar factor);
+
+    private:
+        /*!
+         * \brief Map an equation index onto the entry of the sub-vector holding it.
+         *
+         * \param[in] eqIdx Equation index.
+         *
+         * \return Reference to the corresponding sub-vector entry.
+         */
+        Scalar& at_(std::size_t eqIdx) const;
+
+        IstlVector* v_;
+        std::size_t i_;
+    };
+
+    //! \brief Construct an empty vector; call resize() before use.
+    TpsaVector() = default;
+
+    /*!
+     * \brief Construct a vector sized for the given number of cells.
+     *
+     * \param[in] numDof Number of degrees of freedom, i.e. cells.
+     */
+    explicit TpsaVector(std::size_t numDof)
+    {
+        resize(numDof);
+    }
+
+    /*!
+     * \brief Resize every sub-vector to the given number of cells.
+     *
+     * \param[in] numDof Number of degrees of freedom, i.e. cells.
+     */
+    void resize(std::size_t numDof);
+
+    /*!
+     * \brief Number of cells the vector holds equations for.
+     *
+     * \return Number of degrees of freedom.
+     */
+    std::size_t size() const
+    {
+        return size_;
+    }
+
+    //! \copydoc size()
+    std::size_t N() const
+    {
+        return size_;
+    }
+
+    /*!
+     * \brief Set every entry of every field to a scalar.
+     *
+     * \param[in] value Value assigned to all entries.
+     *
+     * \return Reference to this vector.
+     */
+    TpsaVector& operator=(Scalar value);
+
+    /*!
+     * \brief Add another vector field by field.
+     *
+     * \param[in] other Vector added to this one. Must have the same size.
+     *
+     * \return Reference to this vector.
+     */
+    TpsaVector& operator+=(const TpsaVector& other);
+
+    /*!
+     * \brief Subtract another vector field by field.
+     *
+     * \param[in] other Vector subtracted from this one. Must have the same size.
+     *
+     * \return Reference to this vector.
+     */
+    TpsaVector& operator-=(const TpsaVector& other);
+
+    /*!
+     * \brief Scale every entry of every field.
+     *
+     * \param[in] factor Factor all entries are multiplied by.
+     *
+     * \return Reference to this vector.
+     */
+    TpsaVector& operator*=(Scalar factor);
+
+    /*!
+     * \brief Multiply each field by factor.
+     *
+     * The counterpart of TpsaMatrix::scaleFields().
+     *
+     * \param[in] factors Factor for each field, in field order.
+     *
+     * \note Scales in place.
+     */
+    void scaleFields(const std::array<Scalar, numTpsaFields>& factors);
+
+    /*!
+     * \brief Sum of the absolute values of all entries.
+     *
+     * \return The 1-norm of the vector.
+     */
+    Scalar one_norm() const;
+
+    /*!
+     * \brief Sum of the squares of all entries.
+     *
+     * \return The squared 2-norm of the vector.
+     */
+    Scalar two_norm2() const;
+
+    /*!
+     * \brief Euclidean norm of the vector.
+     *
+     * \return The 2-norm of the vector.
+     */
+    Scalar two_norm() const
+    {
+        return std::sqrt(two_norm2());
+    }
+
+    /*!
+     * \brief Largest absolute value over all entries.
+     *
+     * \return The infinity norm of the vector.
+     */
+    Scalar infinity_norm() const;
+
+    /*!
+     * \brief The seven equations of cell dofIdx, gathered into a dense block.
+     *
+     * \param[in] dofIdx Index of the cell.
+     *
+     * \return Dense block holding the seven equations of that cell.
+     */
+    EqVector operator[](std::size_t dofIdx) const;
+
+    /*!
+     * \brief Writable handle on the seven equations of cell dofIdx.
+     *
+     * \param[in] dofIdx Index of the cell.
+     *
+     * \return Proxy scattering reads and writes over the five sub-vectors.
+     */
+    EntryProxy operator[](std::size_t dofIdx)
+    {
+        return EntryProxy(v_, dofIdx);
+    }
+
+    /*!
+     * \brief The underlying multi-type vector handed to the linear solver.
+     *
+     * \return Reference to the multi-type block vector holding the five sub-vectors.
+     */
+    IstlVector& istlVector()
+    {
+        return v_;
+    }
+
+    //! \copydoc istlVector()
+    const IstlVector& istlVector() const
+    {
+        return v_;
+    }
+
+private:
+    IstlVector v_{};
+    std::size_t size_{0};
+};
+
+} // namespace Opm::Linear
+
+#endif // OPM_TPSA_VECTOR_HPP

--- a/tests/test_tpsa_matrix.cpp
+++ b/tests/test_tpsa_matrix.cpp
@@ -1,0 +1,769 @@
+/*
+  Copyright 2025 NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <config.h>
+
+#define BOOST_TEST_MODULE TpsaMatrixTest
+
+#include <boost/mpl/list.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <opm/simulators/linalg/tpsa/TpsaMatrix.hpp>
+#include <opm/simulators/linalg/tpsa/TpsaVector.hpp>
+
+#include <dune/common/indices.hh>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <set>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace
+{
+
+//! \brief Scalar types every test case is instantiated for.
+#if FLOW_INSTANTIATE_FLOAT
+using ScalarTypes = boost::mpl::list<double, float>;
+#else
+using ScalarTypes = boost::mpl::list<double>;
+#endif // FLOW_INSTANTIATE_FLOAT
+
+template <class Scalar>
+using Matrix = Opm::Linear::TpsaMatrix<Scalar>;
+template <class Scalar>
+using Vector = Opm::Linear::TpsaVector<Scalar>;
+template <class Scalar>
+using MatrixBlock = typename Matrix<Scalar>::MatrixBlock;
+template <class Scalar>
+using EqVector = typename Vector<Scalar>::EqVector;
+
+constexpr int numEq = Opm::Linear::numTpsaEq;
+constexpr int numFields = Opm::Linear::numTpsaFields;
+constexpr std::size_t numCells = 5;
+
+/*!
+ * \brief Relative tolerance, in percent, of the inexact comparisons.
+ *
+ * The assembled values are exactly representable in both precisions, so only the results of
+ * accumulation and scaling need a tolerance. float carries roughly seven significant digits,
+ * which the double tolerance is far below.
+ *
+ * \tparam Scalar Field type the comparison is made in.
+ */
+template <class Scalar>
+struct Tolerance;
+
+template <>
+struct Tolerance<double>
+{
+    static constexpr double percent = 1e-10;
+};
+
+template <>
+struct Tolerance<float>
+{
+    static constexpr float percent = 1e-3;
+};
+
+/*!
+ * \brief Tri-diagonal stencil, as produced by TpsaLinearizer for a 1-D grid.
+ *
+ * \return One entry per cell, holding that row's column indices in ascending order.
+ */
+std::vector<std::set<unsigned> >
+makePattern()
+{
+    std::vector<std::set<unsigned> > pattern(numCells);
+    for (unsigned i = 0; i < numCells; ++i) {
+        pattern[i].insert(i);
+        if (i > 0) {
+            pattern[i].insert(i - 1);
+        }
+        if (i + 1 < numCells) {
+            pattern[i].insert(i + 1);
+        }
+    }
+
+    return pattern;
+}
+
+/*!
+ * \brief A distinct value for every scalar of every block.
+ *
+ * \tparam Scalar Field type of the value.
+ *
+ * \param[in] row Block row index.
+ * \param[in] col Block column index.
+ * \param[in] eqIdx Equation index within the block.
+ * \param[in] pvIdx Primary variable index within the block.
+ *
+ * \return The value the given scalar is expected to hold.
+ */
+template <class Scalar>
+Scalar
+entry(std::size_t row, std::size_t col, int eqIdx, int pvIdx)
+{
+    return Scalar(1000) * static_cast<Scalar>(row) + Scalar(100) * static_cast<Scalar>(col)
+        + Scalar(10) * static_cast<Scalar>(eqIdx) + static_cast<Scalar>(pvIdx) + Scalar(1);
+}
+
+/*!
+ * \brief Build the dense 7x7 block belonging to one (row, col) position.
+ *
+ * \tparam Scalar Field type of the block entries.
+ *
+ * \param[in] row Block row index.
+ * \param[in] col Block column index.
+ *
+ * \return Dense block whose entries are filled from entry().
+ */
+template <class Scalar>
+MatrixBlock<Scalar>
+makeBlock(std::size_t row, std::size_t col)
+{
+    MatrixBlock<Scalar> b(Scalar(0));
+    for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+        for (int pvIdx = 0; pvIdx < numEq; ++pvIdx) {
+            b[eqIdx][pvIdx] = entry<Scalar>(row, col, eqIdx, pvIdx);
+        }
+    }
+
+    return b;
+}
+
+/*!
+ * \brief True for the six displacement-displacement couplings that are dropped.
+ *
+ * \param[in] eqIdx Equation index within the block.
+ * \param[in] pvIdx Primary variable index within the block.
+ *
+ * \return Whether that entry is a displacement-displacement off-diagonal
+ */
+bool
+isDropped(int eqIdx, int pvIdx)
+{
+    return eqIdx < 3 && pvIdx < 3 && eqIdx != pvIdx;
+}
+
+/*!
+ * \brief Field a given equation belongs to.
+ *
+ * \param[in] idx Equation or primary variable index within a block.
+ *
+ * \return Field index: 0/1/2 for u_x/u_y/u_z, 3 for the rotation and 4 for the solid pressure.
+ */
+std::size_t
+fieldOf(int idx)
+{
+    if (idx < 3) {
+        return static_cast<std::size_t>(idx);
+    }
+
+    return (idx < 6) ? 3 : 4;
+}
+
+/*!
+ * \brief Assemble the test matrix the way the linearizer would.
+ *
+ * Adds makeBlock(row, col) to every block of the pattern, going through the same
+ * BlockAddress interface the linearizer uses.
+ *
+ * \tparam Scalar Field type of the matrix entries.
+ *
+ * \param[in,out] m Matrix the blocks are added to. Must already be reserved with \p pattern.
+ * \param[in] pattern Sparsity pattern the matrix was reserved with.
+ */
+template <class Scalar>
+void
+assemble(Matrix<Scalar>& m, const std::vector<std::set<unsigned> >& pattern)
+{
+    for (std::size_t row = 0; row < numCells; ++row) {
+        for (const auto col : pattern[row]) {
+            auto address = m.blockAddress(row, col);
+            const auto b = makeBlock<Scalar>(row, col);
+            // Same syntax the linearizer uses on a MatrixBlock*.
+            *address += b;
+        }
+    }
+}
+
+/*!
+ * \brief A distinct value for every equation of every cell.
+ *
+ * \tparam Scalar Field type of the value.
+ *
+ * \param[in] dofIdx Index of the cell.
+ * \param[in] eqIdx Equation index within the cell.
+ *
+ * \return The value the given entry is expected to hold.
+ */
+template <class Scalar>
+Scalar
+vectorEntry(std::size_t dofIdx, int eqIdx)
+{
+    return Scalar(0.5) * static_cast<Scalar>(dofIdx) + Scalar(0.25) * static_cast<Scalar>(eqIdx)
+        + Scalar(1);
+}
+
+/*!
+ * \brief Fill a vector with vectorEntry(), optionally alternating the sign.
+ *
+ * \tparam Scalar Field type of the vector entries.
+ *
+ * \param[out] v Vector that is filled. Must already be sized for numCells.
+ * \param[in] alternateSign Whether to flip the sign of every other entry, so that the norms
+ *                          and the plain sums differ.
+ */
+template <class Scalar>
+void
+fillVector(Vector<Scalar>& v, bool alternateSign = false)
+{
+    for (std::size_t i = 0; i < numCells; ++i) {
+        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            const Scalar sign = (alternateSign && ((i + eqIdx) % 2 == 1)) ? Scalar(-1) : Scalar(1);
+            v[i][eqIdx] = sign * vectorEntry<Scalar>(i, eqIdx);
+        }
+    }
+}
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ScatterMatchesTheFieldSplit, Scalar, ScalarTypes)
+{
+    using namespace Dune::Indices;
+
+    const auto pattern = makePattern();
+    Matrix<Scalar> m(numCells, numCells);
+    m.reserve(pattern);
+    assemble(m, pattern);
+    const auto& view = m.istlMatrix();
+
+    for (std::size_t row = 0; row < numCells; ++row) {
+        for (const auto col : pattern[row]) {
+            // Diagonal displacement blocks: 1x1, one per component.
+            BOOST_CHECK_EQUAL(view[_0][_0][row][col][0][0], entry<Scalar>(row, col, 0, 0));
+            BOOST_CHECK_EQUAL(view[_1][_1][row][col][0][0], entry<Scalar>(row, col, 1, 1));
+            BOOST_CHECK_EQUAL(view[_2][_2][row][col][0][0], entry<Scalar>(row, col, 2, 2));
+
+            for (int j = 0; j < 3; ++j) {
+                // Displacement-rotation: 1x3
+                BOOST_CHECK_EQUAL(view[_0][_3][row][col][0][j], entry<Scalar>(row, col, 0, 3 + j));
+                BOOST_CHECK_EQUAL(view[_1][_3][row][col][0][j], entry<Scalar>(row, col, 1, 3 + j));
+                BOOST_CHECK_EQUAL(view[_2][_3][row][col][0][j], entry<Scalar>(row, col, 2, 3 + j));
+
+                // Rotation-displacement: 3x1
+                BOOST_CHECK_EQUAL(view[_3][_0][row][col][j][0], entry<Scalar>(row, col, 3 + j, 0));
+                BOOST_CHECK_EQUAL(view[_3][_1][row][col][j][0], entry<Scalar>(row, col, 3 + j, 1));
+                BOOST_CHECK_EQUAL(view[_3][_2][row][col][j][0], entry<Scalar>(row, col, 3 + j, 2));
+
+                // Rotation-solid pressure and solid pressure-rotation
+                BOOST_CHECK_EQUAL(view[_3][_4][row][col][j][0], entry<Scalar>(row, col, 3 + j, 6));
+                BOOST_CHECK_EQUAL(view[_4][_3][row][col][0][j], entry<Scalar>(row, col, 6, 3 + j));
+
+                for (int i = 0; i < 3; ++i) {
+                    BOOST_CHECK_EQUAL(view[_3][_3][row][col][i][j],
+                                      entry<Scalar>(row, col, 3 + i, 3 + j));
+                }
+            }
+
+            // Displacement-solid pressure and solid pressure-displacement
+            BOOST_CHECK_EQUAL(view[_0][_4][row][col][0][0], entry<Scalar>(row, col, 0, 6));
+            BOOST_CHECK_EQUAL(view[_1][_4][row][col][0][0], entry<Scalar>(row, col, 1, 6));
+            BOOST_CHECK_EQUAL(view[_2][_4][row][col][0][0], entry<Scalar>(row, col, 2, 6));
+            BOOST_CHECK_EQUAL(view[_4][_0][row][col][0][0], entry<Scalar>(row, col, 6, 0));
+            BOOST_CHECK_EQUAL(view[_4][_1][row][col][0][0], entry<Scalar>(row, col, 6, 1));
+            BOOST_CHECK_EQUAL(view[_4][_2][row][col][0][0], entry<Scalar>(row, col, 6, 2));
+
+            BOOST_CHECK_EQUAL(view[_4][_4][row][col][0][0], entry<Scalar>(row, col, 6, 6));
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(GatherDropsDisplacementCrossCouplings, Scalar, ScalarTypes)
+{
+    const auto pattern = makePattern();
+    Matrix<Scalar> m(numCells, numCells);
+    m.reserve(pattern);
+    assemble(m, pattern);
+
+    // Reading a block back gives the assembled values, except for the six
+    // displacement-displacement off-diagonals, which are not stored at all, and should return 0.
+    for (std::size_t row = 0; row < numCells; ++row) {
+        for (const auto col : pattern[row]) {
+            MatrixBlock<Scalar> b;
+            m.block(row, col, b);
+            for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+                for (int pvIdx = 0; pvIdx < numEq; ++pvIdx) {
+                    const Scalar expected = isDropped(eqIdx, pvIdx)
+                        ? Scalar(0)
+                        : entry<Scalar>(row, col, eqIdx, pvIdx);
+                    BOOST_CHECK_EQUAL(b[eqIdx][pvIdx], expected);
+                }
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(MatrixVectorProductMatchesDenseReference, Scalar, ScalarTypes)
+{
+    const auto pattern = makePattern();
+    Matrix<Scalar> m(numCells, numCells);
+    m.reserve(pattern);
+    assemble(m, pattern);
+
+    Vector<Scalar> x(numCells);
+    fillVector(x);
+
+    Vector<Scalar> y(numCells);
+    y = Scalar(0);
+    m.istlMatrix().mv(x.istlVector(), y.istlVector());
+
+    // Reference: dense multiply with the dropped entries set to zero.
+    for (std::size_t row = 0; row < numCells; ++row) {
+        EqVector<Scalar> expected(Scalar(0));
+        for (const auto col : pattern[row]) {
+            for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+                for (int pvIdx = 0; pvIdx < numEq; ++pvIdx) {
+                    if (isDropped(eqIdx, pvIdx)) {
+                        continue;
+                    }
+                    expected[eqIdx] += entry<Scalar>(row, col, eqIdx, pvIdx)
+                        * vectorEntry<Scalar>(col, pvIdx);
+                }
+            }
+        }
+
+        const EqVector<Scalar> actual = static_cast<const Vector<Scalar>&>(y)[row];
+        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            BOOST_CHECK_CLOSE(actual[eqIdx], expected[eqIdx], Tolerance<Scalar>::percent);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ClearAndClearRow, Scalar, ScalarTypes)
+{
+    const auto pattern = makePattern();
+    Matrix<Scalar> m(numCells, numCells);
+    m.reserve(pattern);
+    assemble(m, pattern);
+
+    constexpr std::size_t row = 2;
+    m.clearRow(row, Scalar(1));
+
+    MatrixBlock<Scalar> b;
+    for (const auto col : pattern[row]) {
+        m.block(row, col, b);
+        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            for (int pvIdx = 0; pvIdx < numEq; ++pvIdx) {
+                const bool onDiagonal = col == row && eqIdx == pvIdx;
+                BOOST_CHECK_EQUAL(b[eqIdx][pvIdx], onDiagonal ? Scalar(1) : Scalar(0));
+            }
+        }
+    }
+
+    // Other rows are untouched.
+    m.block(1, 1, b);
+    BOOST_CHECK_EQUAL(b[0][0], entry<Scalar>(1, 1, 0, 0));
+
+    m.clear();
+    m.block(1, 1, b);
+    for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+        for (int pvIdx = 0; pvIdx < numEq; ++pvIdx) {
+            BOOST_CHECK_EQUAL(b[eqIdx][pvIdx], Scalar(0));
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(HypreCompatibleDiagonalBlocks, Scalar, ScalarTypes)
+{
+    // Check that displacement and solid-pressure diagonal blocks are 1x1
+    using DD00 = std::decay_t<decltype(std::declval<Matrix<Scalar>&>().dd00())>;
+    using SPSP = std::decay_t<decltype(std::declval<Matrix<Scalar>&>().spsp())>;
+    static_assert(DD00::block_type::rows == 1 && DD00::block_type::cols == 1);
+    static_assert(SPSP::block_type::rows == 1 && SPSP::block_type::cols == 1);
+
+    const auto pattern = makePattern();
+    Matrix<Scalar> m(numCells, numCells);
+    m.reserve(pattern);
+    assemble(m, pattern);
+
+    const Scalar* values = &m.dd00()[0][0][0][0];
+    std::size_t k = 0;
+    for (std::size_t row = 0; row < numCells; ++row) {
+        for (const auto col : pattern[row]) {
+            BOOST_CHECK_EQUAL(values[k], entry<Scalar>(row, col, 0, 0));
+            ++k;
+        }
+    }
+    BOOST_CHECK_EQUAL(k, m.nonzeroes());
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(SetAndAddBlock, Scalar, ScalarTypes)
+{
+    const auto pattern = makePattern();
+    Matrix<Scalar> m(numCells, numCells);
+    m.reserve(pattern);
+
+    // (2, 3) is on the tri-diagonal, so it is part of the pattern.
+    const auto b = makeBlock<Scalar>(2, 3);
+    m.setBlock(2, 3, b);
+
+    MatrixBlock<Scalar> read;
+    m.block(2, 3, read);
+    for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+        for (int pvIdx = 0; pvIdx < numEq; ++pvIdx) {
+            const Scalar expected = isDropped(eqIdx, pvIdx)
+                ? Scalar(0)
+                : entry<Scalar>(2, 3, eqIdx, pvIdx);
+            BOOST_CHECK_EQUAL(read[eqIdx][pvIdx], expected);
+        }
+    }
+
+    // addToBlock accumulates on top of what is already stored.
+    m.addToBlock(2, 3, b);
+    m.block(2, 3, read);
+    for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+        for (int pvIdx = 0; pvIdx < numEq; ++pvIdx) {
+            const Scalar expected = isDropped(eqIdx, pvIdx)
+                ? Scalar(0)
+                : Scalar(2) * entry<Scalar>(2, 3, eqIdx, pvIdx);
+            BOOST_CHECK_EQUAL(read[eqIdx][pvIdx], expected);
+        }
+    }
+
+    // setBlock overwrites rather than accumulating.
+    m.setBlock(2, 3, b);
+    m.block(2, 3, read);
+    BOOST_CHECK_EQUAL(read[0][0], entry<Scalar>(2, 3, 0, 0));
+
+    // Assigning a scalar through the block handle sets every stored entry.
+    auto address = m.blockAddress(2, 3);
+    *address = Scalar(7);
+    m.block(2, 3, read);
+    for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+        for (int pvIdx = 0; pvIdx < numEq; ++pvIdx) {
+            const Scalar expected = isDropped(eqIdx, pvIdx) ? Scalar(0) : Scalar(7);
+            BOOST_CHECK_EQUAL(read[eqIdx][pvIdx], expected);
+        }
+    }
+
+    // Neighbouring blocks are untouched.
+    m.block(2, 2, read);
+    BOOST_CHECK_EQUAL(read[0][0], Scalar(0));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(MatrixScaleFields, Scalar, ScalarTypes)
+{
+    const auto pattern = makePattern();
+    Matrix<Scalar> m(numCells, numCells);
+    m.reserve(pattern);
+    assemble(m, pattern);
+
+    // Distinct factors, so that a sub-matrix picking up the wrong field shows up.
+    const std::array<Scalar, numFields> rowFac{
+        {Scalar(2), Scalar(3), Scalar(5), Scalar(7), Scalar(11)}};
+    const std::array<Scalar, numFields> colFac{
+        {Scalar(13), Scalar(17), Scalar(19), Scalar(23), Scalar(29)}};
+    m.scaleFields(rowFac, colFac);
+
+    const auto checkScaled = [&]() {
+        for (std::size_t row = 0; row < numCells; ++row) {
+            for (const auto col : pattern[row]) {
+                MatrixBlock<Scalar> b;
+                m.block(row, col, b);
+                for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+                    for (int pvIdx = 0; pvIdx < numEq; ++pvIdx) {
+                        if (isDropped(eqIdx, pvIdx)) {
+                            BOOST_CHECK_EQUAL(b[eqIdx][pvIdx], Scalar(0));
+                            continue;
+                        }
+
+                        const Scalar expected = entry<Scalar>(row, col, eqIdx, pvIdx)
+                            * rowFac[fieldOf(eqIdx)] * colFac[fieldOf(pvIdx)];
+                        BOOST_CHECK_CLOSE(b[eqIdx][pvIdx], expected, Tolerance<Scalar>::percent);
+                    }
+                }
+            }
+        }
+    };
+    checkScaled();
+
+    // Unit factors take the early-out branch and must leave the matrix alone.
+    const std::array<Scalar, numFields> ones{
+        {Scalar(1), Scalar(1), Scalar(1), Scalar(1), Scalar(1)}};
+    m.scaleFields(ones, ones);
+    checkScaled();
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(UmvAndUsmvAccumulate, Scalar, ScalarTypes)
+{
+    const auto pattern = makePattern();
+    Matrix<Scalar> m(numCells, numCells);
+    m.reserve(pattern);
+    assemble(m, pattern);
+
+    Vector<Scalar> x(numCells);
+    fillVector(x);
+
+    // mv is checked against a dense reference elsewhere, so it can serve as the
+    // reference for the accumulating variants.
+    Vector<Scalar> product(numCells);
+    product = Scalar(0);
+    m.istlMatrix().mv(x.istlVector(), product.istlVector());
+
+    Vector<Scalar> initial(numCells);
+    fillVector(initial, /*alternateSign =*/ true);
+
+    Vector<Scalar> y = initial;
+    m.istlMatrix().umv(x.istlVector(), y.istlVector());
+    for (std::size_t i = 0; i < numCells; ++i) {
+        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            BOOST_CHECK_CLOSE(y[i][eqIdx],
+                              initial[i][eqIdx] + product[i][eqIdx],
+                              Tolerance<Scalar>::percent);
+        }
+    }
+
+    const Scalar alpha = Scalar(-2.5);
+    Vector<Scalar> z = initial;
+    m.istlMatrix().usmv(alpha, x.istlVector(), z.istlVector());
+    for (std::size_t i = 0; i < numCells; ++i) {
+        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            BOOST_CHECK_CLOSE(z[i][eqIdx],
+                              initial[i][eqIdx] + alpha * product[i][eqIdx],
+                              Tolerance<Scalar>::percent);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(MakeOverlapRowsInvalid, Scalar, ScalarTypes)
+{
+    const auto pattern = makePattern();
+    Matrix<Scalar> m(numCells, numCells);
+    m.reserve(pattern);
+    assemble(m, pattern);
+
+    const std::vector<int> overlapRows{1, 3};
+    m.makeOverlapRowsInvalid(overlapRows);
+
+    for (std::size_t row = 0; row < numCells; ++row) {
+        const bool isOverlap = (row == 1) || (row == 3);
+        for (const auto col : pattern[row]) {
+            MatrixBlock<Scalar> b;
+            m.block(row, col, b);
+            for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+                for (int pvIdx = 0; pvIdx < numEq; ++pvIdx) {
+                    Scalar expected = Scalar(0);
+                    if (isDropped(eqIdx, pvIdx)) {
+                        expected = Scalar(0);
+                    }
+                    else if (!isOverlap) {
+                        expected = entry<Scalar>(row, col, eqIdx, pvIdx);
+                    }
+                    else if (col == row && eqIdx == pvIdx) {
+                        expected = Scalar(1);
+                    }
+
+                    BOOST_CHECK_EQUAL(b[eqIdx][pvIdx], expected);
+                }
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ThrowsOnInvalidUse, Scalar, ScalarTypes)
+{
+    const auto pattern = makePattern();
+    Matrix<Scalar> m(numCells, numCells);
+    m.reserve(pattern);
+
+    // Row 0 of the tri-diagonal stencil only couples to columns 0 and 1.
+    MatrixBlock<Scalar> b;
+    BOOST_CHECK_THROW(m.blockAddress(0, 3), std::logic_error);
+    BOOST_CHECK_THROW(m.block(0, 3, b), std::logic_error);
+    BOOST_CHECK_THROW(m.setBlock(0, 3, b), std::logic_error);
+
+    // A pattern that does not have one entry per matrix row.
+    Matrix<Scalar> mismatched(numCells, numCells);
+    const std::vector<std::set<unsigned> > shortPattern(numCells - 1);
+    BOOST_CHECK_THROW(mismatched.reserve(shortPattern), std::logic_error);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(VectorRoundTrip, Scalar, ScalarTypes)
+{
+    using namespace Dune::Indices;
+
+    Vector<Scalar> v(numCells);
+    v = Scalar(0);
+
+    for (std::size_t i = 0; i < numCells; ++i) {
+        EqVector<Scalar> contribution;
+        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            contribution[eqIdx] = Scalar(10) * static_cast<Scalar>(i) + static_cast<Scalar>(eqIdx);
+        }
+        v[i] += contribution;
+        v[i] += contribution;
+    }
+
+    const Vector<Scalar>& constView = v;
+    for (std::size_t i = 0; i < numCells; ++i) {
+        const EqVector<Scalar> block = constView[i];
+        BOOST_CHECK_EQUAL(block.size(), static_cast<std::size_t>(numEq));
+        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            const Scalar expected
+                = Scalar(2) * (Scalar(10) * static_cast<Scalar>(i) + static_cast<Scalar>(eqIdx));
+            BOOST_CHECK_CLOSE(block[eqIdx], expected, Tolerance<Scalar>::percent);
+        }
+    }
+
+    // Sub-vectors carry the fields in the expected order.
+    BOOST_CHECK_CLOSE(v.istlVector()[_0][3][0], Scalar(2) * Scalar(30), Tolerance<Scalar>::percent);
+    BOOST_CHECK_CLOSE(v.istlVector()[_3][3][1],
+                      Scalar(2) * Scalar(30 + 4),
+                      Tolerance<Scalar>::percent);
+    BOOST_CHECK_CLOSE(v.istlVector()[_4][3][0],
+                      Scalar(2) * Scalar(30 + 6),
+                      Tolerance<Scalar>::percent);
+
+    Scalar expectedOneNorm = Scalar(0);
+    for (std::size_t i = 0; i < numCells; ++i) {
+        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            expectedOneNorm
+                += Scalar(2) * (Scalar(10) * static_cast<Scalar>(i) + static_cast<Scalar>(eqIdx));
+        }
+    }
+    BOOST_CHECK_CLOSE(v.one_norm(), expectedOneNorm, Tolerance<Scalar>::percent);
+
+    v[2] = Scalar(0);
+    BOOST_CHECK_EQUAL(constView[2][4], Scalar(0));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(VectorArithmetic, Scalar, ScalarTypes)
+{
+    Vector<Scalar> a(numCells);
+    fillVector(a);
+
+    Vector<Scalar> b(numCells);
+    fillVector(b, /*alternateSign =*/ true);
+
+    Vector<Scalar> sum = a;
+    sum += b;
+
+    Vector<Scalar> difference = a;
+    difference -= b;
+
+    Vector<Scalar> scaled = a;
+    scaled *= Scalar(3);
+
+    for (std::size_t i = 0; i < numCells; ++i) {
+        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            const Scalar av = a[i][eqIdx];
+            const Scalar bv = b[i][eqIdx];
+            BOOST_CHECK_CLOSE(sum[i][eqIdx], av + bv, Tolerance<Scalar>::percent);
+            BOOST_CHECK_CLOSE(difference[i][eqIdx], av - bv, Tolerance<Scalar>::percent);
+            BOOST_CHECK_CLOSE(scaled[i][eqIdx], Scalar(3) * av, Tolerance<Scalar>::percent);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(VectorNorms, Scalar, ScalarTypes)
+{
+    Vector<Scalar> v(numCells);
+    fillVector(v, /*alternateSign =*/ true);
+
+    Scalar expectedOneNorm = Scalar(0);
+    Scalar expectedTwoNorm2 = Scalar(0);
+    Scalar expectedInfinityNorm = Scalar(0);
+    for (std::size_t i = 0; i < numCells; ++i) {
+        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            const Scalar value = std::abs(vectorEntry<Scalar>(i, eqIdx));
+            expectedOneNorm += value;
+            expectedTwoNorm2 += value * value;
+            expectedInfinityNorm = std::max(expectedInfinityNorm, value);
+        }
+    }
+
+    BOOST_CHECK_CLOSE(v.one_norm(), expectedOneNorm, Tolerance<Scalar>::percent);
+    BOOST_CHECK_CLOSE(v.two_norm2(), expectedTwoNorm2, Tolerance<Scalar>::percent);
+    BOOST_CHECK_CLOSE(v.two_norm(), std::sqrt(expectedTwoNorm2), Tolerance<Scalar>::percent);
+    BOOST_CHECK_CLOSE(v.infinity_norm(), expectedInfinityNorm, Tolerance<Scalar>::percent);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(VectorScaleFields, Scalar, ScalarTypes)
+{
+    Vector<Scalar> v(numCells);
+    fillVector(v);
+
+    const std::array<Scalar, numFields> factors{
+        {Scalar(2), Scalar(3), Scalar(5), Scalar(7), Scalar(11)}};
+    v.scaleFields(factors);
+
+    for (std::size_t i = 0; i < numCells; ++i) {
+        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            const Scalar expected = vectorEntry<Scalar>(i, eqIdx) * factors[fieldOf(eqIdx)];
+            BOOST_CHECK_CLOSE(v[i][eqIdx], expected, Tolerance<Scalar>::percent);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(EntryProxyOperations, Scalar, ScalarTypes)
+{
+    BOOST_CHECK_EQUAL(Vector<Scalar>::EntryProxy::size(), static_cast<std::size_t>(numEq));
+
+    Vector<Scalar> v(numCells);
+    v = Scalar(0);
+
+    EqVector<Scalar> value;
+    for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+        value[eqIdx] = vectorEntry<Scalar>(1, eqIdx);
+    }
+
+    // Scatter a dense block, then gather it back through the conversion operator.
+    v[1] = value;
+    const EqVector<Scalar> gathered = v[1];
+    for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+        BOOST_CHECK_CLOSE(gathered[eqIdx], value[eqIdx], Tolerance<Scalar>::percent);
+    }
+
+    v[1] *= Scalar(4);
+    for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+        BOOST_CHECK_CLOSE(v[1][eqIdx], Scalar(4) * value[eqIdx], Tolerance<Scalar>::percent);
+    }
+
+    v[1] -= value;
+    for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+        BOOST_CHECK_CLOSE(v[1][eqIdx], Scalar(3) * value[eqIdx], Tolerance<Scalar>::percent);
+    }
+
+    // Only cell 1 was touched.
+    for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+        BOOST_CHECK_EQUAL(v[0][eqIdx], Scalar(0));
+        BOOST_CHECK_EQUAL(v[2][eqIdx], Scalar(0));
+    }
+
+    // Proxy-to-proxy assignment
+    v[3] = v[1];
+    for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+        BOOST_CHECK_CLOSE(v[3][eqIdx], v[1][eqIdx], Tolerance<Scalar>::percent);
+    }
+}


### PR DESCRIPTION
First PR in TPSA restructure. Introduces new matrix and vector classes for linear elasticity TPSA. Some features in the new matrix structure is specifically needed to use Hypre (for now the only AMG preconditioner that we got to work in parallel with TPSA system). Matrix and vector are made to interface with the current 7x7 block structure in linearizer and Newton (made in follow-up PRs). The implementation is similar to [SystemTypes](https://github.com/OPM/opm-simulators/blob/master/opm/simulators/linalg/system/SystemTypes.hpp) for flow.