### PR TITLE
MSW: set the segment fluid state temperature for all thermal modes

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -74,6 +74,13 @@ namespace Opm {
         static constexpr bool compositionSwitchEnabled =
             Indices::compositionSwitchIdx != std::numeric_limits<unsigned>::max();
 
+        // True when the segment fluid state stores a temperature (any thermal mode, not just
+        // the fully implicit one). Matches the fluid state's enableTemperature flag (see
+        // WellInterface::BlackOilFluidStateType); used to decide whether createFluidState()
+        // must set the temperature explicitly.
+        static constexpr bool enable_temperature =
+            Base::energyModuleType != EnergyModules::NoTemperature;
+
         // Scales the well-side energy equation onto the mass-balance residual
         // scale. Reuses the reservoir energy factor so both live on the same scale.
         static constexpr Scalar energy_scaling_factor_ =

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -2486,7 +2486,12 @@ namespace Opm
                      DeferredLogger& deferred_logger) const
     {
         SegmentFluidState<ValueType> fluid_state;
-        if constexpr (has_energy) {
+        if constexpr (enable_temperature) {
+            // Set the temperature whenever the fluid state can store it (any thermal mode).
+            // In the fully implicit case @p temperature is the segment temperature primary
+            // variable; otherwise it is the (fixed) first-perforation temperature. When the
+            // fluid state does not store a temperature it falls back to the reservoir
+            // temperature.
             fluid_state.setTemperature(temperature);
         }
         if constexpr (has_brine) {


### PR DESCRIPTION
The fluid state stores a temperature whenever a thermal mode is active (not only the fully implicit one), so set it in those cases too. Needed once the fluid state is used to derive the segment fluid properties.