### PR TITLE
moving getFirstPerforationFluidStateInfo to the WellInterface

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -93,7 +93,7 @@ namespace Opm {
         using typename MSWEval::BVectorWell;
         using MSWEval::SPres;
         using typename Base::PressureMatrix;
-        using FSInfo = std::tuple<Scalar, Scalar>;
+        using FSInfo = typename Base::FSInfo;
 
         using BMatrix = typename Base::BMatrix;
         using CMatrix = typename Base::CMatrix;
@@ -398,8 +398,6 @@ namespace Opm {
         // updating the inflow based on the current reservoir condition
         void updateIPR(const Simulator& ebos_simulator,
                        DeferredLogger& deferred_logger) const override;
-
-        FSInfo getFirstPerforationFluidStateInfo(const Simulator& simulator) const;
 
         // this function can potentially be shared between multisegment wells and standard wells
         template <typename ValueType = EvalWell>

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -772,7 +772,7 @@ namespace Opm
         computePerfCellPressDiffs(simulator);
 
         // Refresh the fluid state before computing the initial inventory.
-        const auto info = this->getFirstPerforationFluidStateInfo(simulator);
+        const auto info = this->getFirstPerfCellConditions(simulator);
         updateSegmentFluidState(info, deferred_logger);
         computeInitialSegmentInventory(deferred_logger);
     }
@@ -1147,7 +1147,7 @@ namespace Opm
     {
         // Rebuild fluid states from the current primary variables before deriving segment
         // properties, so both use consistent PVT data.
-        const FSInfo info = this->getFirstPerforationFluidStateInfo(simulator);
+        const FSInfo info = this->getFirstPerfCellConditions(simulator);
         updateSegmentFluidState(info, deferred_logger);
 
         for (int seg = 0; seg < this->numberOfSegments(); ++seg) {
@@ -1977,7 +1977,7 @@ namespace Opm
         // Needed to construct the injector wellhead fluid state.
         [[maybe_unused]] FSInfo info{};
         if constexpr (has_energy) {
-            info = this->getFirstPerforationFluidStateInfo(simulator);
+            info = this->getFirstPerfCellConditions(simulator);
         }
 
         for (int seg = 0; seg < nseg; ++seg) {
@@ -2023,8 +2023,8 @@ namespace Opm
                 if constexpr (has_energy) {
                     const bool top_injecting_segment = (seg == 0) && this->isInjector();
                     if (top_injecting_segment) {
-                        this->updateWellHeadCondition(simulator, std::get<0>(info),
-                                                      std::get<1>(info), deferred_logger);
+                        this->updateWellHeadCondition(simulator, info.temperature,
+                                                      info.saltConcentration, deferred_logger);
                     }
 
                     // Energy out toward the outlet, using the upwind segment fluid
@@ -2442,32 +2442,6 @@ namespace Opm
         this->primary_variables_.scaledWellFractions(scaled_fractions, deferred_logger);
     }
 
-    template <typename TypeTag>
-    typename MultisegmentWell<TypeTag>::FSInfo
-    MultisegmentWell<TypeTag>::
-    getFirstPerforationFluidStateInfo(const Simulator& simulator) const
-    {
-        Scalar fsTemperature = 0.0;
-        Scalar fsSaltConcentration = 0.0;
-
-        // If this process does not contain active perforations, this->well_cells_ is empty.
-        if (this->well_cells_.size() > 0) {
-            // We use the pvt region of first perforated cell, so we look for global index 0
-            // TODO: it should be a member of the WellInterface, initialized properly
-            const int cell_idx = this->well_cells_[0];
-            const auto& intQuants = simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/0);
-            const auto& fs = intQuants.fluidState();
-
-            fsTemperature = getValue(fs.temperature(FluidSystem::oilPhaseIdx));
-            fsSaltConcentration = getValue(fs.saltConcentration());
-        }
-
-        auto info = std::make_tuple(fsTemperature, fsSaltConcentration);
-
-        // The following broadcast call is neccessary to ensure that processes that do *not* contain
-        // the first perforation get the correct temperature, saltConcentration and pvt_region_index
-        return this->parallel_well_info_.communication().size() == 1 ? info : this->parallel_well_info_.broadcastFirstPerforationValue(info);
-    }
 
     template <typename TypeTag>
     template <typename ValueType>
@@ -2639,9 +2613,9 @@ namespace Opm
                                                        DeferredLogger& deferred_logger) const
     {
         const EvalWell seg_pressure = this->primary_variables_.getSegmentPressure(seg);
-        const Scalar firstPerfTemperature = std::get<0>(info);
+        const Scalar firstPerfTemperature = info.temperature;
         // Salt is not an MSW primary variable: use the constant first-perf value.
-        const EvalWell seg_salt_concentration = std::get<1>(info);
+        const EvalWell seg_salt_concentration = info.saltConcentration;
         const EvalWell seg_temperature = has_energy ? this->primary_variables_.getSegmentTemperature(seg) : firstPerfTemperature;
 
         // TODO: with the energy equation joins, the num_conservation_quantities will be challenged

--- a/opm/simulators/wells/ParallelWellInfo.cpp
+++ b/opm/simulators/wells/ParallelWellInfo.cpp
@@ -847,9 +847,10 @@ template<class Scalar> using cdIter = typename std::vector<Scalar>::const_iterat
         broadcastFirstPerforationValue<int>(const int&) const;                      \
     template T ParallelWellInfo<T>::                                                \
         broadcastFirstPerforationValue<T>(const T&) const;                          \
-    template std::tuple<T, T>                                                       \
-    ParallelWellInfo<T>::broadcastFirstPerforationValue<std::tuple<T, T>>           \
-    (std::tuple<T, T> const&) const;                                                \
+    template FirstPerfCellConditions<T>                                          \
+    ParallelWellInfo<T>::                                                           \
+        broadcastFirstPerforationValue<FirstPerfCellConditions<T>>               \
+        (FirstPerfCellConditions<T> const&) const;                               \
     template void CommunicateAboveBelow<T>::                                        \
         partialSumPerfValues<dIter<T>>(dIter<T>, dIter<T>) const;                   \
     template bool operator<(const ParallelWellInfo<T>&,                             \

--- a/opm/simulators/wells/ParallelWellInfo.hpp
+++ b/opm/simulators/wells/ParallelWellInfo.hpp
@@ -34,6 +34,25 @@ namespace Opm {
 
 class Well;
 
+/// \brief Reservoir temperature and salt concentration of the first perforated cell.
+///
+/// Broadcast to all processes of a distributed well, since the process holding
+/// the first perforation is not necessarily the one needing the values.
+/// \tparam Scalar the simulator scalar type, i.e. double or float.
+template<class Scalar>
+struct FirstPerfCellConditions
+{
+    Scalar temperature{};
+    Scalar saltConcentration{};
+
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(temperature);
+        serializer(saltConcentration);
+    }
+};
+
 /// \brief Class to facilitate getting values associated with the above/below perforation
 ///
 template<class Scalar>

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -47,6 +47,7 @@ namespace Opm {
 #include <opm/simulators/wells/GasLiftGroupInfo.hpp>
 #include <opm/simulators/wells/GasLiftSingleWell.hpp>
 #include <opm/simulators/wells/GasLiftSingleWellGeneric.hpp>
+#include <opm/simulators/wells/ParallelWellInfo.hpp>
 #include <opm/simulators/wells/PerforationData.hpp>
 #include <opm/simulators/wells/WellInterfaceIndices.hpp>
 #include <opm/simulators/wells/WellProdIndexCalculator.hpp>
@@ -101,6 +102,9 @@ public:
     using WellStateType = WellState<Scalar, IndexTraits>;
     using SingleWellStateType = SingleWellState<Scalar, IndexTraits>;
     using GroupStateHelperType = GroupStateHelper<Scalar, IndexTraits>;
+
+    //! \brief Temperature and salt concentration of the first perforated cell.
+    using FSInfo = FirstPerfCellConditions<Scalar>;
 
     using RateConverterType =
     typename WellInterfaceFluidSystem<FluidSystem>::RateConverterType;
@@ -526,6 +530,10 @@ protected:
     Scalar computeConnectionDFactor(const int perf,
                                     const IntensiveQuantities& intQuants,
                                     const SingleWellStateType& ws) const;
+
+    //! \brief Temperature and salt concentration of the first perforated cell,
+    //! broadcast so that all processes of a distributed well get the values.
+    FSInfo getFirstPerfCellConditions(const Simulator& simulator) const;
 };
 
 } // namespace Opm

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -2493,6 +2493,34 @@ namespace Opm
 
     }
 
+
+    template <typename TypeTag>
+    typename WellInterface<TypeTag>::FSInfo
+    WellInterface<TypeTag>::getFirstPerfCellConditions(const Simulator& simulator) const
+    {
+        FSInfo info{};
+
+        // If this process does not contain active perforations, this->well_cells_ is empty.
+        if (this->well_cells_.size() > 0) {
+            // The cell of the first perforation *on this process*. For a distributed well
+            // this is the first perforation of the well only on the process holding it;
+            // the broadcast below replaces the values on all the other processes.
+            const int cell_idx = this->well_cells_[0];
+            const auto& intQuants = simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/0);
+            const auto& fs = intQuants.fluidState();
+
+            info.temperature = getValue(fs.temperature(FluidSystem::oilPhaseIdx));
+            info.saltConcentration = getValue(fs.saltConcentration());
+        }
+
+        // Broadcast from the process holding the first open connection of the well
+        // (ParallelWellInfo::communicateFirstPerforation), so that all processes use the
+        // conditions of the same cell.
+        return this->parallel_well_info_.communication().size() == 1
+            ? info
+            : this->parallel_well_info_.broadcastFirstPerforationValue(info);
+    }
+
 } // namespace Opm
 
 #endif


### PR DESCRIPTION
so both StandardWell and MultisegmentWell can use it. FSInfo becomes a struct FirstPerfCellConditions for better readability.