### PR TITLE
Fix aquifer influx applied to the wrong equation when OIL is inactive

### DIFF
--- a/opm/simulators/aquifers/AquiferAnalytical.hpp
+++ b/opm/simulators/aquifers/AquiferAnalytical.hpp
@@ -193,7 +193,7 @@ public:
 
         // Qai_[idx] is Evaluation: must not pass through getValue() or Newton loses
         // pressure derivatives and the aquifer source becomes explicit.
-        rates[BlackoilIndices::conti0EqIdx + compIdx_()]
+        rates[BlackoilIndices::conti0EqIdx + this->compIdx_()]
             += this->Qai_[idx] / model.dofTotalVolume(cellIdx);
 
         if constexpr (energyModuleType == EnergyModules::FullyImplicitThermal) {
@@ -249,14 +249,6 @@ protected:
     Scalar gravity_() const
     {
         return this->simulator_.problem().gravity()[2];
-    }
-
-    int compIdx_() const
-    {
-        if (this->co2store_or_h2store_())
-            return FluidSystem::oilCompIdx;
-
-        return FluidSystem::waterCompIdx;
     }
 
     void initQuantities()

--- a/opm/simulators/aquifers/AquiferAnalytical.hpp
+++ b/opm/simulators/aquifers/AquiferAnalytical.hpp
@@ -193,7 +193,7 @@ public:
 
         // Qai_[idx] is Evaluation: must not pass through getValue() or Newton loses
         // pressure derivatives and the aquifer source becomes explicit.
-        rates[BlackoilIndices::conti0EqIdx + this->compIdx_()]
+        rates[BlackoilIndices::conti0EqIdx + this->activeCompIdx_]
             += this->Qai_[idx] / model.dofTotalVolume(cellIdx);
 
         if constexpr (energyModuleType == EnergyModules::FullyImplicitThermal) {

--- a/opm/simulators/aquifers/AquiferConstantFlux.hpp
+++ b/opm/simulators/aquifers/AquiferConstantFlux.hpp
@@ -140,7 +140,7 @@ public:
 
         this->connection_flux_[idx] = fw * this->connections_[idx].effective_facearea;
 
-        rates[BlackoilIndices::conti0EqIdx + compIdx_()]
+        rates[BlackoilIndices::conti0EqIdx + this->compIdx_()]
                 += this->connection_flux_[idx] / model.dofTotalVolume(cellIdx);
     }
 
@@ -202,15 +202,6 @@ private:
         return (tot_face_area > 0.0)
             ? connected_face_area / tot_face_area
             : 0.0;
-    }
-
-    // TODO: this is a function from AquiferAnalytical
-    int compIdx_() const
-    {
-        if (this->co2store_or_h2store_())
-            return FluidSystem::oilCompIdx;
-
-        return FluidSystem::waterCompIdx;
     }
 
     Scalar totalFluxRate() const

--- a/opm/simulators/aquifers/AquiferConstantFlux.hpp
+++ b/opm/simulators/aquifers/AquiferConstantFlux.hpp
@@ -140,7 +140,7 @@ public:
 
         this->connection_flux_[idx] = fw * this->connections_[idx].effective_facearea;
 
-        rates[BlackoilIndices::conti0EqIdx + this->compIdx_()]
+        rates[BlackoilIndices::conti0EqIdx + this->activeCompIdx_]
                 += this->connection_flux_[idx] / model.dofTotalVolume(cellIdx);
     }
 

--- a/opm/simulators/aquifers/AquiferInterface.hpp
+++ b/opm/simulators/aquifers/AquiferInterface.hpp
@@ -101,6 +101,14 @@ protected:
         return FluidSystem::waterPhaseIdx;
     }
 
+    // Component of the phase the aquifer feeds, as an ACTIVE index: callers use
+    // it to offset conti0EqIdx.
+    int compIdx_() const
+    {
+        return FluidSystem::activePhaseToActiveCompIdx(
+            FluidSystem::canonicalToActivePhaseIdx(this->phaseIdx_()));
+    }
+
     const int aquiferID_{};
     const Simulator& simulator_;
 };

--- a/opm/simulators/aquifers/AquiferInterface.hpp
+++ b/opm/simulators/aquifers/AquiferInterface.hpp
@@ -22,10 +22,16 @@
 #ifndef OPM_AQUIFERINTERFACE_HEADER_INCLUDED
 #define OPM_AQUIFERINTERFACE_HEADER_INCLUDED
 
+#include <opm/common/ErrorMacros.hpp>
+
 #include <opm/models/common/multiphasebaseproperties.hh>
 #include <opm/models/discretization/common/fvbaseproperties.hh>
 
 #include <opm/output/data/Aquifer.hpp>
+
+#include <fmt/format.h>
+
+#include <stdexcept>
 
 namespace Opm
 {
@@ -44,6 +50,7 @@ public:
                      const Simulator& simulator)
         : aquiferID_(aqID)
         , simulator_(simulator)
+        , activeCompIdx_(resolveActiveCompIdx_())
     {
     }
 
@@ -101,16 +108,27 @@ protected:
         return FluidSystem::waterPhaseIdx;
     }
 
-    // Component of the phase the aquifer feeds, as an ACTIVE index: callers use
-    // it to offset conti0EqIdx.
-    int compIdx_() const
-    {
-        return FluidSystem::activePhaseToActiveCompIdx(
-            FluidSystem::canonicalToActivePhaseIdx(this->phaseIdx_()));
-    }
-
     const int aquiferID_{};
     const Simulator& simulator_;
+
+    // Active component index of the aquifer's phase, for offsetting conti0EqIdx.
+    const int activeCompIdx_{};
+
+private:
+    int resolveActiveCompIdx_() const
+    {
+        const auto phaseIdx = this->phaseIdx_();
+
+        if (! FluidSystem::phaseIsActive(phaseIdx)) {
+            OPM_THROW(std::logic_error,
+                      fmt::format("Aquifer {} needs an active {} phase",
+                                  this->aquiferID_,
+                                  FluidSystem::phaseName(phaseIdx)));
+        }
+
+        return FluidSystem::canonicalToActiveCompIdx(
+            FluidSystem::solventComponentIndex(phaseIdx));
+    }
 };
 
 } // namespace Opm

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -584,6 +584,57 @@ add_test_compareECLFiles(
 
 add_test_compareECLFiles(
   CASENAME
+    aquct_02_gaswater
+  FILENAME
+    AQUCT-02
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gaswater
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    aquifers
+)
+
+add_test_compareECLFiles(
+  CASENAME
+    aquct_03_onephase
+  FILENAME
+    AQUCT-03
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_onephase
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    aquifers
+)
+
+add_test_compareECLFiles(
+  CASENAME
+    aquflux_03_gaswater
+  FILENAME
+    AQUFLUX-03
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_gaswater
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    aquifers
+)
+
+add_test_compareECLFiles(
+  CASENAME
     spe3
   FILENAME
     SPE3CASE1


### PR DESCRIPTION
## Summary

`AquiferAnalytical` and `AquiferConstantFlux` add their influx with

```cpp
rates[BlackoilIndices::conti0EqIdx + compIdx_()] += ...
```

but `compIdx_()` returned a **canonical** component index (`oil=0, water=1, gas=2`), while `conti0EqIdx + n` selects the **n-th active** equation. The two coincide only when OIL is active, so any WATER+GAS deck sends its aquifer water into the gas equation. Affects `AQUCT`, `AQUFETP` (shared base) and `AQUFLUX`.

Two consequences:

1. **Wrong physics.** In a WATER+GAS run the reservoir gains no water and gas is created from nothing.
2. **Memory corruption.** In a single-phase WATER run `numEq == 1`, so the only valid slot is `conti0EqIdx + 0`; canonical `waterCompIdx == 1` writes one past the end of the `RateVector`, which reproduces as `*** stack smashing detected ***`.

This was not caught because every analytic-aquifer regression case (`ctaquifer_2d_oilwater`, `fetkovich_2d`, `aquflux_01`, `aquflux_02`) contains oil.

## Fix

`compIdx_()` is consolidated into `AquiferInterface` next to `phaseIdx_()` and derived from it, so the two can no longer disagree about which phase the aquifer feeds. This also removes the duplicate in `AquiferConstantFlux` that carried a `// TODO: this is a function from AquiferAnalytical` comment.

Going via the phase accessor is deliberate: `canonicalToActiveCompIdx()` returns **-1** for an inactive component, so mapping `waterCompIdx` directly would write to `rates[-1]` in a deck with an aquifer but no water phase. `canonicalToActivePhaseIdx()` throws instead.

## Validation

A few minimal decks covering the phase configurations (one is posted in a comment below), run before and after. Decks with OIL active are **bit-identical** (max relative difference exactly 0 across `FPR`, `FWIP`, `FOIP`, `FGIP` and `AAQT:1`).
WATER+GAS decks now close the water balance and create no gas, and the single-phase WATER deck no longer smashes the stack. Covers `AQUCT`, `AQUFETP` and `AQUFLUX`.

## Notes

- Possibly related, unconfirmed: #3985 reports "AQUANCON is ignored", wrong gas production, and a conventional waterflood model that matches the reference exactly, which fits this signature. I have not examined those decks.
- #7213 also fixes a Carter-Tracy issue but touches only `AquiferCarterTracy.hpp`, so there should be no conflict.
