### PR TITLE
Injection networks: structure, and VFP lookups that stay inside the tables

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
@@ -100,12 +100,21 @@ template<typename Scalar, typename IndexTraits>
 void BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
 updateActiveState(const int report_step)
 {
-    const auto& network = well_model_.schedule()[report_step].network();
+    this->active_ = false;
+    for (const auto& network : details::activeNetworks(well_model_.schedule(), report_step)) {
+        updateActiveStateImpl(network);
+    }
+    this->active_ = well_model_.comm().max(active_);
+}
+
+template<typename Scalar, typename IndexTraits>
+void BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
+updateActiveStateImpl(const Network::ExtNetwork& network)
+{
     if (!network.active()) {
         this->active_ = false;
         return;
     }
-
     bool network_active = false;
     for (const auto& well : well_model_.genericWells()) {
         const bool is_partof_network = network.has_node(well->wellEcl().groupName());
@@ -143,7 +152,7 @@ updateActiveState(const int report_step)
         }
     }
 #endif
-    this->active_ = well_model_.comm().max(network_active);
+    this->active_ = this->active_ || network_active;
 }
 
 template<typename Scalar, typename IndexTraits>

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
@@ -39,6 +39,40 @@
 
 namespace Opm {
 
+namespace details {
+    /// Helper to check if any network (production, gas injection, water injection) is active at a given time step.
+    bool anyNetworkActive(const Schedule& schedule, const int timeStepIdx)
+    {
+        const auto& sstate = schedule[timeStepIdx];
+        return sstate.network().active()
+            || (sstate.injectionNetwork.get_ptr(Phase::GAS) != nullptr
+                && sstate.injectionNetwork.get_ptr(Phase::GAS)->active())
+            || (sstate.injectionNetwork.get_ptr(Phase::WATER) != nullptr
+                && sstate.injectionNetwork.get_ptr(Phase::WATER)->active());
+    }
+
+    /// Helper to get all active networks (production, gas injection, water injection) at a given time step.
+    std::vector<std::reference_wrapper<const Network::ExtNetwork>>
+    activeNetworks(const Schedule& schedule, const int timeStepIdx)
+    {
+        std::vector<std::reference_wrapper<const Network::ExtNetwork>> active_networks;
+        const auto& sstate = schedule[timeStepIdx];
+        if (sstate.network().active()) {
+            active_networks.push_back(std::cref(sstate.network()));
+        }
+        if (sstate.injectionNetwork.get_ptr(Phase::GAS) != nullptr
+            && sstate.injectionNetwork.get_ptr(Phase::GAS)->active()) {
+            active_networks.push_back(std::cref(*sstate.injectionNetwork.get_ptr(Phase::GAS)));
+        }
+        if (sstate.injectionNetwork.get_ptr(Phase::WATER) != nullptr
+            && sstate.injectionNetwork.get_ptr(Phase::WATER)->active()) {
+            active_networks.push_back(std::cref(*sstate.injectionNetwork.get_ptr(Phase::WATER)));
+        }
+        return active_networks;
+    }
+} // namespace details
+
+
 template<typename Scalar, typename IndexTraits>
 BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
 BlackoilWellModelNetworkGeneric(BlackoilWellModelGeneric<Scalar,IndexTraits>& well_model)

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
@@ -37,6 +37,11 @@
 
 #include <opm/input/eclipse/Schedule/VFPInjTable.hpp>
 
+#include <opm/common/OpmLog/OpmLog.hpp>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
 #include <algorithm>
 #include <cassert>
 
@@ -130,8 +135,9 @@ template<typename Scalar, typename IndexTraits>
 void BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
 updateActiveStateImpl(const Network::ExtNetwork& network)
 {
+    // Accumulates into active_ across the domains; an inactive network must not
+    // clear what an earlier domain set.
     if (!network.active()) {
-        this->active_ = false;
         return;
     }
     bool network_active = false;
@@ -259,25 +265,26 @@ updatePressures(const int reportStepIdx,
     const auto previous_node_pressures = this->domain_node_pressures_;
 
     for (const auto& network : details::activeNetworks(well_model_.schedule(), reportStepIdx)) {
+        NetworkPressures result;
         if (network.domain == details::NetworkDomain::Production) {
-            std::tie(this->nodePressures(network.domain), this->branchData(network.domain)) =
-                this->computePressures(network.network.get(),
-                                       *well_model_.getVFPProperties().getProd(),
-                                       well_model_.schedule().getUnits(),
-                                       reportStepIdx,
-                                       well_model_.comm());
-            continue;
+            result = this->computePressures(network.network.get(),
+                                            *well_model_.getVFPProperties().getProd(),
+                                            well_model_.schedule().getUnits(),
+                                            reportStepIdx,
+                                            well_model_.comm());
+        } else {
+            const auto injection_phase = details::injectionPhaseForDomain(network.domain);
+            assert(injection_phase.has_value());
+            result = this->computePressures(network.network.get(),
+                                            *well_model_.getVFPProperties().getInj(),
+                                            well_model_.schedule().getUnits(),
+                                            reportStepIdx,
+                                            well_model_.comm(),
+                                            *injection_phase);
         }
-
-        const auto injection_phase = details::injectionPhaseForDomain(network.domain);
-        assert(injection_phase.has_value());
-        std::tie(this->nodePressures(network.domain), this->branchData(network.domain)) =
-            this->computePressures(network.network.get(),
-                                   *well_model_.getVFPProperties().getInj(),
-                                   well_model_.schedule().getUnits(),
-                                   reportStepIdx,
-                                   well_model_.comm(),
-                                   *injection_phase);
+        this->nodePressures(network.domain) = std::move(result.node_pressures);
+        this->branchData(network.domain) = std::move(result.branch_data);
+        this->invalidNodes(network.domain) = std::move(result.invalid_nodes);
     }
     this->syncLegacyProductionState_();
 
@@ -289,10 +296,24 @@ updatePressures(const int reportStepIdx,
 
     for (const auto& network : details::activeNetworks(well_model_.schedule(), reportStepIdx)) {
         auto& domain_pressures = this->nodePressures(network.domain);
+        const auto& invalid = this->invalidNodes(network.domain);
         const auto& previous_domain_pressures = previous_node_pressures[details::domainIndex(network.domain)];
 
+        if (!invalid.empty()) {
+            // The VFP tables gave no pressure for these nodes (rate/pressure outside what
+            // the tables can deliver). Keep the previous value and report the network as
+            // unbalanced so that the wells get another chance to move into range.
+            network_imbalance = std::max(network_imbalance, upper_update_bound);
+            if (this->invalid_nodes_report_step_ != reportStepIdx) {
+                this->invalid_nodes_report_step_ = reportStepIdx;
+                OpmLog::warning(fmt::format("Network: no VFP solution for node(s) {} at report step {}; "
+                                            "keeping the previous node pressure(s).",
+                                            fmt::join(invalid, ", "), reportStepIdx + 1));
+            }
+        }
+
         if (!previous_domain_pressures.empty()) {
-            for (const auto& [name, new_pressure]: domain_pressures) {
+            for (auto& [name, new_pressure]: domain_pressures) {
                 if (previous_domain_pressures.count(name) <= 0) {
                     if (std::abs(new_pressure) > network_imbalance) {
                         network_imbalance = std::abs(new_pressure);
@@ -301,6 +322,10 @@ updatePressures(const int reportStepIdx,
                 }
 
                 const auto pressure = previous_domain_pressures.at(name);
+                if (invalid.count(name) > 0) {
+                    new_pressure = pressure;
+                    continue;
+                }
                 const Scalar change = (new_pressure - pressure);
                 if (std::abs(change) > network_imbalance) {
                     network_imbalance = std::abs(change);
@@ -310,7 +335,7 @@ updatePressures(const int reportStepIdx,
                 // the maximum update is limited (to 5 bar by default, can be changed with --network-max-pressure-update-in-bars).
                 const Scalar damped_change = std::min(damping_factor * std::abs(change), upper_update_bound);
                 const Scalar sign = change > 0 ? 1. : -1.;
-                domain_pressures[name] = pressure + sign * damped_change;
+                new_pressure = pressure + sign * damped_change;
             }
             continue;
         }
@@ -346,6 +371,10 @@ updatePressures(const int reportStepIdx,
 
         const auto it = this->nodePressures(*domain).find(well->wellEcl().groupName());
         if (it != this->nodePressures(*domain).end()) {
+            if (this->invalidNodes(*domain).count(well->wellEcl().groupName()) > 0) {
+                // No valid leaf pressure this iteration; keep the well's current THP limit.
+                continue;
+            }
             if (well->isProducer()) {
                 // For producers the leaf-node pressure is the group wellhead THP;
                 // apply it directly as a dynamic THP constraint.
@@ -420,12 +449,13 @@ assignNodeAndBranchValues(std::map<std::string, data::NodeData>& nodevalues,
         return;
     }
 
-    auto converged_pressures = node_pressures_;
-    std::tie(converged_pressures, converged_branchvalues) = this->computePressures(network,
-                                                      *well_model_.getVFPProperties().getProd(),
-                                                      well_model_.schedule().getUnits(),
-                                                      reportStepIdx,
-                                                      well_model_.comm());
+    auto converged = this->computePressures(network,
+                                            *well_model_.getVFPProperties().getProd(),
+                                            well_model_.schedule().getUnits(),
+                                            reportStepIdx,
+                                            well_model_.comm());
+    const auto& converged_pressures = converged.node_pressures;
+    converged_branchvalues = std::move(converged.branch_data);
     for (const auto& [node, converged_pressure] : converged_pressures) {
         auto it = nodevalues.find(node);
         assert(it != nodevalues.end() );
@@ -491,7 +521,7 @@ initializeWell(WellInterfaceGeneric<Scalar,IndexTraits>& well)
 }
 
 template <typename Scalar, typename IndexTraits>
-std::pair<std::map<std::string, Scalar>, std::map<std::string, data::BranchData>>
+typename BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::NetworkPressures
 BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
 computePressures(const Network::ExtNetwork& network,
                  const VFPProdProperties<Scalar>& vfp_prod_props,
@@ -509,11 +539,12 @@ computePressures(const Network::ExtNetwork& network,
         network_pressure_computation(
             well_model_, network, vfp_prod_props, unit_system, reportStepIdx, comm);
 
-    return network_pressure_computation.run();
+    auto [node_pressures, branch_data] = network_pressure_computation.run();
+    return {std::move(node_pressures), std::move(branch_data), network_pressure_computation.invalidNodes()};
 }
 
 template <typename Scalar, typename IndexTraits>
-std::pair<std::map<std::string, Scalar>, std::map<std::string, data::BranchData>>
+typename BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::NetworkPressures
 BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
 computePressures(const Network::ExtNetwork& network,
                  const VFPInjProperties<Scalar>& vfp_inj_props,
@@ -532,7 +563,8 @@ computePressures(const Network::ExtNetwork& network,
         network_pressure_computation(
             well_model_, network, vfp_inj_props, unit_system, reportStepIdx, comm, injectionPhase);
 
-    return network_pressure_computation.run();
+    auto [node_pressures, branch_data] = network_pressure_computation.run();
+    return {std::move(node_pressures), std::move(branch_data), network_pressure_computation.invalidNodes()};
 }
 
 template<typename Scalar, typename IndexTraits>

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
@@ -344,26 +344,23 @@ updatePressures(const int reportStepIdx,
 
         const auto it = this->nodePressures(*domain).find(well->wellEcl().groupName());
         if (it != this->nodePressures(*domain).end()) {
-            // For producers and injectors with a well-level VFP table, the leaf-node
-            // pressure represents the wellhead THP at the group level and is correct
-            // to apply as a dynamic THP constraint.
-            // Injectors without an individual VFP table cannot use a THP constraint:
-            // computeBhpAtThpLimitInj would access a non-existent VFP table.
-            const bool can_use_thp = well->isProducer()
-                || (well->isInjector() && well->wellEcl().vfp_table_number() > 0);
-            if (!can_use_thp) {
-                continue;
+            if (well->isProducer()) {
+                // For producers, the leaf-node pressure represents the group
+                // wellhead pressure (THP), so it is correct to use as a dynamic THP limit.
+                const Scalar new_limit = it->second;
+                well->setDynamicThpLimit(new_limit);
+                SingleWellState<Scalar, IndexTraits>& ws = well_model_.wellState()[well->indexOfWell()];
+                const bool thp_is_limit = ws.production_cmode == Well::ProducerCMode::THP;
+                // TODO: not sure why the thp is NOT updated properly elsewhere
+                if (thp_is_limit) {
+                    ws.thp = well->getTHPConstraint(well_model_.summaryState());
+                }
             }
-            const Scalar new_limit = it->second;
-            well->setDynamicThpLimit(new_limit);
-            SingleWellState<Scalar, IndexTraits>& ws = well_model_.wellState()[well->indexOfWell()];
-            const bool thp_is_limit = well->isProducer()
-                ? ws.production_cmode == Well::ProducerCMode::THP
-                : ws.injection_cmode == Well::InjectorCMode::THP;
-            // TODO: not sure why the thp is NOT updated properly elsewhere
-            if (thp_is_limit) {
-                ws.thp = well->getTHPConstraint(well_model_.summaryState());
-            }
+            // Note: injection network leaf-node pressure is not applied as a well-level
+            // dynamic THP here.  The well_potentials are computed once per timestep before
+            // network iterations, so a dynamic THP set from the network is always compared
+            // against stale potentials, causing the constraint to fire incorrectly.
+            // TODO: re-enable when potentials are recomputed after each network balance.
         }
     }
     return network_imbalance;
@@ -456,11 +453,19 @@ initializeWell(WellInterfaceGeneric<Scalar,IndexTraits>& well)
     if (domain.has_value() && !this->nodePressures(*domain).empty()) {
         const auto it = this->nodePressures(*domain).find(well.wellEcl().groupName());
         if (it != this->nodePressures(*domain).end()) {
-            // Only apply a dynamic THP if the well can actually use THP control:
-            // producers always can; injectors need an individual VFP table.
-            const bool can_use_thp = well.isProducer()
-                || (well.isInjector() && well.wellEcl().vfp_table_number() > 0);
-            if (can_use_thp) {
+            // For producers, carry forward the network THP into the new timestep so
+            // prepareTimeStep() and the first Newton solve start with the right constraint.
+            // For injectors, deliberately do NOT initialize the dynamic THP here.
+            // At the start of step N+1, domain_node_pressures_ holds step N's converged
+            // injection network pressure. Applying it via setDynamicThpLimit() before
+            // prepareTimeStep() causes solveWellEquation() to switch injectors to THP
+            // control mode; that mode then persists into updateWellControls() where the
+            // operability check at the (possibly out-of-range) THP fails.
+            // Step 1 is safe because domain_node_pressures_ is empty on first entry and
+            // initializeWell() is a no-op for injectors there.  The same deferred behavior
+            // is the correct default for all subsequent steps: the injection network THP
+            // is applied naturally by the first updatePressures() inside the Newton loop.
+            if (well.isProducer()) {
                 well.setDynamicThpLimit(it->second);
             }
         }

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
@@ -344,17 +344,16 @@ updatePressures(const int reportStepIdx,
 
         const auto it = this->nodePressures(*domain).find(well->wellEcl().groupName());
         if (it != this->nodePressures(*domain).end()) {
-            // The well belongs to a group with a network pressure constraint.
-            // For injectors, only set the dynamic THP if the well has its own
-            // VFP table (vfp_table_number > 0). Without a well-level VFP table
-            // the operability check (computeBhpAtThpLimitInj) cannot use the
-            // constraint and will mark the well inoperable.
+            // For producers and injectors with a well-level VFP table, the leaf-node
+            // pressure represents the wellhead THP at the group level and is correct
+            // to apply as a dynamic THP constraint.
+            // Injectors without an individual VFP table cannot use a THP constraint:
+            // computeBhpAtThpLimitInj would access a non-existent VFP table.
             const bool can_use_thp = well->isProducer()
                 || (well->isInjector() && well->wellEcl().vfp_table_number() > 0);
             if (!can_use_thp) {
                 continue;
             }
-            // Set the dynamic THP constraint of the well accordingly.
             const Scalar new_limit = it->second;
             well->setDynamicThpLimit(new_limit);
             SingleWellState<Scalar, IndexTraits>& ws = well_model_.wellState()[well->indexOfWell()];
@@ -457,11 +456,8 @@ initializeWell(WellInterfaceGeneric<Scalar,IndexTraits>& well)
     if (domain.has_value() && !this->nodePressures(*domain).empty()) {
         const auto it = this->nodePressures(*domain).find(well.wellEcl().groupName());
         if (it != this->nodePressures(*domain).end()) {
-            // The well belongs to a group which has a network nodal pressure.
-            // For injectors, only set the dynamic THP if the well has its own
-            // VFP table (vfp_table_number > 0). Without a well-level VFP table
-            // the operability check (computeBhpAtThpLimitInj) cannot use the
-            // constraint and will mark the well inoperable.
+            // Only apply a dynamic THP if the well can actually use THP control:
+            // producers always can; injectors need an individual VFP table.
             const bool can_use_thp = well.isProducer()
                 || (well.isInjector() && well.wellEcl().vfp_table_number() > 0);
             if (can_use_thp) {

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
@@ -344,8 +344,17 @@ updatePressures(const int reportStepIdx,
 
         const auto it = this->nodePressures(*domain).find(well->wellEcl().groupName());
         if (it != this->nodePressures(*domain).end()) {
-            // The well belongs to a group with a network pressure constraint,
-            // set the dynamic THP constraint of the well accordingly.
+            // The well belongs to a group with a network pressure constraint.
+            // For injectors, only set the dynamic THP if the well has its own
+            // VFP table (vfp_table_number > 0). Without a well-level VFP table
+            // the operability check (computeBhpAtThpLimitInj) cannot use the
+            // constraint and will mark the well inoperable.
+            const bool can_use_thp = well->isProducer()
+                || (well->isInjector() && well->wellEcl().vfp_table_number() > 0);
+            if (!can_use_thp) {
+                continue;
+            }
+            // Set the dynamic THP constraint of the well accordingly.
             const Scalar new_limit = it->second;
             well->setDynamicThpLimit(new_limit);
             SingleWellState<Scalar, IndexTraits>& ws = well_model_.wellState()[well->indexOfWell()];
@@ -448,9 +457,16 @@ initializeWell(WellInterfaceGeneric<Scalar,IndexTraits>& well)
     if (domain.has_value() && !this->nodePressures(*domain).empty()) {
         const auto it = this->nodePressures(*domain).find(well.wellEcl().groupName());
         if (it != this->nodePressures(*domain).end()) {
-            // The well belongs to a group which has a network nodal pressure,
-            // set the dynamic THP constraint based on the network nodal pressure
-            well.setDynamicThpLimit(it->second);
+            // The well belongs to a group which has a network nodal pressure.
+            // For injectors, only set the dynamic THP if the well has its own
+            // VFP table (vfp_table_number > 0). Without a well-level VFP table
+            // the operability check (computeBhpAtThpLimitInj) cannot use the
+            // constraint and will mark the well inoperable.
+            const bool can_use_thp = well.isProducer()
+                || (well.isInjector() && well.wellEcl().vfp_table_number() > 0);
+            if (can_use_thp) {
+                well.setDynamicThpLimit(it->second);
+            }
         }
     }
 }

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
@@ -35,6 +35,7 @@
 #include <opm/simulators/wells/BlackoilWellModelNetworkPressureComputation.hpp>
 #include <opm/simulators/wells/VFPProperties.hpp>
 
+#include <algorithm>
 #include <cassert>
 
 namespace Opm {
@@ -52,23 +53,38 @@ namespace details {
     }
 
     /// Helper to get all active networks (production, gas injection, water injection) at a given time step.
-    std::vector<std::reference_wrapper<const Network::ExtNetwork>>
+    std::vector<ActiveNetworkDescriptor>
     activeNetworks(const Schedule& schedule, const int timeStepIdx)
     {
-        std::vector<std::reference_wrapper<const Network::ExtNetwork>> active_networks;
+        std::vector<ActiveNetworkDescriptor> active_networks;
         const auto& sstate = schedule[timeStepIdx];
         if (sstate.network().active()) {
-            active_networks.push_back(std::cref(sstate.network()));
+            active_networks.push_back({NetworkDomain::Production, std::cref(sstate.network())});
         }
         if (sstate.injectionNetwork.get_ptr(Phase::GAS) != nullptr
             && sstate.injectionNetwork.get_ptr(Phase::GAS)->active()) {
-            active_networks.push_back(std::cref(*sstate.injectionNetwork.get_ptr(Phase::GAS)));
+            active_networks.push_back({NetworkDomain::InjectionGas, std::cref(*sstate.injectionNetwork.get_ptr(Phase::GAS))});
         }
         if (sstate.injectionNetwork.get_ptr(Phase::WATER) != nullptr
             && sstate.injectionNetwork.get_ptr(Phase::WATER)->active()) {
-            active_networks.push_back(std::cref(*sstate.injectionNetwork.get_ptr(Phase::WATER)));
+            active_networks.push_back({NetworkDomain::InjectionWater, std::cref(*sstate.injectionNetwork.get_ptr(Phase::WATER))});
         }
         return active_networks;
+    }
+
+    std::optional<Phase> injectionPhaseForDomain(const NetworkDomain domain)
+    {
+        switch (domain) {
+        case NetworkDomain::InjectionGas:
+            return Phase::GAS;
+        case NetworkDomain::InjectionWater:
+            return Phase::WATER;
+        case NetworkDomain::Production:
+        case NetworkDomain::Count:
+            return std::nullopt;
+        }
+
+        return std::nullopt;
     }
 } // namespace details
 
@@ -93,6 +109,7 @@ setFromRestart(const std::optional<std::map<std::string, double>>& node_pressure
                 this->node_pressures_[it.first] = it.second;
             }
         }
+        this->syncProductionDomainState_();
     }
 }
 
@@ -102,7 +119,7 @@ updateActiveState(const int report_step)
 {
     this->active_ = false;
     for (const auto& network : details::activeNetworks(well_model_.schedule(), report_step)) {
-        updateActiveStateImpl(network);
+        updateActiveStateImpl(network.network.get());
     }
     this->active_ = well_model_.comm().max(active_);
 }
@@ -159,10 +176,15 @@ template<typename Scalar, typename IndexTraits>
 bool BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
 needPreStepRebalance(const int report_step) const
 {
-    const auto& network = well_model_.schedule()[report_step].network();
+    const auto active_networks = details::activeNetworks(well_model_.schedule(), report_step);
     bool network_rebalance_necessary = false;
     for (const auto& well : well_model_.genericWells()) {
-        const bool is_partof_network = network.has_node(well->wellEcl().groupName());
+        const bool is_partof_network = std::any_of(active_networks.begin(),
+                                                   active_networks.end(),
+                                                   [&](const auto& network)
+                                                   {
+                                                       return network.network.get().has_node(well->wellEcl().groupName());
+                                                   });
         // TODO: we might find more relevant events to be included here (including network change events?)
         const auto& events = well_model_.wellState().well(well->indexOfWell()).events;
         if (is_partof_network && events.hasEvent(ScheduleEvents::WELL_STATUS_CHANGE)) {
@@ -179,8 +201,7 @@ bool BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
 shouldBalance(const int reportStepIdx) const
 {
     // if network is not active, we do not need to balance the network
-    const auto& network = well_model_.schedule()[reportStepIdx].network();
-    if (!network.active()) {
+    if (!details::anyNetworkActive(well_model_.schedule(), reportStepIdx)) {
         return false;
     }
 
@@ -205,11 +226,11 @@ bool BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
 willBalanceOnNextIteration(const int reportStepIdx) const
 {
     // if network is not active, we do not need to balance the network
-    const auto& schedule_state = well_model_.schedule()[reportStepIdx];
-    if (!schedule_state.network().active()) {
+    if (!details::anyNetworkActive(well_model_.schedule(), reportStepIdx)) {
         return false;
     }
 
+    const auto& schedule_state = well_model_.schedule()[reportStepIdx];
     if (schedule_state.network_balance().mode() == Network::Balance::CalcMode::NUPCOL) {
         const int nupcol = schedule_state.nupcol();
         return well_model_.iterationContext().withinNupcol(nupcol - 1); // Note the -1 here!
@@ -228,19 +249,35 @@ updatePressures(const int reportStepIdx,
                 const Scalar upper_update_bound)
 {
     OPM_TIMEFUNCTION();
-    // Get the network and return if inactive (no wells in network at this time)
-    const auto& network = well_model_.schedule()[reportStepIdx].network();
-    if (!network.active()) {
+    if (!details::anyNetworkActive(well_model_.schedule(), reportStepIdx)) {
         return 0.0;
     }
 
-    const auto previous_node_pressures = node_pressures_;
+    this->syncProductionDomainState_();
+    const auto previous_node_pressures = this->domain_node_pressures_;
 
-    std::tie(node_pressures_, branch_data_) = this->computePressures(network,
-                                             *well_model_.getVFPProperties().getProd(),
-                                             well_model_.schedule().getUnits(),
-                                             reportStepIdx,
-                                             well_model_.comm());
+    for (const auto& network : details::activeNetworks(well_model_.schedule(), reportStepIdx)) {
+        if (network.domain == details::NetworkDomain::Production) {
+            std::tie(this->nodePressures(network.domain), this->branchData(network.domain)) =
+                this->computePressures(network.network.get(),
+                                       *well_model_.getVFPProperties().getProd(),
+                                       well_model_.schedule().getUnits(),
+                                       reportStepIdx,
+                                       well_model_.comm());
+            continue;
+        }
+
+        const auto injection_phase = details::injectionPhaseForDomain(network.domain);
+        assert(injection_phase.has_value());
+        std::tie(this->nodePressures(network.domain), this->branchData(network.domain)) =
+            this->computePressures(network.network.get(),
+                                   *well_model_.getVFPProperties().getInj(),
+                                   well_model_.schedule().getUnits(),
+                                   reportStepIdx,
+                                   well_model_.comm(),
+                                   *injection_phase);
+    }
+    this->syncLegacyProductionState_();
 
     // here, the network imbalance is the difference between the previous nodal pressure and the new nodal pressure
     Scalar network_imbalance = 0.;
@@ -248,52 +285,76 @@ updatePressures(const int reportStepIdx,
         return network_imbalance;
     }
 
-    if (!previous_node_pressures.empty()) {
-        for (const auto& [name, new_pressure]: node_pressures_) {
-            if (previous_node_pressures.count(name) <= 0) {
-                if (std::abs(new_pressure) > network_imbalance) {
-                    network_imbalance = std::abs(new_pressure);
+    for (const auto& network : details::activeNetworks(well_model_.schedule(), reportStepIdx)) {
+        auto& domain_pressures = this->nodePressures(network.domain);
+        const auto& previous_domain_pressures = previous_node_pressures[details::domainIndex(network.domain)];
+
+        if (!previous_domain_pressures.empty()) {
+            for (const auto& [name, new_pressure]: domain_pressures) {
+                if (previous_domain_pressures.count(name) <= 0) {
+                    if (std::abs(new_pressure) > network_imbalance) {
+                        network_imbalance = std::abs(new_pressure);
+                    }
+                    continue;
                 }
-                continue;
+
+                const auto pressure = previous_domain_pressures.at(name);
+                const Scalar change = (new_pressure - pressure);
+                if (std::abs(change) > network_imbalance) {
+                    network_imbalance = std::abs(change);
+                }
+                // We dampen the nodal pressure change during one iteration since our nodal pressure calculation
+                // is somewhat explicit. There is a relative dampening factor applied to the update value, and also
+                // the maximum update is limited (to 5 bar by default, can be changed with --network-max-pressure-update-in-bars).
+                const Scalar damped_change = std::min(damping_factor * std::abs(change), upper_update_bound);
+                const Scalar sign = change > 0 ? 1. : -1.;
+                domain_pressures[name] = pressure + sign * damped_change;
             }
-            const auto pressure = previous_node_pressures.at(name);
-            const Scalar change = (new_pressure - pressure);
-            if (std::abs(change) > network_imbalance) {
-                network_imbalance = std::abs(change);
-            }
-            // We dampen the nodal pressure change during one iteration since our nodal pressure calculation
-            // is somewhat explicit. There is a relative dampening factor applied to the update value, and also
-            // the maximum update is limited (to 5 bar by default, can be changed with --network-max-pressure-update-in-bars).
-            const Scalar damped_change = std::min(damping_factor * std::abs(change), upper_update_bound);
-            const Scalar sign = change > 0 ? 1. : -1.;
-            node_pressures_[name] = pressure + sign * damped_change;
+            continue;
         }
-    } else {
-        for (const auto& [name, pressure]: node_pressures_) {
+
+        for (const auto& [name, pressure]: domain_pressures) {
             if (std::abs(pressure) > network_imbalance) {
                 network_imbalance = std::abs(pressure);
             }
         }
     }
+    this->syncLegacyProductionState_();
 
     for (auto& well : well_model_.genericWells()) {
 
-        // Producers only, since we so far only support the
-        // "extended" network model (properties defined by
-        // BRANPROP and NODEPROP) which only applies to producers.
-        if (well->isProducer() && well->wellEcl().predictionMode()) {
-            const auto it = node_pressures_.find(well->wellEcl().groupName());
-            if (it != node_pressures_.end()) {
-                // The well belongs to a group with has a network pressure constraint,
-                // set the dynamic THP constraint of the well accordingly.
-                const Scalar new_limit = it->second;
-                well->setDynamicThpLimit(new_limit);
-                SingleWellState<Scalar, IndexTraits>& ws = well_model_.wellState()[well->indexOfWell()];
-                const bool thp_is_limit = ws.production_cmode == Well::ProducerCMode::THP;
-                // TODO: not sure why the thp is NOT updated properly elsewhere
-                if (thp_is_limit) {
-                    ws.thp = well->getTHPConstraint(well_model_.summaryState());
-                }
+        if (!well->wellEcl().predictionMode()) {
+            continue;
+        }
+
+        std::optional<details::NetworkDomain> domain;
+        if (well->isProducer()) {
+            domain = details::NetworkDomain::Production;
+        } else if (well->isInjector()) {
+            if (well->wellEcl().injectorType() == InjectorType::GAS) {
+                domain = details::NetworkDomain::InjectionGas;
+            } else if (well->wellEcl().injectorType() == InjectorType::WATER) {
+                domain = details::NetworkDomain::InjectionWater;
+            }
+        }
+
+        if (!domain.has_value()) {
+            continue;
+        }
+
+        const auto it = this->nodePressures(*domain).find(well->wellEcl().groupName());
+        if (it != this->nodePressures(*domain).end()) {
+            // The well belongs to a group with a network pressure constraint,
+            // set the dynamic THP constraint of the well accordingly.
+            const Scalar new_limit = it->second;
+            well->setDynamicThpLimit(new_limit);
+            SingleWellState<Scalar, IndexTraits>& ws = well_model_.wellState()[well->indexOfWell()];
+            const bool thp_is_limit = well->isProducer()
+                ? ws.production_cmode == Well::ProducerCMode::THP
+                : ws.injection_cmode == Well::InjectorCMode::THP;
+            // TODO: not sure why the thp is NOT updated properly elsewhere
+            if (thp_is_limit) {
+                ws.thp = well->getTHPConstraint(well_model_.summaryState());
             }
         }
     }
@@ -361,8 +422,8 @@ template<typename Scalar, typename IndexTraits>
 void BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
 initialize(const int report_step)
 {
-    const auto& network = well_model_.schedule()[report_step].network();
-    if (network.active() && !node_pressures_.empty()) {
+    if (details::anyNetworkActive(well_model_.schedule(), report_step)) {
+        this->syncProductionDomainState_();
         for (auto& well : well_model_.genericWells()) {
             initializeWell(*well);
         }
@@ -373,12 +434,20 @@ template<typename Scalar, typename IndexTraits>
 void BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
 initializeWell(WellInterfaceGeneric<Scalar,IndexTraits>& well)
 {
-    // Producers only, since we so far only support the
-    // "extended" network model (properties defined by
-    // BRANPROP and NODEPROP) which only applies to producers.
-    if (well.isProducer() && !node_pressures_.empty()) {
-        const auto it = this->node_pressures_.find(well.wellEcl().groupName());
-        if (it != this->node_pressures_.end()) {
+    std::optional<details::NetworkDomain> domain;
+    if (well.isProducer()) {
+        domain = details::NetworkDomain::Production;
+    } else if (well.isInjector()) {
+        if (well.wellEcl().injectorType() == InjectorType::GAS) {
+            domain = details::NetworkDomain::InjectionGas;
+        } else if (well.wellEcl().injectorType() == InjectorType::WATER) {
+            domain = details::NetworkDomain::InjectionWater;
+        }
+    }
+
+    if (domain.has_value() && !this->nodePressures(*domain).empty()) {
+        const auto it = this->nodePressures(*domain).find(well.wellEcl().groupName());
+        if (it != this->nodePressures(*domain).end()) {
             // The well belongs to a group which has a network nodal pressure,
             // set the dynamic THP constraint based on the network nodal pressure
             well.setDynamicThpLimit(it->second);
@@ -408,6 +477,29 @@ computePressures(const Network::ExtNetwork& network,
     return network_pressure_computation.run();
 }
 
+template <typename Scalar, typename IndexTraits>
+std::pair<std::map<std::string, Scalar>, std::map<std::string, data::BranchData>>
+BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
+computePressures(const Network::ExtNetwork& network,
+                 const VFPInjProperties<Scalar>& vfp_inj_props,
+                 const UnitSystem& unit_system,
+                 const int reportStepIdx,
+                 const Parallel::Communication& comm,
+                 const Phase injectionPhase) const
+{
+    OPM_TIMEFUNCTION();
+    if (!network.active()) {
+        return {};
+    }
+
+    NetworkPressureComputation<BlackoilWellModelGeneric<Scalar, IndexTraits>,
+                               VFPInjProperties<Scalar>>
+        network_pressure_computation(
+            well_model_, network, vfp_inj_props, unit_system, reportStepIdx, comm, injectionPhase);
+
+    return network_pressure_computation.run();
+}
+
 template<typename Scalar, typename IndexTraits>
 bool BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
 operator==(const BlackoilWellModelNetworkGeneric<Scalar,IndexTraits>& rhs) const
@@ -417,7 +509,11 @@ operator==(const BlackoilWellModelNetworkGeneric<Scalar,IndexTraits>& rhs) const
         && this->node_pressures_ == rhs.node_pressures_
         && this->last_valid_node_pressures_ == rhs.last_valid_node_pressures_
         && this->branch_data_ == rhs.branch_data_
-        && this->last_valid_branch_data_ == rhs.last_valid_branch_data_;
+    && this->last_valid_branch_data_ == rhs.last_valid_branch_data_
+    && this->domain_node_pressures_ == rhs.domain_node_pressures_
+    && this->last_valid_domain_node_pressures_ == rhs.last_valid_domain_node_pressures_
+    && this->domain_branch_data_ == rhs.domain_branch_data_
+    && this->last_valid_domain_branch_data_ == rhs.last_valid_domain_branch_data_;
 }
 
 template class BlackoilWellModelNetworkGeneric<double, BlackOilDefaultFluidSystemIndices>;

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
@@ -35,6 +35,8 @@
 #include <opm/simulators/wells/BlackoilWellModelNetworkPressureComputation.hpp>
 #include <opm/simulators/wells/VFPProperties.hpp>
 
+#include <opm/input/eclipse/Schedule/VFPInjTable.hpp>
+
 #include <algorithm>
 #include <cassert>
 
@@ -345,8 +347,8 @@ updatePressures(const int reportStepIdx,
         const auto it = this->nodePressures(*domain).find(well->wellEcl().groupName());
         if (it != this->nodePressures(*domain).end()) {
             if (well->isProducer()) {
-                // For producers, the leaf-node pressure represents the group
-                // wellhead pressure (THP), so it is correct to use as a dynamic THP limit.
+                // For producers the leaf-node pressure is the group wellhead THP;
+                // apply it directly as a dynamic THP constraint.
                 const Scalar new_limit = it->second;
                 well->setDynamicThpLimit(new_limit);
                 SingleWellState<Scalar, IndexTraits>& ws = well_model_.wellState()[well->indexOfWell()];
@@ -355,12 +357,31 @@ updatePressures(const int reportStepIdx,
                 if (thp_is_limit) {
                     ws.thp = well->getTHPConstraint(well_model_.summaryState());
                 }
+            } else if (well->isInjector() && well->wellEcl().vfp_table_number() > 0) {
+                // For injectors, apply the network leaf-node pressure as a dynamic THP only
+                // if it falls within the individual well's VFPINJ table THP range.
+                // If P_leaf is outside the range, computeBhpAtThpLimitInj would extrapolate
+                // to invalid values and mark the well inoperable, causing a rate collapse.
+                const auto& inj_vfp = *well_model_.getVFPProperties().getInj();
+                const int table_id = well->wellEcl().injectionControls(
+                    well_model_.summaryState()).vfp_table_number;
+                if (inj_vfp.hasTable(table_id)) {
+                    const auto& thp_axis = inj_vfp.getTable(table_id).getTHPAxis();
+                    const Scalar min_thp = static_cast<Scalar>(thp_axis.front());
+                    const Scalar max_thp = static_cast<Scalar>(thp_axis.back());
+                    const Scalar new_limit = it->second;
+                    if (new_limit >= min_thp && new_limit <= max_thp) {
+                        well->setDynamicThpLimit(new_limit);
+                        SingleWellState<Scalar, IndexTraits>& ws =
+                            well_model_.wellState()[well->indexOfWell()];
+                        const bool thp_is_limit =
+                            ws.injection_cmode == Well::InjectorCMode::THP;
+                        if (thp_is_limit) {
+                            ws.thp = well->getTHPConstraint(well_model_.summaryState());
+                        }
+                    }
+                }
             }
-            // Note: injection network leaf-node pressure is not applied as a well-level
-            // dynamic THP here.  The well_potentials are computed once per timestep before
-            // network iterations, so a dynamic THP set from the network is always compared
-            // against stale potentials, causing the constraint to fire incorrectly.
-            // TODO: re-enable when potentials are recomputed after each network balance.
         }
     }
     return network_imbalance;
@@ -453,18 +474,15 @@ initializeWell(WellInterfaceGeneric<Scalar,IndexTraits>& well)
     if (domain.has_value() && !this->nodePressures(*domain).empty()) {
         const auto it = this->nodePressures(*domain).find(well.wellEcl().groupName());
         if (it != this->nodePressures(*domain).end()) {
-            // For producers, carry forward the network THP into the new timestep so
-            // prepareTimeStep() and the first Newton solve start with the right constraint.
-            // For injectors, deliberately do NOT initialize the dynamic THP here.
-            // At the start of step N+1, domain_node_pressures_ holds step N's converged
-            // injection network pressure. Applying it via setDynamicThpLimit() before
-            // prepareTimeStep() causes solveWellEquation() to switch injectors to THP
-            // control mode; that mode then persists into updateWellControls() where the
-            // operability check at the (possibly out-of-range) THP fails.
-            // Step 1 is safe because domain_node_pressures_ is empty on first entry and
-            // initializeWell() is a no-op for injectors there.  The same deferred behavior
-            // is the correct default for all subsequent steps: the injection network THP
-            // is applied naturally by the first updatePressures() inside the Newton loop.
+            // For producers, carry forward the previous step's converged network pressure
+            // so that prepareTimeStep() starts with the correct THP constraint.
+            // For injectors, do NOT set dynamic_thp_limit_ here.  Setting it before
+            // prepareTimeStep() causes solveWellEquation() to switch the injector to THP
+            // mode; the resulting rate change propagates through the Newton loop and
+            // produces large network imbalances that fail to converge in the allowed
+            // iterations.  The injection network THP is applied for the first time during
+            // the Newton loop via updatePressures(), where the stale-potential bypass in
+            // WellConstraints::activeInjectionConstraint ensures correct switching.
             if (well.isProducer()) {
                 well.setDynamicThpLimit(it->second);
             }

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
@@ -78,21 +78,6 @@ namespace details {
         }
         return active_networks;
     }
-
-    std::optional<Phase> injectionPhaseForDomain(const NetworkDomain domain)
-    {
-        switch (domain) {
-        case NetworkDomain::InjectionGas:
-            return Phase::GAS;
-        case NetworkDomain::InjectionWater:
-            return Phase::WATER;
-        case NetworkDomain::Production:
-        case NetworkDomain::Count:
-            return std::nullopt;
-        }
-
-        return std::nullopt;
-    }
 } // namespace details
 
 
@@ -273,14 +258,11 @@ updatePressures(const int reportStepIdx,
                                             reportStepIdx,
                                             well_model_.comm());
         } else {
-            const auto injection_phase = details::injectionPhaseForDomain(network.domain);
-            assert(injection_phase.has_value());
             result = this->computePressures(network.network.get(),
                                             *well_model_.getVFPProperties().getInj(),
                                             well_model_.schedule().getUnits(),
                                             reportStepIdx,
-                                            well_model_.comm(),
-                                            *injection_phase);
+                                            well_model_.comm());
         }
         this->nodePressures(network.domain) = std::move(result.node_pressures);
         this->branchData(network.domain) = std::move(result.branch_data);
@@ -532,8 +514,7 @@ computePressures(const Network::ExtNetwork& network,
                  const VFPInjProperties<Scalar>& vfp_inj_props,
                  const UnitSystem& unit_system,
                  const int reportStepIdx,
-                 const Parallel::Communication& comm,
-                 const Phase injectionPhase) const
+                 const Parallel::Communication& comm) const
 {
     OPM_TIMEFUNCTION();
     if (!network.active()) {
@@ -543,7 +524,7 @@ computePressures(const Network::ExtNetwork& network,
     NetworkPressureComputation<BlackoilWellModelGeneric<Scalar, IndexTraits>,
                                VFPInjProperties<Scalar>>
         network_pressure_computation(
-            well_model_, network, vfp_inj_props, unit_system, reportStepIdx, comm, injectionPhase);
+            well_model_, network, vfp_inj_props, unit_system, reportStepIdx, comm);
 
     auto [node_pressures, branch_data] = network_pressure_computation.run();
     return {std::move(node_pressures), std::move(branch_data), network_pressure_computation.invalidNodes()};

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.cpp
@@ -354,16 +354,7 @@ updatePressures(const int reportStepIdx,
             continue;
         }
 
-        std::optional<details::NetworkDomain> domain;
-        if (well->isProducer()) {
-            domain = details::NetworkDomain::Production;
-        } else if (well->isInjector()) {
-            if (well->wellEcl().injectorType() == InjectorType::GAS) {
-                domain = details::NetworkDomain::InjectionGas;
-            } else if (well->wellEcl().injectorType() == InjectorType::WATER) {
-                domain = details::NetworkDomain::InjectionWater;
-            }
-        }
+        const auto domain = details::domainForWell(*well);
 
         if (!domain.has_value()) {
             continue;
@@ -490,16 +481,7 @@ template<typename Scalar, typename IndexTraits>
 void BlackoilWellModelNetworkGeneric<Scalar, IndexTraits>::
 initializeWell(WellInterfaceGeneric<Scalar,IndexTraits>& well)
 {
-    std::optional<details::NetworkDomain> domain;
-    if (well.isProducer()) {
-        domain = details::NetworkDomain::Production;
-    } else if (well.isInjector()) {
-        if (well.wellEcl().injectorType() == InjectorType::GAS) {
-            domain = details::NetworkDomain::InjectionGas;
-        } else if (well.wellEcl().injectorType() == InjectorType::WATER) {
-            domain = details::NetworkDomain::InjectionWater;
-        }
-    }
+    const auto domain = details::domainForWell(well);
 
     if (domain.has_value() && !this->nodePressures(*domain).empty()) {
         const auto it = this->nodePressures(*domain).find(well.wellEcl().groupName());
@@ -576,11 +558,11 @@ operator==(const BlackoilWellModelNetworkGeneric<Scalar,IndexTraits>& rhs) const
         && this->node_pressures_ == rhs.node_pressures_
         && this->last_valid_node_pressures_ == rhs.last_valid_node_pressures_
         && this->branch_data_ == rhs.branch_data_
-    && this->last_valid_branch_data_ == rhs.last_valid_branch_data_
-    && this->domain_node_pressures_ == rhs.domain_node_pressures_
-    && this->last_valid_domain_node_pressures_ == rhs.last_valid_domain_node_pressures_
-    && this->domain_branch_data_ == rhs.domain_branch_data_
-    && this->last_valid_domain_branch_data_ == rhs.last_valid_domain_branch_data_;
+        && this->last_valid_branch_data_ == rhs.last_valid_branch_data_
+        && this->domain_node_pressures_ == rhs.domain_node_pressures_
+        && this->last_valid_domain_node_pressures_ == rhs.last_valid_domain_node_pressures_
+        && this->domain_branch_data_ == rhs.domain_branch_data_
+        && this->last_valid_domain_branch_data_ == rhs.last_valid_domain_branch_data_;
 }
 
 template class BlackoilWellModelNetworkGeneric<double, BlackOilDefaultFluidSystemIndices>;

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.hpp
@@ -24,6 +24,7 @@
 #define OPM_BLACKOILWELLMODEL_NETWORK_GENERIC_HEADER_INCLUDED
 
 #include <opm/input/eclipse/Schedule/Network/ExtNetwork.hpp>
+#include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>
 
 #include <opm/output/data/Groups.hpp>
 
@@ -65,6 +66,24 @@ namespace details {
         NetworkDomain domain;
         std::reference_wrapper<const Network::ExtNetwork> network;
     };
+
+    /// The network a well belongs to, or nullopt for a well that is in none of them.
+    template<class Well>
+    std::optional<NetworkDomain> domainForWell(const Well& well)
+    {
+        if (well.isProducer()) {
+            return NetworkDomain::Production;
+        }
+        if (well.isInjector()) {
+            if (well.wellEcl().injectorType() == InjectorType::GAS) {
+                return NetworkDomain::InjectionGas;
+            }
+            if (well.wellEcl().injectorType() == InjectorType::WATER) {
+                return NetworkDomain::InjectionWater;
+            }
+        }
+        return std::nullopt;
+    }
 
     /// Helper to check if any network (production, gas injection, water injection) is active at a given time step.
     bool anyNetworkActive(const Schedule& schedule, const int timeStepIdx);

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.hpp
@@ -44,6 +44,18 @@ namespace Opm {
 
 namespace Opm {
 
+namespace details {
+
+    /// Helper to check if any network (production, gas injection, water injection) is active at a given time step.
+    bool anyNetworkActive(const Schedule& schedule, const int timeStepIdx);
+
+    /// Helper to get all active networks (production, gas injection, water injection) at a given time step.
+    std::vector<std::reference_wrapper<const Network::ExtNetwork>>
+    activeNetworks(const Schedule& schedule, const int timeStepIdx);
+
+} // namespace details
+
+
 /// Class for handling the blackoil well network model.
 template<typename Scalar, typename IndexTraits>
 class BlackoilWellModelNetworkGeneric

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.hpp
@@ -33,6 +33,7 @@
 #include <array>
 #include <map>
 #include <optional>
+#include <set>
 #include <string>
 
 namespace Opm {
@@ -158,14 +159,24 @@ public:
     bool operator==(const BlackoilWellModelNetworkGeneric<Scalar,IndexTraits>& rhs) const;
 
 protected:
-    std::pair<std::map<std::string, Scalar>, std::map<std::string, data::BranchData>>
+    /// Result of one network pressure evaluation for one network (domain).
+    struct NetworkPressures
+    {
+        std::map<std::string, Scalar> node_pressures;
+        std::map<std::string, data::BranchData> branch_data;
+        // Nodes (and their descendants) whose VFP lookup has no solution; their
+        // node_pressures entries are placeholders and must not be used.
+        std::set<std::string> invalid_nodes;
+    };
+
+    NetworkPressures
     computePressures(const Network::ExtNetwork& network,
                      const VFPProdProperties<Scalar>& vfp_prod_props,
                      const UnitSystem& unit_system,
                      const int reportStepIdx,
                      const Parallel::Communication& comm) const;
 
-    std::pair<std::map<std::string, Scalar>, std::map<std::string, data::BranchData>>
+    NetworkPressures
     computePressures(const Network::ExtNetwork& network,
                      const VFPInjProperties<Scalar>& vfp_inj_props,
                      const UnitSystem& unit_system,
@@ -200,6 +211,16 @@ protected:
         return domain_branch_data_[details::domainIndex(domain)];
     }
 
+    const std::set<std::string>& invalidNodes(const details::NetworkDomain domain) const
+    {
+        return domain_invalid_nodes_[details::domainIndex(domain)];
+    }
+
+    std::set<std::string>& invalidNodes(const details::NetworkDomain domain)
+    {
+        return domain_invalid_nodes_[details::domainIndex(domain)];
+    }
+
     void syncLegacyProductionState_()
     {
         this->node_pressures_ = this->nodePressures(productionNetworkDomain());
@@ -222,6 +243,10 @@ protected:
     // Domain-scoped pressure state to avoid collisions between production and injection networks.
     std::array<std::map<std::string, Scalar>, details::domainIndex(details::NetworkDomain::Count)> domain_node_pressures_;
     std::array<std::map<std::string, data::BranchData>, details::domainIndex(details::NetworkDomain::Count)> domain_branch_data_;
+    // Nodes without a valid VFP solution in the last evaluation (per domain); not serialized,
+    // recomputed on every updatePressures().
+    std::array<std::set<std::string>, details::domainIndex(details::NetworkDomain::Count)> domain_invalid_nodes_;
+    int invalid_nodes_report_step_{-1};
     // Valid network pressures for output and initialization for safe restart after failed iterations
     std::map<std::string, Scalar> last_valid_node_pressures_;
     // Valid network branch pressure drops and flow rates for output (outlet branch for production network, inlet branch for injection network) for safe restart after failed iterations

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.hpp
@@ -138,6 +138,7 @@ protected:
                      const int reportStepIdx,
                      const Parallel::Communication& comm) const;
 
+    void updateActiveStateImpl(const Network::ExtNetwork& network);
 
     bool active_{false};
     BlackoilWellModelGeneric<Scalar,IndexTraits>& well_model_;

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.hpp
@@ -30,6 +30,7 @@
 #include <opm/simulators/flow/NewtonIterationContext.hpp>
 #include <opm/simulators/utils/ParallelCommunication.hpp>
 
+#include <array>
 #include <map>
 #include <optional>
 #include <string>
@@ -39,6 +40,7 @@ namespace Opm {
     class UnitSystem;
     template<class Scalar, class IndexTraits> class BlackoilWellModelGeneric;
     template<typename Scalar, typename IndexTraits> class WellInterfaceGeneric;
+    template<typename Scalar> class VFPInjProperties;
     template<typename Scalar> class VFPProdProperties;
 }
 
@@ -46,11 +48,28 @@ namespace Opm {
 
 namespace details {
 
+    enum class NetworkDomain : std::size_t {
+        Production = 0,
+        InjectionGas,
+        InjectionWater,
+        Count
+    };
+
+    constexpr std::size_t domainIndex(const NetworkDomain domain)
+    {
+        return static_cast<std::size_t>(domain);
+    }
+
+    struct ActiveNetworkDescriptor {
+        NetworkDomain domain;
+        std::reference_wrapper<const Network::ExtNetwork> network;
+    };
+
     /// Helper to check if any network (production, gas injection, water injection) is active at a given time step.
     bool anyNetworkActive(const Schedule& schedule, const int timeStepIdx);
 
     /// Helper to get all active networks (production, gas injection, water injection) at a given time step.
-    std::vector<std::reference_wrapper<const Network::ExtNetwork>>
+    std::vector<ActiveNetworkDescriptor>
     activeNetworks(const Schedule& schedule, const int timeStepIdx);
 
 } // namespace details
@@ -111,12 +130,16 @@ public:
     {
         this->last_valid_node_pressures_ = this->node_pressures_;
         this->last_valid_branch_data_ = this->branch_data_;
+        this->last_valid_domain_node_pressures_ = this->domain_node_pressures_;
+        this->last_valid_domain_branch_data_ = this->domain_branch_data_;
     }
 
     void resetState()
     {
         this->node_pressures_ = this->last_valid_node_pressures_;
         this->branch_data_ = this->last_valid_branch_data_;
+        this->domain_node_pressures_ = this->last_valid_domain_node_pressures_;
+        this->domain_branch_data_ = this->last_valid_domain_branch_data_;
     }
 
     template<class Serializer>
@@ -126,6 +149,10 @@ public:
         serializer(last_valid_node_pressures_);
         serializer(branch_data_);
         serializer(last_valid_branch_data_);
+        serializer(domain_node_pressures_);
+        serializer(last_valid_domain_node_pressures_);
+        serializer(domain_branch_data_);
+        serializer(last_valid_domain_branch_data_);
     }
 
     bool operator==(const BlackoilWellModelNetworkGeneric<Scalar,IndexTraits>& rhs) const;
@@ -138,7 +165,52 @@ protected:
                      const int reportStepIdx,
                      const Parallel::Communication& comm) const;
 
+    std::pair<std::map<std::string, Scalar>, std::map<std::string, data::BranchData>>
+    computePressures(const Network::ExtNetwork& network,
+                     const VFPInjProperties<Scalar>& vfp_inj_props,
+                     const UnitSystem& unit_system,
+                     const int reportStepIdx,
+                     const Parallel::Communication& comm,
+                     const Phase injectionPhase) const;
+
     void updateActiveStateImpl(const Network::ExtNetwork& network);
+
+    static constexpr details::NetworkDomain productionNetworkDomain()
+    {
+        return details::NetworkDomain::Production;
+    }
+
+    const std::map<std::string, Scalar>& nodePressures(const details::NetworkDomain domain) const
+    {
+        return domain_node_pressures_[details::domainIndex(domain)];
+    }
+
+    std::map<std::string, Scalar>& nodePressures(const details::NetworkDomain domain)
+    {
+        return domain_node_pressures_[details::domainIndex(domain)];
+    }
+
+    const std::map<std::string, data::BranchData>& branchData(const details::NetworkDomain domain) const
+    {
+        return domain_branch_data_[details::domainIndex(domain)];
+    }
+
+    std::map<std::string, data::BranchData>& branchData(const details::NetworkDomain domain)
+    {
+        return domain_branch_data_[details::domainIndex(domain)];
+    }
+
+    void syncLegacyProductionState_()
+    {
+        this->node_pressures_ = this->nodePressures(productionNetworkDomain());
+        this->branch_data_ = this->branchData(productionNetworkDomain());
+    }
+
+    void syncProductionDomainState_()
+    {
+        this->nodePressures(productionNetworkDomain()) = this->node_pressures_;
+        this->branchData(productionNetworkDomain()) = this->branch_data_;
+    }
 
     bool active_{false};
     BlackoilWellModelGeneric<Scalar,IndexTraits>& well_model_;
@@ -147,10 +219,15 @@ protected:
     std::map<std::string, Scalar> node_pressures_;
     // Network branch pressure drops and flow rates for output (outlet branch for production network, inlet branch for injection network)
     std::map<std::string, data::BranchData> branch_data_;
+    // Domain-scoped pressure state to avoid collisions between production and injection networks.
+    std::array<std::map<std::string, Scalar>, details::domainIndex(details::NetworkDomain::Count)> domain_node_pressures_;
+    std::array<std::map<std::string, data::BranchData>, details::domainIndex(details::NetworkDomain::Count)> domain_branch_data_;
     // Valid network pressures for output and initialization for safe restart after failed iterations
     std::map<std::string, Scalar> last_valid_node_pressures_;
     // Valid network branch pressure drops and flow rates for output (outlet branch for production network, inlet branch for injection network) for safe restart after failed iterations
     std::map<std::string, data::BranchData> last_valid_branch_data_;
+    std::array<std::map<std::string, Scalar>, details::domainIndex(details::NetworkDomain::Count)> last_valid_domain_node_pressures_;
+    std::array<std::map<std::string, data::BranchData>, details::domainIndex(details::NetworkDomain::Count)> last_valid_domain_branch_data_;
 };
 
 } // namespace Opm

--- a/opm/simulators/wells/BlackoilWellModelNetworkGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkGeneric.hpp
@@ -67,7 +67,8 @@ namespace details {
         std::reference_wrapper<const Network::ExtNetwork> network;
     };
 
-    /// The network a well belongs to, or nullopt for a well that is in none of them.
+    /// The network domain corresponding to a well's type
+    /// (producer, or injector and water/gas injection phase), or nullopt.
     template<class Well>
     std::optional<NetworkDomain> domainForWell(const Well& well)
     {
@@ -200,8 +201,7 @@ protected:
                      const VFPInjProperties<Scalar>& vfp_inj_props,
                      const UnitSystem& unit_system,
                      const int reportStepIdx,
-                     const Parallel::Communication& comm,
-                     const Phase injectionPhase) const;
+                     const Parallel::Communication& comm) const;
 
     void updateActiveStateImpl(const Network::ExtNetwork& network);
 

--- a/opm/simulators/wells/BlackoilWellModelNetworkPressureComputation.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkPressureComputation.hpp
@@ -25,15 +25,20 @@
 #include <opm/input/eclipse/Schedule/Network/ExtNetwork.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
+#include <opm/input/eclipse/Units/Units.hpp>
 
 #include <opm/output/data/Groups.hpp>
 
 #include <opm/simulators/wells/BlackoilWellModelGeneric.hpp>
+#include <opm/simulators/wells/VFPHelpers.hpp>
 #include <opm/simulators/wells/VFPInjProperties.hpp>
 #include <opm/simulators/wells/VFPProdProperties.hpp>
 
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <map>
 #include <optional>
 #include <ranges>
@@ -43,6 +48,48 @@
 #include <vector>
 
 namespace Opm {
+
+/// Result of a single network branch VFP lookup.
+template<typename Scalar>
+struct NetworkBranchPressure
+{
+    Scalar pressure{0.0};
+    // False when the table has no solution at this point (zero-filled cells give
+    // bhp <= 1 atm); the pressure must then not be used as a node pressure.
+    bool valid{true};
+    // True when the flow rate or upstream pressure had to be clamped to the table axes.
+    bool clamped{false};
+};
+
+namespace detail {
+    /// Clamp the VFP lookup point to the table axes; the tables must not be extrapolated
+    /// for network branches (a zero-filled tail extrapolates to negative pressures).
+    /// Rates are scaled uniformly so that WFR/GFR fractions are preserved.
+    template<typename Scalar, typename IndexTraits, typename Table>
+    bool clampToTableAxes(const Table& table, std::vector<Scalar>& rates, Scalar& up_press)
+    {
+        bool clamped = false;
+        const auto& thp_axis = table.getTHPAxis();
+        const Scalar thp_lo = thp_axis.front();
+        const Scalar thp_hi = thp_axis.back();
+        if (up_press < thp_lo || up_press > thp_hi) {
+            up_press = std::clamp(up_press, thp_lo, thp_hi);
+            clamped = true;
+        }
+        const auto& flo_axis = table.getFloAxis();
+        const Scalar flo = std::abs(getFlo(table,
+                                           rates[IndexTraits::waterPhaseIdx],
+                                           rates[IndexTraits::oilPhaseIdx],
+                                           rates[IndexTraits::gasPhaseIdx]));
+        const Scalar flo_hi = flo_axis.back();
+        if (flo > flo_hi && flo > 0.0) {
+            const Scalar s = flo_hi / flo;
+            std::ranges::transform(rates, rates.begin(), [s](const auto r) { return s * r; });
+            clamped = true;
+        }
+        return clamped;
+    }
+} // namespace detail
 
 /// @brief  Helper class to insulate the NetworkPressureComputation class from
 ///         the differences between production and injection VFP tables.
@@ -75,29 +122,34 @@ struct NetworkVfpPressureCalculator<Scalar, IndexTraits, VFPProdProperties<Scala
     }
 
     template<typename Branch>
-    static Scalar compute(const VFPProdProperties<Scalar>& vfp_props,
-                          const int table_id,
-                          const std::vector<Scalar>& rates,
-                          const Scalar up_press,
-                          const Branch& upbranch,
-                          const UnitSystem& unit_system)
+    static NetworkBranchPressure<Scalar> compute(const VFPProdProperties<Scalar>& vfp_props,
+                                                 const int table_id,
+                                                 std::vector<Scalar> rates,
+                                                 Scalar up_press,
+                                                 const Branch& upbranch,
+                                                 const UnitSystem& unit_system)
     {
         // NB! ALQ in extended network is never implicitly the gas lift rate (GRAT), i.e., the
         //     gas lift rates only enters the network pressure calculations through the rates
         //     (e.g., in GOR calculations) unless a branch ALQ is set in BRANPROP.
-        const auto alq_type = vfp_props.getTable(table_id).getALQType();
+        const auto& table = vfp_props.getTable(table_id);
+        const auto alq_type = table.getALQType();
         const auto dimension = VFPProdTable::ALQDimension(alq_type, unit_system);
         const Scalar alq = upbranch.alq_value(dimension).value_or(0.0);
 
-        return vfp_props.bhp(table_id,
-                             rates[IndexTraits::waterPhaseIdx],
-                             rates[IndexTraits::oilPhaseIdx],
-                             rates[IndexTraits::gasPhaseIdx],
-                             up_press,
-                             alq,
-                             0.0, // explicit_wfr
-                             0.0, // explicit_gfr
-                             false); // use_expvfp we dont support explicit lookup
+        NetworkBranchPressure<Scalar> result;
+        result.clamped = detail::clampToTableAxes<Scalar, IndexTraits>(table, rates, up_press);
+        result.pressure = vfp_props.bhp(table_id,
+                                        rates[IndexTraits::waterPhaseIdx],
+                                        rates[IndexTraits::oilPhaseIdx],
+                                        rates[IndexTraits::gasPhaseIdx],
+                                        up_press,
+                                        alq,
+                                        0.0, // explicit_wfr
+                                        0.0, // explicit_gfr
+                                        false); // use_expvfp we dont support explicit lookup
+        result.valid = result.pressure > unit::atm;
+        return result;
     }
 };
 
@@ -125,18 +177,22 @@ struct NetworkVfpPressureCalculator<Scalar, IndexTraits, VFPInjProperties<Scalar
     }
 
     template<typename Branch>
-    static Scalar compute(const VFPInjProperties<Scalar>& vfp_props,
-                          const int table_id,
-                          const std::vector<Scalar>& rates,
-                          const Scalar up_press,
-                          const Branch&,
-                          const UnitSystem&)
+    static NetworkBranchPressure<Scalar> compute(const VFPInjProperties<Scalar>& vfp_props,
+                                                 const int table_id,
+                                                 std::vector<Scalar> rates,
+                                                 Scalar up_press,
+                                                 const Branch&,
+                                                 const UnitSystem&)
     {
-        return vfp_props.bhp(table_id,
-                             rates[IndexTraits::waterPhaseIdx],
-                             rates[IndexTraits::oilPhaseIdx],
-                             rates[IndexTraits::gasPhaseIdx],
-                             up_press);
+        NetworkBranchPressure<Scalar> result;
+        result.clamped = detail::clampToTableAxes<Scalar, IndexTraits>(vfp_props.getTable(table_id), rates, up_press);
+        result.pressure = vfp_props.bhp(table_id,
+                                        rates[IndexTraits::waterPhaseIdx],
+                                        rates[IndexTraits::oilPhaseIdx],
+                                        rates[IndexTraits::gasPhaseIdx],
+                                        up_press);
+        result.valid = result.pressure > unit::atm;
+        return result;
     }
 };
 
@@ -204,6 +260,14 @@ public:
         }
 
         return {node_pressures_, branch_data_};
+    }
+
+    /// Nodes whose pressure could not be computed from the VFP tables (and their
+    /// descendants). Their entries in the pressure map are placeholders (the upstream
+    /// pressure) and must not be used as node pressures.
+    const std::set<std::string>& invalidNodes() const
+    {
+        return invalid_nodes_;
     }
 
 private:
@@ -354,7 +418,12 @@ private:
                 continue;
             }
 
-            const Scalar up_press = node_pressures_[(*upbranch).uptree_node()];
+            const std::string& up_node = (*upbranch).uptree_node();
+            const Scalar up_press = node_pressures_[up_node];
+            // Descendants of a node without a valid pressure have none either.
+            if (invalid_nodes_.count(up_node) > 0) {
+                invalid_nodes_.insert(node);
+            }
             const auto vfp_table = (*upbranch).vfp_table();
             if (!vfp_table) {
                 // Table number specified as 9999 in the deck, no pressure loss.
@@ -377,7 +446,23 @@ private:
             auto rates = node_inflows.at(node);
             assert(rates.size() == 3);
             Calc::prepareRates(rates);
-            auto node_pressure = Calc::compute(vfp_props_, *vfp_table, rates, up_press, *upbranch, unit_system_);
+            const auto branch = Calc::compute(vfp_props_, *vfp_table, rates, up_press, *upbranch, unit_system_);
+            // An invalid lookup (zero-filled table cells) gets the upstream pressure as a
+            // placeholder so downstream lookups stay in range; callers must consult invalidNodes().
+            const Scalar node_pressure = branch.valid ? branch.pressure : up_press;
+            if (!branch.valid) {
+                invalid_nodes_.insert(node);
+            }
+            if (!branch.valid || branch.clamped) {
+                OpmLog::debug(fmt::format("Network branch {} -> {}: VFP table {} {} at rates ({:.4g}, {:.4g}, {:.4g}) sm3/d, "
+                                          "upstream pressure {:.2f} bar",
+                                          up_node, node, *vfp_table,
+                                          branch.valid ? "lookup clamped to the table axes" : "has no solution",
+                                          rates[IndexTraits::waterPhaseIdx] * unit::day,
+                                          rates[IndexTraits::oilPhaseIdx] * unit::day,
+                                          rates[IndexTraits::gasPhaseIdx] * unit::day,
+                                          up_press / unit::barsa));
+            }
             node_pressures_[node] = node_pressure;
             // Prefer inserting after computing the pressure, hence negating rates
             branch_data_.try_emplace(node,
@@ -397,6 +482,7 @@ private:
     const std::optional<Phase> injection_phase_;
     std::map<std::string, Scalar> node_pressures_;
     std::map<std::string, data::BranchData> branch_data_;
+    std::set<std::string> invalid_nodes_;
 };
 
 } // namespace Opm

--- a/opm/simulators/wells/BlackoilWellModelNetworkPressureComputation.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkPressureComputation.hpp
@@ -35,6 +35,7 @@
 #include <algorithm>
 #include <cassert>
 #include <map>
+#include <optional>
 #include <ranges>
 #include <set>
 #include <stack>
@@ -60,7 +61,9 @@ struct NetworkVfpPressureCalculator<Scalar, IndexTraits, VFPProdProperties<Scala
 
     template <class GroupState>
     static const std::vector<Scalar>
-    leafNodeRate(const GroupState& group_state, const std::string& node)
+    leafNodeRate(const GroupState& group_state,
+                 const std::string& node,
+                 const std::optional<Phase>&)
     {
         return group_state.network_leaf_node_production_rates(node);
     }
@@ -102,7 +105,9 @@ struct NetworkVfpPressureCalculator<Scalar, IndexTraits, VFPInjProperties<Scalar
 
     template <class GroupState>
     static const std::vector<Scalar>
-    leafNodeRate(const GroupState& group_state, const std::string& node)
+    leafNodeRate(const GroupState& group_state,
+                 const std::string& node,
+                 const std::optional<Phase>&)
     {
         return group_state.network_leaf_node_injection_rates(node);
     }
@@ -135,13 +140,15 @@ public:
                                const VfpProperties& vfp_props,
                                const UnitSystem& unit_system,
                                const int report_step_idx,
-                               const Communication& comm)
+                               const Communication& comm,
+                               const std::optional<Phase>& injection_phase = std::nullopt)
         : well_model_(well_model)
         , network_(network)
         , vfp_props_(vfp_props)
         , unit_system_(unit_system)
         , report_step_idx_(report_step_idx)
         , comm_(comm)
+        , injection_phase_(injection_phase)
     {
     }
 
@@ -215,7 +222,9 @@ private:
             }
 
             using Calc = NetworkVfpPressureCalculator<Scalar, IndexTraits, VfpProperties>;
-            node_inflows[node] = Calc::leafNodeRate(well_model_.groupStateHelper().groupState(), node);
+            node_inflows[node] = Calc::leafNodeRate(well_model_.groupStateHelper().groupState(),
+                                                    node,
+                                                    injection_phase_);
             if (network_.node(node).add_gas_lift_gas()) {
                 addGasLiftGas(node, node_inflows[node]);
             }
@@ -248,7 +257,7 @@ private:
         }
         // Sum ALQ across all processes to get total ALQ for the node.
         // Note that communication is required here since each
-        // process has different wells, and the loop above therefore 
+        // process has different wells, and the loop above therefore
         // only considers local wells.
         // However, all processes have all groups and their rates available,
         // so we do not need to communicate those.
@@ -359,6 +368,7 @@ private:
     const UnitSystem& unit_system_;
     const int report_step_idx_;
     const Communication& comm_;
+    const std::optional<Phase> injection_phase_;
     std::map<std::string, Scalar> node_pressures_;
     std::map<std::string, data::BranchData> branch_data_;
 };

--- a/opm/simulators/wells/BlackoilWellModelNetworkPressureComputation.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkPressureComputation.hpp
@@ -247,6 +247,9 @@ public:
             // at each node using VFP tables and rates.
             computeNodePressures(root_to_child_nodes, node_inflows);
 
+#ifdef OPM_NETWORK_PRESSURE_TRACE
+            // Off unless the macro is defined: this builds a string per node per
+            // sub-iteration per domain, whether or not the log keeps it.
             OpmLog::debug("Network pressure computation completed for root " + root.get().name() + ". Node pressures:");
             for (const auto& [node, pressure] : node_pressures_) {
                 OpmLog::debug("Network node " + node + " pressure: " + std::to_string(pressure/1e5) + " bar");
@@ -256,6 +259,7 @@ public:
                 OpmLog::debug("Network node " + node + " inflows: "
                     + std::to_string(inflows[0]*86400) + ", " + std::to_string(inflows[1]*86400) + ", " + std::to_string(inflows[2]*86400));
             }
+#endif
 
         }
 

--- a/opm/simulators/wells/BlackoilWellModelNetworkPressureComputation.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkPressureComputation.hpp
@@ -190,6 +190,17 @@ public:
             // Going the other way (from roots to leafs), calculate the pressure
             // at each node using VFP tables and rates.
             computeNodePressures(root_to_child_nodes, node_inflows);
+
+            OpmLog::debug("Network pressure computation completed for root " + root.get().name() + ". Node pressures:");
+            for (const auto& [node, pressure] : node_pressures_) {
+                OpmLog::debug("Network node " + node + " pressure: " + std::to_string(pressure/1e5) + " bar");
+            }
+            OpmLog::debug("Node inflows:");
+            for (const auto& [node, inflows] : node_inflows) {
+                OpmLog::debug("Network node " + node + " inflows: "
+                    + std::to_string(inflows[0]*86400) + ", " + std::to_string(inflows[1]*86400) + ", " + std::to_string(inflows[2]*86400));
+            }
+
         }
 
         return {node_pressures_, branch_data_};

--- a/opm/simulators/wells/BlackoilWellModelNetworkPressureComputation.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkPressureComputation.hpp
@@ -60,6 +60,12 @@ struct NetworkVfpPressureCalculator<Scalar, IndexTraits, VFPProdProperties<Scala
     }
 
     template <class GroupState>
+    static bool hasLeafNodeRate(const GroupState& group_state, const std::string& node)
+    {
+        return group_state.has_network_leaf_node_production_rates(node);
+    }
+
+    template <class GroupState>
     static const std::vector<Scalar>
     leafNodeRate(const GroupState& group_state,
                  const std::string& node,
@@ -101,6 +107,12 @@ struct NetworkVfpPressureCalculator<Scalar, IndexTraits, VFPInjProperties<Scalar
 {
     static void prepareRates(std::vector<Scalar>&)
     {
+    }
+
+    template <class GroupState>
+    static bool hasLeafNodeRate(const GroupState& group_state, const std::string& node)
+    {
+        return group_state.has_network_leaf_node_injection_rates(node);
     }
 
     template <class GroupState>
@@ -215,13 +227,16 @@ private:
         const std::vector<Scalar> zero_rates(3, 0.0);
 
         for (const auto& node : leaf_nodes) {
-            // Guard against empty leaf nodes (may not be present in GRUPTREE)
-            if (!well_model_.groupStateHelper().groupState().has_production_rates(node)) {
+            // Guard against empty leaf nodes (may not be present in GRUPTREE).
+            // Use the domain-correct check so injection networks query the injection
+            // rate map rather than the production rate map (which is always empty for
+            // pure injection groups, causing zero-rate pressure calculations).
+            using Calc = NetworkVfpPressureCalculator<Scalar, IndexTraits, VfpProperties>;
+            if (!Calc::hasLeafNodeRate(well_model_.groupStateHelper().groupState(), node)) {
                 node_inflows[node] = zero_rates;
                 continue;
             }
 
-            using Calc = NetworkVfpPressureCalculator<Scalar, IndexTraits, VfpProperties>;
             node_inflows[node] = Calc::leafNodeRate(well_model_.groupStateHelper().groupState(),
                                                     node,
                                                     injection_phase_);

--- a/opm/simulators/wells/BlackoilWellModelNetworkPressureComputation.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkPressureComputation.hpp
@@ -40,7 +40,6 @@
 #include <cassert>
 #include <cmath>
 #include <map>
-#include <optional>
 #include <ranges>
 #include <set>
 #include <stack>
@@ -107,7 +106,8 @@ struct NetworkVfpPressureCalculator<Scalar, IndexTraits, VFPProdProperties<Scala
     }
 
     template <class GroupState>
-    static bool hasLeafNodeRate(const GroupState& group_state, const std::string& node)
+    static bool hasLeafNodeRate(const GroupState& group_state,
+                                const std::string& node)
     {
         return group_state.has_network_leaf_node_production_rates(node);
     }
@@ -115,8 +115,7 @@ struct NetworkVfpPressureCalculator<Scalar, IndexTraits, VFPProdProperties<Scala
     template <class GroupState>
     static const std::vector<Scalar>
     leafNodeRate(const GroupState& group_state,
-                 const std::string& node,
-                 const std::optional<Phase>&)
+                 const std::string& node)
     {
         return group_state.network_leaf_node_production_rates(node);
     }
@@ -162,7 +161,8 @@ struct NetworkVfpPressureCalculator<Scalar, IndexTraits, VFPInjProperties<Scalar
     }
 
     template <class GroupState>
-    static bool hasLeafNodeRate(const GroupState& group_state, const std::string& node)
+    static bool hasLeafNodeRate(const GroupState& group_state,
+                                const std::string& node)
     {
         return group_state.has_network_leaf_node_injection_rates(node);
     }
@@ -170,8 +170,7 @@ struct NetworkVfpPressureCalculator<Scalar, IndexTraits, VFPInjProperties<Scalar
     template <class GroupState>
     static const std::vector<Scalar>
     leafNodeRate(const GroupState& group_state,
-                 const std::string& node,
-                 const std::optional<Phase>&)
+                 const std::string& node)
     {
         return group_state.network_leaf_node_injection_rates(node);
     }
@@ -208,15 +207,13 @@ public:
                                const VfpProperties& vfp_props,
                                const UnitSystem& unit_system,
                                const int report_step_idx,
-                               const Communication& comm,
-                               const std::optional<Phase>& injection_phase = std::nullopt)
+                               const Communication& comm)
         : well_model_(well_model)
         , network_(network)
         , vfp_props_(vfp_props)
         , unit_system_(unit_system)
         , report_step_idx_(report_step_idx)
         , comm_(comm)
-        , injection_phase_(injection_phase)
     {
     }
 
@@ -317,8 +314,7 @@ private:
             }
 
             node_inflows[node] = Calc::leafNodeRate(well_model_.groupStateHelper().groupState(),
-                                                    node,
-                                                    injection_phase_);
+                                                    node);
             if (network_.node(node).add_gas_lift_gas()) {
                 addGasLiftGas(node, node_inflows[node]);
             }
@@ -483,7 +479,6 @@ private:
     const UnitSystem& unit_system_;
     const int report_step_idx_;
     const Communication& comm_;
-    const std::optional<Phase> injection_phase_;
     std::map<std::string, Scalar> node_pressures_;
     std::map<std::string, data::BranchData> branch_data_;
     std::set<std::string> invalid_nodes_;

--- a/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
@@ -166,6 +166,25 @@ update(const bool mandatory_network_balance,
                                                       dt,
                                                       well_model_.groupStateHelper(),
                                                       well_model_.wellState());
+                    // Option B: after re-solving at the current network THP, update
+                    // ws.well_potentials for injection wells.  The rate_less_than_potential
+                    // check in WellConstraints::activeInjectionConstraint compares current
+                    // injection rates against ws.well_potentials to decide whether switching
+                    // to THP mode would increase or decrease injection.  The potentials are
+                    // normally computed once per timestep at the static WCONINJE THP and are
+                    // stale during network iterations.  Refreshing them here (from the rate
+                    // the well just solved to under the current network THP) makes the check
+                    // accurate for subsequent outer iterations.
+                    if (well->isInjector()) {
+                        auto& ws = well_model_.wellState().well(well->indexOfWell());
+                        if (ws.injection_cmode == Well::InjectorCMode::THP) {
+                            const int np = well_model_.numPhases();
+                            for (int p = 0; p < np; ++p) {
+                                ws.well_potentials[p] =
+                                    std::max(Scalar{0.0}, ws.surface_rates[p]);
+                            }
+                        }
+                    }
                 }
             }
             well_model_.updateAndCommunicateGroupData(episodeIdx, /*update_wellgrouptarget*/ true);

--- a/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
@@ -166,6 +166,10 @@ computeWellGroupThp(const double dt, DeferredLogger& local_deferredLogger)
 {
     OPM_TIMEFUNCTION();
     const int reportStepIdx = well_model_.simulator().episodeIndex();
+    // This function is only relevant for auto-choke groups, and
+    // therefore as of now only relevant for the production network.
+    // \TODO: If we later also want to support auto-choke groups in the
+    // injection network, we should change this function also.
     const auto& network = well_model_.schedule()[reportStepIdx].network();
     const auto& balance = well_model_.schedule()[reportStepIdx].network_balance();
     const Scalar thp_tolerance = balance.thp_tolerance();

--- a/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
@@ -41,6 +41,8 @@
 
 #include <fmt/format.h>
 
+#include <optional>
+
 namespace Opm {
 
 template<typename TypeTag>
@@ -139,12 +141,27 @@ update(const bool mandatory_network_balance,
             }
 
             for (const auto& well : well_model_) {
-                if (well->isInjector() || !well->wellEcl().predictionMode()) {
+                if (!well->wellEcl().predictionMode()) {
                      continue;
                 }
 
-                const auto it = this->node_pressures_.find(well->wellEcl().groupName());
-                if (it != this->node_pressures_.end()) {
+                std::optional<details::NetworkDomain> domain;
+                if (well->isProducer()) {
+                    domain = details::NetworkDomain::Production;
+                } else if (well->isInjector()) {
+                    if (well->wellEcl().injectorType() == InjectorType::GAS) {
+                        domain = details::NetworkDomain::InjectionGas;
+                    } else if (well->wellEcl().injectorType() == InjectorType::WATER) {
+                        domain = details::NetworkDomain::InjectionWater;
+                    }
+                }
+
+                if (!domain.has_value()) {
+                    continue;
+                }
+
+                const auto it = this->nodePressures(*domain).find(well->wellEcl().groupName());
+                if (it != this->nodePressures(*domain).end()) {
                     well->prepareWellBeforeAssembling(well_model_.simulator(),
                                                       dt,
                                                       well_model_.groupStateHelper(),

--- a/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
@@ -145,16 +145,7 @@ update(const bool mandatory_network_balance,
                      continue;
                 }
 
-                std::optional<details::NetworkDomain> domain;
-                if (well->isProducer()) {
-                    domain = details::NetworkDomain::Production;
-                } else if (well->isInjector()) {
-                    if (well->wellEcl().injectorType() == InjectorType::GAS) {
-                        domain = details::NetworkDomain::InjectionGas;
-                    } else if (well->wellEcl().injectorType() == InjectorType::WATER) {
-                        domain = details::NetworkDomain::InjectionWater;
-                    }
-                }
+                const auto domain = details::domainForWell(*well);
 
                 if (!domain.has_value()) {
                     continue;

--- a/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
@@ -93,8 +93,7 @@ update(const bool mandatory_network_balance,
 {
     OPM_TIMEFUNCTION();
     const int episodeIdx = well_model_.simulator().episodeIndex();
-    const auto& network = well_model_.schedule()[episodeIdx].network();
-    if (!well_model_.wellsActive() && !network.active()) {
+    if (!well_model_.wellsActive() && !details::anyNetworkActive(well_model_.schedule(), episodeIdx)) {
         return {/*more_network_update=*/false, /*network_imbalance=*/0.0};
     }
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -596,8 +596,7 @@ namespace Opm {
                 well->setPrevSurfaceRates(this->wellState(), this->prevWellState());
             }
 
-            const auto& network = this->schedule()[timeStepIdx].network();
-            if (network.active()) {
+            if (details::anyNetworkActive(this->schedule(), timeStepIdx)) {
                 this->network_.initializeWell(*well);
             }
             try {
@@ -1172,8 +1171,7 @@ namespace Opm {
                 this->updateNetworkActiveState_();
             }
             const int episodeIdx = simulator_.episodeIndex();
-            const auto& network = this->schedule()[episodeIdx].network();
-            if (!this->wellsActive() && !network.active()) {
+            if (!this->wellsActive() && !details::anyNetworkActive(this->schedule(), episodeIdx)) {
                 return;
             }
         }

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1238,8 +1238,15 @@ namespace Opm {
         while (do_network_update) {
             if (!this->isRescoupSlaveCoupledNetworkIteration_()
                 && network_update_iteration >= max_iteration ) {
-                // only output to terminal if we at the last newton iterations where we try to balance the network.
                 const int episodeIdx = simulator_.episodeIndex();
+                const auto& balance = this->schedule()[episodeIdx].network_balance();
+                // If the imbalance is already within tolerance, the network is converged; the
+                // outer loop continued only due to ALQ or control changes. Don't report this
+                // as an unconverged result -- just break quietly.
+                if (network_imbalance <= balance.pressure_tolerance()) {
+                    break;
+                }
+                // only output to terminal if we at the last newton iterations where we try to balance the network.
                 if (this->network_.willBalanceOnNextIteration(episodeIdx)) {
                     if (this->terminal_output_) {
                         const std::string msg = fmt::format("Maximum of {:d} network iterations has been used and we stop the update, \n"

--- a/opm/simulators/wells/GroupState.cpp
+++ b/opm/simulators/wells/GroupState.cpp
@@ -103,6 +103,12 @@ void GroupState<Scalar>::update_production_rates(const std::string& gname,
 }
 
 template<class Scalar>
+bool GroupState<Scalar>::has_network_leaf_node_injection_rates(const std::string& gname) const
+{
+    return this->m_network_leaf_node_injection_rates.count(gname) > 0;
+}
+
+template<class Scalar>
 void GroupState<Scalar>::update_network_leaf_node_injection_rates(const std::string& gname,
                                                  const std::vector<Scalar>& rates)
 {
@@ -163,6 +169,12 @@ GroupState<Scalar>::network_leaf_node_injection_rates(const std::string& gname) 
         throw std::logic_error("No such group: " + gname);
 
     return group_iter->second;
+}
+
+template<class Scalar>
+bool GroupState<Scalar>::has_network_leaf_node_production_rates(const std::string& gname) const
+{
+    return this->m_network_leaf_node_production_rates.count(gname) > 0;
 }
 
 template<class Scalar>

--- a/opm/simulators/wells/GroupState.hpp
+++ b/opm/simulators/wells/GroupState.hpp
@@ -55,7 +55,9 @@ public:
     void update_network_leaf_node_production_rates(const std::string& gname,
                                  const std::vector<Scalar>& rates);
     const std::vector<Scalar>& production_rates(const std::string& gname) const;
+    bool has_network_leaf_node_injection_rates(const std::string& gname) const;
     const std::vector<Scalar>& network_leaf_node_injection_rates(const std::string& gname) const;
+    bool has_network_leaf_node_production_rates(const std::string& gname) const;
     const std::vector<Scalar>& network_leaf_node_production_rates(const std::string& gname) const;
 
     void update_well_group_thp(const std::string& gname, const double& thp);

--- a/opm/simulators/wells/GroupStateHelper.cpp
+++ b/opm/simulators/wells/GroupStateHelper.cpp
@@ -1311,9 +1311,13 @@ GroupStateHelper<Scalar, IndexTraits>::updateNetworkLeafNodeRates()
         }
     };
     do_update(this->schedule_[this->report_step_].network(), /*is_injector=*/false);
-    // TODO: do the below to support injection networks when available.
-    // do_update(this->schedule_[this->report_step_].gas_injection_network(), /*is_injector=*/true);
-    // do_update(this->schedule_[this->report_step_].water_injection_network(), /*is_injector=*/true);
+    for (const Phase phase : {Phase::GAS, Phase::WATER}) {
+        if (const auto injNetwork = this->schedule_[this->report_step_].injectionNetwork.get_ptr(phase);
+            injNetwork != nullptr)
+        {
+            do_update(*injNetwork, /* is_injector = */ true);
+        }
+    }
 }
 
 template <typename Scalar, typename IndexTraits>

--- a/opm/simulators/wells/WellConstraints.cpp
+++ b/opm/simulators/wells/WellConstraints.cpp
@@ -148,10 +148,7 @@ activeInjectionConstraint(const SingleWellState<Scalar, IndexTraits>& ws,
             return Well::InjectorCMode::RESV;
     }
 
-    // Note: we are not working on injecting network yet, so it is possible we need to change the following line
-    // to be as follows to incorporate the injecting network nodal pressure
-    // if (well_.wellHasTHPConstraints(summaryState) && currentControl != Well::InjectorCMode::THP)
-    if (controls.hasControl(Well::InjectorCMode::THP) && currentControl != Well::InjectorCMode::THP)
+    if (well_.wellHasTHPConstraints(summaryState) && currentControl != Well::InjectorCMode::THP)
     {
         const auto& thp = well_.getTHPConstraint(summaryState);
         Scalar current_thp = ws.thp;

--- a/opm/simulators/wells/WellConstraints.cpp
+++ b/opm/simulators/wells/WellConstraints.cpp
@@ -148,20 +148,30 @@ activeInjectionConstraint(const SingleWellState<Scalar, IndexTraits>& ws,
             return Well::InjectorCMode::RESV;
     }
 
-    // Note: we are not working on injecting network yet, so it is possible we need to change the following line
-    // to be as follows to incorporate the injecting network nodal pressure
-    // if (well_.wellHasTHPConstraints(summaryState) && currentControl != Well::InjectorCMode::THP)
-    if (controls.hasControl(Well::InjectorCMode::THP) && currentControl != Well::InjectorCMode::THP)
+    // Use wellHasTHPConstraints so that injection wells with a dynamic THP from
+    // the injection network (dynamic_thp_limit_ set) also enter this check.
+    // Wells with neither an explicit WCONINJE THP nor a network-derived THP are
+    // unaffected because wellHasTHPConstraints returns false for them.
+    if (well_.wellHasTHPConstraints(summaryState) && currentControl != Well::InjectorCMode::THP)
     {
         const auto& thp = well_.getTHPConstraint(summaryState);
         Scalar current_thp = ws.thp;
         if (thp < current_thp) {
+            // When the THP comes from the injection network (dynamic_thp_limit_ is set),
+            // well potentials were computed before network iterations at a different (static)
+            // THP and are stale. The rate_less_than_potential check would always suppress
+            // switching in that case. Bypass the check for dynamic THP — this mirrors the
+            // default production-well behaviour (no WVFPEXP) where switching is unconditional.
             bool rate_less_than_potential = true;
-            for (int p = 0; p < well_.numPhases(); ++p) {
-                // Currently we use the well potentials here computed before the iterations.
-                // We may need to recompute the well potentials to get a more
-                // accurate check here.
-                rate_less_than_potential = rate_less_than_potential && (ws.surface_rates[p]) <= ws.well_potentials[p];
+            if (!well_.getDynamicThpLimit().has_value()) {
+                for (int p = 0; p < well_.numPhases(); ++p) {
+                    // Currently we use the well potentials here computed before the iterations.
+                    // We may need to recompute the well potentials to get a more
+                    // accurate check here.
+                    rate_less_than_potential = rate_less_than_potential && (ws.surface_rates[p]) <= ws.well_potentials[p];
+                }
+            } else {
+                rate_less_than_potential = false;
             }
             if (!rate_less_than_potential) {
                 thp_limit_violated_but_not_switched = false;

--- a/opm/simulators/wells/WellConstraints.cpp
+++ b/opm/simulators/wells/WellConstraints.cpp
@@ -148,7 +148,10 @@ activeInjectionConstraint(const SingleWellState<Scalar, IndexTraits>& ws,
             return Well::InjectorCMode::RESV;
     }
 
-    if (well_.wellHasTHPConstraints(summaryState) && currentControl != Well::InjectorCMode::THP)
+    // Note: we are not working on injecting network yet, so it is possible we need to change the following line
+    // to be as follows to incorporate the injecting network nodal pressure
+    // if (well_.wellHasTHPConstraints(summaryState) && currentControl != Well::InjectorCMode::THP)
+    if (controls.hasControl(Well::InjectorCMode::THP) && currentControl != Well::InjectorCMode::THP)
     {
         const auto& thp = well_.getTHPConstraint(summaryState);
         Scalar current_thp = ws.thp;

--- a/tests/test_networkpressure.cpp
+++ b/tests/test_networkpressure.cpp
@@ -332,7 +332,7 @@ BOOST_AUTO_TEST_CASE(gas_injection_pressure_computation)
     BOOST_CHECK_CLOSE(s.vfp_inj_props.bhp(3, 0.0, 0.0, gasrate, thp), expected_bhp, 1e-7);
     using Comm = Dune::Communication<int>;
 
-    // NetworkPressureComputation stores const references to comm and unit system, hence 
+    // NetworkPressureComputation stores const references to comm and unit system, hence
     // we need to make sure that their lifetime is longer than the constructor lasts
     auto comm = Comm{};
     auto unit_system = UnitSystem {};
@@ -357,7 +357,7 @@ BOOST_AUTO_TEST_CASE(water_injection_pressure_computation)
 
     // Test using mock setup.
     using Comm = Dune::Communication<int>;
-    // NetworkPressureComputation stores const references to comm and unit system, hence 
+    // NetworkPressureComputation stores const references to comm and unit system, hence
     // we need to make sure that their lifetime is longer than the constructor lasts
     auto comm = Comm{};
     auto unit_system = UnitSystem {};

--- a/tests/test_networkpressure.cpp
+++ b/tests/test_networkpressure.cpp
@@ -229,6 +229,8 @@ struct MockWellModel
         struct MockGroupState
         {
             bool has_production_rates(const std::string) const { return true; }
+            bool has_network_leaf_node_injection_rates(const std::string) const { return true; }
+            bool has_network_leaf_node_production_rates(const std::string) const { return true; }
             std::vector<double> network_leaf_node_injection_rates(const std::string) const
             {
                 // Phase order water, oil, gas.

--- a/tests/test_networkpressure.cpp
+++ b/tests/test_networkpressure.cpp
@@ -44,6 +44,7 @@
 #include <filesystem>
 #include <memory>
 #include <map>
+#include <optional>
 #include <sstream>
 #include <limits>
 #include <string>
@@ -228,22 +229,28 @@ struct MockWellModel
 
         struct MockGroupState
         {
+            // Leaf rates in Sm3/day, phase order water, oil, gas. Tests may override
+            // these before running the computation.
+            static inline std::vector<double> injection_rates_sm3_day {500.0, 0.0, 5000.0};
+            static inline std::vector<double> production_rates_sm3_day {500.0, 500.0, 5000.0};
+
+            static std::vector<double> toSI(const std::vector<double>& r)
+            {
+                std::vector<double> out(r.size());
+                std::ranges::transform(r, out.begin(), [](double v) { return convert::from(v, cubic(meter) / day); });
+                return out;
+            }
+
             bool has_production_rates(const std::string) const { return true; }
             bool has_network_leaf_node_injection_rates(const std::string) const { return true; }
             bool has_network_leaf_node_production_rates(const std::string) const { return true; }
             std::vector<double> network_leaf_node_injection_rates(const std::string) const
             {
-                // Phase order water, oil, gas.
-                return {convert::from(500.0, cubic(meter) / day),
-                        0.0,
-                        convert::from(5000.0, cubic(meter) / day)};
+                return toSI(injection_rates_sm3_day);
             }
             std::vector<double> network_leaf_node_production_rates(const std::string) const
             {
-                // Phase order water, oil, gas.
-                return {convert::from(500.0, cubic(meter) / day),
-                        convert::from(500.0, cubic(meter) / day),
-                        convert::from(5000.0, cubic(meter) / day)};
+                return toSI(production_rates_sm3_day);
             }
             Scalar well_group_thp(const std::string&) const { return convert::from(100.0, bars); }
         };
@@ -292,7 +299,7 @@ double terminalPressure(NetworkScenario scenario)
 
 struct NetworkSetup
 {
-    NetworkSetup(NetworkScenario scenario)
+    NetworkSetup(NetworkScenario scenario, std::optional<double> terminal_pressure_override = std::nullopt)
         : deck{Parser{}.parseString(inputString(scenario))}
     {
         // Set up VFP property objects.
@@ -308,8 +315,11 @@ struct NetworkSetup
         network.add_branch(Network::Branch{"M5S", "PLAT-A", 3, 0.0});
         network.add_branch(Network::Branch{"G1", "M5S", 9999, 0.0});
         Network::Node node{"PLAT-A"};
-        node.terminal_pressure(terminalPressure(scenario));
+        node.terminal_pressure(terminal_pressure_override.value_or(terminalPressure(scenario)));
         network.update_node(node);
+        // Restore the default leaf rates so tests do not leak state into each other.
+        MockWellModel::MockGroupStateHelper::MockGroupState::injection_rates_sm3_day = {500.0, 0.0, 5000.0};
+        MockWellModel::MockGroupStateHelper::MockGroupState::production_rates_sm3_day = {500.0, 500.0, 5000.0};
     }
 
     Deck deck;
@@ -393,6 +403,69 @@ BOOST_AUTO_TEST_CASE(production_pressure_computation)
     BOOST_REQUIRE(pressures.find("G1") != pressures.end());
     const auto expected_pressure = convert::from(31.0, bars);
     BOOST_CHECK_CLOSE(pressures.at("G1"), expected_pressure, 1e-7);
+}
+
+// The tables below use zero-filled cells for (rate, THP) combinations the flow line
+// cannot deliver, and their axes do not cover every state the wells may be in during
+// network iterations. A network branch lookup must never extrapolate into that region
+// (it gives negative pressures) nor accept a zero-filled cell as a node pressure.
+
+BOOST_AUTO_TEST_CASE(gas_injection_rate_beyond_flow_axis)
+{
+    auto s = NetworkSetup{NetworkScenario::GasInjection};
+    // 2.5e6 Sm3/d is beyond the last flow-axis point (2.0e6); a linear extrapolation of the
+    // THP=350 row (..., 86.011, 0.000) gives a pressure of about -213 bar.
+    MockWellModel::MockGroupStateHelper::MockGroupState::injection_rates_sm3_day = {0.0, 0.0, 2.5e6};
+
+    using Comm = Dune::Communication<int>;
+    auto comm = Comm{};
+    auto unit_system = UnitSystem {};
+    NetworkPressureComputation<MockWellModel, VFPInjProperties<double>, Comm> comp(
+        s.well_model, s.network, s.vfp_inj_props, unit_system, 0, comm);
+    const auto [pressures, branch_data] = comp.run();
+    BOOST_REQUIRE(pressures.find("G1") != pressures.end());
+    // Clamped to the axis end the table gives 0.0 -> no solution: the node is flagged and the
+    // placeholder pressure is the upstream (terminal) pressure, never a negative value.
+    BOOST_CHECK(pressures.at("M5S") >= unit::atm);
+    BOOST_CHECK(pressures.at("G1") >= unit::atm);
+    BOOST_CHECK(comp.invalidNodes().count("M5S") == 1);
+    BOOST_CHECK(comp.invalidNodes().count("G1") == 1);
+}
+
+BOOST_AUTO_TEST_CASE(gas_injection_zero_cell_region)
+{
+    // At THP=100 bar the table is zero for rates >= 589394 Sm3/d.
+    auto s = NetworkSetup{NetworkScenario::GasInjection, convert::from(100.0, bars)};
+    MockWellModel::MockGroupStateHelper::MockGroupState::injection_rates_sm3_day = {0.0, 0.0, 6.0e5};
+
+    using Comm = Dune::Communication<int>;
+    auto comm = Comm{};
+    auto unit_system = UnitSystem {};
+    NetworkPressureComputation<MockWellModel, VFPInjProperties<double>, Comm> comp(
+        s.well_model, s.network, s.vfp_inj_props, unit_system, 0, comm);
+    const auto [pressures, branch_data] = comp.run();
+    BOOST_REQUIRE(pressures.find("G1") != pressures.end());
+    BOOST_CHECK(pressures.at("G1") >= unit::atm);
+    BOOST_CHECK(comp.invalidNodes().count("M5S") == 1);
+    BOOST_CHECK(comp.invalidNodes().count("G1") == 1);
+}
+
+BOOST_AUTO_TEST_CASE(gas_injection_thp_below_axis)
+{
+    // Terminal pressure 20 bar is below the first THP-axis point (50 bar). Extrapolating the
+    // first interval gives 68.834 - 0.6*(135.406 - 68.834) = 28.9 bar; clamping to the axis
+    // gives the THP=50 row value 68.834 bar.
+    auto s = NetworkSetup{NetworkScenario::GasInjection, convert::from(20.0, bars)};
+
+    using Comm = Dune::Communication<int>;
+    auto comm = Comm{};
+    auto unit_system = UnitSystem {};
+    NetworkPressureComputation<MockWellModel, VFPInjProperties<double>, Comm> comp(
+        s.well_model, s.network, s.vfp_inj_props, unit_system, 0, comm);
+    const auto [pressures, branch_data] = comp.run();
+    BOOST_REQUIRE(pressures.find("G1") != pressures.end());
+    BOOST_CHECK_CLOSE(pressures.at("G1"), convert::from(68.834, bars), 1e-7);
+    BOOST_CHECK(comp.invalidNodes().empty());
 }
 
 BOOST_AUTO_TEST_SUITE_END() // NetworkPressureComputationTests


### PR DESCRIPTION
First slice out of #7348, as agreed there: atgeirr's nine base commits, plus the one on top of them that stops the network reading its VFP tables outside where they are defined.

That last commit introduces `NetworkBranchPressure` (pressure, plus whether the lookup was clamped and whether it has a solution at all) and the invalid-node concept: a node whose lookup lands outside the table gets no pressure rather than a zero, and its descendants inherit that instead of being poisoned by it. Six cases in `tests/test_networkpressure.cpp` cover it, each written to fail without the fix.

Nothing here changes production networks: NETWORK-01 and NETWORK-01_STANDARD are identical to master across all 369 summary vectors except TCPU, and `compareParallelSim_flow+NETWORK-01` passes. Note that the seven `compareECLFiles_flow+NETWORK-01*` tests fail in my checkout on master as well, because my opm-tests predates `GWGR`/`FWGR` in the summary — nothing to do with this branch.

Needs OPM/opm-common#5314 (GNETINJE implies a standard network type). The bracketing node-pressure update, the summary output and the simultaneous solve follow in later slices; #7348 keeps the whole picture in the meantime.