### PR TITLE
using the reservoir equation index for the coupling matrix C

### DIFF
--- a/opm/simulators/wells/MultisegmentWellAssemble.cpp
+++ b/opm/simulators/wells/MultisegmentWellAssemble.cpp
@@ -405,6 +405,7 @@ void MultisegmentWellAssemble<FluidSystem,Indices>::
 assemblePerforationEq(const int seg,
                       const int local_perf_index,
                       const int comp_idx,
+                      const int reservoir_eq_idx,
                       const EvalWell& cq_s_effective,
                       Equations& eqns1) const
 {
@@ -421,7 +422,7 @@ assemblePerforationEq(const int seg,
     // assemble the jacobians
     for (int pv_idx = 0; pv_idx < numWellEq; ++pv_idx) {
         // also need to consider the efficiency factor when manipulating the jacobians.
-        eqns.C()[seg][local_perf_index][pv_idx][comp_idx] -= cq_s_effective.derivative(pv_idx + Indices::numEq); // input in transformed matrix
+        eqns.C()[seg][local_perf_index][pv_idx][reservoir_eq_idx] -= cq_s_effective.derivative(pv_idx + Indices::numEq); // input in transformed matrix
 
         // the index name for the D should be eq_idx / pv_idx
         eqns.D()[seg][seg][comp_idx][pv_idx] += cq_s_effective.derivative(pv_idx + Indices::numEq);

--- a/opm/simulators/wells/MultisegmentWellAssemble.hpp
+++ b/opm/simulators/wells/MultisegmentWellAssemble.hpp
@@ -129,9 +129,14 @@ public:
                             Equations& eqns) const;
 
     //! \brief Assemble equation for a perforation.
+    //! \details comp_idx is the index of the well equation, while
+    //! reservoir_eq_idx is the index of the corresponding reservoir equation
+    //! (for the coupling matrix C). They coincide for the mass conservation
+    //! equations, but can differ for the energy equation.
     void assemblePerforationEq(const int seg,
                                const int local_perf_index,
                                const int comp_idx,
+                               const int reservoir_eq_idx,
                                const EvalWell& cq_s_effective,
                                Equations& eqns) const;
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1947,7 +1947,7 @@ namespace Opm
                     this->connectionRates_[local_perf_index][comp_idx] = Base::restrictEval(cq_s_effective);
 
                     MultisegmentWellAssemble(*this).
-                        assemblePerforationEq(seg, local_perf_index, comp_idx, cq_s_effective, this->linSys_);
+                        assemblePerforationEq(seg, local_perf_index, comp_idx, comp_idx, cq_s_effective, this->linSys_);
                 }
 
                 // assembling the energy equation for the perforation if needed
@@ -2769,6 +2769,7 @@ namespace Opm
         MultisegmentWellAssemble(*this).
             assemblePerforationEq(seg, local_perf_index,
                                   MSWEval::PrimaryVariables::Temperature,
+                                  Indices::contiEnergyEqIdx,
                                   energy_scaling_factor_ * energy_flux,
                                   this->linSys_);
     }

--- a/opm/simulators/wells/StandardWellAssemble.cpp
+++ b/opm/simulators/wells/StandardWellAssemble.cpp
@@ -201,6 +201,7 @@ template<class FluidSystem, class Indices>
 void StandardWellAssemble<FluidSystem,Indices>::
 assemblePerforationEq(const EvalWell& cq_s_effective,
                       const int componentIdx,
+                      const int reservoirEqIdx,
                       const int cell_idx,
                       const int numWellEq,
                       StandardWellEquationsType& eqns1) const
@@ -213,7 +214,7 @@ assemblePerforationEq(const EvalWell& cq_s_effective,
        // assemble the jacobians
     for (int pvIdx = 0; pvIdx < numWellEq; ++pvIdx) {
         // also need to consider the efficiency factor when manipulating the jacobians.
-        eqns.C()[0][cell_idx][pvIdx][componentIdx] -= cq_s_effective.derivative(pvIdx+Indices::numEq); // intput in transformed matrix
+        eqns.C()[0][cell_idx][pvIdx][reservoirEqIdx] -= cq_s_effective.derivative(pvIdx+Indices::numEq); // input in transformed matrix
         eqns.D()[0][0][componentIdx][pvIdx] += cq_s_effective.derivative(pvIdx+Indices::numEq);
     }
 

--- a/opm/simulators/wells/StandardWellAssemble.hpp
+++ b/opm/simulators/wells/StandardWellAssemble.hpp
@@ -74,8 +74,13 @@ public:
                                StandardWellEquationsType& eqns) const;
 
     //! \brief Assemble equation for a perforation.
+    //! \details componentIdx is the index of the well equation, while
+    //! reservoirEqIdx is the index of the corresponding reservoir equation
+    //! (for the coupling matrix C). They coincide for the mass conservation
+    //! equations, but can differ for the energy equation.
     void assemblePerforationEq(const EvalWell& cq_s_effective,
                                const int componentIdx,
+                               const int reservoirEqIdx,
                                const int cell_idx,
                                const int numWellEq,
                                StandardWellEquationsType& eqns) const;

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -415,6 +415,7 @@ namespace Opm
                 StandardWellAssemble<FluidSystem,Indices>(*this).
                     assemblePerforationEq(cq_s_effective,
                                           componentIdx,
+                                          componentIdx,
                                           perf,
                                           this->primary_variables_.numWellEq(),
                                           this->linSys_);


### PR DESCRIPTION
assemblePerforationEq() now takes the reservoir equation index for the C column in addition to the well equation index. The two coincide for the mass conservation equations, but differ for the energy equation when, e.g., brine is active.