### PR TITLE
Msw segment fs cleanups

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -241,9 +241,9 @@ namespace Opm {
                              WellStateType& well_state,
                              const Scalar relaxation_factor = 1.0);
 
-        // Compute the initial fluid inventory for well mass equations. Requires an up-to-date
+        // Compute the initial segment inventory for well equations. Requires an up-to-date
         // segment fluid state (see updateSegmentFluidState()).
-        void computeInitialSegmentFluids();
+        void computeInitialSegmentInventory();
 
         // compute the pressure difference between the perforation and cell center
         void computePerfCellPressDiffs(const Simulator& simulator);
@@ -403,8 +403,6 @@ namespace Opm {
 
         SegmentFluidState<EvalWell>
         createSegmentFluidState(int seg, const FSInfo& info, DeferredLogger& deferred_logger) const;
-
-        void computeInitialSegmentEnergy();
 
         // assemble the energy equation contribution for a single perforation/connection
         void assemblePerforationEnergyEq(const IntensiveQuantities& int_quants,

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -243,7 +243,7 @@ namespace Opm {
 
         // Compute the initial segment inventory for well equations. Requires an up-to-date
         // segment fluid state (see updateSegmentFluidState()).
-        void computeInitialSegmentInventory();
+        void computeInitialSegmentInventory(DeferredLogger& deferred_logger);
 
         // compute the pressure difference between the perforation and cell center
         void computePerfCellPressDiffs(const Simulator& simulator);
@@ -348,9 +348,9 @@ namespace Opm {
 
         void updateWaterThroughput(const double dt, WellStateType& well_state) const override;
 
-        // Compute segment surface volume from its cached volume ratio. Requires an up-to-date
-        // segment fluid state (see updateSegmentFluidState()).
-        EvalWell getSegmentSurfaceVolume(const int seg_idx) const;
+        // Compute segment surface volume from the given volume ratio.
+        EvalWell getSegmentSurfaceVolume(const int seg_idx,
+                                         const EvalWell& volume_ratio) const;
 
         // turn on crossflow to avoid singular well equations
         // when the well is banned from cross-flow and the BHP is not properly initialized,

--- a/opm/simulators/wells/MultisegmentWellSegments.hpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.hpp
@@ -71,12 +71,12 @@ public:
                                 const PrimaryVariables& primary_variables,
                                 DeferredLogger& deferred_logger);
 
-    //! \brief Update the cached volume ratio of a segment from its fluid state and composition.
+    //! \brief Volume ratio of a segment from its fluid state and composition.
     template<class FluidState>
-    void updateVolumeRatio(const int seg,
-                           const FluidState& fluid_state,
-                           const PrimaryVariables& primary_variables,
-                           DeferredLogger& deferred_logger);
+    EvalWell computeVolumeRatio(const int seg,
+                                const FluidState& fluid_state,
+                                const PrimaryVariables& primary_variables,
+                                DeferredLogger& deferred_logger) const;
 
     //! \brief Update upwinding segments.
     void updateUpwindingSegments(const PrimaryVariables& primary_variables);
@@ -142,7 +142,7 @@ public:
 
     //! \brief Segment volume ratio (reservoir volume per unit surface volume).
     //!
-    //! Updated by updateVolumeRatio() for reuse when computing the segment surface volume.
+    //! Set by computeFluidProperties(), like the other per-segment quantities.
     const EvalWell& volumeRatio(const int seg) const
     {
         return volume_ratios_[seg];
@@ -233,19 +233,19 @@ private:
     //! Reuses fluid-state PVT properties where they represent the requested composition, and
     //! evaluates the required saturated properties for single-phase cases.
     template<class FluidState>
-    void phaseState(const FluidState& fluid_state,
-                    const std::vector<EvalWell>& mix_s,
-                    PhaseState& state,
-                    DeferredLogger& deferred_logger) const;
+    void calculatePhaseState(const FluidState& fluid_state,
+                             const std::vector<EvalWell>& mix_s,
+                             PhaseState& state,
+                             DeferredLogger& deferred_logger) const;
 };
 
 template<typename FluidSystem, typename Indices>
 template<class FluidState>
 void MultisegmentWellSegments<FluidSystem,Indices>::
-phaseState(const FluidState& fluid_state,
-           const std::vector<EvalWell>& mix_s,
-           PhaseState& state,
-           DeferredLogger& deferred_logger) const
+calculatePhaseState(const FluidState& fluid_state,
+                    const std::vector<EvalWell>& mix_s,
+                    PhaseState& state,
+                    DeferredLogger& deferred_logger) const
 {
     const int pvt_region_index = well_.pvtRegionIdx();
 
@@ -342,11 +342,12 @@ phaseState(const FluidState& fluid_state,
 
 template<typename FluidSystem, typename Indices>
 template<class FluidState>
-void MultisegmentWellSegments<FluidSystem,Indices>::
-updateVolumeRatio(const int seg,
-                  const FluidState& fluid_state,
-                  const PrimaryVariables& primary_variables,
-                  DeferredLogger& deferred_logger)
+typename MultisegmentWellSegments<FluidSystem,Indices>::EvalWell
+MultisegmentWellSegments<FluidSystem,Indices>::
+computeVolumeRatio(const int seg,
+                   const FluidState& fluid_state,
+                   const PrimaryVariables& primary_variables,
+                   DeferredLogger& deferred_logger) const
 {
     const int num_quantities = well_.numConservationQuantities();
     std::vector<EvalWell> mix_s(num_quantities, 0.0);
@@ -355,8 +356,8 @@ updateVolumeRatio(const int seg,
     }
 
     PhaseState state(num_quantities);
-    phaseState(fluid_state, mix_s, state, deferred_logger);
-    volume_ratios_[seg] = state.vol_ratio;
+    calculatePhaseState(fluid_state, mix_s, state, deferred_logger);
+    return state.vol_ratio;
 }
 
 template<typename FluidSystem, typename Indices>
@@ -396,7 +397,7 @@ computeFluidProperties(const std::vector<FluidState>& segment_fluid_states,
             mix_s[comp_idx] = primary_variables.surfaceVolumeFraction(seg, comp_idx);
         }
 
-        phaseState(fs, mix_s, state, deferred_logger);
+        calculatePhaseState(fs, mix_s, state, deferred_logger);
         volume_ratios_[seg] = state.vol_ratio;
 
         std::ranges::fill(phase_densities_[seg], 0.0);

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -696,12 +696,15 @@ namespace Opm
     template <typename TypeTag>
     void
     MultisegmentWell<TypeTag>::
-    computeInitialSegmentFluids()
+    computeInitialSegmentInventory()
     {
         for (int seg = 0; seg < this->numberOfSegments(); ++seg) {
             const Scalar surface_volume = getSegmentSurfaceVolume(seg).value();
             for (int comp_idx = 0; comp_idx < this->num_conservation_quantities_; ++comp_idx) {
                 segment_fluid_initial_[seg][comp_idx] = surface_volume * this->primary_variables_.surfaceVolumeFraction(seg, comp_idx).value();
+            }
+            if constexpr (has_energy) {
+                segment_initial_energy_[seg] = computeSegmentEnergy<Scalar>(seg);
             }
         }
     }
@@ -768,10 +771,7 @@ namespace Opm
         // cached segment volume ratio.
         const auto info = this->getFirstPerforationFluidStateInfo(simulator);
         updateSegmentFluidState(info, deferred_logger);
-        computeInitialSegmentFluids();
-        if constexpr (has_energy) {
-            computeInitialSegmentEnergy();
-        }
+        computeInitialSegmentInventory();
     }
 
 
@@ -2759,15 +2759,6 @@ namespace Opm
                                   MSWEval::PrimaryVariables::Temperature,
                                   energy_scaling_factor_ * energy_flux,
                                   this->linSys_);
-    }
-
-    template <typename TypeTag>
-    void
-    MultisegmentWell<TypeTag>::computeInitialSegmentEnergy()
-    {
-        for (int seg = 0; seg < this->numberOfSegments(); ++seg) {
-            segment_initial_energy_[seg] = computeSegmentEnergy<Scalar>(seg);
-        }
     }
 
     template <typename TypeTag>

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -696,10 +696,13 @@ namespace Opm
     template <typename TypeTag>
     void
     MultisegmentWell<TypeTag>::
-    computeInitialSegmentInventory()
+    computeInitialSegmentInventory(DeferredLogger& deferred_logger)
     {
         for (int seg = 0; seg < this->numberOfSegments(); ++seg) {
-            const Scalar surface_volume = getSegmentSurfaceVolume(seg).value();
+            const EvalWell volume_ratio =
+                this->segments_.computeVolumeRatio(seg, segment_fluid_state_[seg],
+                                                   this->primary_variables_, deferred_logger);
+            const Scalar surface_volume = getSegmentSurfaceVolume(seg, volume_ratio).value();
             for (int comp_idx = 0; comp_idx < this->num_conservation_quantities_; ++comp_idx) {
                 segment_fluid_initial_[seg][comp_idx] = surface_volume * this->primary_variables_.surfaceVolumeFraction(seg, comp_idx).value();
             }
@@ -767,11 +770,10 @@ namespace Opm
         updatePrimaryVariables(groupStateHelper);
         computePerfCellPressDiffs(simulator);
 
-        // Refresh the fluid state before computing the initial inventory, which reuses its
-        // cached segment volume ratio.
+        // Refresh the fluid state before computing the initial inventory.
         const auto info = this->getFirstPerforationFluidStateInfo(simulator);
         updateSegmentFluidState(info, deferred_logger);
-        computeInitialSegmentInventory();
+        computeInitialSegmentInventory(deferred_logger);
     }
 
 
@@ -1947,7 +1949,9 @@ namespace Opm
         for (int seg = 0; seg < nseg; ++seg) {
             // calculating the accumulation term
             {
-                const EvalWell segment_surface_volume = getSegmentSurfaceVolume(seg);
+                // The ratios were refreshed by computeSegmentFluidProperties() above.
+                const EvalWell segment_surface_volume =
+                    getSegmentSurfaceVolume(seg, this->segments_.volumeRatio(seg));
 
                 // Add a regularization_factor to increase the accumulation term
                 // This will make the system less stiff and help convergence for
@@ -2148,11 +2152,11 @@ namespace Opm
     template<typename TypeTag>
     typename MultisegmentWell<TypeTag>::EvalWell
     MultisegmentWell<TypeTag>::
-    getSegmentSurfaceVolume(const int seg_idx) const
+    getSegmentSurfaceVolume(const int seg_idx,
+                            const EvalWell& volume_ratio) const
     {
-        // Reuse the volume ratio cached when the segment fluid state was rebuilt.
         const Scalar volume = this->wellEcl().getSegments()[seg_idx].volume();
-        return volume / this->segments_.volumeRatio(seg_idx);
+        return volume / volume_ratio;
     }
 
 
@@ -2848,9 +2852,6 @@ namespace Opm
     {
         for (int seg = 0; seg < this->numberOfSegments(); ++seg) {
             segment_fluid_state_[seg] = this->createSegmentFluidState(seg, info, deferred_logger);
-            // Cache the volume ratio for getSegmentSurfaceVolume().
-            this->segments_.updateVolumeRatio(seg, segment_fluid_state_[seg],
-                                              this->primary_variables_, deferred_logger);
         }
     }
 


### PR DESCRIPTION
after https://github.com/OPM/opm-simulators/pull/7362

it includes the following two commits, 

[Consolidated initialization into computeInitialSegmentInventory().](https://github.com/OPM/opm-simulators/commit/31ac2bf3ca1f080c506f8519f96d5a4c8da26850) 

It initializes mass inventory and, when enabled, energy inventory in the
same per-segment loop; the separate computeInitialSegmentEnergy() helper was removed.

[MSW: compute the segment volume ratio where it is used](https://github.com/OPM/opm-simulators/commit/ac70c9f2735e73e4b4d5ce5feb6de120a40006c1) 

Before: updateSegmentFluidState() cached the volume ratio of every segment and
getSegmentSurfaceVolume() read that cache; on the assembly path
computeFluidProperties() overwrote it immediately, so the work was discarded.

Now: updateSegmentFluidState() only builds the fluid states, the ratio is
computed where it is consumed and passed to getSegmentSurfaceVolume(), and
volume_ratios_ has a single writer.