### PR TITLE
Reservoir coupling: make a master group's injection target reflect what the slaves are actually producing

### DIFF
--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlave.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlave.cpp
@@ -460,6 +460,24 @@ markSlaveGroupsInSchedule(Schedule& schedule, const int report_step_idx)
     this->report_step_data_->markSlaveGroupsInSchedule(schedule, report_step_idx);
 }
 
+template <class Scalar>
+void
+ReservoirCouplingSlave<Scalar>::
+setWellsSolvedThisSyncStep(bool value)
+{
+    assert(this->report_step_data_);
+    this->report_step_data_->setWellsSolvedThisSyncStep(value);
+}
+
+template <class Scalar>
+bool
+ReservoirCouplingSlave<Scalar>::
+wellsSolvedThisSyncStep() const
+{
+    assert(this->report_step_data_);
+    return this->report_step_data_->wellsSolvedThisSyncStep();
+}
+
 // ------------------
 // Private methods
 // ------------------

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlave.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlave.hpp
@@ -161,6 +161,10 @@ public:
     /// @details Delegates to ReservoirCouplingSlaveReportStep.
     void markSlaveGroupsInSchedule(Schedule& schedule, int report_step_idx);
 
+    /// @brief Record whether the initial well solve for this sync step has run
+    /// @details Delegates to ReservoirCouplingSlaveReportStep
+    void setWellsSolvedThisSyncStep(bool value);
+
     const std::string& slaveGroupIdxToGroupName(std::size_t group_idx) const {
         return this->slave_group_order_.at(group_idx);
     }
@@ -187,10 +191,15 @@ public:
     /// MPI_Comm_disconnect() to complete - it is a collective operation.
     void receiveTerminateAndDisconnect();
 
+    /// @brief True once the initial well solve for this sync step has run
+    /// @details Delegates to ReservoirCouplingSlaveReportStep
+    bool wellsSolvedThisSyncStep() const;
+
 private:
     void checkGrupSlavGroupNames_();
     std::pair<double, bool> getGrupSlavActivationDateAndCheckHistoryMatchingMode_() const;
     bool historyMatchingMode_() const { return this->history_matching_mode_; }
+
     std::size_t numMasterGroups_() const { return this->slave_to_master_group_map_.size(); }
     //! \brief Receive the master's go-ahead after reporting our OK status.
     //!

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.hpp
@@ -267,6 +267,17 @@ public:
     /// @param cmode Production control mode dictated by the master
     void setMasterProductionTarget(const std::string& gname, const Scalar target, const Group::ProductionCMode cmode);
 
+    /// @brief Record whether the initial well solve for this sync step has run
+    /// @param value False before the solve, true after it
+    void setWellsSolvedThisSyncStep(bool value) { wells_solved_this_sync_step_ = value; }
+
+    /// @brief True once the initial well solve for this sync step has run
+    /// @details Before it, a well that opens in this report step still carries the
+    ///   rates SingleWellState::update_producer_targets() derived from its WCONPROD
+    ///   target, which must not be reported to the master as achieved production.
+    ///   See RescoupSendSlaveGroupData::unsolvedNewWellProductionRates_().
+    bool wellsSolvedThisSyncStep() const { return wells_solved_this_sync_step_; }
+
 
 private:
     /// @brief Generic helper method for sending data to the master process via MPI
@@ -301,6 +312,10 @@ private:
     // Used to control reservoir coupling synchronization of summary data sent from
     // the slave to the master process.
     bool is_last_substep_of_sync_timestep_{false};
+    // Flag to track whether the initial well solve of this sync timestep has run.
+    // Cleared before the pre-solve send of slave group data and set after the solve;
+    // see wellsSolvedThisSyncStep().
+    bool wells_solved_this_sync_step_{false};
 
     // Master-imposed targets and corresponding control modes, received from the master
     // process at the beginning of each sync timestep. Cleared and repopulated on every

--- a/opm/simulators/wells/BlackoilWellModelRescoup.hpp
+++ b/opm/simulators/wells/BlackoilWellModelRescoup.hpp
@@ -140,7 +140,9 @@ public:
     /// Blocking receive of the per-master-group production targets and
     /// injection limits computed by the master.  The received values are
     /// written into the slave's group state via the receiver helper.
-    /// Called from the slave's beginTimeStep first-substep handshake.
+    /// Called from the slave's beginTimeStep first-substep handshake, and
+    /// once per network iteration from maybeSendSlaveGroupFlowToMaster_(),
+    /// where the master sends injection targets only.
     void receiveGroupConstraintsFromMaster();
 
     /// \brief Receive master-computed network-leaf node pressures and
@@ -241,6 +243,22 @@ private:
     ///   network exchange; the (public) global version is the OR over all
     ///   activated slaves and gates the master's own iteration.
     bool masterNetworkHasMasterGroupLeavesForSlave_(std::size_t slave_idx) const;
+
+    /// \brief Master-side: recompute the master's group state from the slave
+    ///   rates just received and send the resulting injection targets on.
+    ///
+    /// Called immediately after each non-final receiveSlaveGroupData() inside
+    /// the network iteration, so that a target derived from slave production
+    /// (GCONINJE REIN, SALE or VREP) keeps up with the production the slaves
+    /// report as the network iteration proceeds.  Its slave-side counterpart
+    /// is the receiveGroupConstraintsFromMaster() in
+    /// BlackoilWellModel::maybeSendSlaveGroupFlowToMaster_().
+    void refreshAndSendInjectionTargets_();
+
+    /// \brief Send injection targets to each activated slave, replacing the
+    ///   ones the slaves are currently holding.  Production constraints are
+    ///   not resent.  Only called by refreshAndSendInjectionTargets_().
+    void sendMasterGroupInjectionTargetsToSlaves_();
 
     /// \brief Slave-side: true iff this slave's own deck put the named group
     ///   into its own surface network as a fixed-pressure node.

--- a/opm/simulators/wells/BlackoilWellModelRescoup_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelRescoup_impl.hpp
@@ -109,6 +109,7 @@ maybeExchangeNetworkOuterIterationWithSlaves(bool more_network_update)
         if (!is_final) {
             // receive slaves' updated network_surface_rates for the next outer iteration.
             this->receiveSlaveGroupData();
+            this->refreshAndSendInjectionTargets_();
         }
     }
 }
@@ -144,6 +145,7 @@ maybeExchangeNetworkSubIterationWithSlaves()
     }
     this->sendMasterGroupNodePressuresToSlaves(/*is_final=*/false);
     this->receiveSlaveGroupData();
+    this->refreshAndSendInjectionTargets_();
 }
 
 template<typename TypeTag>
@@ -411,6 +413,37 @@ masterNetworkHasMasterGroupLeavesForSlave_(std::size_t slave_idx) const
         }
     }
     return false;
+}
+
+template<typename TypeTag>
+void
+BlackoilWellModelRescoup<TypeTag>::
+refreshAndSendInjectionTargets_()
+{
+    // Called right after a receiveSlaveGroupData() inside the network iteration.
+    // Fold the rates just received into the master's group state -- that is what
+    // recomputes the reinjection and voidage rates that a GCONINJE REIN, SALE
+    // or VREP target is built from -- and ship the resulting targets to the
+    // slaves, replacing the ones they are currently holding.  Without this the
+    // targets stay at the values computed in beginTimeStep(), from slave
+    // production of the previous sync step.
+    const int report_step_idx = this->well_model_.simulator().episodeIndex();
+    this->well_model_.updateAndCommunicateGroupData(
+        report_step_idx, /*update_wellgrouptarget=*/false);
+    this->sendMasterGroupInjectionTargetsToSlaves_();
+}
+
+template<typename TypeTag>
+void
+BlackoilWellModelRescoup<TypeTag>::
+sendMasterGroupInjectionTargetsToSlaves_()
+{
+    OPM_TIMEFUNCTION();
+    RescoupConstraintsCalculator<Scalar, IndexTraits> constraints_calculator{
+        this->well_model_.guideRateHandler(),
+        this->groupStateHelper()
+    };
+    constraints_calculator.recalculateInjectionTargetsAndSendToSlaves();
 }
 
 template<typename TypeTag>

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -476,6 +476,10 @@ namespace Opm {
 #ifdef RESERVOIR_COUPLING_ENABLED
         if (this->isReservoirCouplingSlave()) {
             if (this->reservoirCouplingSlave().isFirstSubstepOfSyncTimestep()) {
+                // The wells have not been solved for this sync step yet, so a well that
+                // opens in this report step still carries its WCONPROD target as its rate.
+                // See RescoupSendSlaveGroupData::collectSlaveGroupSurfaceProductionRates_().
+                this->reservoirCouplingSlave().setWellsSolvedThisSyncStep(false);
                 this->rescoupHelper_.sendSlaveGroupDataToMaster();
                 this->rescoupHelper_.receiveGroupConstraintsFromMaster();
                 this->rescoupHelper_.receiveCoupledNetworkActiveStatus();
@@ -538,6 +542,8 @@ namespace Opm {
 
 #ifdef RESERVOIR_COUPLING_ENABLED
         if (slave_needs_well_solution) {  // isReservoirCouplingSlave()
+            // The initial well solve above has run, so the well states now hold solved rates.
+            this->reservoirCouplingSlave().setWellsSolvedThisSyncStep(true);
             // Need to update group data based on new well solution.
             this->updateAndCommunicateGroupData(reportStepIdx, /*update_wellgrouptarget*/ false);
             this->rescoupHelper_.sendSlaveGroupDataToMaster();

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2368,6 +2368,11 @@ namespace Opm {
         if (!is_final) {
             this->updateAndCommunicateGroupData(reportStepIdx, /*update_wellgrouptarget=*/false);
             this->rescoupHelper_.sendSlaveGroupDataToMaster();
+            // The master turns the rates just sent into fresh injection targets
+            // for the groups it controls through a derived GCONINJE mode, and
+            // sends them straight back.  See
+            // BlackoilWellModelRescoup::refreshAndSendInjectionTargets_().
+            this->rescoupHelper_.receiveGroupConstraintsFromMaster();
             return /*more_network_update=*/true;
         }
         return /*more_network_update=*/false;

--- a/opm/simulators/wells/GroupStateHelper.cpp
+++ b/opm/simulators/wells/GroupStateHelper.cpp
@@ -1155,39 +1155,8 @@ GroupStateHelper<Scalar, IndexTraits>::sumWellPhaseRates(bool res_rates,
     }
 
     for (const std::string& well_name : group.wells()) {
-        const auto well_index = this->wellState().index(well_name);
-        if (!well_index.has_value())
-            continue;
-
-        if (!this->wellState().wellIsOwned(well_index.value(), well_name)) // Only sum once
-        {
-            continue;
-        }
-
-        const auto& well_ecl = this->schedule_.getWell(well_name, this->report_step_);
-        // only count producers or injectors
-        if ((well_ecl.isProducer() && is_injector) || (well_ecl.isInjector() && !is_injector))
-            continue;
-
-        const auto& ws = this->wellState().well(well_index.value());
-        if (ws.status == Opm::Well::Status::SHUT)
-            continue;
-
-        const Scalar factor = well_ecl.getEfficiencyFactor(network)
-            * this->wellState().well(well_index.value()).efficiency_scaling_factor;
-        if (res_rates) {
-            const auto& well_rates = ws.reservoir_rates;
-            if (is_injector)
-                rate += factor * well_rates[phase_pos];
-            else
-                rate -= factor * well_rates[phase_pos];
-        } else {
-            const auto& well_rates = ws.surface_rates;
-            if (is_injector)
-                rate += factor * well_rates[phase_pos];
-            else
-                rate -= factor * well_rates[phase_pos];
-        }
+        rate += this->wellRateContributionToGroup(
+            well_name, phase_pos, res_rates, is_injector, network);
     }
     return rate;
 }
@@ -1613,6 +1582,41 @@ GroupStateHelper<Scalar, IndexTraits>::updateWellRatesFromGroupTargetScale(
             }
         }
     }
+}
+
+template <typename Scalar, typename IndexTraits>
+Scalar
+GroupStateHelper<Scalar, IndexTraits>::wellRateContributionToGroup(const std::string& well_name,
+                                                                  const int phase_pos,
+                                                                  const bool res_rates,
+                                                                  const bool is_injector,
+                                                                  const bool network) const
+{
+    const auto well_index = this->wellState().index(well_name);
+    if (!well_index.has_value())
+        return 0.0;
+
+    if (!this->wellState().wellIsOwned(well_index.value(), well_name)) // Only sum once
+    {
+        return 0.0;
+    }
+
+    const auto& well_ecl = this->schedule_.getWell(well_name, this->report_step_);
+    // only count producers or injectors
+    if ((well_ecl.isProducer() && is_injector) || (well_ecl.isInjector() && !is_injector))
+        return 0.0;
+
+    const auto& ws = this->wellState().well(well_index.value());
+    if (ws.status == Opm::Well::Status::SHUT)
+        return 0.0;
+
+    const Scalar factor = well_ecl.getEfficiencyFactor(network)
+        * ws.efficiency_scaling_factor;
+    const auto& well_rates = res_rates ? ws.reservoir_rates : ws.surface_rates;
+    // Production rates are negative in the well state; a group rate sum is a positive
+    // magnitude for both directions.
+    return is_injector ? factor * well_rates[phase_pos]
+                       : -factor * well_rates[phase_pos];
 }
 
 template <typename Scalar, typename IndexTraits>

--- a/opm/simulators/wells/GroupStateHelper.hpp
+++ b/opm/simulators/wells/GroupStateHelper.hpp
@@ -517,6 +517,28 @@ public:
                                              bool is_injector,
                                              WellState<Scalar, IndexTraits>& well_state) const;
 
+    /// \brief The contribution of a single well to a group rate sum.
+    ///
+    /// Applies the filters, the efficiency factor and the sign convention that
+    /// sumWellPhaseRates() uses, so a caller that needs to add or remove one well's
+    /// share of such a sum stays consistent with it.  Returns zero when the well does
+    /// not contribute at all: not present in this rank's well state, not owned by this
+    /// rank (each well is counted once), of the wrong type for the sum, or shut.
+    ///
+    /// Being owner-filtered, the result is rank-local, exactly like sumWellPhaseRates();
+    /// a caller that compares it against an already-reduced quantity must reduce it too.
+    ///
+    /// \param well_name Name of the well
+    /// \param phase_pos Active phase index
+    /// \param res_rates Use reservoir rates instead of surface rates
+    /// \param is_injector Sum injectors rather than producers
+    /// \param network Use the network efficiency factors (GEFAC/WEFAC item 3)
+    Scalar wellRateContributionToGroup(const std::string& well_name,
+                                       const int phase_pos,
+                                       const bool res_rates,
+                                       const bool is_injector,
+                                       const bool network = false) const;
+
     /// Returns the name of the worst offending well and its fraction (i.e. violated_phase / preferred_phase)
     std::pair<std::optional<std::string>, Scalar>
     worstOffendingWell(const Group& group,

--- a/opm/simulators/wells/rescoup/RescoupConstraintsCalculator.cpp
+++ b/opm/simulators/wells/rescoup/RescoupConstraintsCalculator.cpp
@@ -260,6 +260,42 @@ calculateMasterGroupConstraintsAndSendToSlaves()
     this->group_state_helper_.groupState().communicate_rates(comm);
 }
 
+// Recompute the injection targets against the slave rates the master holds now
+// and ship them to the slaves, replacing the targets sent earlier in this sync
+// step.  See the declaration in the header for why this second send exists.
+template <class Scalar, class IndexTraits>
+void
+RescoupConstraintsCalculator<Scalar, IndexTraits>::
+recalculateInjectionTargetsAndSendToSlaves()
+{
+    // As in calculateMasterGroupConstraintsAndSendToSlaves(), the body must run
+    // on every rank of the master communicator: GroupConstraintCalculator relies
+    // on GroupStateHelper, which performs collective operations.  The MPI sends
+    // themselves are rank-0-only inside the send helpers.
+    auto& rescoup_master = this->reservoir_coupling_master_;
+    GroupConstraintCalculator calculator{
+        this->well_model_,
+        this->group_state_helper_
+    };
+    const auto num_slaves = rescoup_master.numSlaves();
+    for (std::size_t slave_idx = 0; slave_idx < num_slaves; ++slave_idx) {
+        if (!rescoup_master.slaveIsActivated(slave_idx)) {
+            continue;
+        }
+        auto injection_targets = this->calculateSlaveGroupInjectionTargets_(slave_idx, calculator);
+        // An empty production-constraint list tells the slave that no production
+        // constraints follow; the ones it received earlier this sync step stay in
+        // force.
+        this->sendSlaveGroupConstraintsToSlave_(
+            rescoup_master, slave_idx, injection_targets, /*production_constraints=*/{}
+        );
+    }
+}
+
+// ----------------------------------------------------------------------
+// Private methods alphabetically for class RescoupConstraintsCalculator
+// ----------------------------------------------------------------------
+
 template <class Scalar, class IndexTraits>
 std::tuple<
   std::vector<typename RescoupConstraintsCalculator<Scalar, IndexTraits>::InjectionGroupTarget>,
@@ -268,34 +304,14 @@ std::tuple<
 RescoupConstraintsCalculator<Scalar, IndexTraits>::
 calculateSlaveGroupConstraints_(std::size_t slave_idx, GroupConstraintCalculator<Scalar, IndexTraits>& calculator) const
 {
-    std::vector<InjectionGroupTarget> injection_targets;
+    std::vector<InjectionGroupTarget> injection_targets =
+        this->calculateSlaveGroupInjectionTargets_(slave_idx, calculator);
     std::vector<ProductionGroupConstraints> production_constraints;
     auto& rescoup_master = this->reservoir_coupling_master_;
-    static const std::array<ReservoirCoupling::Phase, 3> phases = {
-        ReservoirCoupling::Phase::Water, ReservoirCoupling::Phase::Oil, ReservoirCoupling::Phase::Gas
-    };
     const auto& master_groups = rescoup_master.getMasterGroupNamesForSlave(slave_idx);
     for (std::size_t group_idx = 0; group_idx < master_groups.size(); ++group_idx) {
         const auto& group_name = master_groups[group_idx];
         const Group& group = this->schedule_.getGroup(group_name, this->report_step_idx_);
-        if (group.isInjectionGroup()) {
-            for (ReservoirCoupling::Phase phase : phases) {
-                auto target_info = calculator.groupInjectionTarget(group, phase);
-                if (target_info.has_value()) {
-                    // Always send injection targets as RATE. The numeric value is
-                    // already a surface rate for all modes (RATE, REIN, RESV, VREP),
-                    // and the slave cannot evaluate derived modes (REIN, VREP, RESV)
-                    // because it lacks the master's schedule data (reinj_group,
-                    // voidage_group, GCONSUMP, resv_coeff, etc.).
-                    injection_targets.push_back(
-                        InjectionGroupTarget{
-                            group_idx, target_info->constraint,
-                            Group::InjectionCMode::RATE, phase
-                        }
-                    );
-                }
-            }
-        }
         if (group.isProductionGroup()) {
             auto constraints = calculator.groupProductionConstraints(group);
             if (constraints.has_value()) {
@@ -315,6 +331,43 @@ calculateSlaveGroupConstraints_(std::size_t slave_idx, GroupConstraintCalculator
         }
     }
     return {injection_targets, production_constraints};
+}
+
+template <class Scalar, class IndexTraits>
+std::vector<typename RescoupConstraintsCalculator<Scalar, IndexTraits>::InjectionGroupTarget>
+RescoupConstraintsCalculator<Scalar, IndexTraits>::
+calculateSlaveGroupInjectionTargets_(std::size_t slave_idx, GroupConstraintCalculator<Scalar, IndexTraits>& calculator) const
+{
+    std::vector<InjectionGroupTarget> injection_targets;
+    auto& rescoup_master = this->reservoir_coupling_master_;
+    static const std::array<ReservoirCoupling::Phase, 3> phases = {
+        ReservoirCoupling::Phase::Water, ReservoirCoupling::Phase::Oil, ReservoirCoupling::Phase::Gas
+    };
+    const auto& master_groups = rescoup_master.getMasterGroupNamesForSlave(slave_idx);
+    for (std::size_t group_idx = 0; group_idx < master_groups.size(); ++group_idx) {
+        const auto& group_name = master_groups[group_idx];
+        const Group& group = this->schedule_.getGroup(group_name, this->report_step_idx_);
+        if (!group.isInjectionGroup()) {
+            continue;
+        }
+        for (ReservoirCoupling::Phase phase : phases) {
+            auto target_info = calculator.groupInjectionTarget(group, phase);
+            if (target_info.has_value()) {
+                // Always send injection targets as RATE. The numeric value is
+                // already a surface rate for all modes (RATE, REIN, RESV, VREP),
+                // and the slave cannot evaluate derived modes (REIN, VREP, RESV)
+                // because it lacks the master's schedule data (reinj_group,
+                // voidage_group, GCONSUMP, resv_coeff, etc.).
+                injection_targets.push_back(
+                    InjectionGroupTarget{
+                        group_idx, target_info->constraint,
+                        Group::InjectionCMode::RATE, phase
+                    }
+                );
+            }
+        }
+    }
+    return injection_targets;
 }
 
 template <class Scalar, class IndexTraits>

--- a/opm/simulators/wells/rescoup/RescoupConstraintsCalculator.hpp
+++ b/opm/simulators/wells/rescoup/RescoupConstraintsCalculator.hpp
@@ -79,6 +79,39 @@ public:
     ///   corresponding .cpp file for the per-phase walkthrough and the
     ///   collective-call invariants.
     void calculateMasterGroupConstraintsAndSendToSlaves();
+
+    /// @brief Recompute only the injection targets and send them to each
+    ///   activated slave, replacing the ones sent earlier in this sync step.
+    /// @details The injection targets computed by
+    ///   `calculateMasterGroupConstraintsAndSendToSlaves()` are derived from
+    ///   the slave production rates the master holds at that moment, which
+    ///   are the rates the slaves reported *before* solving their wells for
+    ///   this sync step.  The `GCONINJE` modes that turn production into an
+    ///   injection target are `REIN` (a fraction of the reinjection rate),
+    ///   `SALE` (the reinjection rate less the `GCONSALE` sales target) and
+    ///   `VREP` (the voidage of what was produced), so under any of those a
+    ///   step in which slave production changes gets an injection target for
+    ///   the previous step's production.  This entry point is called from each
+    ///   master network iteration, once the slaves' latest rates have arrived,
+    ///   and ships targets recomputed from them.  Production constraints are
+    ///   deliberately left untouched: the slaves have already solved their
+    ///   wells against them, and they are what produced the rates this
+    ///   recomputation is based on.
+    ///
+    ///   The recomputation is unconditional: it runs for every master group of
+    ///   every activated slave, whatever mode each one is under.  A `RATE`
+    ///   target is a constant from the deck and a `RESV` target moves only with
+    ///   the other phases' reservoir injection, so for those the recomputation
+    ///   produces the value the slave already holds and the send is redundant.
+    ///   TODO: skip the groups whose target cannot have changed.  The test is
+    ///   not simply the group's own `GCONINJE` record: `groupInjectionTarget()`
+    ///   walks up the hierarchy, so it is the mode of the controlling ancestor
+    ///   that decides, and that mode changes during a run -- a group on `REIN`
+    ///   switches to `RATE` as soon as its target reaches the `GCONINJE`
+    ///   maximum.  The filter would therefore have to be evaluated per refresh
+    ///   over the whole chain.
+    void recalculateInjectionTargetsAndSendToSlaves();
+
 private:
     /// @brief Phase 1: compute initial guide-rate-distributed targets and
     ///   per-rate-type limits for one slave's master groups.
@@ -99,6 +132,18 @@ private:
     ///   slave's master groups, ready for Phase 2 / Phase 3.
     std::tuple<std::vector<InjectionGroupTarget>, std::vector<ProductionGroupConstraints>>
         calculateSlaveGroupConstraints_(std::size_t slave_idx, GroupConstraintCalculator<Scalar, IndexTraits>& calculator) const;
+
+    /// @brief Compute the per-phase injection targets for one slave's
+    ///   master groups.
+    /// @details The injection half of `calculateSlaveGroupConstraints_()`,
+    ///   split out so that `recalculateInjectionTargetsAndSendToSlaves()`
+    ///   can reuse it without recomputing the production constraints.
+    /// @param slave_idx Zero-based index of the activated slave.
+    /// @param calculator Group-constraint calculator bound to the current
+    ///   group/well state.
+    /// @return One entry per (master group, phase) that has a target.
+    std::vector<InjectionGroupTarget>
+        calculateSlaveGroupInjectionTargets_(std::size_t slave_idx, GroupConstraintCalculator<Scalar, IndexTraits>& calculator) const;
 
     /// @brief Phase 2: cap each capacity-limited master group's
     ///   production target at the slave's reported potential and

--- a/opm/simulators/wells/rescoup/RescoupConstraintsCalculator.hpp
+++ b/opm/simulators/wells/rescoup/RescoupConstraintsCalculator.hpp
@@ -187,16 +187,6 @@ private:
         const ReservoirCoupling::Potentials<Scalar>& potentials,
         Group::ProductionCMode cmode) const;
 
-    /// @brief Pre-phase: restore each master group's `production_control`
-    ///   cmode to its Schedule-defined GCONPROD value.
-    /// @details The previous sync step's Phase 2 finalize switched these
-    ///   to individual control; this restore lets the upcoming
-    ///   distribution see the user-specified cmode.  Reads from the
-    ///   Schedule directly (rather than caching the pre-sync state) so
-    ///   new GCONPROD records at report-step boundaries are picked up
-    ///   automatically.
-    void restoreMasterGroupControlsFromSchedule_();
-
     /// @brief Phase 3: send the computed constraints for one slave to
     ///   that slave over MPI.
     /// @details The underlying MPI sends in

--- a/opm/simulators/wells/rescoup/RescoupSendSlaveGroupData.cpp
+++ b/opm/simulators/wells/rescoup/RescoupSendSlaveGroupData.cpp
@@ -425,6 +425,13 @@ unsolvedNewWellProductionRates_(const std::string& group_name, bool network) con
     const auto report_step = this->groupStateHelper_.reportStepIdx();
     const auto& schedule = this->groupStateHelper_.schedule();
     const auto& group = schedule.getGroup(group_name, report_step);
+    // NOTE: the live schedule events are read on purpose.  NEW_WELL is cleared after the
+    // first time step of the report step, so the correction applies only to the sync step
+    // in which the well opens; from the next one its rates come from a solve and belong
+    // in the sum.  Do not switch this to BlackoilWellModel::reportStepStartEvents(),
+    // which keeps the flag for the whole report step: wellsSolvedThisSyncStep() is
+    // cleared before the pre-solve send of *every* sync step, so a valid converged rate
+    // would then be subtracted on each of them.
     const auto& events = schedule[report_step].wellgroup_events();
     // Mirror sumWellPhaseRates(): a slave group may hold no wells of its own, so
     // descend into child groups, applying each child's efficiency factor.

--- a/opm/simulators/wells/rescoup/RescoupSendSlaveGroupData.cpp
+++ b/opm/simulators/wells/rescoup/RescoupSendSlaveGroupData.cpp
@@ -180,6 +180,12 @@ collectSlaveGroupSurfaceProductionRates_(std::size_t group_idx) const
     auto& rescoup_slave = this->reservoir_coupling_slave_;
     const auto& group_name = rescoup_slave.slaveGroupIdxToGroupName(group_idx);
     GuideRate::RateVector production_rates = this->groupStateHelper_.getProductionGroupRateVector(group_name);
+    // Correct the sum for wells that have not been solved yet; see
+    // unsolvedNewWellProductionRates_().
+    const auto unsolved = this->unsolvedNewWellProductionRates_(group_name, /*network=*/false);
+    production_rates.oil_rat -= unsolved[ReservoirCoupling::Phase::Oil];
+    production_rates.gas_rat -= unsolved[ReservoirCoupling::Phase::Gas];
+    production_rates.wat_rat -= unsolved[ReservoirCoupling::Phase::Water];
     // NOTE: GuideRate::RateVector is a vector of doubles, so we need to convert it to Scalar
     // TODO: Fix GuideRate::RateVector to be a vector of Scalars instead of doubles
     return ProductionRates{production_rates};
@@ -222,10 +228,14 @@ collectSlaveGroupNetworkSurfaceProductionRates_(std::size_t group_idx) const
     oil_rate = this->comm().sum(oil_rate);
     gas_rate = this->comm().sum(gas_rate);
     water_rate = this->comm().sum(water_rate);
+    // Correct the sums for wells that have not been solved yet; see
+    // unsolvedNewWellProductionRates_().  The master uses these rates as the
+    // flow of its network's leaf nodes.
+    const auto unsolved = this->unsolvedNewWellProductionRates_(group_name, /*network=*/true);
     ProductionRates network_rates;
-    network_rates[ReservoirCoupling::Phase::Oil] = oil_rate;
-    network_rates[ReservoirCoupling::Phase::Gas] = gas_rate;
-    network_rates[ReservoirCoupling::Phase::Water] = water_rate;
+    network_rates[ReservoirCoupling::Phase::Oil] = oil_rate - unsolved[ReservoirCoupling::Phase::Oil];
+    network_rates[ReservoirCoupling::Phase::Gas] = gas_rate - unsolved[ReservoirCoupling::Phase::Gas];
+    network_rates[ReservoirCoupling::Phase::Water] = water_rate - unsolved[ReservoirCoupling::Phase::Water];
     return network_rates;
 }
 
@@ -380,6 +390,54 @@ sendSlaveGroupInjectionDataToMaster_() const
         injection_data.emplace_back(this->collectSlaveGroupInjectionData_(group_idx));
     }
     rescoup_slave.sendInjectionDataToMaster(injection_data);
+}
+
+// A well that opens in this report step is put on its WCONPROD target by
+// updateWellStateWithTarget() before the sync step's well solve runs, so on the
+// send that precedes that solve the well state holds a target, not a solved
+// rate.  Shipping it to the master would report a target as achieved
+// production: the master folds the slave group rates into the field's
+// reinjection base, so a multi-million sm3/day gas target arriving that way
+// inflates the reinjection target and pushes the injectors onto their own rate
+// limits.  Leave such a well out of the sums until it has been solved; from the
+// post-solve send onwards its real rates are included.
+template<typename Scalar, typename IndexTraits>
+typename RescoupSendSlaveGroupData<Scalar, IndexTraits>::ProductionRates
+RescoupSendSlaveGroupData<Scalar, IndexTraits>::
+unsolvedNewWellProductionRates_(const std::string& group_name, bool network) const
+{
+    ProductionRates rates;
+    if (this->reservoir_coupling_slave_.wellsSolvedThisSyncStep()) {
+        return rates;
+    }
+    const auto report_step = this->groupStateHelper_.reportStepIdx();
+    const auto& schedule = this->groupStateHelper_.schedule();
+    const auto& group = schedule.getGroup(group_name, report_step);
+    const auto& events = schedule[report_step].wellgroup_events();
+    // Mirror sumWellPhaseRates(): a slave group may hold no wells of its own, so
+    // descend into child groups, applying each child's efficiency factor.
+    for (const auto& child_name : group.groups()) {
+        const auto& child = schedule.getGroup(child_name, report_step);
+        const auto child_rates = this->unsolvedNewWellProductionRates_(child_name, network);
+        const auto gefac = child.getGroupEfficiencyFactor(network);
+        for (const auto phase : {ReservoirCoupling::Phase::Oil,
+                                 ReservoirCoupling::Phase::Gas,
+                                 ReservoirCoupling::Phase::Water}) {
+            rates[phase] += gefac * child_rates[phase];
+        }
+    }
+    for (const auto& wname : group.wells()) {
+        if (!events.hasEvent(wname, ScheduleEvents::NEW_WELL)) {
+            continue;
+        }
+        const auto& well = schedule.getWell(wname, report_step);
+        const auto efficiency = well.getEfficiencyFactor(network);
+        const auto well_rates = this->groupStateHelper_.getWellRateVector(wname);
+        rates[ReservoirCoupling::Phase::Oil] += efficiency * well_rates.oil_rat;
+        rates[ReservoirCoupling::Phase::Gas] += efficiency * well_rates.gas_rat;
+        rates[ReservoirCoupling::Phase::Water] += efficiency * well_rates.wat_rat;
+    }
+    return rates;
 }
 
 

--- a/opm/simulators/wells/rescoup/RescoupSendSlaveGroupData.cpp
+++ b/opm/simulators/wells/rescoup/RescoupSendSlaveGroupData.cpp
@@ -181,11 +181,12 @@ collectSlaveGroupSurfaceProductionRates_(std::size_t group_idx) const
     const auto& group_name = rescoup_slave.slaveGroupIdxToGroupName(group_idx);
     GuideRate::RateVector production_rates = this->groupStateHelper_.getProductionGroupRateVector(group_name);
     // Correct the sum for wells that have not been solved yet; see
-    // unsolvedNewWellProductionRates_().
+    // unsolvedNewWellProductionRates_().  The group state rates read above have already
+    // been reduced across the ranks, so the rank-local correction is reduced to match.
     const auto unsolved = this->unsolvedNewWellProductionRates_(group_name, /*network=*/false);
-    production_rates.oil_rat -= unsolved[ReservoirCoupling::Phase::Oil];
-    production_rates.gas_rat -= unsolved[ReservoirCoupling::Phase::Gas];
-    production_rates.wat_rat -= unsolved[ReservoirCoupling::Phase::Water];
+    production_rates.oil_rat -= this->comm().sum(unsolved[ReservoirCoupling::Phase::Oil]);
+    production_rates.gas_rat -= this->comm().sum(unsolved[ReservoirCoupling::Phase::Gas]);
+    production_rates.wat_rat -= this->comm().sum(unsolved[ReservoirCoupling::Phase::Water]);
     // NOTE: GuideRate::RateVector is a vector of doubles, so we need to convert it to Scalar
     // TODO: Fix GuideRate::RateVector to be a vector of Scalars instead of doubles
     return ProductionRates{production_rates};
@@ -224,18 +225,23 @@ collectSlaveGroupNetworkSurfaceProductionRates_(std::size_t group_idx) const
             /*is_injector=*/false, /*network=*/true);
     }
 
+    // Correct the sums for wells that have not been solved yet; see
+    // unsolvedNewWellProductionRates_().  The master uses these rates as the flow of
+    // its network's leaf nodes.  The correction is rank-local, like the sums above, so
+    // it is applied before the reduction.
+    const auto unsolved = this->unsolvedNewWellProductionRates_(group_name, /*network=*/true);
+    oil_rate -= unsolved[ReservoirCoupling::Phase::Oil];
+    gas_rate -= unsolved[ReservoirCoupling::Phase::Gas];
+    water_rate -= unsolved[ReservoirCoupling::Phase::Water];
+
     // Sum across all MPI ranks since wells in a group may be owned by different ranks
     oil_rate = this->comm().sum(oil_rate);
     gas_rate = this->comm().sum(gas_rate);
     water_rate = this->comm().sum(water_rate);
-    // Correct the sums for wells that have not been solved yet; see
-    // unsolvedNewWellProductionRates_().  The master uses these rates as the
-    // flow of its network's leaf nodes.
-    const auto unsolved = this->unsolvedNewWellProductionRates_(group_name, /*network=*/true);
     ProductionRates network_rates;
-    network_rates[ReservoirCoupling::Phase::Oil] = oil_rate - unsolved[ReservoirCoupling::Phase::Oil];
-    network_rates[ReservoirCoupling::Phase::Gas] = gas_rate - unsolved[ReservoirCoupling::Phase::Gas];
-    network_rates[ReservoirCoupling::Phase::Water] = water_rate - unsolved[ReservoirCoupling::Phase::Water];
+    network_rates[ReservoirCoupling::Phase::Oil] = oil_rate;
+    network_rates[ReservoirCoupling::Phase::Gas] = gas_rate;
+    network_rates[ReservoirCoupling::Phase::Water] = water_rate;
     return network_rates;
 }
 
@@ -393,14 +399,20 @@ sendSlaveGroupInjectionDataToMaster_() const
 }
 
 // A well that opens in this report step is put on its WCONPROD target by
-// updateWellStateWithTarget() before the sync step's well solve runs, so on the
-// send that precedes that solve the well state holds a target, not a solved
+// SingleWellState::update_producer_targets() before the sync step's well solve runs,
+// so on the send that precedes that solve the well state holds a target, not a solved
 // rate.  Shipping it to the master would report a target as achieved
 // production: the master folds the slave group rates into the field's
 // reinjection base, so a multi-million sm3/day gas target arriving that way
 // inflates the reinjection target and pushes the injectors onto their own rate
 // limits.  Leave such a well out of the sums until it has been solved; from the
 // post-solve send onwards its real rates are included.
+//
+// The correction is built with GroupStateHelper::wellRateContributionToGroup(), the same
+// per-well step the sums themselves use, so it removes exactly what they added: only
+// producers, only wells this rank owns and that are not shut, with the same efficiency
+// factor and sign.  It is therefore rank-local, and each call site reduces it to match
+// whatever it is being subtracted from.
 template<typename Scalar, typename IndexTraits>
 typename RescoupSendSlaveGroupData<Scalar, IndexTraits>::ProductionRates
 RescoupSendSlaveGroupData<Scalar, IndexTraits>::
@@ -426,16 +438,24 @@ unsolvedNewWellProductionRates_(const std::string& group_name, bool network) con
             rates[phase] += gefac * child_rates[phase];
         }
     }
+    const auto& pu = this->phase_usage_;
     for (const auto& wname : group.wells()) {
         if (!events.hasEvent(wname, ScheduleEvents::NEW_WELL)) {
             continue;
         }
-        const auto& well = schedule.getWell(wname, report_step);
-        const auto efficiency = well.getEfficiencyFactor(network);
-        const auto well_rates = this->groupStateHelper_.getWellRateVector(wname);
-        rates[ReservoirCoupling::Phase::Oil] += efficiency * well_rates.oil_rat;
-        rates[ReservoirCoupling::Phase::Gas] += efficiency * well_rates.gas_rat;
-        rates[ReservoirCoupling::Phase::Water] += efficiency * well_rates.wat_rat;
+        // Ask for the well's share of the sum we are correcting, so the filters
+        // (producers only, present, owned by this rank, not shut), the efficiency
+        // factor and the sign are the ones that sum actually used.
+        auto contribution = [&](const auto canonical_phase_idx) {
+            return pu.phaseIsActive(canonical_phase_idx)
+                ? this->groupStateHelper_.wellRateContributionToGroup(
+                      wname, pu.canonicalToActivePhaseIdx(canonical_phase_idx),
+                      /*res_rates=*/false, /*is_injector=*/false, network)
+                : Scalar{0};
+        };
+        rates[ReservoirCoupling::Phase::Oil] += contribution(IndexTraits::oilPhaseIdx);
+        rates[ReservoirCoupling::Phase::Gas] += contribution(IndexTraits::gasPhaseIdx);
+        rates[ReservoirCoupling::Phase::Water] += contribution(IndexTraits::waterPhaseIdx);
     }
     return rates;
 }

--- a/opm/simulators/wells/rescoup/RescoupSendSlaveGroupData.hpp
+++ b/opm/simulators/wells/rescoup/RescoupSendSlaveGroupData.hpp
@@ -144,6 +144,20 @@ private:
     /// via MPI communication through the ReservoirCouplingSlave.
     void sendSlaveGroupInjectionDataToMaster_() const;
 
+    /// @brief The part of a group's surface production rates that comes from
+    ///   wells which open in this report step but have not been solved yet
+    /// @param group_name Name of the slave group; the walk descends into child
+    ///   groups, so a slave group that holds no wells of its own is handled too
+    /// @param network True to use the network efficiency factors (GEFAC/WEFAC
+    ///   item 3), matching the `network` argument of the rate sum being
+    ///   corrected
+    /// @return Rates to subtract, all zero once the wells have been solved
+    /// @note Before this sync step's well solve, such a well contributes the
+    ///       rates updateWellStateWithTarget() derived from its WCONPROD
+    ///       target rather than rates from a solve.  Reporting those to the
+    ///       master states a target as achieved production; see the call sites.
+    ProductionRates unsolvedNewWellProductionRates_(const std::string& group_name, bool network) const;
+
     /// Reference to the GroupStateHelper for group state management
     const GroupStateHelperType& groupStateHelper_;
 


### PR DESCRIPTION
The first two commits are about the same thing from two sides: a master group under a `GCONINJE` mode that turns production into an injection target — `REIN`, `SALE` or `VREP` — has that target computed from the slave production the master has been told about, and today that figure can be either wrong or stale. The third is an unrelated one-line cleanup in a file the second one touches; see below.

#### 1. A newly opened well reports its target as achieved production

A coupling slave sends its group rates to the master twice per sync step: once in `beginTimeStep()` before it solves its wells for the step, and once after. That ordering is deliberate — the master needs the slave's state to compute the constraints the slave is then solved against — and it is harmless while the pre-solve well state holds the previous step's converged rates.

A well that opens in the report step has none. `SingleWellState::update_producer_targets()` seeds it with its `WCONPROD` target as an initial guess for the solve, which `WellInterface::initializeProducerWellState()` then uses as a rate cap. So on the first send the slave reports a target as if it were achieved production, once per newly opened well.

The consequence is not a one-step blip. The master folds the slave group rates into the field's reinjection base, so an inflated gas figure pushes the field's `REIN` target past the `GCONINJE` maximum, and the field's gas injection control switches to `RATE`. In `RATE` mode the target *is* the maximum, independent of production, so the correct rates that arrive later in the same sync step cannot bring it back down — the injectors stay on their cap for the whole step.

The commit tracks in `ReservoirCouplingSlaveReportStep`, alongside the other per-sync-step flags kept there, whether the wells have been solved this sync step, and while they have not, leaves a well that opens in this report step out of the group rates the slave sends. The `NEW_WELL` event alone cannot serve as the condition: it stays set for the whole report step and so cannot tell the two sends apart. The exclusion covers the surface production rates and the network surface rates — the master uses the latter as the flow of its network's leaf nodes.

#### 2. The injection targets are computed once per sync step and never revised

`calculateMasterGroupConstraintsAndSendToSlaves()` has a single call site, on the first substep of a sync step, and the injection targets it produces are the ones the slaves use for the whole step. For one of the production-derived modes that means the target is built from the production the slaves reported *before* they solved their wells, i.e. the previous step's production. The per-iteration exchanges inside the master's network solve send node pressures and receive slave rates; they never re-send constraints.

So a step in which slave production changes injects the wrong amount for its whole length, and with a field under `GCONINJE ... REIN` the gas that is not injected leaves the balance as sales gas.

The commit recomputes the injection targets after each non-final slave-rate receive inside the master's network iteration and sends them on; the slave gains one matching receive in `maybeSendSlaveGroupFlowToMaster_()`, so the message pairing keeps its shape. Production constraints are deliberately not resent — the slaves have already solved their wells against them, and they are what produced the rates the recomputation is based on; the message carries a production count of zero and the slaves keep what they hold. The injection half of `calculateSlaveGroupConstraints_()` is split out as `calculateSlaveGroupInjectionTargets_()` so both entry points share it.

#### 3. A declaration left without a definition

Unrelated to the above and included only because it is in a file the second commit already changes: `restoreMasterGroupControlsFromSchedule_()` lost both its only caller and its definition in #7203, and the declaration in `RescoupConstraintsCalculator` was left behind. It is a single deleted declaration and changes nothing at run time. 

#### Effect on `rescoup/rc_m1` in opm-tests

[`rc_m1`](https://github.com/OPM/opm-tests/blob/master/rescoup/rc_m1/master/RC-01_MAST_PRED.DATA) has `GCONINJE 'FIELD' 'GAS' 'REIN' 4.0E6 1* 1.0` with `GCONSUMP 'FIELD' 200000`, so the field's gas injection target is its gas production minus consumption, capped at 4.0e6 sm3/day. Two wells open in slave `mod2` during the run, `E-1H` on 01-Jan-2019 and `E-2H` on 01-Feb-2019, each with a 4.0e6 sm3/day `WCONPROD` gas target.

Tight coupling, all 38 report steps, master against this PR:

| | master | **this PR** |
|---|---:|---:|
| peak field gas injection `FGIR` (deck `GCONINJE` maximum 4.0e6) | 4.500e6 | **4.000e6** |
| minimum field gas sales rate `FGSR` | −2.437e6 | **−1,446** |
| time steps with `FGSR` below −1e5 | 2 / 260 | **0 / 260** |
| peak `FGSR` (deck `GCONSALE` maximum 1.05e6) | 1.208e6 | 1.189e6 |
| mean 2021 field gas rate (deck implies 5.2e6) | 5.199e6 | 5.197e6 |
| cumulative field oil `FOPT` | 1.3405e7 | 1.3416e7 |

The two steps in the first three rows are exactly the two dates a well opens, and they are what the two plots below show. On master the field injects 4.5e6 sm3/day of gas on each — above the 4.0e6 the deck allows, with the injector `C-4H` sitting on its own `WCONINJE` limit — and the gas balance closes with a *negative* sales rate of −2.4e6 sm3/day, which is not physical: the field cannot sell less than nothing. With the PR neither step exceeds 4.0e6 and the sales rate stays at its ordinary magnitude.

Field gas injection rate over the run, master (red) against this PR (blue) — see the FGIR plot below. The two red spikes to 4.5e6 sm3/day in January and February 2019 are the two steps a well opens; the plateau the two curves share from late 2020 onwards is the 4.0e6 sm3/day `GCONINJE` maximum, so the spikes are plainly above the limit the deck sets. Everywhere else the curves lie on top of each other.

<img width="1080" height="888" alt="FGIR" src="https://github.com/user-attachments/assets/50a34c1a-3f13-4741-9660-b080b690212c" />

Field gas sales rate on the same dates — see the FGSR plot below. Sales gas is the residue of the gas balance, `FGPR − GCONSUMP − FGIR`, so the two over-injection steps drive it to −2.44e6 and −2.36e6 sm3/day on master. The PR has neither excursion. Note also that both curves settle on 1.0e6 sm3/day from late 2020, which is the `GCONSALE` sales target: the change does not disturb the sales control.

<img width="1068" height="890" alt="FGSR" src="https://github.com/user-attachments/assets/c25189f8-1729-438f-8914-8d76a814b42d" />

The `FGSR` peak and the 2021 gas rate barely move, as expected: they are governed by the `GCONSALE` limit and the reinjection cap, not by these two steps. Cumulative field oil rises by 0.08%.

#### Not fixed here — two things we ran into and would like an opinion on

Neither is caused by these commits and neither is addressed by them, but both showed up while measuring, and they interact with the same keywords.

**The reinjection target still lags production within a step.** After this PR the injection target is recomputed as often as the master receives fresh slave rates, but on `rc_m1` those refreshes all see the same numbers: the master's coupled-network loop converges inside its first Newton iteration and then stops exchanging, and a slave with no network of its own is not re-solved between exchanges. The target for a step therefore still corresponds to the production at the start of it. Since sales gas is the residue `FGPR − GCONSUMP − FGIR`, the whole lag lands in the sales rate: on `rc_m1` the overshoot above the sales target equals the production growth over the step, about 15,500 sm3/day per day of step length, so 5-day steps overshoot by ~78,000 and the 1-day step that closes a report step by ~13,000: This is visible in the FGSR plot above, and it is the one part of that plot this PR does not change: from the moment `GCONSALE` takes effect on 1 July 2019 both curves sit just above the 1.0e6 sales target, creep up through 2019 (1.0011e6 in August, 1.0036e6 by January 2020) and then climb steeply through 2020 — 1.017e6 in July, 1.067e6 in October — until the reinjection cap binds in November 2020 and they peak at 1.208e6 (master) and 1.189e6 (this branch), both well above the 1.05e6 the deck allows. The two curves lie on top of each other throughout: the lag is untouched by these commits. Closing this properly seems to need an outer coupling iteration over the whole time step (slaves solve, report, master recomputes targets, slaves re-solve), which is a larger design question than we wanted to open in this PR. Note also that the master and its slaves do not take the same number of Newton iterations — on `rc_m1` the master takes one per step where `mod1` takes two — so there is no existing common loop to hang more exchanges on.

**`checkGconsaleLimits()` runs before the end-of-step slave sync, and moving it does not help.** On a master the sales check at `BlackoilWellModel_impl.hpp` runs before `rescoupSyncSummaryData()`, the call that brings in the slaves' converged end-of-step rates, so it evaluates the sales rate against the lagged production described above. On `rc_m1` it computes exactly the 1.0e6 sales target on every step through 2020 while the summary reports 1.065e6 to 1.078e6, and the `GCONSALE` maximum therefore fires exactly once in the whole run. We tried moving the call after the sync. It makes the sales cap hold almost perfectly — and makes everything else much worse: the field freezes at 3.88e6 sm3/day of gas for the rest of the run instead of developing to the 5.2e6 the deck implies, and cumulative field oil drops by 4.9%. The reason is that while injection is below the `GCONINJE` maximum the two controls imply each other for *any* production rate — the `GRAT` target is `sales target + injection + consumption`, and the `REIN`/`SALE` injection target is `production − consumption − sales target` — so the pair has no unique fixed point and switching to `GRAT` simply pins the field wherever it happens to be. Reacting to the violation earlier freezes it earlier and lower. Only when injection saturates at the `GCONINJE` maximum does the `GRAT` target become a definite number. Raising the deck's `GCONSALE` maximum from 1.05e6 to 1.1e6 — enough that the lag-driven overshoot no longer reaches it before the reinjection cap binds — makes the reordering behave well again, which confirms the mechanism but is a deck-side workaround for a simulator-side lag.
