### PR TITLE
Switch to Using RstState::Load() Without Runspec

### DIFF
--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -47,7 +47,9 @@
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldData.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/GridDims.hpp>
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/Tabdims.hpp>
 
 #include <opm/input/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/input/eclipse/Parser/InputErrorAction.hpp>
@@ -147,8 +149,8 @@ namespace {
         // optional<EclipseGrid> is too expensive however since doing so
         // will create a copy of the grid inside the optional<>.
         const auto rst_state = Opm::RestartIO::RstState::
-            load(std::move(rst_view),
-                 eclipseState.runspec(), parser,
+            load(std::move(rst_view), parser,
+                 static_cast<int>(eclipseState.runspec().tabdims().getNumPVTTables()),
                  &eclipseState.getInputGrid());
 
         eclipseState.loadRestartAquifers(rst_state.aquifers);


### PR DESCRIPTION
PR OPM/opm-common#5308 added an overload of `RstState::load()` that does not require a `Runspec` argument.  While we do have such an object here the restart file loading mechanism should not depend on the dimensions set in the restarted run.  Restarted runs may increase such dimensions, e.g., the number of actions or conditions per action, so it's better to not provide those values in any way.

We still pass the run's number of PVT tables as an argument to `load()`.  This will be subject to future removal once `load()` supports this mode.