### PR TITLE
flow: synchronize thermal intensive cache

### DIFF
--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -488,9 +488,11 @@ public:
             }
         }
 
-        // Drift compensation needs to be updated before calling the temperature equation
+        // For sequential implicit thermal: finalize TEMP solve,
+        // then refresh cached intensive quantities (temperature-dependent).
         if constexpr(energyModuleType == EnergyModules::SequentialImplicitThermal) {
             this->temperatureModel_.endTimeStep(wellModel_.wellState());
+            this->model().invalidateAndUpdateIntensiveQuantities(/*timeIdx=*/0);
         }
     }
 


### PR DESCRIPTION
This may possibly have been done on purpose, but it creates problem when restarting.

Currently, the intensive quantities are not updated after a new temperature has been solved by the sequential implicit temperature model. This means that the intensive quantities lag with one additional time level.

When doing restart, we rebuild the intensive quantities from primaries. The rebuilt intensive quantities do reflect the updated temperature, meaning we cannot reproduce the same simulator state after deserialization.