### PR TITLE
detecting when the first perforation values cannot be made consistent

### DIFF
--- a/opm/simulators/wells/ParallelWellInfo.cpp
+++ b/opm/simulators/wells/ParallelWellInfo.cpp
@@ -29,9 +29,12 @@
 #endif
 
 #include <fmt/format.h>
+#include <algorithm>
+#include <array>
 #include <cassert>
 #include <iterator>
 #include <numeric>
+#include <ranges>
 
 namespace Dune
 {
@@ -594,14 +597,43 @@ int ParallelWellInfo<Scalar>::globalPerfToLocalPerf(const int globalIndex) const
 template<class Scalar>
 void ParallelWellInfo<Scalar>::communicateFirstPerforation(bool hasFirst)
 {
-    int first = hasFirst ? 1 : 0;
-    std::vector<int> firstVec(comm_->size());
-    comm_->allgather(&first, 1, firstVec.data());
-    const auto found =
-        std::ranges::find_if(firstVec,
-                             [](int i) -> bool { return i != 0; });
-    if (found != firstVec.end())
-        rankWithFirstPerf_ = found - firstVec.begin();
+    // The same ParallelWellInfo is reused for all the report steps, so any process
+    // selected for an earlier one has to be forgotten. Otherwise a well that no
+    // longer has open connections would keep broadcasting from it.
+    rankWithFirstPerf_ = -1;
+
+    // Two flags per process: whether it holds the first open connection of the well,
+    // and whether it holds any of its open connections (those pushed with
+    // pushBackEclIndex()). The second one distinguishes "the well has no open
+    // connections anywhere", where broadcastFirstPerforationValue() returning each
+    // process its own value is the documented behaviour, from "the well has open
+    // connections, but no process claims the first one", where the processes are
+    // meant to agree on the values of that connection and silently would not.
+    const std::array<int, 2> local {
+        hasFirst ? 1 : 0,
+        commAboveBelow_->numLocalPerfs() > 0 ? 1 : 0
+    };
+    std::vector<int> allVec(2 * comm_->size());
+    comm_->allgather(local.data(), 2, allVec.data());
+
+    for (int rank = 0; rank < comm_->size(); ++rank) {
+        if (allVec[2 * rank] != 0) {
+            rankWithFirstPerf_ = rank;
+            return;
+        }
+    }
+
+    const bool wellHasOpenConnections =
+        std::ranges::any_of(std::views::iota(0, comm_->size()),
+                            [&allVec](const int rank)
+                            { return allVec[2 * rank + 1] != 0; });
+    if (wellHasOpenConnections) {
+        OPM_THROW(std::logic_error,
+                  fmt::format("Well {} has open connections, but none of its {} processes "
+                              "holds the first one, so the values of that connection cannot "
+                              "be made consistent across them.",
+                              name_, comm_->size()));
+    }
 }
 
 template<class Scalar>

--- a/tests/test_parallelwellinfo.cpp
+++ b/tests/test_parallelwellinfo.cpp
@@ -480,3 +480,42 @@ BOOST_AUTO_TEST_CASE(EmptyWell) {
 
     BOOST_CHECK_EQUAL(local_p, global_p);
 }
+
+// A perforated well where no process reports the first open connection cannot have
+// its first perforation values made consistent, so this has to be detected.
+BOOST_AUTO_TEST_CASE(PerforatedWellWithoutFirstPerforation) {
+    auto comm = Opm::Parallel::Communication(Dune::MPIHelper::getCommunicator());
+    Opm::ParallelWellInfo<double> pw({"WELL1", true}, comm);
+
+    pw.beginReset();
+    pw.pushBackEclIndex(-1, comm.rank());
+    pw.endReset();
+
+    BOOST_CHECK_THROW(pw.communicateFirstPerforation(false), std::logic_error);
+}
+
+// The same ParallelWellInfo is reused for all the report steps, so a well that
+// loses its open connections must not keep broadcasting from the process that
+// held the first one earlier.
+BOOST_AUTO_TEST_CASE(FirstPerforationForgottenWhenConnectionsClose) {
+    auto comm = Opm::Parallel::Communication(Dune::MPIHelper::getCommunicator());
+    Opm::ParallelWellInfo<double> pw({"WELL1", true}, comm);
+
+    // First report step: the well is perforated and rank 0 holds its first connection.
+    pw.beginReset();
+    pw.pushBackEclIndex(-1, comm.rank());
+    pw.endReset();
+    pw.communicateFirstPerforation(comm.rank() == 0);
+
+    const double from_first = 1.0;
+    BOOST_CHECK_EQUAL(pw.broadcastFirstPerforationValue(from_first), from_first);
+
+    // Second report step: all the connections are closed, so every process has to
+    // keep its own value instead of the one of the process selected above.
+    pw.beginReset();
+    pw.endReset();
+    pw.communicateFirstPerforation(false);
+
+    const double per_rank = 1.0 + comm.rank();
+    BOOST_CHECK_EQUAL(pw.broadcastFirstPerforationValue(per_rank), per_rank);
+}


### PR DESCRIPTION
broadcastFirstPerforationValue() does nothing when no process reported holding the first open connection of the well, and every process then keeps its own value. That is intended when the well has no open connections at all, but if the well is perforated it means the processes silently end up with different values for the pvt region, the reference density and the pressure, temperature and salt concentration of the first connection.

communicateFirstPerforation() now also gathers whether a process has any perforation, so the two cases can be told apart, and throws for the second.