### PR TITLE
Fixes threshold pressure initialization across faults.

### DIFF
--- a/opm/simulators/flow/GenericThresholdPressure_impl.hpp
+++ b/opm/simulators/flow/GenericThresholdPressure_impl.hpp
@@ -214,7 +214,7 @@ configureThpresft_()
 
     // extract the multipliers
     int numFaults = faults.size();
-    int numCartesianElem = eclState_.getInputGrid().getCartesianSize();
+    int numCartesianElem = cartMapper_.cartesianSize();
     thpresftValues_.resize(numFaults, -1.0);
     cartElemFaultIdx_.resize(numCartesianElem, -1);
     for (std::size_t faultIdx = 0; faultIdx < faults.size(); ++faultIdx) {


### PR DESCRIPTION
In this case on non-root ranks the eclipse input grid is not there and cannot be accessed. Hence a throw happened if there were entries in THPRESFT and a deadlock occurred. We fix this by using the cartesian mapper to get the catesian size..

Note that there might be more fixes needed as I am running into other deadlocks for a model now.