### PR TITLE
TPSA restructure (2/3): New preconditioner structure

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -177,6 +177,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/linalg/system/WellMatrixMerger.cpp
   opm/simulators/linalg/tpsa/TpsaMatrix.cpp
   opm/simulators/linalg/tpsa/TpsaVector.cpp
+  opm/simulators/linalg/tpsa/TpsaPreconditioner.cpp
   opm/simulators/linalg/TPSALinearSolverParameters.cpp
   opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
   opm/simulators/timestepping/AdaptiveTimeStepping.cpp
@@ -521,6 +522,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_tpsa_face_properties.cpp
   tests/test_tpsa_localresidual.cpp
   tests/test_tpsa_matrix.cpp
+  tests/test_tpsa_preconditioner.cpp
   tests/test_tpsa_primaryvariables.cpp
   tests/test_vfpproperties.cpp
   tests/test_WellMatrixMerger.cpp
@@ -1137,6 +1139,8 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/linalg/system/WellMatrixMerger.hpp
   opm/simulators/linalg/ISTLSolverTPSA.hpp
   opm/simulators/linalg/tpsa/TpsaMatrix.hpp
+  opm/simulators/linalg/tpsa/TpsaPreconditioner.hpp
+  opm/simulators/linalg/tpsa/TpsaPreconditionerFactory.hpp
   opm/simulators/linalg/tpsa/TpsaTypes.hpp
   opm/simulators/linalg/tpsa/TpsaVector.hpp
   opm/simulators/linalg/istlpreconditionerwrappers.hh

--- a/opm/models/discretization/common/tpsalinearizer.hpp
+++ b/opm/models/discretization/common/tpsalinearizer.hpp
@@ -70,6 +70,7 @@ class TpsaLinearizer
 
     using ADVectorBlock = Dune::FieldVector<Evaluation, numEq>;
     using MatrixBlock = typename SparseMatrixAdapter::MatrixBlock;
+    using BlockAddress = typename SparseMatrixAdapter::BlockAddress;
     using VectorBlock = Dune::FieldVector<Scalar, numEq>;
 
     using StressInfoVector = Dune::FieldVector<Scalar, 3>;
@@ -386,7 +387,7 @@ private:
                         const auto scvfIdx = dofIdx - 1;
                         const auto& scvf = stencil.interiorFace(scvfIdx);
                         const Scalar area = scvf.area();
-                        loc_nbinfo[dofIdx - 1] = NeighborInfo{ neighborIdx, area, nullptr };
+                        loc_nbinfo[dofIdx - 1] = NeighborInfo{ neighborIdx, area, BlockAddress{} };
 
                         int faceId = scvf.dirId();
                         loc_stressinfo[dofIdx - 1] =
@@ -496,7 +497,7 @@ private:
 
                 // Loop over neighboring cells
                 short loc = 0;
-                for (const auto& nbInfo : nbInfos) {
+                for (auto& nbInfo : nbInfos) {
                     OPM_TIMEBLOCK_LOCAL(calculationForEachFaceTPSA, Subsystem::Assembly);
 
                     // Reset local residual and Jacobian
@@ -743,7 +744,7 @@ private:
     Simulator* simulatorPtr_{};
     LinearizationType linearizationType_{};
 
-    std::vector<MatrixBlock*> diagMatAddress_{};
+    std::vector<BlockAddress> diagMatAddress_{};
     std::unique_ptr<SparseMatrixAdapter> jacobian_{};
     GlobalEqVector residual_;
 
@@ -757,7 +758,7 @@ private:
     {
         unsigned int neighbor;
         double faceArea;
-        MatrixBlock* matBlockAddress;
+        BlockAddress matBlockAddress;
     };
     SparseTable<NeighborInfo> neighborInfo_{};
 

--- a/opm/simulators/flow/TTagFlowProblemTPSA.hpp
+++ b/opm/simulators/flow/TTagFlowProblemTPSA.hpp
@@ -42,7 +42,10 @@
 #include <opm/simulators/flow/FlowProblemTPSA.hpp>
 #include <opm/simulators/linalg/matrixblock.hh>
 #include <opm/simulators/linalg/ISTLSolverTPSA.hpp>
-#include <opm/simulators/linalg/istlsparsematrixadapter.hh>
+#include <opm/simulators/linalg/tpsa/TpsaMatrix.hpp>
+#include <opm/simulators/linalg/tpsa/TpsaVector.hpp>
+
+#include <type_traits>
 
 
 namespace Opm::Properties {
@@ -94,7 +97,17 @@ struct EqVectorTPSA<TypeTag, TTag::FlowProblemTpsa>
 // Global TPSA equation vector
 template<class TypeTag>
 struct GlobalEqVectorTPSA<TypeTag, TTag::FlowProblemTpsa>
-{ using type = Dune::BlockVector<GetPropType<TypeTag, Properties::EqVectorTPSA>>; };
+{
+private:
+    using Scalar = GetPropType<TypeTag, Scalar>;
+    static_assert(std::is_same_v<GetPropType<TypeTag, Properties::EqVectorTPSA>,
+                                 typename Linear::TpsaVector<Scalar>::EqVector>,
+                  "Linear::TpsaVector implements the 7-equation elasticity field "
+                  "split; EqVectorTPSA must be the matching block type");
+
+public:
+    using type = Linear::TpsaVector<Scalar>;
+};
 
 // TPSA Newton method
 template<class TypeTag>
@@ -132,12 +145,11 @@ struct SparseMatrixAdapterTPSA<TypeTag, TTag::FlowProblemTpsa>
 {
 private:
     using Scalar = GetPropType<TypeTag, Scalar>;
-    enum { numEq = getPropValue<TypeTag, Properties::NumEqTPSA>() };
-    using Block = MatrixBlock<Scalar, numEq, numEq>;
+    static_assert(getPropValue<TypeTag, Properties::NumEqTPSA>() == Linear::numTpsaEq,
+                  "Linear::TpsaMatrix implements the 7-equation elasticity field split");
 
 public:
-    using type = typename Linear::IstlSparseMatrixAdapter<Block>;
-
+    using type = Linear::TpsaMatrix<Scalar>;
 };
 
 // Set linear solver backend

--- a/opm/simulators/linalg/ISTLSolverTPSA.hpp
+++ b/opm/simulators/linalg/ISTLSolverTPSA.hpp
@@ -26,10 +26,12 @@
 #define ISTL_SOLVER_TPSA_HPP
 
 #include <dune/istl/owneroverlapcopy.hh>
+#include <dune/istl/solver.hh>
 
 #include <opm/common/CriticalError.hpp>
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/Exceptions.hpp>
+#include <opm/common/TimingMacros.hpp>
 
 #include <opm/models/tpsa/tpsabaseproperties.hpp>
 #include <opm/models/utils/parametersystem.hpp>
@@ -37,48 +39,58 @@
 
 #include <opm/simulators/linalg/AbstractISTLSolver.hpp>
 #include <opm/simulators/linalg/ExtractParallelGridInformationToISTL.hpp>
+#include <opm/simulators/linalg/FlexibleSolver.hpp>
 #include <opm/simulators/linalg/ISTLSolver.hpp>
 #include <opm/simulators/linalg/PropertyTree.hpp>
 #include <opm/simulators/linalg/setupPropertyTree.hpp>
 #include <opm/simulators/linalg/TPSALinearSolverParameters.hpp>
-#include <opm/simulators/linalg/WriteSystemMatrixHelper.hpp>
+#include <opm/simulators/linalg/tpsa/TpsaPreconditionerFactory.hpp>
+#include <opm/simulators/linalg/tpsa/TpsaTypes.hpp>
 
 #include <algorithm>
 #include <any>
 #include <cctype>
+#include <cstddef>
+#include <functional>
 #include <memory>
 #include <stdexcept>
 #include <string>
-#include <utility>
 #include <vector>
-
-#include <fmt/format.h>
-
 
 namespace Opm {
 
 /*!
-* \brief Class for setting up ISTL linear solvers for TPSA
-*
-* Implements AbstractISTLSolver interface for TPSA linear solvers.
-*/
+ * \brief Linear solver for the field-split TPSA system.
+ *
+ * The Jacobian handed in by TpsaLinearizer is a Linear::TpsaMatrix, which
+ * already stores the system as the 19 sub-matrices of the five-field split
+ * (see TpsaTypes.hpp), and the residual is a Linear::TpsaVector wrapping the
+ * matching Dune::MultiTypeBlockVector.
+ */
 template <class TypeTag>
-class ISTLSolverTPSA : public AbstractISTLSolver<GetPropType<TypeTag, Properties::SparseMatrixAdapterTPSA>,
-                                                 GetPropType<TypeTag, Properties::GlobalEqVectorTPSA>>
+class ISTLSolverTPSA :
+    public AbstractISTLSolver<GetPropType<TypeTag, Properties::SparseMatrixAdapterTPSA>,
+                              GetPropType<TypeTag, Properties::GlobalEqVectorTPSA> >
 {
     using ElementMapper = GetPropType<TypeTag, Properties::ElementMapper>;
+    using Scalar = GetPropType<TypeTag, Properties::Scalar>;
     using Simulator = GetPropType<TypeTag, Properties::Simulator>;
     using SparseMatrixAdapter = GetPropType<TypeTag, Properties::SparseMatrixAdapterTPSA>;
     using Vector = GetPropType<TypeTag, Properties::GlobalEqVectorTPSA>;
-
     using Matrix = typename SparseMatrixAdapter::IstlMatrix;
+    using MultiVector = Linear::TpsaMultiVector<Scalar>;
 
+    using SolverType = Dune::InverseOperator<MultiVector, MultiVector>;
+    using PrecondType = Dune::PreconditionerWithUpdate<MultiVector, MultiVector>;
 
 #if HAVE_MPI
-        using CommunicationType = Dune::OwnerOverlapCopyCommunication<int,int>;
+    using CommunicationType = Dune::OwnerOverlapCopyCommunication<int, int>;
 #else
-        using CommunicationType = Dune::Communication<int>;
+    using CommunicationType = Dune::Communication<int>;
 #endif
+
+    //! \brief No pressure equation to single out in the mechanics system.
+    static constexpr std::size_t pressureIndex = 0;
 
 public:
     /*!
@@ -86,12 +98,12 @@ public:
     *
     * \param simulator Simulator object
     */
-    ISTLSolverTPSA(const Simulator& simulator)
+    explicit ISTLSolverTPSA(const Simulator& simulator)
         : simulator_(simulator)
-        , solveCount_(0)
-        , iterations_(0)
-        , matrix_(nullptr)
-        , rhs_(nullptr)
+          , solveCount_(0)
+          , iterations_(0)
+          , matrix_(nullptr)
+          , rhs_(nullptr)
     {
         // Init parameters
         parameters_.init();
@@ -118,7 +130,7 @@ public:
 
         // Reset comm_ pointer
 #if HAVE_MPI
-            comm_.reset( new CommunicationType( simulator_.vanguard().grid().comm() ) );
+        comm_.reset(new CommunicationType(simulator_.vanguard().grid().comm()));
 #endif
 
         // Extract and copy parallel grid information
@@ -133,12 +145,11 @@ public:
         // Get info on overlapping rows
         ElementMapper elemMapper(simulator_.vanguard().gridView(), Dune::mcmgElementLayout());
         std::vector<int> dummyInteriorRows;
-        detail::findOverlapAndInterior(simulator_.vanguard().grid(), elemMapper, overlapRows_, dummyInteriorRows);
+        detail::findOverlapAndInterior(simulator_.vanguard().grid(),
+                                       elemMapper,
+                                       overlapRows_,
+                                       dummyInteriorRows);
 
-        // Set number of interior cells in FlexibleSolverInfo
-        flexibleSolver_.interiorCellNum_ = detail::numMatrixRowsToUseInSolver(simulator_.vanguard().grid(), true);
-
-        // Print parameters to PRT/DBG logs.
         detail::printLinearSolverParameters(parameters_, prm_, simulator_.gridView().comm());
     }
 
@@ -148,44 +159,39 @@ public:
     * \param M System matrix
     * \param b Right-hand side vector
     */
-    void initPrepare(const Matrix& M, Vector& b)
+    void initPrepare(const SparseMatrixAdapter& M, Vector& b)
     {
-        // Update matrix entries if it has not been initialized yet
-        const bool firstcall = (matrix_ == nullptr);
-        if (firstcall) {
-            // Model will not change the matrix object. Hence simply store a pointer to the original one with a deleter
-            // that does nothing.
-            // OBS: We need to be able to scale the linear system, hence const_cast
-            matrix_ = const_cast<Matrix*>(&M);
-        }
-        else {
-            // Pointers should not change; throw if the case
-            if (&M != matrix_) {
-                OPM_THROW(std::logic_error, "TPSA: Matrix objects are expected to be reused when reassembling!");
-            }
-
+        if (matrix_ == nullptr) {
+            // The model reuses the same matrix object for the whole run; keep a
+            // pointer to it. The const_cast mirrors ISTLSolver: the solver has
+            // to be able to modify the assembled system (overlap rows).
+            matrix_ = const_cast<SparseMatrixAdapter*>(&M);
+        } else if (&M != matrix_) {
+            OPM_THROW(std::logic_error,
+                      "TPSA: Matrix objects are expected to be reused when reassembling!");
         }
 
         // Set right-hand side vector
         rhs_ = &b;
 
-        // Zero out the overlapping cells in matrix (not in ilu0 case)
-        std::string type = prm_.template get<std::string>("preconditioner.type", "paroverilu0");
-        std::transform(type.begin(), type.end(), type.begin(), ::tolower);
+        // Zero out the overlapping cells (not for the overlapping ILU variant,which handles them
+        // itself).
+        auto type = prm_.get<std::string>("preconditioner.type", "paroverilu0");
+        std::ranges::transform(type, type.begin(), ::tolower);
         if (isParallel() && type != "paroverilu0") {
-            detail::makeOverlapRowsInvalid(getMatrix(), overlapRows_);
+            matrix_->makeOverlapRowsInvalid(overlapRows_);
         }
     }
 
     /*!
     * \copydoc AbstractISTLSolver::prepare
     */
-    void prepare(const Matrix& M, Vector& b) override
+    void prepare(const SparseMatrixAdapter& M, Vector& b) override
     {
+        OPM_TIMEBLOCK(istlSolverPrepare);
         try {
             initPrepare(M, b);
-
-            prepareFlexibleSolver();
+            prepareSolver();
         }
         OPM_CATCH_AND_RETHROW_AS_CRITICAL_ERROR
             ("TPSA: Failure likely due to a faulty linear solver JSON specification. "
@@ -195,38 +201,12 @@ public:
     /*!
     * \copydoc AbstractISTLSolver::prepare
     */
-    void prepare(const SparseMatrixAdapter& M, Vector& b) override
+    void prepare(const Matrix& /*M*/, Vector& /*b*/) override
     {
-        prepare(M.istlMatrix(), b);
-    }
-
-    /*!
-    * \brief Prepare linear solver
-    *
-    * Create linear solver using FlexibleSolverInfo struct from ISTLSolver.hpp, or update preconditioner if solver has
-    * been created
-    */
-    void prepareFlexibleSolver()
-    {
-        // Create solver or just update preconditioner
-        if (!flexibleSolver_.solver_) {
-            // Dummy weights calculator
-            // TODO: TPSA specific weights calculation for AMG preconditioner
-            std::function<Vector()> weightCalculator;
-
-            // Create FlexibleSolver
-            flexibleSolver_.create(getMatrix(),
-                                   isParallel(),
-                                   prm_,
-                                   /*pressureIndex=*/0,
-                                   weightCalculator,
-                                   /*forceSerial_=*/false,
-                                   comm_.get());
-        }
-        else {
-            // Update preconditioner
-            flexibleSolver_.pre_->update();
-        }
+        // The five-field view is not enough to prepare the solve: the overlap
+        // handling needs the owning TpsaMatrix
+        OPM_THROW(std::logic_error,
+                  "TPSA: prepare() needs the TpsaMatrix itself, not just its field-split view");
     }
 
     /*!
@@ -234,23 +214,15 @@ public:
     */
     bool solve(Vector& x) override
     {
-        // Increase solver count
+        OPM_TIMEBLOCK(istlSolverSolve);
         ++solveCount_;
 
-        // Write system matrix if verbosity level is high
-        const int verbosity = prm_.get("verbosity", 0);
-        if (verbosity > 10) {
-            // simulator_ is only used to get names
-            Helper::writeSystem(simulator_,
-                                getMatrix(),
-                                *rhs_,
-                                comm_.get());
-        }
+        x = 0.0;
 
         // Solve linear system
         Dune::InverseOperatorResult result;
-        assert(flexibleSolver_.solver_);
-        flexibleSolver_.solver_->apply(x, *rhs_, result);
+        assert(solver_);
+        solver_->apply(x.istlVector(), rhs_->istlVector(), result);
 
         // Store no. linear iterations
         iterations_ = result.iterations;
@@ -274,13 +246,15 @@ public:
     * \copydoc AbstractISTLSolver::eraseMatrix
     */
     void eraseMatrix() override
-    { }
+    {
+    }
 
     /*!
     * \copydoc AbstractISTLSolver::setActiveSolver
     */
     void setActiveSolver(int /*num*/) override
-    { }
+    {
+    }
 
     /*!
     * \copydoc AbstractISTLSolver::numAvailableSolvers
@@ -294,13 +268,15 @@ public:
     * \copydoc AbstractISTLSolver::setResidual
     */
     void setResidual(Vector& /*b*/) override
-    { }
+    {
+    }
 
     /*!
     * \copydoc AbstractISTLSolver::setMatrix
     */
     void setMatrix(const SparseMatrixAdapter& /*M*/) override
-    { }
+    {
+    }
 
     // ///
     // Public get functions
@@ -369,29 +345,65 @@ protected:
     // Protected get functions
     // ///
     /*!
-    * \brief Get reference to system matrix object
-    *
-    * \returns Reference to matrix
-    */
-    Matrix& getMatrix()
+     * \brief Create the solver on the first call, refresh the preconditioner on
+     *        every later one.
+     */
+    void prepareSolver()
     {
-        if (!matrix_) {
-            OPM_THROW(std::runtime_error, "TPSA: System matrix \"M\" not defined!");
+        OPM_TIMEBLOCK(flexibleSolverPrepare);
+
+        if (solver_ == nullptr) {
+            OPM_TIMEBLOCK(flexibleSolverCreate);
+            createSolver();
+        } else {
+            OPM_TIMEBLOCK(flexibleSolverUpdate);
+            precond_->update();
         }
-        return *matrix_;
     }
 
+
     /*!
-    * \brief Get reference to system matrix object
-    *
-    * \returns Reference to matrix
-    */
-    const Matrix& getMatrix() const
+     * \brief Build the linear operator and the flexible solver for the TPSA system
+     *
+     * \warning matrix_ and comm_ must be set before calling this function. The
+     *          matrix is handed to the operator by reference, so it must outlive
+     *          the solver.
+     */
+    void createSolver()
     {
-        if (!matrix_) {
-            OPM_THROW(std::runtime_error, "TPSA: System matrix \"M\" not defined!");
+        // The mechanics system has no equation weights.
+        std::function<MultiVector()> weightCalculator;
+
+        Matrix& matrixView = matrix_->istlMatrix();
+
+        if (isParallel()) {
+#if HAVE_MPI
+            // All five fields live on the same dof partition, so they share the same
+            // communicator.
+            multiComm_ = std::make_unique<TpsaComm>(*comm_, *comm_, *comm_, *comm_, *comm_);
+
+            parOperator_ = std::make_unique<TpsaParOperator<Scalar> >(matrixView, *multiComm_);
+            parSolver_ = std::make_unique<
+                Dune::FlexibleSolver<TpsaParOperator<Scalar> > >(*parOperator_,
+                                                                 *multiComm_,
+                                                                 prm_,
+                                                                 weightCalculator,
+                                                                 pressureIndex);
+
+            solver_ = parSolver_.get();
+            precond_ = &parSolver_->preconditioner();
+#endif
+        } else {
+            seqOperator_ = std::make_unique<TpsaSeqOperator<Scalar> >(matrixView);
+            seqSolver_ = std::make_unique<
+                Dune::FlexibleSolver<TpsaSeqOperator<Scalar> > >(*seqOperator_,
+                                                                 prm_,
+                                                                 weightCalculator,
+                                                                 pressureIndex);
+
+            solver_ = seqSolver_.get();
+            precond_ = &seqSolver_->preconditioner();
         }
-        return *matrix_;
     }
 
     const Simulator& simulator_;
@@ -399,17 +411,30 @@ protected:
     int solveCount_;
     int iterations_;
 
-    detail::FlexibleSolverInfo<Matrix, Vector, CommunicationType> flexibleSolver_;
     TpsaLinearSolverParameters parameters_;
     PropertyTree prm_;
 
-    Matrix* matrix_;
+    SparseMatrixAdapter* matrix_;
     Vector* rhs_;
 
     std::shared_ptr<CommunicationType> comm_;
     std::vector<int> overlapRows_;
+
+    // Serial solver components
+    std::unique_ptr<TpsaSeqOperator<Scalar> > seqOperator_;
+    std::unique_ptr<Dune::FlexibleSolver<TpsaSeqOperator<Scalar> > > seqSolver_;
+
+    // Parallel solver components
+#if HAVE_MPI
+    std::unique_ptr<TpsaComm> multiComm_;
+    std::unique_ptr<TpsaParOperator<Scalar> > parOperator_;
+    std::unique_ptr<Dune::FlexibleSolver<TpsaParOperator<Scalar> > > parSolver_;
+#endif
+
+    SolverType* solver_ = nullptr;
+    PrecondType* precond_ = nullptr;
 };
 
 }  // namespace Opm
 
-#endif
+#endif // ISTL_SOLVER_TPSA_HPP

--- a/opm/simulators/linalg/TPSALinearSolverParameters.cpp
+++ b/opm/simulators/linalg/TPSALinearSolverParameters.cpp
@@ -77,9 +77,9 @@ void TpsaLinearSolverParameters::registerParameters()
     Parameters::Register<Parameters::TpsaLinearSolverIgnoreConvergenceFailure>
         ("Continue simulation even if TPSA linear solver did not converge");
     Parameters::Register<Parameters::TpsaLinearSolver>
-        ("Configuration for linear solver. Valid preset options are: ilu0, dilu, amg or umfpack. "
-         "Alternatively, you can request a configuration to be read from a JSON file by giving the filename here, "
-         "ending with '.json.'");
+        ("Configuration for linear solver. Valid preset options are: hypre, ilu0, dilu, "
+         "or amg. Alternatively, you can request a configuration to be read from a JSON file by "
+         "giving the filename here, ending with '.json'");
     Parameters::Register<Parameters::TpsaLinearSolverPrintJsonDefinition>
         ("Print JSON formatted configuration of the TPSA linear solver. Can be used to make configuration JSON file "
         "for --tpsa-linear-solver");
@@ -101,7 +101,7 @@ void TpsaLinearSolverParameters::reset()
     ilu_fillin_level_ = 0;
     newton_use_gmres_ = false;
     ignoreConvergenceFailure_ = false;
-    linsolver_ = "ilu0";
+    linsolver_ = "hypre";
     linear_solver_print_json_definition_ = false;
 }
 

--- a/opm/simulators/linalg/TPSALinearSolverParameters.hpp
+++ b/opm/simulators/linalg/TPSALinearSolverParameters.hpp
@@ -42,7 +42,7 @@ struct TpsaIluRelaxation { static constexpr double value = 0.9; };
 struct TpsaIluFillinLevel { static constexpr int value = 0; };
 struct TpsaUseGmres { static constexpr bool value = false; };
 struct TpsaLinearSolverIgnoreConvergenceFailure { static constexpr bool value = false; };
-struct TpsaLinearSolver { static constexpr auto value = "ilu0"; };
+struct TpsaLinearSolver { static constexpr auto value = "hypre"; };
 struct TpsaLinearSolverPrintJsonDefinition { static constexpr auto value = false; };
 
 }  // namespace Opm::Parameters

--- a/opm/simulators/linalg/setupPropertyTree.cpp
+++ b/opm/simulators/linalg/setupPropertyTree.cpp
@@ -34,6 +34,9 @@ namespace Opm
 
 namespace
 {
+    constexpr int cprDefaultMaxIter = 20;
+    constexpr double cprDefaultReduction = 0.005;
+
     // Populate DUNE AMG parameters under the given root prefix.
     inline void setupDuneAMG(PropertyTree& prm, const std::string& root)
     {
@@ -58,6 +61,24 @@ namespace
         prm.put(root + "maxconnectivity", prm.get<int>(root + "maxconnectivity", 15));
         prm.put(root + "maxaggsize", prm.get<int>(root + "maxaggsize", 6));
         prm.put(root + "minaggsize", prm.get<int>(root + "minaggsize", 4));
+    }
+
+    // Populate ILU0 preconditioner parameters under the given root prefix.
+    inline void
+    setupIluPrec(PropertyTree& prm,
+                 const std::string& root,
+                 const FlowLinearSolverParameters& p)
+    {
+        using namespace std::string_literals;
+        if (p.linear_solver_accelerator_ == Parameters::LinearSolverAcceleratorType::GPU
+            && !p.is_nldd_local_solver_) {
+            // TODO: We could add ParOverILU0 as an alias in the GPU path to simplify this.
+            prm.put(root + "type", "opmilu0"s);
+        } else {
+            prm.put(root + "type", "paroverilu0"s);
+        }
+        prm.put(root + "relaxation", p.ilu_relaxation_);
+        prm.put(root + "ilulevel", p.ilu_fillin_level_);
     }
 
     // Populate Hypre BoomerAMG defaults under the given root prefix.
@@ -171,6 +192,45 @@ namespace
                   "--linear-solver=dilu).");
 #endif
     }
+
+    /*!
+     * \brief Configure a TPSA block preconditioner
+     *
+     * \param prm Property tree to add the block solver configuration to
+     * \param root Key prefix of the block's sub-tree, including the trailing
+     *             dot, e.g. "preconditioner.disp_disp_solver."
+     * \param type Preconditioner to use for this block
+     * \param p Linear solver parameters (e.g. ILU setup)
+     */
+    void
+    setupTpsaBlockSolver(PropertyTree& prm,
+                         const std::string& root,
+                         const std::string& type,
+                         const FlowLinearSolverParameters& p)
+    {
+        using namespace std::string_literals;
+
+        prm.put(root + "solver", "loopsolver"s);
+        prm.put(root + "maxiter", 1);
+        prm.put(root + "tol", 0.0);
+        prm.put(root + "verbosity", 0);
+
+        const std::string prec = root + "preconditioner.";
+        if (type == "hypre") {
+            // Hypre's own defaults, see HypreSetup.hpp.
+            prm.put(prec + "type", "hypre"s);
+        } else if (type == "ilu0") {
+            setupIluPrec(prm, prec, p);
+        } else if (type == "dilu") {
+            prm.put(prec + "type", "dilu"s);
+        } else if (type == "amg") {
+            prm.put(prec + "type", "amg"s);
+            setupDuneAMG(prm, prec);
+        } else {
+            OPM_THROW(std::invalid_argument,
+                      fmt::format("Unknown TPSA block preconditioner \"{}\".", type));
+        }
+    }
 } // anonymous namespace
 
 /// Set up a property tree intended for FlexibleSolver by either reading
@@ -205,42 +265,46 @@ setupPropertyTree(FlowLinearSolverParameters p, // Note: copying the parameters 
     // We use lower case as the internal canonical representation of solver names.
     std::ranges::transform(conf, conf.begin(), ::tolower);
 
-    // Use CPR configuration.
-    if (!tpsaSetup) {
-        if ((conf == "cpr_trueimpes") || (conf == "cpr_quasiimpes") || (conf == "cpr_trueimpesanalytic")) {
-            if (!linearSolverMaxIterSet) {
-                // Use our own default unless it was explicitly overridden by user.
-                p.linear_solver_maxiter_ = 20;
-            }
-            if (!linearSolverReductionSet) {
-                // Use our own default unless it was explicitly overridden by user.
-                p.linear_solver_reduction_ = 0.005;
-            }
-            return setupCPR(conf, p);
-        }
+    // Setup TPSA block preconditioners
+    if (tpsaSetup) {
+        return setupTpsa(conf, p);
+    }
 
-        if ((conf == "cpr") || (conf == "cprw")) {
-            if (!linearSolverMaxIterSet) {
-                // Use our own default unless it was explicitly overridden by user.
-                p.linear_solver_maxiter_ = 20;
-            }
-            if (!linearSolverReductionSet) {
-                // Use our own default unless it was explicitly overridden by user.
-                p.linear_solver_reduction_ = 0.005;
-            }
-            return setupCPRW(conf, p);
+    // Use CPR configuration.
+    if ((conf == "cpr_trueimpes") || (conf == "cpr_quasiimpes")
+        || (conf == "cpr_trueimpesanalytic")) {
+        if (!linearSolverMaxIterSet) {
+            // Use our own default unless it was explicitly overridden by user.
+            p.linear_solver_maxiter_ = cprDefaultMaxIter;
         }
-        
-        // System CPR configuration (coupled reservoir-well system solver).
-        if (conf == "system_cpr") {
-            if (!linearSolverMaxIterSet) {
-                p.linear_solver_maxiter_ = 20;
-            }
-            if (!linearSolverReductionSet) {
-                p.linear_solver_reduction_ = 0.005;
-            }
-            return setupSystemCPR(conf, p);
+        if (!linearSolverReductionSet) {
+            // Use our own default unless it was explicitly overridden by user.
+            p.linear_solver_reduction_ = cprDefaultReduction;
         }
+        return setupCPR(conf, p);
+    }
+
+    if ((conf == "cpr") || (conf == "cprw")) {
+        if (!linearSolverMaxIterSet) {
+            // Use our own default unless it was explicitly overridden by user.
+            p.linear_solver_maxiter_ = cprDefaultMaxIter;
+        }
+        if (!linearSolverReductionSet) {
+            // Use our own default unless it was explicitly overridden by user.
+            p.linear_solver_reduction_ = cprDefaultReduction;
+        }
+        return setupCPRW(conf, p);
+    }
+
+    // System CPR configuration (coupled reservoir-well system solver).
+    if (conf == "system_cpr") {
+        if (!linearSolverMaxIterSet) {
+            p.linear_solver_maxiter_ = cprDefaultMaxIter;
+        }
+        if (!linearSolverReductionSet) {
+            p.linear_solver_reduction_ = cprDefaultReduction;
+        }
+        return setupSystemCPR(conf, p);
     }
 
     if (conf == "amg") {
@@ -289,21 +353,13 @@ setupPropertyTree(FlowLinearSolverParameters p, // Note: copying the parameters 
     }
 
     // No valid configuration option found.
-    if (tpsaSetup) {
-        OPM_THROW(std::invalid_argument,
-                  fmt::format("No valid settings found for --tpsa-linear-solver={}! "
-                              "Valid preset options are: ilu0, dilu, amg, or umfpack.", conf));
-    }
-    else {
-        OPM_THROW(std::invalid_argument,
-                conf + " is not a valid setting for --linear-solver-configuration."
-                " Please use ilu0, dilu, isai, cpr, cprw, cpr_trueimpes, cpr_quasiimpes, cpr_trueimpesanalytic, or system_cpr");
-    }
-
-
+    OPM_THROW(std::invalid_argument,
+              conf + " is not a valid setting for --linear-solver-configuration."
+              " Please use ilu0, dilu, isai, cpr, cprw, cpr_trueimpes, cpr_quasiimpes, cpr_trueimpesanalytic, or system_cpr");
 }
 
-std::string getSolverString(const FlowLinearSolverParameters& p)
+std::string
+getSolverString(const FlowLinearSolverParameters& p)
 {
     if (p.newton_use_gmres_)
     {
@@ -413,6 +469,48 @@ setupAMG([[maybe_unused]] const std::string& conf, const FlowLinearSolverParamet
     return prm;
 }
 
+PropertyTree
+setupTpsa(std::string conf, const FlowLinearSolverParameters& p)
+{
+    using namespace std::string_literals;
+    if (conf != "hypre" && conf != "ilu0" && conf != "dilu" && conf != "amg") {
+        OPM_THROW(std::invalid_argument,
+                  fmt::format(
+                      "No valid settings found for --tpsa-linear-solver={}! Valid preset "
+                      "options are: default, hypre, ilu0, dilu or amg. Alternatively, give "
+                      "the name of a .json file holding a full solver configuration.", conf)
+            );
+    }
+
+#if ! HAVE_HYPRE
+    if (conf == "hypre") {
+        OpmLog::warning(
+            "--tpsa-linear-solver=hypre requires a build with Hypre support (USE_HYPRE=ON). "
+            "Switching to ilu0!");
+        conf = "ilu0"s;
+    }
+#endif
+
+    PropertyTree prm;
+    prm.put("tol", p.linear_solver_reduction_);
+    prm.put("maxiter", p.linear_solver_maxiter_);
+    prm.put("verbosity", p.linear_solver_verbosity_);
+    prm.put("solver", getSolverString(p));
+
+    prm.put("preconditioner.type", "tpsa_block"s);
+    prm.put("preconditioner.verbosity", p.linear_solver_verbosity_);
+
+    // The three displacement blocks and the solid pressure block are scalar
+    // (1x1) by construction, so they take the requested preconditioner.
+    setupTpsaBlockSolver(prm, "preconditioner.disp_disp_solver.", conf, p);
+    setupTpsaBlockSolver(prm, "preconditioner.spres_spres_solver.", conf, p);
+
+    // The rotation block is 3x3, so it always uses ILU regardless of the choice
+    // above.
+    setupTpsaBlockSolver(prm, "preconditioner.rot_rot_solver.", "ilu0"s, p);
+
+    return prm;
+}
 
 PropertyTree
 setupILU([[maybe_unused]] const std::string& conf, const FlowLinearSolverParameters& p)
@@ -423,14 +521,7 @@ setupILU([[maybe_unused]] const std::string& conf, const FlowLinearSolverParamet
     prm.put("maxiter", p.linear_solver_maxiter_);
     prm.put("verbosity", p.linear_solver_verbosity_);
     prm.put("solver", getSolverString(p));
-    if (p.linear_solver_accelerator_ == Parameters::LinearSolverAcceleratorType::GPU && !p.is_nldd_local_solver_) {
-        // TODO: We could add ParOverILU0 as an alias in the GPU path to simplify this.
-        prm.put("preconditioner.type", "opmilu0"s);
-    } else {
-        prm.put("preconditioner.type", "paroverilu0"s);
-    }
-    prm.put("preconditioner.relaxation", p.ilu_relaxation_);
-    prm.put("preconditioner.ilulevel", p.ilu_fillin_level_);
+    setupIluPrec(prm, "preconditioner.", p);
     return prm;
 }
 

--- a/opm/simulators/linalg/setupPropertyTree.hpp
+++ b/opm/simulators/linalg/setupPropertyTree.hpp
@@ -47,6 +47,7 @@ void validateSystemCPRTree(const PropertyTree& prm);
 // --matrix-add-well-contributions=true. Call this after detecting system_cpr is active.
 void checkSystemCPRMatrixAddWell(bool matrixAddWellContributions);
 PropertyTree setupAMG(const std::string& conf, const FlowLinearSolverParameters& p);
+PropertyTree setupTpsa(std::string conf, const FlowLinearSolverParameters& p);
 PropertyTree setupILU(const std::string& conf, const FlowLinearSolverParameters& p);
 PropertyTree setupLegacyMixedILU(const std::string& conf, const FlowLinearSolverParameters& p);
 PropertyTree setupMixedILU(const std::string& conf, const FlowLinearSolverParameters& p);

--- a/opm/simulators/linalg/tpsa/TpsaMatrix.cpp
+++ b/opm/simulators/linalg/tpsa/TpsaMatrix.cpp
@@ -7,7 +7,7 @@
 
   OPM is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 2 of the License, or
+  the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
   OPM is distributed in the hope that it will be useful,
@@ -17,10 +17,6 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
-
-  Consult the COPYING file in the top-level source directory of this
-  module for the precise wording of the license and the list of
-  copyright holders.
 */
 #include <config.h>
 

--- a/opm/simulators/linalg/tpsa/TpsaMatrix.hpp
+++ b/opm/simulators/linalg/tpsa/TpsaMatrix.hpp
@@ -7,7 +7,7 @@
 
   OPM is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 2 of the License, or
+  the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
   OPM is distributed in the hope that it will be useful,
@@ -17,10 +17,6 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
-
-  Consult the COPYING file in the top-level source directory of this
-  module for the precise wording of the license and the list of
-  copyright holders.
 */
 #ifndef OPM_TPSA_MATRIX_HPP
 #define OPM_TPSA_MATRIX_HPP

--- a/opm/simulators/linalg/tpsa/TpsaPreconditioner.cpp
+++ b/opm/simulators/linalg/tpsa/TpsaPreconditioner.cpp
@@ -1,0 +1,68 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2025 NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <config.h>
+
+#include <opm/simulators/linalg/tpsa/TpsaPreconditioner_impl.hpp>
+#include <opm/simulators/linalg/tpsa/TpsaPreconditionerFactory.hpp>
+
+#include <opm/simulators/linalg/FlexibleSolver_impl.hpp>
+#include <opm/simulators/linalg/PreconditionerFactory_impl.hpp>
+
+#define INSTANTIATE_TPSA_PF_SEQ(T)                                          \
+    template class Opm::TpsaPreconditioner<T,                               \
+                                           Opm::SeqDispDispOperatorT<T>,    \
+                                           Opm::SeqRotRotOperatorT<T>,      \
+                                           Opm::SeqSPresSPresOperatorT<T>>; \
+    template class Dune::FlexibleSolver<Opm::TpsaSeqOperator<T>>;           \
+    template class Opm::PreconditionerFactory<Opm::TpsaSeqOperator<T>,      \
+                                              Dune::Amg::SequentialInformation>;
+
+#if HAVE_MPI
+#define INSTANTIATE_TPSA_PF_PAR(T)                                                    \
+    template class Opm::TpsaPreconditioner<T,                                         \
+                                           Opm::ParDispDispOperatorT<T>,              \
+                                           Opm::ParRotRotOperatorT<T>,                \
+                                           Opm::ParSPresSPresOperatorT<T>,            \
+                                           Opm::TpsaParComm>;                         \
+    template class Dune::FlexibleSolver<Opm::TpsaParOperator<T>>;                     \
+    template Dune::FlexibleSolver<Opm::TpsaParOperator<T>>::FlexibleSolver(           \
+        Opm::TpsaParOperator<T>& op,                                                  \
+        const Opm::TpsaComm& comm,                                                    \
+        const Opm::PropertyTree& prm,                                                 \
+        const std::function<Opm::Linear::TpsaMultiVector<T>()>& weightsCalculator,    \
+        std::size_t pressureIndex);                                                   \
+    template class Opm::PreconditionerFactory<Opm::TpsaParOperator<T>, Opm::TpsaComm>;\
+    template class Opm::PreconditionerFactory<Opm::TpsaParOperator<T>,                \
+                                              Dune::Amg::SequentialInformation>;
+
+#define INSTANTIATE_TPSA_PF(T) \
+    INSTANTIATE_TPSA_PF_PAR(T) \
+    INSTANTIATE_TPSA_PF_SEQ(T)
+
+#else
+#define INSTANTIATE_TPSA_PF(T) INSTANTIATE_TPSA_PF_SEQ(T)
+#endif
+
+INSTANTIATE_TPSA_PF(double)
+
+#if FLOW_INSTANTIATE_FLOAT
+INSTANTIATE_TPSA_PF(float)
+#endif

--- a/opm/simulators/linalg/tpsa/TpsaPreconditioner.hpp
+++ b/opm/simulators/linalg/tpsa/TpsaPreconditioner.hpp
@@ -1,0 +1,210 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2025 NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_TPSA_PRECONDITIONER_HPP
+#define OPM_TPSA_PRECONDITIONER_HPP
+
+#include <dune/istl/operators.hh>
+#include <dune/istl/owneroverlapcopy.hh>
+#include <dune/istl/schwarz.hh>
+#include <dune/istl/paamg/pinfo.hh>
+
+#include <opm/simulators/linalg/FlexibleSolver.hpp>
+#include <opm/simulators/linalg/PreconditionerWithUpdate.hpp>
+#include <opm/simulators/linalg/PropertyTree.hpp>
+#include <opm/simulators/linalg/tpsa/TpsaTypes.hpp>
+
+#include <functional>
+#include <memory>
+#include <type_traits>
+
+namespace Opm
+{
+
+//! \brief Sequential operator for one of the three scalar displacement blocks.
+template <typename Scalar>
+using SeqDispDispOperatorT = Dune::MatrixAdapter<Linear::DispDispMatrix00T<Scalar>,
+                                                 Linear::DispVector0T<Scalar>,
+                                                 Linear::DispVector0T<Scalar> >;
+//! \brief Sequential operator for the rotation block.
+template <typename Scalar>
+using SeqRotRotOperatorT = Dune::MatrixAdapter<Linear::RotRotMatrixT<Scalar>,
+                                               Linear::RotVectorT<Scalar>,
+                                               Linear::RotVectorT<Scalar> >;
+//! \brief Sequential operator for the solid pressure block.
+template <typename Scalar>
+using SeqSPresSPresOperatorT = Dune::MatrixAdapter<Linear::SPresSPresMatrixT<Scalar>,
+                                                   Linear::SPresVectorT<Scalar>,
+                                                   Linear::SPresVectorT<Scalar> >;
+
+#if HAVE_MPI
+//! \brief Communication type of a single TPSA field.
+using TpsaParComm = Dune::OwnerOverlapCopyCommunication<int, int>;
+
+//! \brief Parallel operator for one of the three scalar displacement blocks.
+template <typename Scalar>
+using ParDispDispOperatorT = Dune::OverlappingSchwarzOperator<Linear::DispDispMatrix00T<Scalar>,
+                                                              Linear::DispVector0T<Scalar>,
+                                                              Linear::DispVector0T<Scalar>,
+                                                              TpsaParComm>;
+//! \brief Parallel operator for the rotation block.
+template <typename Scalar>
+using ParRotRotOperatorT = Dune::OverlappingSchwarzOperator<Linear::RotRotMatrixT<Scalar>,
+                                                            Linear::RotVectorT<Scalar>,
+                                                            Linear::RotVectorT<Scalar>,
+                                                            TpsaParComm>;
+//! \brief Parallel operator for the solid pressure block.
+template <typename Scalar>
+using ParSPresSPresOperatorT = Dune::OverlappingSchwarzOperator<Linear::SPresSPresMatrixT<Scalar>,
+                                                                Linear::SPresVectorT<Scalar>,
+                                                                Linear::SPresVectorT<Scalar>,
+                                                                TpsaParComm>;
+#endif
+
+/*!
+ * \brief Block lower-triangular preconditioner for the field-split TPSA system.
+ *
+ * Solves the three scalar displacement blocks, carries their contribution over
+ * to the rotation and solid pressure defects, and solves those in turn.  Each
+ * diagonal block gets its own Dune::FlexibleSolver, configured through the
+ * `disp_disp_solver`, `rot_rot_solver` and `spres_spres_solver` sub-trees; the
+ * three displacement blocks share the `disp_disp_solver` configuration.
+ *
+ * \tparam Scalar Field type of the matrix entries
+ * \tparam DispOp Linear operator type of a single scalar displacement block,
+ *                SeqDispDispOperatorT or ParDispDispOperatorT
+ * \tparam RotOp Linear operator type of the rotation block, SeqRotRotOperatorT
+ *               or ParRotRotOperatorT
+ * \tparam SPresOp Linear operator type of the solid pressure block,
+ *                 SeqSPresSPresOperatorT or ParSPresSPresOperatorT
+ * \tparam Comm Communication type of the sub-solvers. Defaults to
+ *              Dune::Amg::SequentialInformation, which selects the sequential
+ *              implementation
+ */
+template <class Scalar, class DispOp, class RotOp, class SPresOp,
+          class Comm = Dune::Amg::SequentialInformation>
+class TpsaPreconditioner
+    : public Dune::PreconditionerWithUpdate<Linear::TpsaMultiVector<Scalar>,
+                                            Linear::TpsaMultiVector<Scalar> >
+{
+    using MultiVector = Linear::TpsaMultiVector<Scalar>;
+    using DispSolver = Dune::FlexibleSolver<DispOp>;
+    using RotSolver = Dune::FlexibleSolver<RotOp>;
+    using SPresSolver = Dune::FlexibleSolver<SPresOp>;
+
+public:
+    //! \brief Whether this instance runs the parallel code path.
+    static constexpr bool isParallel = !std::is_same_v<Comm, Dune::Amg::SequentialInformation>;
+
+    //! \brief Field indices into the multi-vector: u_x, u_y, u_z, rotation, solid pressure.
+    static constexpr auto _0 = Dune::Indices::_0;
+    static constexpr auto _1 = Dune::Indices::_1;
+    static constexpr auto _2 = Dune::Indices::_2;
+    static constexpr auto _3 = Dune::Indices::_3;
+    static constexpr auto _4 = Dune::Indices::_4;
+
+    //! \brief The sub-solvers have no pressure equation to single out.
+    static constexpr std::size_t pressureIdx = 0;
+
+    /*!
+     * \brief Sequential constructor.
+     *
+     * \param S View of the TPSA system matrix.
+     * \param prm Configuration of the diagonal block solvers. Must hold the
+     *            `disp_disp_solver`, `rot_rot_solver` and `spres_spres_solver`
+     *            sub-trees
+     */
+    TpsaPreconditioner(const Linear::TpsaMatrixView<Scalar>& S, const PropertyTree& prm)
+        requires (!isParallel);
+
+    /*!
+     * \brief Parallel constructor.
+     *
+     * \param S View of the TPSA system matrix.
+     * \param prm Configuration of the diagonal block solvers. Must hold the
+     *            `disp_disp_solver`, `rot_rot_solver` and `spres_spres_solver`
+     *            sub-trees
+     * \param comm Communication of a single field. All five fields live on the
+     *             same dof partition, so the same object is used for each of
+     *             them. Only referenced, so it must outlive the preconditioner
+     */
+    TpsaPreconditioner(const Linear::TpsaMatrixView<Scalar>& S,
+                       const PropertyTree& prm,
+                       const Comm& comm)
+        requires (isParallel);
+
+    //! \brief Nothing to prepare, the sub-solvers set themselves up.
+    void pre(MultiVector&, MultiVector&) override;
+
+    //! \brief Nothing to clean up after the last apply().
+    void post(MultiVector&) override;
+
+    //! \brief Solver category, overlapping in parallel and sequential otherwise.
+    Dune::SolverCategory::Category category() const override;
+
+    //! \brief Recompute the preconditioners of all five diagonal block solvers.
+    void update() override;
+
+    //! \brief The block solvers are rebuilt from the current matrix on update().
+    bool hasPerfectUpdate() const override;
+
+    /*!
+     * \brief Apply the preconditioner, i.e. approximately solve S v = d.
+     *
+     * Sweeps over the fields in the order u_x, u_y, u_z, rotation, solid
+     * pressure. The displacement updates are substituted into the rotation and
+     * solid pressure defects before those blocks are solved.
+     *
+     * \param v Update, overwritten by the result
+     * \param d Defect to precondition
+     */
+    void apply(MultiVector& v, const MultiVector& d) override;
+
+private:
+    /*!
+     * \brief Build an operator and a Dune::FlexibleSolver for each diagonal block.
+     *
+     * \param prm Configuration of the diagonal block solvers
+     */
+    void initSubSolvers_(const PropertyTree& prm);
+
+    //! \brief The system to precondition, owned by the caller.
+    const Linear::TpsaMatrixView<Scalar>& S_;
+    //! \brief Communication of a single field, only set in the parallel case.
+    const Comm* comm_{nullptr};
+
+    // Operators of the diagonal blocks, referenced by the solvers below.
+    std::unique_ptr<DispOp> dispOp0_;
+    std::unique_ptr<DispOp> dispOp1_;
+    std::unique_ptr<DispOp> dispOp2_;
+    std::unique_ptr<RotOp> rotOp_;
+    std::unique_ptr<SPresOp> sPresOp_;
+
+    // Solvers of the diagonal blocks.
+    std::unique_ptr<DispSolver> dispSolver0_;
+    std::unique_ptr<DispSolver> dispSolver1_;
+    std::unique_ptr<DispSolver> dispSolver2_;
+    std::unique_ptr<RotSolver> rotSolver_;
+    std::unique_ptr<SPresSolver> sPresSolver_;
+};
+
+} // namespace Opm
+
+#endif // OPM_TPSA_PRECONDITIONER_HPP

--- a/opm/simulators/linalg/tpsa/TpsaPreconditionerFactory.hpp
+++ b/opm/simulators/linalg/tpsa/TpsaPreconditionerFactory.hpp
@@ -1,0 +1,199 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2025 NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_TPSA_PRECONDITIONER_FACTORY_HPP
+#define OPM_TPSA_PRECONDITIONER_FACTORY_HPP
+
+#include <dune/istl/operators.hh>
+#include <dune/istl/paamg/pinfo.hh>
+
+#include <opm/simulators/linalg/PreconditionerFactory.hpp>
+#include <opm/simulators/linalg/system/MultiComm.hpp>
+#include <opm/simulators/linalg/tpsa/TpsaPreconditioner.hpp>
+#include <opm/simulators/linalg/tpsa/TpsaTypes.hpp>
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+
+namespace Opm
+{
+
+template <class Operator, class Comm, typename>
+struct StandardPreconditioners;
+
+template <typename Scalar>
+using TpsaSeqOperator = Dune::MatrixAdapter<Linear::TpsaMatrixView<Scalar>,
+                                            Linear::TpsaMultiVector<Scalar>,
+                                            Linear::TpsaMultiVector<Scalar> >;
+
+#if HAVE_MPI
+//! \brief One communicator per field; in practice the same one five times.
+using TpsaComm = Dune::MultiCommunicator<const Dune::OwnerOverlapCopyCommunication<int, int>&,
+                                         const Dune::OwnerOverlapCopyCommunication<int, int>&,
+                                         const Dune::OwnerOverlapCopyCommunication<int, int>&,
+                                         const Dune::OwnerOverlapCopyCommunication<int, int>&,
+                                         const Dune::OwnerOverlapCopyCommunication<int, int>&>;
+
+template <typename Scalar>
+using TpsaParOperator = Dune::OverlappingSchwarzOperator<Linear::TpsaMatrixView<Scalar>,
+                                                         Linear::TpsaMultiVector<Scalar>,
+                                                         Linear::TpsaMultiVector<Scalar>,
+                                                         TpsaComm>;
+#endif
+
+namespace detail
+{
+
+    template <typename Scalar>
+    void
+    addTpsaBlockSeq()
+    {
+        using O = TpsaSeqOperator<Scalar>;
+        using F = PreconditionerFactory<O, Dune::Amg::SequentialInformation>;
+        using V = Linear::TpsaMultiVector<Scalar>;
+        using P = PropertyTree;
+
+        F::addCreator("tpsa_block",
+                      [](const O& op,
+                         const P& prm,
+                         const std::function<V()>&,
+                         std::size_t) {
+                          using PreCond = TpsaPreconditioner<Scalar,
+                                                             SeqDispDispOperatorT<Scalar>,
+                                                             SeqRotRotOperatorT<Scalar>,
+                                                             SeqSPresSPresOperatorT<Scalar> >;
+                          return std::make_shared<PreCond>(op.getmat(), prm);
+                      });
+    }
+
+#if HAVE_MPI
+    template <typename Scalar>
+    void
+    addTpsaBlockParSeq()
+    {
+        // An MPI build running on a single rank still instantiates the parallel
+        // operator, but with sequential information.
+        using O = TpsaParOperator<Scalar>;
+        using F = PreconditionerFactory<O, Dune::Amg::SequentialInformation>;
+        using V = Linear::TpsaMultiVector<Scalar>;
+        using P = PropertyTree;
+
+        F::addCreator("tpsa_block",
+                      [](const O& op,
+                         const P& prm,
+                         const std::function<V()>&,
+                         std::size_t) {
+                          using PreCond = TpsaPreconditioner<Scalar,
+                                                             SeqDispDispOperatorT<Scalar>,
+                                                             SeqRotRotOperatorT<Scalar>,
+                                                             SeqSPresSPresOperatorT<Scalar> >;
+                          return std::make_shared<PreCond>(op.getmat(), prm);
+                      });
+    }
+
+    template <typename Scalar>
+    void
+    addTpsaBlockPar()
+    {
+        using O = TpsaParOperator<Scalar>;
+        using F = PreconditionerFactory<O, TpsaComm>;
+        using V = Linear::TpsaMultiVector<Scalar>;
+        using P = PropertyTree;
+
+        F::addCreator("tpsa_block",
+                      [](const O& op,
+                         const P& prm,
+                         const std::function<V()>&,
+                         std::size_t,
+                         const TpsaComm& comm) {
+                          // All five fields share one dof partition.
+                          const auto& fieldComm = comm[Dune::Indices::_0];
+                          using PreCond = TpsaPreconditioner<Scalar,
+                                                             ParDispDispOperatorT<Scalar>,
+                                                             ParRotRotOperatorT<Scalar>,
+                                                             ParSPresSPresOperatorT<Scalar>,
+                                                             TpsaParComm>;
+                          return std::make_shared<PreCond>(op.getmat(), prm, fieldComm);
+                      });
+    }
+#endif
+
+} // namespace detail
+
+template <>
+struct StandardPreconditioners<TpsaSeqOperator<double>, Dune::Amg::SequentialInformation, void>
+{
+    static void add()
+    {
+        detail::addTpsaBlockSeq<double>();
+    }
+};
+
+template <>
+struct StandardPreconditioners<TpsaSeqOperator<float>, Dune::Amg::SequentialInformation, void>
+{
+    static void add()
+    {
+        detail::addTpsaBlockSeq<float>();
+    }
+};
+
+#if HAVE_MPI
+template <>
+struct StandardPreconditioners<TpsaParOperator<double>, Dune::Amg::SequentialInformation, void>
+{
+    static void add()
+    {
+        detail::addTpsaBlockParSeq<double>();
+    }
+};
+
+template <>
+struct StandardPreconditioners<TpsaParOperator<float>, Dune::Amg::SequentialInformation, void>
+{
+    static void add()
+    {
+        detail::addTpsaBlockParSeq<float>();
+    }
+};
+
+template <>
+struct StandardPreconditioners<TpsaParOperator<double>, TpsaComm, void>
+{
+    static void add()
+    {
+        detail::addTpsaBlockPar<double>();
+    }
+};
+
+template <>
+struct StandardPreconditioners<TpsaParOperator<float>, TpsaComm, void>
+{
+    static void add()
+    {
+        detail::addTpsaBlockPar<float>();
+    }
+};
+#endif
+
+} // namespace Opm
+
+#endif // OPM_TPSA_PRECONDITIONER_FACTORY_HPP

--- a/opm/simulators/linalg/tpsa/TpsaPreconditioner_impl.hpp
+++ b/opm/simulators/linalg/tpsa/TpsaPreconditioner_impl.hpp
@@ -1,0 +1,215 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2025 NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_TPSA_PRECONDITIONER_IMPL_HPP
+#define OPM_TPSA_PRECONDITIONER_IMPL_HPP
+
+#ifndef OPM_TPSA_PRECONDITIONER_HPP
+#include <config.h>
+#include <opm/simulators/linalg/tpsa/TpsaPreconditioner.hpp>
+#endif
+
+namespace Opm
+{
+
+template <class Scalar, class DispOp, class RotOp, class SPresOp, class Comm>
+TpsaPreconditioner<Scalar, DispOp, RotOp, SPresOp, Comm>::
+TpsaPreconditioner(const Linear::TpsaMatrixView<Scalar>& S, const PropertyTree& prm)
+    requires (!isParallel)
+    : S_(S)
+{
+    initSubSolvers_(prm);
+}
+
+template <class Scalar, class DispOp, class RotOp, class SPresOp, class Comm>
+TpsaPreconditioner<Scalar, DispOp, RotOp, SPresOp, Comm>::
+TpsaPreconditioner(const Linear::TpsaMatrixView<Scalar>& S,
+                   const PropertyTree& prm,
+                   const Comm& comm)
+    requires (isParallel)
+    : S_(S)
+    , comm_(&comm)
+{
+    initSubSolvers_(prm);
+}
+
+template <class Scalar, class DispOp, class RotOp, class SPresOp, class Comm>
+void
+TpsaPreconditioner<Scalar, DispOp, RotOp, SPresOp, Comm>::
+pre(MultiVector&, MultiVector&)
+{
+}
+
+template <class Scalar, class DispOp, class RotOp, class SPresOp, class Comm>
+void
+TpsaPreconditioner<Scalar, DispOp, RotOp, SPresOp, Comm>::
+post(MultiVector&)
+{
+}
+
+template <class Scalar, class DispOp, class RotOp, class SPresOp, class Comm>
+Dune::SolverCategory::Category
+TpsaPreconditioner<Scalar, DispOp, RotOp, SPresOp, Comm>::
+category() const
+{
+    if constexpr (isParallel) {
+        return Dune::SolverCategory::overlapping;
+    } else {
+        return Dune::SolverCategory::sequential;
+    }
+}
+
+template <class Scalar, class DispOp, class RotOp, class SPresOp, class Comm>
+void
+TpsaPreconditioner<Scalar, DispOp, RotOp, SPresOp, Comm>::
+update()
+{
+    dispSolver0_->preconditioner().update();
+    dispSolver1_->preconditioner().update();
+    dispSolver2_->preconditioner().update();
+    rotSolver_->preconditioner().update();
+    sPresSolver_->preconditioner().update();
+}
+
+template <class Scalar, class DispOp, class RotOp, class SPresOp, class Comm>
+bool
+TpsaPreconditioner<Scalar, DispOp, RotOp, SPresOp, Comm>::
+hasPerfectUpdate() const
+{
+    return true;
+}
+
+template <class Scalar, class DispOp, class RotOp, class SPresOp, class Comm>
+void
+TpsaPreconditioner<Scalar, DispOp, RotOp, SPresOp, Comm>::
+apply(MultiVector& v, const MultiVector& d)
+{
+    Dune::InverseOperatorResult result;
+
+    // The defects of the coupled fields are updated as the sweep proceeds,
+    // so they need their own copies.
+    auto d0 = d[_0];
+    auto d1 = d[_1];
+    auto d2 = d[_2];
+    auto d3 = d[_3];
+    auto d4 = d[_4];
+
+    // Ensure that v is zero-initialized for apply()
+    v = 0.0;
+
+    dispSolver0_->apply(v[_0], d0, result);
+    dispSolver1_->apply(v[_1], d1, result);
+    dispSolver2_->apply(v[_2], d2, result);
+
+    S_[_3][_0].mmv(v[_0], d3);
+    S_[_3][_1].mmv(v[_1], d3);
+    S_[_3][_2].mmv(v[_2], d3);
+    rotSolver_->apply(v[_3], d3, result);
+
+    S_[_4][_0].mmv(v[_0], d4);
+    S_[_4][_1].mmv(v[_1], d4);
+    S_[_4][_2].mmv(v[_2], d4);
+    sPresSolver_->apply(v[_4], d4, result);
+}
+
+template <class Scalar, class DispOp, class RotOp, class SPresOp, class Comm>
+void
+TpsaPreconditioner<Scalar, DispOp, RotOp, SPresOp, Comm>::
+initSubSolvers_(const PropertyTree& prm)
+{
+    const auto dispPrm = prm.get_child("disp_disp_solver");
+    const auto rotPrm = prm.get_child("rot_rot_solver");
+    const auto sPresPrm = prm.get_child("spres_spres_solver");
+
+    std::function<Linear::DispVector0T<Scalar>()> dispWeightCalc;
+    std::function<Linear::RotVectorT<Scalar>()> rotWeightCalc;
+    std::function<Linear::SPresVectorT<Scalar>()> sPresWeightCalc;
+
+    if constexpr (isParallel) {
+        dispOp0_ = std::make_unique<DispOp>(S_[_0][_0], *comm_);
+        dispSolver0_ = std::make_unique<DispSolver>(*dispOp0_,
+                                                    *comm_,
+                                                    dispPrm,
+                                                    dispWeightCalc,
+                                                    pressureIdx);
+
+        dispOp1_ = std::make_unique<DispOp>(S_[_1][_1], *comm_);
+        dispSolver1_ = std::make_unique<DispSolver>(*dispOp1_,
+                                                    *comm_,
+                                                    dispPrm,
+                                                    dispWeightCalc,
+                                                    pressureIdx);
+
+        dispOp2_ = std::make_unique<DispOp>(S_[_2][_2], *comm_);
+        dispSolver2_ = std::make_unique<DispSolver>(*dispOp2_,
+                                                    *comm_,
+                                                    dispPrm,
+                                                    dispWeightCalc,
+                                                    pressureIdx);
+
+        rotOp_ = std::make_unique<RotOp>(S_[_3][_3], *comm_);
+        rotSolver_ = std::make_unique<RotSolver>(*rotOp_,
+                                                 *comm_,
+                                                 rotPrm,
+                                                 rotWeightCalc,
+                                                 pressureIdx);
+
+        sPresOp_ = std::make_unique<SPresOp>(S_[_4][_4], *comm_);
+        sPresSolver_ = std::make_unique<SPresSolver>(*sPresOp_,
+                                                     *comm_,
+                                                     sPresPrm,
+                                                     sPresWeightCalc,
+                                                     pressureIdx);
+    } else {
+        dispOp0_ = std::make_unique<DispOp>(S_[_0][_0]);
+        dispSolver0_ = std::make_unique<DispSolver>(*dispOp0_,
+                                                    dispPrm,
+                                                    dispWeightCalc,
+                                                    pressureIdx);
+
+        dispOp1_ = std::make_unique<DispOp>(S_[_1][_1]);
+        dispSolver1_ = std::make_unique<DispSolver>(*dispOp1_,
+                                                    dispPrm,
+                                                    dispWeightCalc,
+                                                    pressureIdx);
+
+        dispOp2_ = std::make_unique<DispOp>(S_[_2][_2]);
+        dispSolver2_ = std::make_unique<DispSolver>(*dispOp2_,
+                                                    dispPrm,
+                                                    dispWeightCalc,
+                                                    pressureIdx);
+
+        rotOp_ = std::make_unique<RotOp>(S_[_3][_3]);
+        rotSolver_ = std::make_unique<RotSolver>(*rotOp_,
+                                                 rotPrm,
+                                                 rotWeightCalc,
+                                                 pressureIdx);
+
+        sPresOp_ = std::make_unique<SPresOp>(S_[_4][_4]);
+        sPresSolver_ = std::make_unique<SPresSolver>(*sPresOp_,
+                                                     sPresPrm,
+                                                     sPresWeightCalc,
+                                                     pressureIdx);
+    }
+}
+
+} // namespace Opm
+
+#endif // OPM_TPSA_PRECONDITIONER_IMPL_HPP

--- a/opm/simulators/linalg/tpsa/TpsaTypes.hpp
+++ b/opm/simulators/linalg/tpsa/TpsaTypes.hpp
@@ -7,7 +7,7 @@
 
   OPM is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 2 of the License, or
+  the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
   OPM is distributed in the hope that it will be useful,
@@ -17,10 +17,6 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
-
-  Consult the COPYING file in the top-level source directory of this
-  module for the precise wording of the license and the list of
-  copyright holders.
 */
 #ifndef OPM_TPSA_TYPES_HPP
 #define OPM_TPSA_TYPES_HPP

--- a/opm/simulators/linalg/tpsa/TpsaVector.cpp
+++ b/opm/simulators/linalg/tpsa/TpsaVector.cpp
@@ -7,7 +7,7 @@
 
   OPM is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 2 of the License, or
+  the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
   OPM is distributed in the hope that it will be useful,
@@ -17,10 +17,6 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
-
-  Consult the COPYING file in the top-level source directory of this
-  module for the precise wording of the license and the list of
-  copyright holders.
 */
 #include <config.h>
 

--- a/opm/simulators/linalg/tpsa/TpsaVector.hpp
+++ b/opm/simulators/linalg/tpsa/TpsaVector.hpp
@@ -7,7 +7,7 @@
 
   OPM is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 2 of the License, or
+  the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
   OPM is distributed in the hope that it will be useful,
@@ -17,10 +17,6 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
-
-  Consult the COPYING file in the top-level source directory of this
-  module for the precise wording of the license and the list of
-  copyright holders.
 */
 #ifndef OPM_TPSA_VECTOR_HPP
 #define OPM_TPSA_VECTOR_HPP

--- a/tests/test_tpsa_matrix.cpp
+++ b/tests/test_tpsa_matrix.cpp
@@ -5,7 +5,7 @@
 
   OPM is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 2 of the License, or
+  the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
   OPM is distributed in the hope that it will be useful,

--- a/tests/test_tpsa_preconditioner.cpp
+++ b/tests/test_tpsa_preconditioner.cpp
@@ -1,0 +1,319 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2025 NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <config.h>
+
+#define BOOST_TEST_MODULE TpsaPreconditionerTest
+
+#include <boost/mpl/list.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <opm/simulators/linalg/PropertyTree.hpp>
+#include <opm/simulators/linalg/tpsa/TpsaMatrix.hpp>
+#include <opm/simulators/linalg/tpsa/TpsaPreconditioner.hpp>
+#include <opm/simulators/linalg/tpsa/TpsaVector.hpp>
+
+#include <array>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+//! \brief Scalar types every test case is instantiated for.
+#if FLOW_INSTANTIATE_FLOAT
+using ScalarTypes = boost::mpl::list<double, float>;
+#else
+using ScalarTypes = boost::mpl::list<double>;
+#endif // FLOW_INSTANTIATE_FLOAT
+
+template <class Scalar>
+using Matrix = Opm::Linear::TpsaMatrix<Scalar>;
+template <class Scalar>
+using Vector = Opm::Linear::TpsaVector<Scalar>;
+template <class Scalar>
+using MatrixBlock = typename Matrix<Scalar>::MatrixBlock;
+template <class Scalar>
+using EqVector = typename Vector<Scalar>::EqVector;
+template <class Scalar>
+using Preconditioner = Opm::TpsaPreconditioner<Scalar,
+                                               Opm::SeqDispDispOperatorT<Scalar>,
+                                               Opm::SeqRotRotOperatorT<Scalar>,
+                                               Opm::SeqSPresSPresOperatorT<Scalar> >;
+
+constexpr int numEq = Opm::Linear::numTpsaEq;
+
+/*!
+ * \brief Relative tolerance, in percent, of the inexact comparisons.
+ *
+ * \tparam Scalar Field type the comparison is made in.
+ */
+template <class Scalar>
+struct Tolerance;
+
+template <>
+struct Tolerance<double>
+{
+    static constexpr double percent = 1e-8;
+    static constexpr double abs = 1e-8;
+};
+
+template <>
+struct Tolerance<float>
+{
+    static constexpr float percent = 1e-2;
+    static constexpr float abs = 1e-3f;
+};
+
+/*!
+ * \brief A single-cell TPSA matrix, small enough that the block-triangular sweep
+ *        in apply() can be checked against a hand-derived reference.
+ *
+ * \tparam Scalar Field type of the matrix entries.
+ *
+ * \param[in,out] m Matrix the block is written into.
+ */
+template <class Scalar>
+void
+fillSingleCellMatrix(Matrix<Scalar>& m)
+{
+    const std::vector<std::set<unsigned> > pattern {{0}};
+    m.reserve(pattern);
+
+    MatrixBlock<Scalar> b(Scalar(0));
+    b[0][0] = Scalar(4);
+    b[1][1] = Scalar(5);
+    b[2][2] = Scalar(6);
+
+    b[3][3] = Scalar(10);
+    b[3][4] = Scalar(1);
+    b[3][5] = Scalar(1);
+    b[4][3] = Scalar(1);
+    b[4][4] = Scalar(10);
+    b[4][5] = Scalar(1);
+    b[5][3] = Scalar(1);
+    b[5][4] = Scalar(1);
+    b[5][5] = Scalar(10);
+
+    b[6][6] = Scalar(7);
+
+    // Rotation-displacement coupling, read via S_[_3][_0..2] in apply().
+    b[3][0] = Scalar(1);
+    b[4][1] = Scalar(1);
+    b[5][2] = Scalar(1);
+
+    // Solid pressure-displacement coupling, read via S_[_4][_0..2] in apply().
+    b[6][0] = Scalar(0.5);
+    b[6][1] = Scalar(0.5);
+    b[6][2] = Scalar(0.5);
+
+    m.setBlock(0, 0, b);
+}
+
+/*!
+ * \brief Simple configuration of the three diagonal block solvers.
+ *
+ * \param[in] preconditionerType Preconditioner used by each of the three block
+ *                               solvers.
+ */
+template <class Scalar>
+Opm::PropertyTree
+makeBlockSolverPrm(const std::string& preconditionerType)
+{
+    using namespace std::string_literals;
+    Opm::PropertyTree prm;
+    for (const auto& root : {"disp_disp_solver"s, "rot_rot_solver"s, "spres_spres_solver"s}) {
+        prm.put(root + ".solver", "loopsolver"s);
+        prm.put(root + ".maxiter", 1);
+        prm.put(root + ".tol", 0.0);
+        prm.put(root + ".verbosity", 0);
+        prm.put(root + ".preconditioner.type", preconditionerType);
+    }
+    return prm;
+}
+
+/*!
+ * \brief A two-cell TPSA matrix with cell-to-cell coupling.
+ *
+ * \tparam Scalar Field type of the matrix entries.
+ *
+ * \param[in,out] m Matrix the blocks are written into.
+ */
+template <class Scalar>
+void
+fillTwoCellMatrix(Matrix<Scalar>& m)
+{
+    const std::vector<std::set<unsigned> > pattern {{0, 1}, {0, 1}};
+    m.reserve(pattern);
+
+    MatrixBlock<Scalar> diag(Scalar(0));
+    diag[0][0] = Scalar(8);
+    diag[1][1] = Scalar(9);
+    diag[2][2] = Scalar(10);
+
+    diag[3][3] = Scalar(20);
+    diag[3][4] = Scalar(1);
+    diag[3][5] = Scalar(1);
+    diag[4][3] = Scalar(1);
+    diag[4][4] = Scalar(20);
+    diag[4][5] = Scalar(1);
+    diag[5][3] = Scalar(1);
+    diag[5][4] = Scalar(1);
+    diag[5][5] = Scalar(20);
+
+    diag[6][6] = Scalar(15);
+
+    diag[3][0] = Scalar(1);
+    diag[4][1] = Scalar(1);
+    diag[5][2] = Scalar(1);
+
+    diag[6][0] = Scalar(0.5);
+    diag[6][1] = Scalar(0.5);
+    diag[6][2] = Scalar(0.5);
+
+    MatrixBlock<Scalar> offDiag(Scalar(0));
+    offDiag[0][0] = Scalar(2);
+    offDiag[1][1] = Scalar(2);
+    offDiag[2][2] = Scalar(2);
+
+    offDiag[3][3] = Scalar(2);
+    offDiag[3][4] = Scalar(0.3);
+    offDiag[3][5] = Scalar(0.3);
+    offDiag[4][3] = Scalar(0.3);
+    offDiag[4][4] = Scalar(2);
+    offDiag[4][5] = Scalar(0.3);
+    offDiag[5][3] = Scalar(0.3);
+    offDiag[5][4] = Scalar(0.3);
+    offDiag[5][5] = Scalar(2);
+
+    offDiag[6][6] = Scalar(1.5);
+
+    m.setBlock(0, 0, diag);
+    m.setBlock(1, 1, diag);
+    m.setBlock(0, 1, offDiag);
+    m.setBlock(1, 0, offDiag);
+}
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ApplySolvesSingleCellBlockSystem, Scalar, ScalarTypes)
+{
+    Matrix<Scalar> m(1, 1);
+    fillSingleCellMatrix(m);
+    const auto prm = makeBlockSolverPrm<Scalar>("ilu0");
+    Preconditioner<Scalar> precond(m.istlMatrix(), prm);
+
+    Vector<Scalar> d(1);
+    d = Scalar(0);
+    EqVector<Scalar> dContribution;
+    dContribution[0] = Scalar(8);
+    dContribution[1] = Scalar(10);
+    dContribution[2] = Scalar(12);
+    dContribution[3] = Scalar(3);
+    dContribution[4] = Scalar(5);
+    dContribution[5] = Scalar(8);
+    dContribution[6] = Scalar(5);
+    d[0] = dContribution;
+
+    Vector<Scalar> v(1);
+    v = Scalar(0);
+    precond.apply(v.istlVector(), d.istlVector());
+
+    // Hand-derived reference: with a single cell there is no fill-in, so the
+    // block-triangular sweep in apply() is exact.
+    //   v0 = d0 / 4 = 2, v1 = d1 / 5 = 2, v2 = d2 / 6 = 2
+    //   d3' = d3 - [v0, v1, v2] = [1, 3, 6]
+    //   v3 = RotRot^-1 * d3', RotRot = [[10,1,1],[1,10,1],[1,1,10]]
+    //   d4' = d4 - 0.5 * (v0 + v1 + v2) = 2
+    //   v4 = d4' / 7
+    const std::array<Scalar, numEq> expected {
+        Scalar(2), Scalar(2), Scalar(2),
+        Scalar(1) / Scalar(54), Scalar(13) / Scalar(54), Scalar(31) / Scalar(54),
+        Scalar(2) / Scalar(7)};
+
+    const EqVector<Scalar> result = v[0];
+    for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+        BOOST_CHECK_CLOSE(result[eqIdx], expected[eqIdx], Tolerance<Scalar>::percent);
+    }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ApplyIsIndependentOfTheIncomingUpdate, Scalar, ScalarTypes)
+{
+    // A "jac" block solver only ever looks at the diagonal block of whatever it
+    // is given, so with cell-to-cell coupling (see fillTwoCellMatrix()) a
+    // single loopsolver sweep is an *approximate* solve. That makes its result
+    // depend on the initial guess it starts from, hence can be used to test v = 0.0
+    // inside apply()
+    Matrix<Scalar> m(2, 2);
+    fillTwoCellMatrix(m);
+    const auto prm = makeBlockSolverPrm<Scalar>("jac");
+    Preconditioner<Scalar> precond(m.istlMatrix(), prm);
+
+    Vector<Scalar> d(2);
+    d = Scalar(0);
+    EqVector<Scalar> d0;
+    d0[0] = Scalar(8);
+    d0[1] = Scalar(10);
+    d0[2] = Scalar(12);
+    d0[3] = Scalar(3);
+    d0[4] = Scalar(5);
+    d0[5] = Scalar(8);
+    d0[6] = Scalar(5);
+    d[0] = d0;
+    EqVector<Scalar> d1;
+    d1[0] = Scalar(-4);
+    d1[1] = Scalar(6);
+    d1[2] = Scalar(-9);
+    d1[3] = Scalar(-2);
+    d1[4] = Scalar(4);
+    d1[5] = Scalar(-6);
+    d1[6] = Scalar(-3);
+    d[1] = d1;
+
+    const auto applyFrom = [&](Vector<Scalar>& v) {
+        precond.apply(v.istlVector(), d.istlVector());
+        return std::array<EqVector<Scalar>, 2> {v[0], v[1]};
+    };
+
+    // A zero initial guess
+    Vector<Scalar> vZero(2);
+    vZero = Scalar(0);
+    const auto resultZero = applyFrom(vZero);
+
+    // A garbage initial guess, different in each cell
+    Vector<Scalar> vGarbage(2);
+    EqVector<Scalar> garbage0;
+    EqVector<Scalar> garbage1;
+    for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+        garbage0[eqIdx] = Scalar(1000 + eqIdx);
+        garbage1[eqIdx] = Scalar(-2000 - eqIdx);
+    }
+    vGarbage[0] = garbage0;
+    vGarbage[1] = garbage1;
+    const auto resultGarbage = applyFrom(vGarbage);
+
+    for (std::size_t cell = 0; cell < 2; ++cell) {
+        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            BOOST_CHECK_SMALL(resultZero[cell][eqIdx] - resultGarbage[cell][eqIdx],
+                              Tolerance<Scalar>::abs);
+        }
+    }
+}


### PR DESCRIPTION
Use the new matrix and vector framework for TPSA to make a new preconditioner structure, following the same principles as the [SystemPreconditioner](https://github.com/OPM/opm-simulators/blob/master/opm/simulators/linalg/system/SystemPreconditioner.hpp) for flow. This enable the use of separate preconditioners on the diagonal blocks of the TPSA system matrix. New default solver is Hypre, with fallback to ILU0 if not installed. 

Includes PR https://github.com/OPM/opm-simulators/pull/7357, which should be merged first. Draft mode until then.