### PR TITLE
Msw segment fs derive properties

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -74,10 +74,8 @@ namespace Opm {
         static constexpr bool compositionSwitchEnabled =
             Indices::compositionSwitchIdx != std::numeric_limits<unsigned>::max();
 
-        // True when the segment fluid state stores a temperature (any thermal mode, not just
-        // the fully implicit one). Matches the fluid state's enableTemperature flag (see
-        // WellInterface::BlackOilFluidStateType); used to decide whether createFluidState()
-        // must set the temperature explicitly.
+        // True when the segment fluid state stores a temperature. This includes thermal modes
+        // without a fully implicit energy equation.
         static constexpr bool enable_temperature =
             Base::energyModuleType != EnergyModules::NoTemperature;
 
@@ -243,8 +241,9 @@ namespace Opm {
                              WellStateType& well_state,
                              const Scalar relaxation_factor = 1.0);
 
-        // computing the accumulation term for later use in well mass equations
-        void computeInitialSegmentFluids(const FSInfo& info, DeferredLogger& deferred_logger);
+        // Compute the initial fluid inventory for well mass equations. Requires an up-to-date
+        // segment fluid state (see updateSegmentFluidState()).
+        void computeInitialSegmentFluids();
 
         // compute the pressure difference between the perforation and cell center
         void computePerfCellPressDiffs(const Simulator& simulator);
@@ -349,9 +348,9 @@ namespace Opm {
 
         void updateWaterThroughput(const double dt, WellStateType& well_state) const override;
 
-        EvalWell getSegmentSurfaceVolume(const int seg_idx,
-                                         const FSInfo& info,
-                                         DeferredLogger& deferred_logger) const;
+        // Compute segment surface volume from its cached volume ratio. Requires an up-to-date
+        // segment fluid state (see updateSegmentFluidState()).
+        EvalWell getSegmentSurfaceVolume(const int seg_idx) const;
 
         // turn on crossflow to avoid singular well equations
         // when the well is banned from cross-flow and the BHP is not properly initialized,
@@ -394,7 +393,6 @@ namespace Opm {
         FSInfo getFirstPerforationFluidStateInfo(const Simulator& simulator) const;
 
         // this function can potentially be shared between multisegment wells and standard wells
-        // TODO: this function largely overlaps with calculatePhaseProperties(), some refactoring/unification should be done
         template <typename ValueType = EvalWell>
         SegmentFluidState<ValueType>
         createFluidState(const std::vector<ValueType>& fluid_composition,

--- a/opm/simulators/wells/MultisegmentWellSegments.cpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.cpp
@@ -93,6 +93,7 @@ MultisegmentWellSegments(const int numSegments,
     , depth_diffs_(numSegments, 0.0)
     , surface_densities_(surfaceDensities<FluidSystem>(well.pvtRegionIdx(), well.numConservationQuantities()))
     , densities_(numSegments, 0.0)
+    , volume_ratios_(numSegments, 0.0)
     , mass_rates_(numSegments, 0.0)
     , viscosities_(numSegments, 0.0)
     , upwinding_segments_(numSegments, 0)
@@ -161,62 +162,6 @@ MultisegmentWellSegments(const int numSegments,
 
 template<class FluidSystem, class Indices>
 void MultisegmentWellSegments<FluidSystem,Indices>::
-computeFluidProperties(const Scalar firstPerfTemperature,
-                       const Scalar firstPerfSaltConcentration,
-                       const PrimaryVariables& primary_variables,
-                       DeferredLogger& deferred_logger)
-{
-    const int num_quantities = well_.numConservationQuantities();
-    PhaseCalcResult result(static_cast<size_t>(num_quantities));
-
-    // \Note: we do not have salt concentration supported as primary variable yet.
-    // \Note: this will change when we implement the brine equation in the multisegment well
-    const EvalWell saltConcentration = firstPerfSaltConcentration;
-
-    for (std::size_t seg = 0; seg < perforations_.size(); ++seg) {
-        const EvalWell temperature = enable_energy ?  primary_variables.getSegmentTemperature(seg) : firstPerfTemperature;
-
-        calculatePhaseProperties(result, temperature, saltConcentration,
-                                 primary_variables, seg, true, deferred_logger);
-
-        phase_densities_[seg] = result.phase_densities;
-        phase_viscosities_[seg] = result.phase_viscosities;
-
-        const auto& mix = result.mix;
-        const auto& mix_s = result.mix_s;
-        const auto& b = result.b;
-        const auto& volrat = result.vol_ratio;
-
-        viscosities_[seg] = 0.;
-        // calculate the average viscosity
-        for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
-            const EvalWell fraction =  mix[comp_idx] / b[comp_idx] / volrat;
-            // TODO: a little more work needs to be done to handle the negative fractions here
-            phase_fractions_[seg][comp_idx] = fraction; // >= 0.0 ? fraction : 0.0;
-            viscosities_[seg] += phase_viscosities_[seg][comp_idx] * phase_fractions_[seg][comp_idx];
-        }
-
-        EvalWell density(0.0);
-        for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
-            density += surface_densities_[comp_idx] * mix_s[comp_idx];
-        }
-        densities_[seg] = density / volrat;
-
-        // TODO: the enthalpy flux rate should be calculated in the similar manner.
-        // calculate the mass rates
-        mass_rates_[seg] = 0.;
-        for (int comp_idx = 0; comp_idx < well_.numConservationQuantities(); ++comp_idx) {
-            const int upwind_seg = upwinding_segments_[seg];
-            const EvalWell rate = primary_variables.getSegmentRateUpwinding(seg,
-                                                                            upwind_seg,
-                                                                            comp_idx);
-            mass_rates_[seg] += rate * surface_densities_[comp_idx];
-        }
-    }
-}
-
-template<class FluidSystem, class Indices>
-void MultisegmentWellSegments<FluidSystem,Indices>::
 updateUpwindingSegments(const PrimaryVariables& primary_variables)
 {
     for (std::size_t seg = 0; seg < perforations_.size(); ++seg) {
@@ -256,29 +201,6 @@ getPressureDiffSegLocalPerf(const int seg,
                             const int local_perf_index) const
 {
     return well_.gravity() * densities_[seg].value() * local_perforation_depth_diffs_[local_perf_index];
-}
-
-template<class FluidSystem, class Indices>
-typename MultisegmentWellSegments<FluidSystem,Indices>::EvalWell
-MultisegmentWellSegments<FluidSystem,Indices>::
-getSurfaceVolume(const Scalar firstPerfTemperature,
-                 const Scalar firstPerfSaltConcentration,
-                 const PrimaryVariables& primary_variables,
-                 const int seg_idx,
-                 DeferredLogger& deferred_logger) const
-{
-    const EvalWell saltConcentration {firstPerfSaltConcentration};
-    const EvalWell temperature = enable_energy ? primary_variables.getSegmentTemperature(seg_idx) : firstPerfTemperature;
-    PhaseCalcResult result(static_cast<size_t>(well_.numConservationQuantities()));
-    calculatePhaseProperties(result, temperature, saltConcentration,
-                             primary_variables, seg_idx, false, deferred_logger);
-
-    const EvalWell& vol_ratio = result.vol_ratio;
-
-    // We increase the segment volume with a factor 10 to stabilize the system.
-    const Scalar volume = well_.wellEcl().getSegments()[seg_idx].volume();
-
-    return volume / vol_ratio;
 }
 
 template<class FluidSystem, class Indices>
@@ -775,157 +697,6 @@ mixtureDensityWithExponents(const AutoICD& aicd, const int seg) const
     return mixDens;
 }
 
-template<class FluidSystem, class Indices>
-void
-MultisegmentWellSegments<FluidSystem, Indices>::
-calculatePhaseProperties(PhaseCalcResult& result,
-                         const EvalWell& temperature,
-                         const EvalWell& saltConcentration,
-                         const PrimaryVariables& primary_variables,
-                         const int seg,
-                         const bool update_visc_and_den,
-                         DeferredLogger& deferred_logger) const
-{
-    result.clear();
-
-    auto& b = result.b;
-    auto& mix_s = result.mix_s;
-    auto& mix = result.mix;
-    auto& vol_ratio = result.vol_ratio;
-    auto& phase_viscosities = result.phase_viscosities;
-    auto& phase_densities = result.phase_densities;
-
-    // we might use reference here
-    const EvalWell seg_pressure = primary_variables.getSegmentPressure(seg);
-
-    const int num_quantities = well_.numConservationQuantities();
-    for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
-        mix_s[comp_idx] = primary_variables.surfaceVolumeFraction(seg, comp_idx);
-    }
-
-    const bool waterActive = FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx);
-    const bool gasActive = FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx);
-    const bool oilActive = FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx);
-
-    const int waterActiveCompIdx = waterActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::waterCompIdx) : -1;
-    const int gasActiveCompIdx = gasActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::gasCompIdx) : -1;
-    const int oilActiveCompIdx = oilActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::oilCompIdx) : -1;
-
-    const int pvt_region_index = well_.pvtRegionIdx();
-
-    // water phase
-    if (waterActive) {
-        // rsw is only for interface usage
-        const EvalWell rsw{0.};
-        b[waterActiveCompIdx] = FluidSystem::waterPvt().inverseFormationVolumeFactor(
-                                             pvt_region_index, temperature, seg_pressure, rsw, saltConcentration);
-        if (update_visc_and_den) {
-            // TODO: should not we use phaseIndex here?
-            phase_viscosities[waterActiveCompIdx] = FluidSystem::waterPvt().viscosity(
-                                             pvt_region_index, temperature, seg_pressure, rsw, saltConcentration);
-            phase_densities[waterActiveCompIdx] = b[waterActiveCompIdx] * surface_densities_[waterActiveCompIdx];
-        }
-    }
-
-    EvalWell rv {0.};
-    // gas phase
-    if (gasActive) {
-        // rvw is only for interface usage
-        const EvalWell rvw{0.};
-        const bool oil_exist = oilActive && mix_s[oilActiveCompIdx] > 0.0;
-        if (oil_exist) {
-            const EvalWell rvmax = max(
-                    FluidSystem::gasPvt().saturatedOilVaporizationFactor(pvt_region_index, temperature, seg_pressure),
-                    0.);
-            if (mix_s[gasActiveCompIdx] > 0.0) {
-                rv = std::clamp(mix_s[oilActiveCompIdx] / mix_s[gasActiveCompIdx], EvalWell{0.}, rvmax);
-            }
-            b[gasActiveCompIdx] = FluidSystem::gasPvt().inverseFormationVolumeFactor(
-                                               pvt_region_index, temperature, seg_pressure, rv, rvw);
-            if (update_visc_and_den) {
-                phase_viscosities[gasActiveCompIdx] = FluidSystem::gasPvt().viscosity(
-                                                 pvt_region_index, temperature, seg_pressure, rv, rvw);
-                phase_densities[gasActiveCompIdx] = b[gasActiveCompIdx] * surface_densities_[gasActiveCompIdx]
-                                                    + rv * b[gasActiveCompIdx] * surface_densities_[oilActiveCompIdx];
-            }
-        } else { // no oil here
-            b[gasActiveCompIdx] = FluidSystem::gasPvt().saturatedInverseFormationVolumeFactor(
-                                                  pvt_region_index, temperature, seg_pressure);
-            if (update_visc_and_den) {
-                phase_viscosities[gasActiveCompIdx] = FluidSystem::gasPvt().saturatedViscosity(
-                                                       pvt_region_index, temperature, seg_pressure);
-                phase_densities[gasActiveCompIdx] = b[gasActiveCompIdx] * surface_densities_[gasActiveCompIdx];
-            }
-        }
-    }
-
-    EvalWell rs {0.};
-    // oil phase
-    if (oilActive) {
-        const bool gas_exist = gasActive && mix_s[gasActiveCompIdx] > 0.0;
-        if (gas_exist) {
-            const EvalWell rsmax = max(
-                    FluidSystem::oilPvt().saturatedGasDissolutionFactor(pvt_region_index, temperature, seg_pressure),
-                    0.);
-            if (mix_s[oilActiveCompIdx] > 0.0) {
-                rs = std::clamp(mix_s[gasActiveCompIdx] / mix_s[oilActiveCompIdx], EvalWell{0.}, rsmax);
-            }
-            b[oilActiveCompIdx] = FluidSystem::oilPvt().inverseFormationVolumeFactor(
-                                                        pvt_region_index, temperature, seg_pressure, rs);
-            if (update_visc_and_den) {
-                phase_viscosities[oilActiveCompIdx] = FluidSystem::oilPvt().viscosity(pvt_region_index, temperature,
-                                                                                      seg_pressure, rs);
-                phase_densities[oilActiveCompIdx] = b[oilActiveCompIdx] * surface_densities_[oilActiveCompIdx]
-                                              + rs * b[oilActiveCompIdx] * surface_densities_[gasActiveCompIdx];
-            }
-        } else { // no gas phase
-            b[oilActiveCompIdx] = FluidSystem::oilPvt().saturatedInverseFormationVolumeFactor(pvt_region_index,
-                                                                                              temperature, seg_pressure);
-            if (update_visc_and_den) {
-                phase_viscosities[oilActiveCompIdx] = FluidSystem::oilPvt().saturatedViscosity(pvt_region_index,
-                                                                                               temperature, seg_pressure);
-                phase_densities[oilActiveCompIdx] = b[oilActiveCompIdx] * surface_densities_[oilActiveCompIdx];
-            }
-        }
-    }
-
-    mix = mix_s;
-    if (oilActive && gasActive) {
-        const EvalWell d = 1.0 - rs * rv;
-        if (d <= 0.0) {
-            const std::string str =
-                fmt::format("Problematic d value {} obtained for well {} during segment density calculations "
-                            "with rs {}, rv {} and pressure {}. Continue as if no dissolution (rs = 0) and "
-                            "vaporization (rv = 0) for this connection.",
-                            d, well_.name(), rs, rv, seg_pressure);
-            deferred_logger.debug(str);
-        } else {
-            if (rs > 0.0) {
-                mix[gasActiveCompIdx] = (mix_s[gasActiveCompIdx] - mix_s[oilActiveCompIdx] * rs) / d;
-            }
-            if (rv > 0.0) {
-                mix[oilActiveCompIdx] = (mix_s[oilActiveCompIdx] - mix_s[gasActiveCompIdx] * rv) / d;
-            }
-        }
-    }
-
-    for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
-        vol_ratio += mix[comp_idx] / b[comp_idx];
-    }
-}
-
-template<typename FluidSystem, typename Indices>
-void
-MultisegmentWellSegments<FluidSystem, Indices>::
-PhaseCalcResult::clear()
-{
-    std::ranges::fill(b, 0.0);
-    std::ranges::fill(mix, 0.0);
-    std::ranges::fill(mix_s, 0.0);
-    std::ranges::fill(phase_viscosities, 0.0);
-    std::ranges::fill(phase_densities, 0.0);
-    vol_ratio = 0.0;
-}
 
 #include <opm/simulators/utils/InstantiationIndicesMacros.hpp>
 

--- a/opm/simulators/wells/MultisegmentWellSegments.hpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.hpp
@@ -22,10 +22,18 @@
 #ifndef OPM_MULTISEGMENTWELL_SEGMENTS_HEADER_INCLUDED
 #define OPM_MULTISEGMENTWELL_SEGMENTS_HEADER_INCLUDED
 
+#include <opm/material/densead/EvaluationFormat.hpp>
+
+#include <opm/simulators/utils/DeferredLogger.hpp>
 #include <opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp>
 #include <opm/simulators/wells/ParallelWellInfo.hpp>
+#include <opm/simulators/wells/WellInterfaceGeneric.hpp>
 
+#include <fmt/format.h>
+
+#include <algorithm>
 #include <cstddef>
+#include <string>
 #include <vector>
 
 namespace Opm {
@@ -48,17 +56,27 @@ class MultisegmentWellSegments
     using EvalWell = typename PrimaryVariables::EvalWell;
     using IndexTraits = typename FluidSystem::IndexTraitsType;
 
-    static constexpr bool enable_energy = Indices::enableFullyImplicitThermal;
-
 public:
     MultisegmentWellSegments(const int numSegments,
                              const ParallelWellInfo<Scalar>& parallel_well_info,
                              WellInterfaceGeneric<Scalar, IndexTraits>& well);
 
-    void computeFluidProperties(const Scalar firstPerfTemperature,
-                                const Scalar firstPerfSaltConcentration,
+    //! \brief Compute per-segment fluid properties from the pre-computed segment fluid states.
+    //!
+    //! Reuses the inverse formation volume factors and dissolution/vaporization ratios in each
+    //! fluid state where applicable, and evaluates the remaining PVT properties. Also updates
+    //! the cached segment volume ratios.
+    template<class FluidState>
+    void computeFluidProperties(const std::vector<FluidState>& segment_fluid_states,
                                 const PrimaryVariables& primary_variables,
                                 DeferredLogger& deferred_logger);
+
+    //! \brief Update the cached volume ratio of a segment from its fluid state and composition.
+    template<class FluidState>
+    void updateVolumeRatio(const int seg,
+                           const FluidState& fluid_state,
+                           const PrimaryVariables& primary_variables,
+                           DeferredLogger& deferred_logger);
 
     //! \brief Update upwinding segments.
     void updateUpwindingSegments(const PrimaryVariables& primary_variables);
@@ -69,12 +87,6 @@ public:
     //! Pressure difference between segment and perforation.
     Scalar getPressureDiffSegLocalPerf(const int seg,
                                        const int local_perf_index) const;
-
-    EvalWell getSurfaceVolume(const Scalar firstPerfTemperature,
-                              const Scalar firstPerfSaltConcentration,
-                              const PrimaryVariables& primary_variables,
-                              const int seg_idx,
-                              DeferredLogger& deferred_logger) const;
 
     EvalWell getFrictionPressureLoss(const int seg,
                                      const bool extra_reverse_flow_derivatives = false) const;
@@ -128,6 +140,14 @@ public:
         return densities_[seg];
     }
 
+    //! \brief Segment volume ratio (reservoir volume per unit surface volume).
+    //!
+    //! Updated by updateVolumeRatio() for reuse when computing the segment surface volume.
+    const EvalWell& volumeRatio(const int seg) const
+    {
+        return volume_ratios_[seg];
+    }
+
     Scalar local_perforation_depth_diff(const int local_perf_index) const
     {
         return local_perforation_depth_diffs_[local_perf_index];
@@ -166,6 +186,10 @@ private:
     // we should not have this member variable
     std::vector<EvalWell> densities_;
 
+    // Segment volume ratios (reservoir volume per unit surface volume), derived from the fluid
+    // state and surface composition.
+    std::vector<EvalWell> volume_ratios_;
+
     // the mass rate of the segments
     std::vector<EvalWell> mass_rates_;
 
@@ -189,34 +213,266 @@ private:
     Scalar mixtureDensityWithExponents(const int seg) const;
     Scalar mixtureDensityWithExponents(const AutoICD& aicd, const int seg) const;
 
-    // this class is used to store the result of phase property calculation
-    struct PhaseCalcResult {
-        explicit PhaseCalcResult(const std::size_t num_quantities)
+    // Intermediate PVT properties used to calculate segment fluid properties and volume ratios.
+    struct PhaseState
+    {
+        explicit PhaseState(const std::size_t num_quantities)
             : b(num_quantities, 0.0)
             , mix(num_quantities, 0.0)
-            , mix_s(num_quantities, 0.0)
-            , phase_viscosities(num_quantities, 0.0)
-            , phase_densities(num_quantities, 0.0)
         {}
-
-        void clear();
 
         std::vector<EvalWell> b;
         std::vector<EvalWell> mix;
-        std::vector<EvalWell> mix_s;
-        std::vector<EvalWell> phase_viscosities;
-        std::vector<EvalWell> phase_densities;
+        EvalWell rs{0.};
+        EvalWell rv{0.};
         EvalWell vol_ratio{0.};
     };
 
-    void calculatePhaseProperties(PhaseCalcResult& result,
-                                  const EvalWell& temperature,
-                                  const EvalWell& saltConcentration,
-                                  const PrimaryVariables& primary_variables,
-                                  int seg,
-                                  bool update_visc_and_den,
-                                  DeferredLogger& deferred_logger) const;
+    //! \brief Fill @p state from the segment fluid state and surface composition @p mix_s.
+    //!
+    //! Reuses fluid-state PVT properties where they represent the requested composition, and
+    //! evaluates the required saturated properties for single-phase cases.
+    template<class FluidState>
+    void phaseState(const FluidState& fluid_state,
+                    const std::vector<EvalWell>& mix_s,
+                    PhaseState& state,
+                    DeferredLogger& deferred_logger) const;
 };
+
+template<typename FluidSystem, typename Indices>
+template<class FluidState>
+void MultisegmentWellSegments<FluidSystem,Indices>::
+phaseState(const FluidState& fluid_state,
+           const std::vector<EvalWell>& mix_s,
+           PhaseState& state,
+           DeferredLogger& deferred_logger) const
+{
+    const int pvt_region_index = well_.pvtRegionIdx();
+
+    const bool waterActive = FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx);
+    const bool gasActive = FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx);
+    const bool oilActive = FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx);
+
+    const int waterActiveCompIdx = waterActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::waterCompIdx) : -1;
+    const int gasActiveCompIdx = gasActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::gasCompIdx) : -1;
+    const int oilActiveCompIdx = oilActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::oilCompIdx) : -1;
+
+    // Pressure and temperature are the same for all phases in the wellbore.
+    const unsigned pressure_phase = waterActive ? FluidSystem::waterPhaseIdx
+                                   : oilActive ? FluidSystem::oilPhaseIdx
+                                               : FluidSystem::gasPhaseIdx;
+    const EvalWell temperature = fluid_state.temperature(pressure_phase);
+    const EvalWell seg_pressure = fluid_state.pressure(pressure_phase);
+
+    state.rs = 0.;
+    state.rv = 0.;
+    state.vol_ratio = 0.;
+
+    // water phase; the stored inverse formation volume factor was evaluated exactly this way
+    if (waterActive) {
+        state.b[waterActiveCompIdx] = fluid_state.invB(FluidSystem::waterPhaseIdx);
+    }
+
+    // gas phase
+    if (gasActive) {
+        const bool oil_exist = oilActive && mix_s[oilActiveCompIdx] > 0.0;
+        if (oil_exist) {
+            if (mix_s[gasActiveCompIdx] > 0.0) {
+                // with free gas present the stored Rv is the capped (possibly saturated)
+                // vaporization ratio needed here, and the stored inverse formation volume
+                // factor was evaluated with it on the undersaturated table
+                state.rv = fluid_state.Rv();
+                state.b[gasActiveCompIdx] = fluid_state.invB(FluidSystem::gasPhaseIdx);
+            } else {
+                // No free gas: the fluid state holds saturated Rv, but calculate the inverse
+                // formation volume factor with the local Rv and Rvw set to zero.
+                const EvalWell rvw{0.};
+                state.b[gasActiveCompIdx] = FluidSystem::gasPvt().inverseFormationVolumeFactor(
+                        pvt_region_index, temperature, seg_pressure, state.rv, rvw);
+            }
+        } else { // no oil here
+            state.b[gasActiveCompIdx] = FluidSystem::gasPvt().saturatedInverseFormationVolumeFactor(
+                    pvt_region_index, temperature, seg_pressure);
+        }
+    }
+
+    // oil phase
+    if (oilActive) {
+        const bool gas_exist = gasActive && mix_s[gasActiveCompIdx] > 0.0;
+        if (gas_exist) {
+            if (mix_s[oilActiveCompIdx] > 0.0) {
+                state.rs = fluid_state.Rs();
+                state.b[oilActiveCompIdx] = fluid_state.invB(FluidSystem::oilPhaseIdx);
+            } else {
+                // dead oil; the fluid state stores the saturated Rs here, so evaluate anew
+                state.b[oilActiveCompIdx] = FluidSystem::oilPvt().inverseFormationVolumeFactor(
+                        pvt_region_index, temperature, seg_pressure, state.rs);
+            }
+        } else { // no gas phase
+            state.b[oilActiveCompIdx] = FluidSystem::oilPvt().saturatedInverseFormationVolumeFactor(
+                    pvt_region_index, temperature, seg_pressure);
+        }
+    }
+
+    state.mix = mix_s;
+    if (oilActive && gasActive) {
+        const EvalWell d = 1.0 - state.rs * state.rv;
+        if (d <= 0.0) {
+            const std::string str =
+                fmt::format("Problematic d value {} obtained for well {} during segment density calculations "
+                            "with rs {}, rv {} and pressure {}. Continue as if no dissolution (rs = 0) and "
+                            "vaporization (rv = 0) for this connection.",
+                            d, well_.name(), state.rs, state.rv, seg_pressure);
+            deferred_logger.debug(str);
+        } else {
+            if (state.rs > 0.0) {
+                state.mix[gasActiveCompIdx] = (mix_s[gasActiveCompIdx] - mix_s[oilActiveCompIdx] * state.rs) / d;
+            }
+            if (state.rv > 0.0) {
+                state.mix[oilActiveCompIdx] = (mix_s[oilActiveCompIdx] - mix_s[gasActiveCompIdx] * state.rv) / d;
+            }
+        }
+    }
+
+    const int num_quantities = well_.numConservationQuantities();
+    for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
+        state.vol_ratio += state.mix[comp_idx] / state.b[comp_idx];
+    }
+}
+
+template<typename FluidSystem, typename Indices>
+template<class FluidState>
+void MultisegmentWellSegments<FluidSystem,Indices>::
+updateVolumeRatio(const int seg,
+                  const FluidState& fluid_state,
+                  const PrimaryVariables& primary_variables,
+                  DeferredLogger& deferred_logger)
+{
+    const int num_quantities = well_.numConservationQuantities();
+    std::vector<EvalWell> mix_s(num_quantities, 0.0);
+    for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
+        mix_s[comp_idx] = primary_variables.surfaceVolumeFraction(seg, comp_idx);
+    }
+
+    PhaseState state(num_quantities);
+    phaseState(fluid_state, mix_s, state, deferred_logger);
+    volume_ratios_[seg] = state.vol_ratio;
+}
+
+template<typename FluidSystem, typename Indices>
+template<class FluidState>
+void MultisegmentWellSegments<FluidSystem,Indices>::
+computeFluidProperties(const std::vector<FluidState>& segment_fluid_states,
+                       const PrimaryVariables& primary_variables,
+                       DeferredLogger& deferred_logger)
+{
+    const int num_quantities = well_.numConservationQuantities();
+    const int pvt_region_index = well_.pvtRegionIdx();
+
+    const bool waterActive = FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx);
+    const bool gasActive = FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx);
+    const bool oilActive = FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx);
+
+    const int waterActiveCompIdx = waterActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::waterCompIdx) : -1;
+    const int gasActiveCompIdx = gasActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::gasCompIdx) : -1;
+    const int oilActiveCompIdx = oilActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::oilCompIdx) : -1;
+
+    std::vector<EvalWell> mix_s(num_quantities, 0.0);
+    PhaseState state(num_quantities);
+
+    for (std::size_t seg = 0; seg < perforations_.size(); ++seg) {
+        const auto& fs = segment_fluid_states[seg];
+
+        // Pressure and temperature are the same for all phases in the wellbore; the salt
+        // concentration is zero when brine is inactive (the water PVT ignores it then).
+        const unsigned pressure_phase = waterActive ? FluidSystem::waterPhaseIdx
+                                       : oilActive ? FluidSystem::oilPhaseIdx
+                                                   : FluidSystem::gasPhaseIdx;
+        const EvalWell temperature = fs.temperature(pressure_phase);
+        const EvalWell seg_pressure = fs.pressure(pressure_phase);
+        const EvalWell saltConcentration = fs.saltConcentration();
+
+        for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
+            mix_s[comp_idx] = primary_variables.surfaceVolumeFraction(seg, comp_idx);
+        }
+
+        phaseState(fs, mix_s, state, deferred_logger);
+        volume_ratios_[seg] = state.vol_ratio;
+
+        std::ranges::fill(phase_densities_[seg], 0.0);
+        std::ranges::fill(phase_viscosities_[seg], 0.0);
+
+        // water phase
+        if (waterActive) {
+            // rsw is only for interface usage
+            const EvalWell rsw{0.};
+            phase_viscosities_[seg][waterActiveCompIdx] = FluidSystem::waterPvt().viscosity(
+                    pvt_region_index, temperature, seg_pressure, rsw, saltConcentration);
+            phase_densities_[seg][waterActiveCompIdx] =
+                    state.b[waterActiveCompIdx] * surface_densities_[waterActiveCompIdx];
+        }
+
+        // gas phase
+        if (gasActive) {
+            // rvw is only for interface usage
+            const EvalWell rvw{0.};
+            const bool oil_exist = oilActive && mix_s[oilActiveCompIdx] > 0.0;
+            const EvalWell& b_g = state.b[gasActiveCompIdx];
+            if (oil_exist) {
+                phase_viscosities_[seg][gasActiveCompIdx] = FluidSystem::gasPvt().viscosity(
+                        pvt_region_index, temperature, seg_pressure, state.rv, rvw);
+                phase_densities_[seg][gasActiveCompIdx] = b_g * surface_densities_[gasActiveCompIdx]
+                                                          + state.rv * b_g * surface_densities_[oilActiveCompIdx];
+            } else { // no oil here
+                phase_viscosities_[seg][gasActiveCompIdx] = FluidSystem::gasPvt().saturatedViscosity(
+                        pvt_region_index, temperature, seg_pressure);
+                phase_densities_[seg][gasActiveCompIdx] = b_g * surface_densities_[gasActiveCompIdx];
+            }
+        }
+
+        // oil phase
+        if (oilActive) {
+            const bool gas_exist = gasActive && mix_s[gasActiveCompIdx] > 0.0;
+            const EvalWell& b_o = state.b[oilActiveCompIdx];
+            if (gas_exist) {
+                phase_viscosities_[seg][oilActiveCompIdx] = FluidSystem::oilPvt().viscosity(
+                        pvt_region_index, temperature, seg_pressure, state.rs);
+                phase_densities_[seg][oilActiveCompIdx] = b_o * surface_densities_[oilActiveCompIdx]
+                                                          + state.rs * b_o * surface_densities_[gasActiveCompIdx];
+            } else { // no gas phase
+                phase_viscosities_[seg][oilActiveCompIdx] = FluidSystem::oilPvt().saturatedViscosity(
+                        pvt_region_index, temperature, seg_pressure);
+                phase_densities_[seg][oilActiveCompIdx] = b_o * surface_densities_[oilActiveCompIdx];
+            }
+        }
+
+        viscosities_[seg] = 0.;
+        // calculate the average viscosity
+        for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
+            const EvalWell fraction = state.mix[comp_idx] / state.b[comp_idx] / state.vol_ratio;
+            // TODO: a little more work needs to be done to handle the negative fractions here
+            phase_fractions_[seg][comp_idx] = fraction; // >= 0.0 ? fraction : 0.0;
+            viscosities_[seg] += phase_viscosities_[seg][comp_idx] * phase_fractions_[seg][comp_idx];
+        }
+
+        EvalWell density(0.0);
+        for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
+            density += surface_densities_[comp_idx] * mix_s[comp_idx];
+        }
+        densities_[seg] = density / state.vol_ratio;
+
+        // calculate the mass rates
+        mass_rates_[seg] = 0.;
+        for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
+            const int upwind_seg = upwinding_segments_[seg];
+            const EvalWell rate = primary_variables.getSegmentRateUpwinding(seg,
+                                                                            upwind_seg,
+                                                                            comp_idx);
+            mass_rates_[seg] += rate * surface_densities_[comp_idx];
+        }
+
+    }
+}
 
 } // namespace Opm
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -274,10 +274,6 @@ namespace Opm
             this->linSys_.recoverSolutionWell(x, xw);
 
             updateWellState(simulator, xw, groupStateHelper, well_state);
-            if constexpr (has_energy) {
-                const FSInfo info = this->getFirstPerforationFluidStateInfo(simulator);
-                updateSegmentFluidState(info, deferred_logger);
-            }
         }
         catch (const NumericalProblem& exp) {
             // Add information about the well and log to deferred logger
@@ -700,11 +696,10 @@ namespace Opm
     template <typename TypeTag>
     void
     MultisegmentWell<TypeTag>::
-    computeInitialSegmentFluids(const FSInfo& info,
-                                DeferredLogger& deferred_logger)
+    computeInitialSegmentFluids()
     {
         for (int seg = 0; seg < this->numberOfSegments(); ++seg) {
-            const Scalar surface_volume = getSegmentSurfaceVolume(seg, info, deferred_logger).value();
+            const Scalar surface_volume = getSegmentSurfaceVolume(seg).value();
             for (int comp_idx = 0; comp_idx < this->num_conservation_quantities_; ++comp_idx) {
                 segment_fluid_initial_[seg][comp_idx] = surface_volume * this->primary_variables_.surfaceVolumeFraction(seg, comp_idx).value();
             }
@@ -769,13 +764,12 @@ namespace Opm
         updatePrimaryVariables(groupStateHelper);
         computePerfCellPressDiffs(simulator);
 
+        // Refresh the fluid state before computing the initial inventory, which reuses its
+        // cached segment volume ratio.
         const auto info = this->getFirstPerforationFluidStateInfo(simulator);
-
-        computeInitialSegmentFluids(info, deferred_logger);
+        updateSegmentFluidState(info, deferred_logger);
+        computeInitialSegmentFluids();
         if constexpr (has_energy) {
-            // after updating the primary variables, we need to update the segment fluid state
-            // it is only consumed by the energy equation, so we only do it when energy is active
-            updateSegmentFluidState(info, deferred_logger);
             computeInitialSegmentEnergy();
         }
     }
@@ -1148,24 +1142,11 @@ namespace Opm
     MultisegmentWell<TypeTag>::
     computeSegmentFluidProperties(const Simulator& simulator, DeferredLogger& deferred_logger)
     {
-        // TODO: the concept of phases and components are rather confusing in this function.
-        // needs to be addressed sooner or later.
-
-        // get the temperature for later use. It is only useful when we are not handling
-        // thermal related simulation
-        // basically, it is a single value for all the segments
-        // not sure how to handle the pvt region related to segment
-        // for the current approach, we use the pvt region of the first perforated cell
-        // although there are some text indicating using the pvt region of the lowest
-        // perforated cell
-        // TODO: later to investigate how to handle the pvt region
-
-        auto info = this->getFirstPerforationFluidStateInfo(simulator);
-        const Scalar firstPerfTemperature = std::get<0>(info);
-        const Scalar firstPerfSaltConcentration = std::get<1>(info);
-
-        this->segments_.computeFluidProperties(firstPerfTemperature,
-                                               firstPerfSaltConcentration,
+        // Rebuild fluid states from the current primary variables before deriving segment
+        // properties, so both use consistent PVT data.
+        const FSInfo info = this->getFirstPerforationFluidStateInfo(simulator);
+        updateSegmentFluidState(info, deferred_logger);
+        this->segments_.computeFluidProperties(this->segment_fluid_state_,
                                                this->primary_variables_,
                                                deferred_logger);
     }
@@ -1562,13 +1543,6 @@ namespace Opm
         bool converged = false;
         bool relax_convergence = false;
         this->regularize_ = false;
-        // The first-perforation fluid-state info is needed to refresh the segment
-        // fluid state for the energy equation. It depends solely on the reservoir cell
-        // state, which does not change during the inner iterations.
-        [[maybe_unused]] FSInfo info{};
-        if constexpr (has_energy) {
-            info = this->getFirstPerforationFluidStateInfo(simulator);
-        }
         for (; it < max_iter_number; ++it, ++debug_cost_counter_) {
 
             if (it > this->param_.strict_inner_iter_wells_) {
@@ -1618,10 +1592,6 @@ namespace Opm
             try{
                 dx_well = this->linSys_.solve();
                 updateWellState(simulator, dx_well, groupStateHelper, well_state, relaxation_factor);
-                if constexpr (has_energy) {
-                    // segment fluid state is only consumed by the energy equation
-                    updateSegmentFluidState(info, deferred_logger);
-                }
             }
             catch(const NumericalProblem& exp) {
                 // Add information about the well and log to deferred logger
@@ -1725,13 +1695,6 @@ namespace Opm
         this->operability_status_.resetOperability();
         this->operability_status_.solvable = true;
 
-        // The first-perforation fluid-state info is needed to refresh the segment
-        // fluid state for the energy equation. It depends solely on the reservoir cell
-        // state, which does not change during the inner iterations.
-        [[maybe_unused]] FSInfo info{};
-        if constexpr (has_energy) {
-            info = this->getFirstPerforationFluidStateInfo(simulator);
-        }
         for (; it < max_iter_number; ++it, ++debug_cost_counter_) {
             ++its_since_last_switch;
             if (allow_switching && its_since_last_switch >= min_its_after_switch && status_switch_count < max_status_switch){
@@ -1811,10 +1774,6 @@ namespace Opm
             try{
                 const BVectorWell dx_well = this->linSys_.solve();
                 updateWellState(simulator, dx_well, groupStateHelper, well_state, relaxation_factor);
-                if constexpr (has_energy) {
-                    // segment fluid state is only consumed by the energy equation
-                    updateSegmentFluidState(info, deferred_logger);
-                }
             }
             catch(const NumericalProblem& exp) {
                 // Add information about the well and log to deferred logger
@@ -1979,12 +1938,16 @@ namespace Opm
             this->linSys_.sumDistributed(this->parallel_well_info_.communication());
         }
 
-        const FSInfo info = this->getFirstPerforationFluidStateInfo(simulator);
+        // Needed to construct the injector wellhead fluid state.
+        [[maybe_unused]] FSInfo info{};
+        if constexpr (has_energy) {
+            info = this->getFirstPerforationFluidStateInfo(simulator);
+        }
 
         for (int seg = 0; seg < nseg; ++seg) {
             // calculating the accumulation term
             {
-                const EvalWell segment_surface_volume = getSegmentSurfaceVolume(seg, info, deferred_logger);
+                const EvalWell segment_surface_volume = getSegmentSurfaceVolume(seg);
 
                 // Add a regularization_factor to increase the accumulation term
                 // This will make the system less stiff and help convergence for
@@ -2185,18 +2148,11 @@ namespace Opm
     template<typename TypeTag>
     typename MultisegmentWell<TypeTag>::EvalWell
     MultisegmentWell<TypeTag>::
-    getSegmentSurfaceVolume(const int seg_idx,
-                            const FSInfo& info,
-                            DeferredLogger& deferred_logger) const
+    getSegmentSurfaceVolume(const int seg_idx) const
     {
-        const Scalar firstPerfTemperature = std::get<0>(info);
-        const Scalar firstPerfSaltConcentration = std::get<1>(info);
-
-        return this->segments_.getSurfaceVolume(firstPerfTemperature,
-                                                firstPerfSaltConcentration,
-                                                this->primary_variables_,
-                                                seg_idx,
-                                                deferred_logger);
+        // Reuse the volume ratio cached when the segment fluid state was rebuilt.
+        const Scalar volume = this->wellEcl().getSegments()[seg_idx].volume();
+        return volume / this->segments_.volumeRatio(seg_idx);
     }
 
 
@@ -2487,11 +2443,8 @@ namespace Opm
     {
         SegmentFluidState<ValueType> fluid_state;
         if constexpr (enable_temperature) {
-            // Set the temperature whenever the fluid state can store it (any thermal mode).
-            // In the fully implicit case @p temperature is the segment temperature primary
-            // variable; otherwise it is the (fixed) first-perforation temperature. When the
-            // fluid state does not store a temperature it falls back to the reservoir
-            // temperature.
+            // Populate temperature for every fluid state that stores it, including thermal
+            // modes without a fully implicit energy equation.
             fluid_state.setTemperature(temperature);
         }
         if constexpr (has_brine) {
@@ -2904,6 +2857,9 @@ namespace Opm
     {
         for (int seg = 0; seg < this->numberOfSegments(); ++seg) {
             segment_fluid_state_[seg] = this->createSegmentFluidState(seg, info, deferred_logger);
+            // Cache the volume ratio for getSegmentSurfaceVolume().
+            this->segments_.updateVolumeRatio(seg, segment_fluid_state_[seg],
+                                              this->primary_variables_, deferred_logger);
         }
     }
 


### PR DESCRIPTION
after https://github.com/OPM/opm-simulators/pull/7361, 

MSW: derive segment fluid properties from the segment fluid states
The per-segment fluid state becomes the single source of truth for the
segment fluid properties and surface volume, for thermal and non-thermal
runs alike. It is rebuilt from the current primary variables at the point
of consumption (computeSegmentFluidProperties), and its stored inverse
formation volume factors and Rs/Rv are reused whenever they coincide with
the values the property calculation needs (both oil and gas present, the
common case). This removes the duplicated from-scratch PVT calculations
in computeFluidProperties()/getSurfaceVolume() and the scattered fluid
state refresh calls, while reproducing the previous results exactly.