### PR TITLE
MSW: move segment property calculations back to the .cpp file

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -106,6 +106,11 @@ namespace Opm {
         template <typename ValueType>
         using SegmentFluidState = Base::template BlackOilFluidStateType<ValueType>;
 
+        // The segment fluid state type depends on the TypeTag, which MultisegmentWellSegments
+        // does not have. Extract the values it needs so its property calculations can stay in
+        // the .cpp file.
+        using SegmentPvt = typename MultisegmentWellSegments<FluidSystem, Indices>::SegmentPvt;
+
         MultisegmentWell(const Well& well,
                          const ParallelWellInfo<Scalar>& pw_info,
                          const int time_step,
@@ -226,6 +231,10 @@ namespace Opm {
 
         // segment fluid state
         std::vector<SegmentFluidState<EvalWell>> segment_fluid_state_;
+
+        // the values MultisegmentWellSegments needs from the segment fluid states, refilled
+        // from segment_fluid_state_ before the segment properties are computed
+        std::vector<SegmentPvt> segment_pvt_;
 
         // fluid state under the wellhead condition, it is used to calculate the enthalpy
         // under operation condition for energy injection
@@ -404,10 +413,6 @@ namespace Opm {
         SegmentFluidState<EvalWell>
         createSegmentFluidState(int seg, const FSInfo& info, DeferredLogger& deferred_logger) const;
 
-        // The segment fluid state type depends on the TypeTag, which MultisegmentWellSegments
-        // does not have. Extract the values it needs so its property calculations can stay in
-        // the .cpp file.
-        using SegmentPvt = typename MultisegmentWellSegments<FluidSystem, Indices>::SegmentPvt;
         SegmentPvt segmentPvt(const SegmentFluidState<EvalWell>& fluid_state) const;
 
         // assemble the energy equation contribution for a single perforation/connection

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -404,6 +404,12 @@ namespace Opm {
         SegmentFluidState<EvalWell>
         createSegmentFluidState(int seg, const FSInfo& info, DeferredLogger& deferred_logger) const;
 
+        // The segment fluid state type depends on the TypeTag, which MultisegmentWellSegments
+        // does not have. Extract the values it needs so its property calculations can stay in
+        // the .cpp file.
+        using SegmentPvt = typename MultisegmentWellSegments<FluidSystem, Indices>::SegmentPvt;
+        SegmentPvt segmentPvt(const SegmentFluidState<EvalWell>& fluid_state) const;
+
         // assemble the energy equation contribution for a single perforation/connection
         void assemblePerforationEnergyEq(const IntensiveQuantities& int_quants,
                                          const std::vector<EvalWell>& cq_s,

--- a/opm/simulators/wells/MultisegmentWellSegments.cpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.cpp
@@ -698,6 +698,232 @@ mixtureDensityWithExponents(const AutoICD& aicd, const int seg) const
 }
 
 
+template<typename FluidSystem, typename Indices>
+void MultisegmentWellSegments<FluidSystem,Indices>::
+calculatePhaseState(const SegmentPvt& pvt,
+                    const std::vector<EvalWell>& mix_s,
+                    PhaseState& state,
+                    DeferredLogger& deferred_logger) const
+{
+    const int pvt_region_index = well_.pvtRegionIdx();
+
+    const bool waterActive = FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx);
+    const bool gasActive = FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx);
+    const bool oilActive = FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx);
+
+    const int waterActiveCompIdx = waterActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::waterCompIdx) : -1;
+    const int gasActiveCompIdx = gasActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::gasCompIdx) : -1;
+    const int oilActiveCompIdx = oilActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::oilCompIdx) : -1;
+
+    // Pressure and temperature are the same for all phases in the wellbore.
+    const EvalWell temperature = pvt.temperature;
+    const EvalWell seg_pressure = pvt.pressure;
+
+    state.rs = 0.;
+    state.rv = 0.;
+    state.vol_ratio = 0.;
+
+    // water phase; the stored inverse formation volume factor was evaluated exactly this way
+    if (waterActive) {
+        state.b[waterActiveCompIdx] = pvt.invB[FluidSystem::waterPhaseIdx];
+    }
+
+    // gas phase
+    if (gasActive) {
+        const bool oil_exist = oilActive && mix_s[oilActiveCompIdx] > 0.0;
+        if (oil_exist) {
+            if (mix_s[gasActiveCompIdx] > 0.0) {
+                // with free gas present the stored Rv is the capped (possibly saturated)
+                // vaporization ratio needed here, and the stored inverse formation volume
+                // factor was evaluated with it on the undersaturated table
+                state.rv = pvt.Rv;
+                state.b[gasActiveCompIdx] = pvt.invB[FluidSystem::gasPhaseIdx];
+            } else {
+                // No free gas: the fluid state holds saturated Rv, but calculate the inverse
+                // formation volume factor with the local Rv and Rvw set to zero.
+                const EvalWell rvw{0.};
+                state.b[gasActiveCompIdx] = FluidSystem::gasPvt().inverseFormationVolumeFactor(
+                        pvt_region_index, temperature, seg_pressure, state.rv, rvw);
+            }
+        } else { // no oil here
+            state.b[gasActiveCompIdx] = FluidSystem::gasPvt().saturatedInverseFormationVolumeFactor(
+                    pvt_region_index, temperature, seg_pressure);
+        }
+    }
+
+    // oil phase
+    if (oilActive) {
+        const bool gas_exist = gasActive && mix_s[gasActiveCompIdx] > 0.0;
+        if (gas_exist) {
+            if (mix_s[oilActiveCompIdx] > 0.0) {
+                state.rs = pvt.Rs;
+                state.b[oilActiveCompIdx] = pvt.invB[FluidSystem::oilPhaseIdx];
+            } else {
+                // dead oil; the fluid state stores the saturated Rs here, so evaluate anew
+                state.b[oilActiveCompIdx] = FluidSystem::oilPvt().inverseFormationVolumeFactor(
+                        pvt_region_index, temperature, seg_pressure, state.rs);
+            }
+        } else { // no gas phase
+            state.b[oilActiveCompIdx] = FluidSystem::oilPvt().saturatedInverseFormationVolumeFactor(
+                    pvt_region_index, temperature, seg_pressure);
+        }
+    }
+
+    state.mix = mix_s;
+    if (oilActive && gasActive) {
+        const EvalWell d = 1.0 - state.rs * state.rv;
+        if (d <= 0.0) {
+            const std::string str =
+                fmt::format("Problematic d value {} obtained for well {} during segment density calculations "
+                            "with rs {}, rv {} and pressure {}. Continue as if no dissolution (rs = 0) and "
+                            "vaporization (rv = 0) for this connection.",
+                            d, well_.name(), state.rs, state.rv, seg_pressure);
+            deferred_logger.debug(str);
+        } else {
+            if (state.rs > 0.0) {
+                state.mix[gasActiveCompIdx] = (mix_s[gasActiveCompIdx] - mix_s[oilActiveCompIdx] * state.rs) / d;
+            }
+            if (state.rv > 0.0) {
+                state.mix[oilActiveCompIdx] = (mix_s[oilActiveCompIdx] - mix_s[gasActiveCompIdx] * state.rv) / d;
+            }
+        }
+    }
+
+    const int num_quantities = well_.numConservationQuantities();
+    for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
+        state.vol_ratio += state.mix[comp_idx] / state.b[comp_idx];
+    }
+}
+
+template<typename FluidSystem, typename Indices>
+typename MultisegmentWellSegments<FluidSystem,Indices>::EvalWell
+MultisegmentWellSegments<FluidSystem,Indices>::
+computeVolumeRatio(const int seg,
+                   const SegmentPvt& pvt,
+                   const PrimaryVariables& primary_variables,
+                   DeferredLogger& deferred_logger) const
+{
+    const int num_quantities = well_.numConservationQuantities();
+    std::vector<EvalWell> mix_s(num_quantities, 0.0);
+    for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
+        mix_s[comp_idx] = primary_variables.surfaceVolumeFraction(seg, comp_idx);
+    }
+
+    PhaseState state(num_quantities);
+    calculatePhaseState(pvt, mix_s, state, deferred_logger);
+    return state.vol_ratio;
+}
+
+template<typename FluidSystem, typename Indices>
+void MultisegmentWellSegments<FluidSystem,Indices>::
+computeFluidProperties(const std::vector<SegmentPvt>& segment_pvt,
+                       const PrimaryVariables& primary_variables,
+                       DeferredLogger& deferred_logger)
+{
+    const int num_quantities = well_.numConservationQuantities();
+    const int pvt_region_index = well_.pvtRegionIdx();
+
+    const bool waterActive = FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx);
+    const bool gasActive = FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx);
+    const bool oilActive = FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx);
+
+    const int waterActiveCompIdx = waterActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::waterCompIdx) : -1;
+    const int gasActiveCompIdx = gasActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::gasCompIdx) : -1;
+    const int oilActiveCompIdx = oilActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::oilCompIdx) : -1;
+
+    std::vector<EvalWell> mix_s(num_quantities, 0.0);
+    PhaseState state(num_quantities);
+
+    for (std::size_t seg = 0; seg < perforations_.size(); ++seg) {
+        const auto& pvt = segment_pvt[seg];
+
+        // Pressure and temperature are the same for all phases in the wellbore; the salt
+        // concentration is zero when brine is inactive (the water PVT ignores it then).
+        const EvalWell temperature = pvt.temperature;
+        const EvalWell seg_pressure = pvt.pressure;
+        const EvalWell saltConcentration = pvt.saltConcentration;
+
+        for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
+            mix_s[comp_idx] = primary_variables.surfaceVolumeFraction(seg, comp_idx);
+        }
+
+        calculatePhaseState(pvt, mix_s, state, deferred_logger);
+        volume_ratios_[seg] = state.vol_ratio;
+
+        std::ranges::fill(phase_densities_[seg], 0.0);
+        std::ranges::fill(phase_viscosities_[seg], 0.0);
+
+        // water phase
+        if (waterActive) {
+            // rsw is only for interface usage
+            const EvalWell rsw{0.};
+            phase_viscosities_[seg][waterActiveCompIdx] = FluidSystem::waterPvt().viscosity(
+                    pvt_region_index, temperature, seg_pressure, rsw, saltConcentration);
+            phase_densities_[seg][waterActiveCompIdx] =
+                    state.b[waterActiveCompIdx] * surface_densities_[waterActiveCompIdx];
+        }
+
+        // gas phase
+        if (gasActive) {
+            // rvw is only for interface usage
+            const EvalWell rvw{0.};
+            const bool oil_exist = oilActive && mix_s[oilActiveCompIdx] > 0.0;
+            const EvalWell& b_g = state.b[gasActiveCompIdx];
+            if (oil_exist) {
+                phase_viscosities_[seg][gasActiveCompIdx] = FluidSystem::gasPvt().viscosity(
+                        pvt_region_index, temperature, seg_pressure, state.rv, rvw);
+                phase_densities_[seg][gasActiveCompIdx] = b_g * surface_densities_[gasActiveCompIdx]
+                                                          + state.rv * b_g * surface_densities_[oilActiveCompIdx];
+            } else { // no oil here
+                phase_viscosities_[seg][gasActiveCompIdx] = FluidSystem::gasPvt().saturatedViscosity(
+                        pvt_region_index, temperature, seg_pressure);
+                phase_densities_[seg][gasActiveCompIdx] = b_g * surface_densities_[gasActiveCompIdx];
+            }
+        }
+
+        // oil phase
+        if (oilActive) {
+            const bool gas_exist = gasActive && mix_s[gasActiveCompIdx] > 0.0;
+            const EvalWell& b_o = state.b[oilActiveCompIdx];
+            if (gas_exist) {
+                phase_viscosities_[seg][oilActiveCompIdx] = FluidSystem::oilPvt().viscosity(
+                        pvt_region_index, temperature, seg_pressure, state.rs);
+                phase_densities_[seg][oilActiveCompIdx] = b_o * surface_densities_[oilActiveCompIdx]
+                                                          + state.rs * b_o * surface_densities_[gasActiveCompIdx];
+            } else { // no gas phase
+                phase_viscosities_[seg][oilActiveCompIdx] = FluidSystem::oilPvt().saturatedViscosity(
+                        pvt_region_index, temperature, seg_pressure);
+                phase_densities_[seg][oilActiveCompIdx] = b_o * surface_densities_[oilActiveCompIdx];
+            }
+        }
+
+        viscosities_[seg] = 0.;
+        // calculate the average viscosity
+        for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
+            const EvalWell fraction = state.mix[comp_idx] / state.b[comp_idx] / state.vol_ratio;
+            // TODO: a little more work needs to be done to handle the negative fractions here
+            phase_fractions_[seg][comp_idx] = fraction; // >= 0.0 ? fraction : 0.0;
+            viscosities_[seg] += phase_viscosities_[seg][comp_idx] * phase_fractions_[seg][comp_idx];
+        }
+
+        EvalWell density(0.0);
+        for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
+            density += surface_densities_[comp_idx] * mix_s[comp_idx];
+        }
+        densities_[seg] = density / state.vol_ratio;
+
+        // calculate the mass rates
+        mass_rates_[seg] = 0.;
+        for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
+            const int upwind_seg = upwinding_segments_[seg];
+            const EvalWell rate = primary_variables.getSegmentRateUpwinding(seg,
+                                                                            upwind_seg,
+                                                                            comp_idx);
+            mass_rates_[seg] += rate * surface_densities_[comp_idx];
+        }
+    }
+}
+
 #include <opm/simulators/utils/InstantiationIndicesMacros.hpp>
 
 INSTANTIATE_TYPE_INDICES(MultisegmentWellSegments, double)

--- a/opm/simulators/wells/MultisegmentWellSegments.hpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.hpp
@@ -22,18 +22,11 @@
 #ifndef OPM_MULTISEGMENTWELL_SEGMENTS_HEADER_INCLUDED
 #define OPM_MULTISEGMENTWELL_SEGMENTS_HEADER_INCLUDED
 
-#include <opm/material/densead/EvaluationFormat.hpp>
-
-#include <opm/simulators/utils/DeferredLogger.hpp>
 #include <opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp>
 #include <opm/simulators/wells/ParallelWellInfo.hpp>
-#include <opm/simulators/wells/WellInterfaceGeneric.hpp>
 
-#include <fmt/format.h>
-
-#include <algorithm>
+#include <array>
 #include <cstddef>
-#include <string>
 #include <vector>
 
 namespace Opm {
@@ -61,20 +54,34 @@ public:
                              const ParallelWellInfo<Scalar>& parallel_well_info,
                              WellInterfaceGeneric<Scalar, IndexTraits>& well);
 
-    //! \brief Compute per-segment fluid properties from the pre-computed segment fluid states.
+    //! \brief The quantities taken from a segment fluid state.
     //!
-    //! Reuses the inverse formation volume factors and dissolution/vaporization ratios in each
-    //! fluid state where applicable, and evaluates the remaining PVT properties. Also updates
-    //! the cached segment volume ratios.
-    template<class FluidState>
-    void computeFluidProperties(const std::vector<FluidState>& segment_fluid_states,
+    //! The fluid state type depends on the TypeTag, which this class does not have, so the
+    //! caller extracts the values needed here. Pressure and temperature are the same for all
+    //! phases in the wellbore, so a single value of each is stored. @p invB is indexed by
+    //! canonical phase index.
+    struct SegmentPvt
+    {
+        EvalWell pressure{0.};
+        EvalWell temperature{0.};
+        EvalWell saltConcentration{0.};
+        std::array<EvalWell, FluidSystem::numPhases> invB{};
+        EvalWell Rs{0.};
+        EvalWell Rv{0.};
+    };
+
+    //! \brief Compute per-segment fluid properties from the pre-computed segment PVT values.
+    //!
+    //! Reuses the inverse formation volume factors and dissolution/vaporization ratios where
+    //! applicable, and evaluates the remaining PVT properties. Also updates the cached segment
+    //! volume ratios.
+    void computeFluidProperties(const std::vector<SegmentPvt>& segment_pvt,
                                 const PrimaryVariables& primary_variables,
                                 DeferredLogger& deferred_logger);
 
-    //! \brief Volume ratio of a segment from its fluid state and composition.
-    template<class FluidState>
+    //! \brief Volume ratio of a segment from its PVT values and composition.
     EvalWell computeVolumeRatio(const int seg,
-                                const FluidState& fluid_state,
+                                const SegmentPvt& pvt,
                                 const PrimaryVariables& primary_variables,
                                 DeferredLogger& deferred_logger) const;
 
@@ -228,252 +235,15 @@ private:
         EvalWell vol_ratio{0.};
     };
 
-    //! \brief Fill @p state from the segment fluid state and surface composition @p mix_s.
+    //! \brief Fill @p state from the segment PVT values and surface composition @p mix_s.
     //!
-    //! Reuses fluid-state PVT properties where they represent the requested composition, and
+    //! Reuses the PVT properties where they represent the requested composition, and
     //! evaluates the required saturated properties for single-phase cases.
-    template<class FluidState>
-    void calculatePhaseState(const FluidState& fluid_state,
+    void calculatePhaseState(const SegmentPvt& pvt,
                              const std::vector<EvalWell>& mix_s,
                              PhaseState& state,
                              DeferredLogger& deferred_logger) const;
 };
-
-template<typename FluidSystem, typename Indices>
-template<class FluidState>
-void MultisegmentWellSegments<FluidSystem,Indices>::
-calculatePhaseState(const FluidState& fluid_state,
-                    const std::vector<EvalWell>& mix_s,
-                    PhaseState& state,
-                    DeferredLogger& deferred_logger) const
-{
-    const int pvt_region_index = well_.pvtRegionIdx();
-
-    const bool waterActive = FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx);
-    const bool gasActive = FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx);
-    const bool oilActive = FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx);
-
-    const int waterActiveCompIdx = waterActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::waterCompIdx) : -1;
-    const int gasActiveCompIdx = gasActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::gasCompIdx) : -1;
-    const int oilActiveCompIdx = oilActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::oilCompIdx) : -1;
-
-    // Pressure and temperature are the same for all phases in the wellbore.
-    const unsigned pressure_phase = waterActive ? FluidSystem::waterPhaseIdx
-                                   : oilActive ? FluidSystem::oilPhaseIdx
-                                               : FluidSystem::gasPhaseIdx;
-    const EvalWell temperature = fluid_state.temperature(pressure_phase);
-    const EvalWell seg_pressure = fluid_state.pressure(pressure_phase);
-
-    state.rs = 0.;
-    state.rv = 0.;
-    state.vol_ratio = 0.;
-
-    // water phase; the stored inverse formation volume factor was evaluated exactly this way
-    if (waterActive) {
-        state.b[waterActiveCompIdx] = fluid_state.invB(FluidSystem::waterPhaseIdx);
-    }
-
-    // gas phase
-    if (gasActive) {
-        const bool oil_exist = oilActive && mix_s[oilActiveCompIdx] > 0.0;
-        if (oil_exist) {
-            if (mix_s[gasActiveCompIdx] > 0.0) {
-                // with free gas present the stored Rv is the capped (possibly saturated)
-                // vaporization ratio needed here, and the stored inverse formation volume
-                // factor was evaluated with it on the undersaturated table
-                state.rv = fluid_state.Rv();
-                state.b[gasActiveCompIdx] = fluid_state.invB(FluidSystem::gasPhaseIdx);
-            } else {
-                // No free gas: the fluid state holds saturated Rv, but calculate the inverse
-                // formation volume factor with the local Rv and Rvw set to zero.
-                const EvalWell rvw{0.};
-                state.b[gasActiveCompIdx] = FluidSystem::gasPvt().inverseFormationVolumeFactor(
-                        pvt_region_index, temperature, seg_pressure, state.rv, rvw);
-            }
-        } else { // no oil here
-            state.b[gasActiveCompIdx] = FluidSystem::gasPvt().saturatedInverseFormationVolumeFactor(
-                    pvt_region_index, temperature, seg_pressure);
-        }
-    }
-
-    // oil phase
-    if (oilActive) {
-        const bool gas_exist = gasActive && mix_s[gasActiveCompIdx] > 0.0;
-        if (gas_exist) {
-            if (mix_s[oilActiveCompIdx] > 0.0) {
-                state.rs = fluid_state.Rs();
-                state.b[oilActiveCompIdx] = fluid_state.invB(FluidSystem::oilPhaseIdx);
-            } else {
-                // dead oil; the fluid state stores the saturated Rs here, so evaluate anew
-                state.b[oilActiveCompIdx] = FluidSystem::oilPvt().inverseFormationVolumeFactor(
-                        pvt_region_index, temperature, seg_pressure, state.rs);
-            }
-        } else { // no gas phase
-            state.b[oilActiveCompIdx] = FluidSystem::oilPvt().saturatedInverseFormationVolumeFactor(
-                    pvt_region_index, temperature, seg_pressure);
-        }
-    }
-
-    state.mix = mix_s;
-    if (oilActive && gasActive) {
-        const EvalWell d = 1.0 - state.rs * state.rv;
-        if (d <= 0.0) {
-            const std::string str =
-                fmt::format("Problematic d value {} obtained for well {} during segment density calculations "
-                            "with rs {}, rv {} and pressure {}. Continue as if no dissolution (rs = 0) and "
-                            "vaporization (rv = 0) for this connection.",
-                            d, well_.name(), state.rs, state.rv, seg_pressure);
-            deferred_logger.debug(str);
-        } else {
-            if (state.rs > 0.0) {
-                state.mix[gasActiveCompIdx] = (mix_s[gasActiveCompIdx] - mix_s[oilActiveCompIdx] * state.rs) / d;
-            }
-            if (state.rv > 0.0) {
-                state.mix[oilActiveCompIdx] = (mix_s[oilActiveCompIdx] - mix_s[gasActiveCompIdx] * state.rv) / d;
-            }
-        }
-    }
-
-    const int num_quantities = well_.numConservationQuantities();
-    for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
-        state.vol_ratio += state.mix[comp_idx] / state.b[comp_idx];
-    }
-}
-
-template<typename FluidSystem, typename Indices>
-template<class FluidState>
-typename MultisegmentWellSegments<FluidSystem,Indices>::EvalWell
-MultisegmentWellSegments<FluidSystem,Indices>::
-computeVolumeRatio(const int seg,
-                   const FluidState& fluid_state,
-                   const PrimaryVariables& primary_variables,
-                   DeferredLogger& deferred_logger) const
-{
-    const int num_quantities = well_.numConservationQuantities();
-    std::vector<EvalWell> mix_s(num_quantities, 0.0);
-    for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
-        mix_s[comp_idx] = primary_variables.surfaceVolumeFraction(seg, comp_idx);
-    }
-
-    PhaseState state(num_quantities);
-    calculatePhaseState(fluid_state, mix_s, state, deferred_logger);
-    return state.vol_ratio;
-}
-
-template<typename FluidSystem, typename Indices>
-template<class FluidState>
-void MultisegmentWellSegments<FluidSystem,Indices>::
-computeFluidProperties(const std::vector<FluidState>& segment_fluid_states,
-                       const PrimaryVariables& primary_variables,
-                       DeferredLogger& deferred_logger)
-{
-    const int num_quantities = well_.numConservationQuantities();
-    const int pvt_region_index = well_.pvtRegionIdx();
-
-    const bool waterActive = FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx);
-    const bool gasActive = FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx);
-    const bool oilActive = FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx);
-
-    const int waterActiveCompIdx = waterActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::waterCompIdx) : -1;
-    const int gasActiveCompIdx = gasActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::gasCompIdx) : -1;
-    const int oilActiveCompIdx = oilActive ? FluidSystem::canonicalToActiveCompIdx(FluidSystem::oilCompIdx) : -1;
-
-    std::vector<EvalWell> mix_s(num_quantities, 0.0);
-    PhaseState state(num_quantities);
-
-    for (std::size_t seg = 0; seg < perforations_.size(); ++seg) {
-        const auto& fs = segment_fluid_states[seg];
-
-        // Pressure and temperature are the same for all phases in the wellbore; the salt
-        // concentration is zero when brine is inactive (the water PVT ignores it then).
-        const unsigned pressure_phase = waterActive ? FluidSystem::waterPhaseIdx
-                                       : oilActive ? FluidSystem::oilPhaseIdx
-                                                   : FluidSystem::gasPhaseIdx;
-        const EvalWell temperature = fs.temperature(pressure_phase);
-        const EvalWell seg_pressure = fs.pressure(pressure_phase);
-        const EvalWell saltConcentration = fs.saltConcentration();
-
-        for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
-            mix_s[comp_idx] = primary_variables.surfaceVolumeFraction(seg, comp_idx);
-        }
-
-        calculatePhaseState(fs, mix_s, state, deferred_logger);
-        volume_ratios_[seg] = state.vol_ratio;
-
-        std::ranges::fill(phase_densities_[seg], 0.0);
-        std::ranges::fill(phase_viscosities_[seg], 0.0);
-
-        // water phase
-        if (waterActive) {
-            // rsw is only for interface usage
-            const EvalWell rsw{0.};
-            phase_viscosities_[seg][waterActiveCompIdx] = FluidSystem::waterPvt().viscosity(
-                    pvt_region_index, temperature, seg_pressure, rsw, saltConcentration);
-            phase_densities_[seg][waterActiveCompIdx] =
-                    state.b[waterActiveCompIdx] * surface_densities_[waterActiveCompIdx];
-        }
-
-        // gas phase
-        if (gasActive) {
-            // rvw is only for interface usage
-            const EvalWell rvw{0.};
-            const bool oil_exist = oilActive && mix_s[oilActiveCompIdx] > 0.0;
-            const EvalWell& b_g = state.b[gasActiveCompIdx];
-            if (oil_exist) {
-                phase_viscosities_[seg][gasActiveCompIdx] = FluidSystem::gasPvt().viscosity(
-                        pvt_region_index, temperature, seg_pressure, state.rv, rvw);
-                phase_densities_[seg][gasActiveCompIdx] = b_g * surface_densities_[gasActiveCompIdx]
-                                                          + state.rv * b_g * surface_densities_[oilActiveCompIdx];
-            } else { // no oil here
-                phase_viscosities_[seg][gasActiveCompIdx] = FluidSystem::gasPvt().saturatedViscosity(
-                        pvt_region_index, temperature, seg_pressure);
-                phase_densities_[seg][gasActiveCompIdx] = b_g * surface_densities_[gasActiveCompIdx];
-            }
-        }
-
-        // oil phase
-        if (oilActive) {
-            const bool gas_exist = gasActive && mix_s[gasActiveCompIdx] > 0.0;
-            const EvalWell& b_o = state.b[oilActiveCompIdx];
-            if (gas_exist) {
-                phase_viscosities_[seg][oilActiveCompIdx] = FluidSystem::oilPvt().viscosity(
-                        pvt_region_index, temperature, seg_pressure, state.rs);
-                phase_densities_[seg][oilActiveCompIdx] = b_o * surface_densities_[oilActiveCompIdx]
-                                                          + state.rs * b_o * surface_densities_[gasActiveCompIdx];
-            } else { // no gas phase
-                phase_viscosities_[seg][oilActiveCompIdx] = FluidSystem::oilPvt().saturatedViscosity(
-                        pvt_region_index, temperature, seg_pressure);
-                phase_densities_[seg][oilActiveCompIdx] = b_o * surface_densities_[oilActiveCompIdx];
-            }
-        }
-
-        viscosities_[seg] = 0.;
-        // calculate the average viscosity
-        for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
-            const EvalWell fraction = state.mix[comp_idx] / state.b[comp_idx] / state.vol_ratio;
-            // TODO: a little more work needs to be done to handle the negative fractions here
-            phase_fractions_[seg][comp_idx] = fraction; // >= 0.0 ? fraction : 0.0;
-            viscosities_[seg] += phase_viscosities_[seg][comp_idx] * phase_fractions_[seg][comp_idx];
-        }
-
-        EvalWell density(0.0);
-        for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
-            density += surface_densities_[comp_idx] * mix_s[comp_idx];
-        }
-        densities_[seg] = density / state.vol_ratio;
-
-        // calculate the mass rates
-        mass_rates_[seg] = 0.;
-        for (int comp_idx = 0; comp_idx < num_quantities; ++comp_idx) {
-            const int upwind_seg = upwinding_segments_[seg];
-            const EvalWell rate = primary_variables.getSegmentRateUpwinding(seg,
-                                                                            upwind_seg,
-                                                                            comp_idx);
-            mass_rates_[seg] += rate * surface_densities_[comp_idx];
-        }
-
-    }
-}
 
 } // namespace Opm
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -700,7 +700,7 @@ namespace Opm
     {
         for (int seg = 0; seg < this->numberOfSegments(); ++seg) {
             const EvalWell volume_ratio =
-                this->segments_.computeVolumeRatio(seg, segment_fluid_state_[seg],
+                this->segments_.computeVolumeRatio(seg, segmentPvt(segment_fluid_state_[seg]),
                                                    this->primary_variables_, deferred_logger);
             const Scalar surface_volume = getSegmentSurfaceVolume(seg, volume_ratio).value();
             for (int comp_idx = 0; comp_idx < this->num_conservation_quantities_; ++comp_idx) {
@@ -1148,9 +1148,43 @@ namespace Opm
         // properties, so both use consistent PVT data.
         const FSInfo info = this->getFirstPerforationFluidStateInfo(simulator);
         updateSegmentFluidState(info, deferred_logger);
-        this->segments_.computeFluidProperties(this->segment_fluid_state_,
+
+        std::vector<SegmentPvt> segment_pvt(this->numberOfSegments());
+        for (int seg = 0; seg < this->numberOfSegments(); ++seg) {
+            segment_pvt[seg] = segmentPvt(segment_fluid_state_[seg]);
+        }
+        this->segments_.computeFluidProperties(segment_pvt,
                                                this->primary_variables_,
                                                deferred_logger);
+    }
+
+    template <typename TypeTag>
+    typename MultisegmentWell<TypeTag>::SegmentPvt
+    MultisegmentWell<TypeTag>::
+    segmentPvt(const SegmentFluidState<EvalWell>& fluid_state) const
+    {
+        // Pressure and temperature are the same for all phases in the wellbore, so pick any
+        // active one to read them from.
+        const bool waterActive = FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx);
+        const bool oilActive = FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx);
+        const unsigned pressure_phase = waterActive ? FluidSystem::waterPhaseIdx
+                                       : oilActive ? FluidSystem::oilPhaseIdx
+                                                   : FluidSystem::gasPhaseIdx;
+
+        SegmentPvt pvt;
+        pvt.pressure = fluid_state.pressure(pressure_phase);
+        pvt.temperature = fluid_state.temperature(pressure_phase);
+        pvt.saltConcentration = fluid_state.saltConcentration();
+        for (unsigned phaseIdx = 0; phaseIdx < FluidSystem::numPhases; ++phaseIdx) {
+            if (FluidSystem::phaseIsActive(phaseIdx)) {
+                pvt.invB[phaseIdx] = fluid_state.invB(phaseIdx);
+            }
+        }
+        if constexpr (compositionSwitchEnabled) {
+            pvt.Rs = fluid_state.Rs();
+            pvt.Rv = fluid_state.Rv();
+        }
+        return pvt;
     }
 
     template<typename TypeTag>

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -76,6 +76,7 @@ namespace Opm
     , segment_fluid_initial_(this->numberOfSegments(), std::vector<Scalar>(this->num_conservation_quantities_, 0.0))
     , segment_initial_energy_(this->numberOfSegments(), 0.0)
     , segment_fluid_state_(this->numberOfSegments(), SegmentFluidState<EvalWell>{})
+    , segment_pvt_(this->numberOfSegments())
     {
         // not handling solvent or polymer for now with multisegment well
         if constexpr (has_solvent) {
@@ -1149,11 +1150,10 @@ namespace Opm
         const FSInfo info = this->getFirstPerforationFluidStateInfo(simulator);
         updateSegmentFluidState(info, deferred_logger);
 
-        std::vector<SegmentPvt> segment_pvt(this->numberOfSegments());
         for (int seg = 0; seg < this->numberOfSegments(); ++seg) {
-            segment_pvt[seg] = segmentPvt(segment_fluid_state_[seg]);
+            segment_pvt_[seg] = segmentPvt(segment_fluid_state_[seg]);
         }
-        this->segments_.computeFluidProperties(segment_pvt,
+        this->segments_.computeFluidProperties(segment_pvt_,
                                                this->primary_variables_,
                                                deferred_logger);
     }


### PR DESCRIPTION
The segment property calculations were templated on the fluid state type, which depends on the TypeTag that MultisegmentWellSegments does not have, so they had to live in the header.

They only read pressure, temperature, salt concentration, the inverse formation volume factors and Rs/Rv from the fluid state, and those are all EvalWell, which is concrete for <FluidSystem, Indices>. Pass them in a small struct instead, so computeFluidProperties(), computeVolumeRatio() and calculatePhaseState() are no longer templates and are instantiated with the class in the .cpp file.