### PR TITLE
Write compositional saturation pressure to restart output

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -468,6 +468,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_aqantrc_flow_keyword.cpp
   tests/test_blackoil_amg.cpp
   tests/test_blackoilprimaryvariables.cpp
+  tests/test_compositionalcontainer.cpp
   tests/test_compwell_equations.cpp
   tests/test_compwell_jacobian.cpp
   tests/test_convergenceoutputconfiguration.cpp

--- a/opm/simulators/flow/CompositionalContainer.cpp
+++ b/opm/simulators/flow/CompositionalContainer.cpp
@@ -80,15 +80,15 @@ allocate(const unsigned bufferSize,
         gasPressure_.resize(bufferSize, 0.0);
     }
 
-    // Summary-only substeps must not retain a PSAT buffer from a previous
-    // preparation pass: its presence enables a nonlinear solve in every cell.
+    // A pass without restart output must not retain a PSAT buffer from the
+    // previous pass: its presence enables a nonlinear solve in every cell.
     saturationPressure_.clear();
-    if (auto& psat = rstKeywords["PSAT"]; psat > 0) {
+    saturationPressureRequested_ = false;
+    if (auto& psat = rstKeywords["PSAT"]; psat > 0 && isRestartOutput) {
+        saturationPressureRequested_ = true;
         psat = 0;
-        if (isRestartOutput) {
-            this->allocated_ = true;
-            saturationPressure_.resize(bufferSize, 0.0);
-        }
+        this->allocated_ = true;
+        saturationPressure_.resize(bufferSize, 0.0);
     }
 
     if (auto& vmf = rstKeywords["VMF"]; vmf > 0) {
@@ -249,16 +249,16 @@ cellSaturationPressure(const Scalar liquidFraction,
                        const Scalar temperature,
                        const CompositionalConfig::EOSType eosType) -> std::optional<Scalar>
 {
-    // Compare the flash's exact single-phase labels: a two-phase Rachford-Rice
-    // result can round slightly outside (0, 1).
+    // Compare against the flash's exact single-phase labels. Round-off can put
+    // a two-phase Rachford-Rice result slightly outside the interval [0, 1].
     const bool liquidOnly = (liquidFraction == 1.0);
     const bool vapourOnly = (liquidFraction == 0.0);
     if (!liquidOnly && !vapourOnly) {
         return oilPressure;
     }
 
-    // The zero-component instantiation exists only to register a parameter
-    // and has no equation of state to solve.
+    // The zero-component instantiation exists only to register
+    // ForceDisableFluidInPlaceOutput and has no equation of state to solve.
     if constexpr (numComponents > 0) {
         using Solver = SaturationPressure<Scalar, FluidSystem>;
         typename Solver::CompVec incipient;

--- a/opm/simulators/flow/CompositionalContainer.cpp
+++ b/opm/simulators/flow/CompositionalContainer.cpp
@@ -251,8 +251,8 @@ cellSaturationPressure(const Scalar liquidFraction,
 {
     // Compare against the flash's exact single-phase labels. Round-off can put
     // a two-phase Rachford-Rice result slightly outside the interval [0, 1].
-    const bool liquidOnly = (liquidFraction == 1.0);
-    const bool vapourOnly = (liquidFraction == 0.0);
+    const bool liquidOnly = liquidFraction == Scalar{1};
+    const bool vapourOnly = liquidFraction == Scalar{0};
     if (!liquidOnly && !vapourOnly) {
         return oilPressure;
     }

--- a/opm/simulators/flow/CompositionalContainer.cpp
+++ b/opm/simulators/flow/CompositionalContainer.cpp
@@ -23,11 +23,15 @@
 #include <config.h>
 #include <opm/simulators/flow/CompositionalContainer.hpp>
 
+#include <opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp>
+
+#include <opm/material/constraintsolvers/SaturationPressure.hpp>
 #include <opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp>
 
 #include <opm/output/data/Solution.hpp>
 
 #include <algorithm>
+#include <optional>
 #include <tuple>
 
 #include <fmt/format.h>
@@ -37,7 +41,8 @@ namespace Opm {
 template<class FluidSystem>
 void CompositionalContainer<FluidSystem>::
 allocate(const unsigned bufferSize,
-         std::map<std::string, int>& rstKeywords)
+         std::map<std::string, int>& rstKeywords,
+         const bool isRestartOutput)
 {
     if (auto& zmf = rstKeywords["ZMF"]; zmf > 0) {
         this->allocated_ = true;
@@ -73,6 +78,17 @@ allocate(const unsigned bufferSize,
         this->allocated_ = true;
         pgas = 0;
         gasPressure_.resize(bufferSize, 0.0);
+    }
+
+    // Summary-only substeps must not retain a PSAT buffer from a previous
+    // preparation pass: its presence enables a nonlinear solve in every cell.
+    saturationPressure_.clear();
+    if (auto& psat = rstKeywords["PSAT"]; psat > 0) {
+        psat = 0;
+        if (isRestartOutput) {
+            this->allocated_ = true;
+            saturationPressure_.resize(bufferSize, 0.0);
+        }
     }
 
     if (auto& vmf = rstKeywords["VMF"]; vmf > 0) {
@@ -142,6 +158,16 @@ assignPhasePressures(const unsigned globalDofIdx,
 
 template<class FluidSystem>
 void CompositionalContainer<FluidSystem>::
+assignSaturationPressure(const unsigned globalDofIdx,
+                         const Scalar psat)
+{
+    if (!saturationPressure_.empty()) {
+        saturationPressure_[globalDofIdx] = psat;
+    }
+}
+
+template<class FluidSystem>
+void CompositionalContainer<FluidSystem>::
 assignVaporFraction(const unsigned globalDofIdx,
                     const Scalar vmf)
 {
@@ -205,6 +231,7 @@ outputRestart(data::Solution& sol,
 
     entries.emplace_back("POIL", UnitSystem::measure::pressure, oilPressure_);
     entries.emplace_back("PGAS", UnitSystem::measure::pressure, gasPressure_);
+    entries.emplace_back("PSAT", UnitSystem::measure::pressure, saturationPressure_);
     entries.emplace_back("VMF", UnitSystem::measure::identity, vaporFraction_);
 
     std::ranges::for_each(entries,
@@ -212,6 +239,38 @@ outputRestart(data::Solution& sol,
                           { doInsert(array, data::TargetType::RESTART_SOLUTION); });
 
     this->allocated_ = false;
+}
+
+template<class FluidSystem>
+auto CompositionalContainer<FluidSystem>::
+cellSaturationPressure(const Scalar liquidFraction,
+                       const Scalar oilPressure,
+                       const std::array<Scalar, numComponents>& moleFractions,
+                       const Scalar temperature,
+                       const CompositionalConfig::EOSType eosType) -> std::optional<Scalar>
+{
+    // Compare the flash's exact single-phase labels: a two-phase Rachford-Rice
+    // result can round slightly outside (0, 1).
+    const bool liquidOnly = (liquidFraction == 1.0);
+    const bool vapourOnly = (liquidFraction == 0.0);
+    if (!liquidOnly && !vapourOnly) {
+        return oilPressure;
+    }
+
+    // The zero-component instantiation exists only to register a parameter
+    // and has no equation of state to solve.
+    if constexpr (numComponents > 0) {
+        using Solver = SaturationPressure<Scalar, FluidSystem>;
+        typename Solver::CompVec incipient;
+        Scalar psat = 0.0;
+        const bool found = liquidOnly
+            ? Solver::bubblePressure(moleFractions, temperature, eosType, psat, incipient)
+            : Solver::dewPressure(moleFractions, temperature, eosType, psat, incipient);
+        if (found) {
+            return psat;
+        }
+    }
+    return std::nullopt;
 }
 
 #define INSTANTIATE_COMP_THREEPHASE(NUM) \

--- a/opm/simulators/flow/CompositionalContainer.cpp
+++ b/opm/simulators/flow/CompositionalContainer.cpp
@@ -42,7 +42,7 @@ template<class FluidSystem>
 void CompositionalContainer<FluidSystem>::
 allocate(const unsigned bufferSize,
          std::map<std::string, int>& rstKeywords,
-         const bool isRestartOutput)
+         const RestartOutput restartOutput)
 {
     if (auto& zmf = rstKeywords["ZMF"]; zmf > 0) {
         this->allocated_ = true;
@@ -84,7 +84,7 @@ allocate(const unsigned bufferSize,
     // previous pass: its presence enables a nonlinear solve in every cell.
     saturationPressure_.clear();
     saturationPressureRequested_ = false;
-    if (auto& psat = rstKeywords["PSAT"]; psat > 0 && isRestartOutput) {
+    if (auto& psat = rstKeywords["PSAT"]; psat > 0 && restartOutput == RestartOutput::Enabled) {
         saturationPressureRequested_ = true;
         psat = 0;
         this->allocated_ = true;
@@ -261,8 +261,8 @@ cellSaturationPressure(const Scalar liquidFraction,
     // ForceDisableFluidInPlaceOutput and has no equation of state to solve.
     if constexpr (numComponents > 0) {
         using Solver = SaturationPressure<Scalar, FluidSystem>;
-        typename Solver::CompVec incipient;
-        Scalar psat = 0.0;
+        typename Solver::CompVec incipient{};
+        Scalar psat{};
         const bool found = liquidOnly
             ? Solver::bubblePressure(moleFractions, temperature, eosType, psat, incipient)
             : Solver::dewPressure(moleFractions, temperature, eosType, psat, incipient);

--- a/opm/simulators/flow/CompositionalContainer.hpp
+++ b/opm/simulators/flow/CompositionalContainer.hpp
@@ -26,9 +26,12 @@
 #ifndef OPM_COMPOSITIONAL_CONTAINER_HPP
 #define OPM_COMPOSITIONAL_CONTAINER_HPP
 
+#include <opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp>
+
 #include <array>
 #include <functional>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -51,7 +54,8 @@ class CompositionalContainer
 
 public:
     void allocate(const unsigned bufferSize,
-                  std::map<std::string, int>& rstKeywords);
+                  std::map<std::string, int>& rstKeywords,
+                  const bool isRestartOutput);
 
     using AssignFunction = std::function<Scalar(const unsigned)>;
 
@@ -67,6 +71,24 @@ public:
     void assignPhasePressures(const unsigned globalDofIdx,
                               const Scalar oilPressure,
                               const Scalar gasPressure);
+
+    void assignSaturationPressure(const unsigned globalDofIdx,
+                                  const Scalar psat);
+
+    /// Return the cell pressure for two hydrocarbon phases, or the bubble/dew
+    /// pressure of the total composition for a single phase. Return std::nullopt
+    /// if the solver cannot determine a saturation pressure.
+    ///
+    /// \p liquidFraction is the flash liquid fraction L: exactly one denotes
+    /// liquid only, exactly zero vapour only, and other values denote two phases.
+    /// Use L because computed phase saturations can contain round-off residuals.
+    /// Plain-value arguments allow testing phase selection without a simulator.
+    [[nodiscard]] static std::optional<Scalar>
+    cellSaturationPressure(const Scalar liquidFraction,
+                           const Scalar oilPressure,
+                           const std::array<Scalar, numComponents>& moleFractions,
+                           const Scalar temperature,
+                           const CompositionalConfig::EOSType eosType);
 
     void assignVaporFraction(const unsigned globalDofIdx,
                              const Scalar vmf);
@@ -89,6 +111,9 @@ public:
     bool vaporFractionAllocated() const
     { return !vaporFraction_.empty(); }
 
+    bool saturationPressureAllocated() const
+    { return !saturationPressure_.empty(); }
+
     bool allocated() const
     { return allocated_; }
 
@@ -101,6 +126,8 @@ private:
     // phase pressures (POIL, PGAS)
     ScalarBuffer oilPressure_;
     ScalarBuffer gasPressure_;
+    // saturation pressure (PSAT)
+    ScalarBuffer saturationPressure_;
     // vapour mole fraction of the total mixture (VMF)
     ScalarBuffer vaporFraction_;
 };

--- a/opm/simulators/flow/CompositionalContainer.hpp
+++ b/opm/simulators/flow/CompositionalContainer.hpp
@@ -53,6 +53,9 @@ class CompositionalContainer
     static constexpr int waterPhaseIdx = FluidSystem::waterPhaseIdx;
 
 public:
+    /// Allocate compositional restart fields requested by \p rstKeywords.
+    /// PSAT is allocated only for restart output because computing it requires
+    /// a nonlinear saturation-pressure solve in each cell.
     void allocate(const unsigned bufferSize,
                   std::map<std::string, int>& rstKeywords,
                   const bool isRestartOutput);
@@ -75,9 +78,9 @@ public:
     void assignSaturationPressure(const unsigned globalDofIdx,
                                   const Scalar psat);
 
-    /// Return the cell pressure for two hydrocarbon phases, or the bubble/dew
-    /// pressure of the total composition for a single phase. Return std::nullopt
-    /// if the solver cannot determine a saturation pressure.
+    /// Return the oil-phase pressure for two hydrocarbon phases, or the
+    /// bubble/dew pressure of the total composition for a single phase. Return
+    /// std::nullopt if the solver cannot determine a saturation pressure.
     ///
     /// \p liquidFraction is the flash liquid fraction L: exactly one denotes
     /// liquid only, exactly zero vapour only, and other values denote two phases.
@@ -114,6 +117,11 @@ public:
     bool saturationPressureAllocated() const
     { return !saturationPressure_.empty(); }
 
+    /// Whether PSAT was requested in this allocation pass. Unlike the buffer
+    /// state above, this remains true on MPI ranks with no local cells.
+    bool saturationPressureRequested() const
+    { return saturationPressureRequested_; }
+
     bool allocated() const
     { return allocated_; }
 
@@ -128,6 +136,7 @@ private:
     ScalarBuffer gasPressure_;
     // saturation pressure (PSAT)
     ScalarBuffer saturationPressure_;
+    bool saturationPressureRequested_ = false;
     // vapour mole fraction of the total mixture (VMF)
     ScalarBuffer vaporFraction_;
 };

--- a/opm/simulators/flow/CompositionalContainer.hpp
+++ b/opm/simulators/flow/CompositionalContainer.hpp
@@ -56,8 +56,9 @@ public:
     enum class RestartOutput { Disabled, Enabled };
 
     /// Allocate compositional restart fields requested by \p rstKeywords.
-    /// PSAT is allocated only for restart output because computing it requires
-    /// a nonlinear saturation-pressure solve in each cell.
+    /// PSAT is currently consumed only by restart output. Allocate it only
+    /// for passes that will write restart data because filling the buffer
+    /// requires a nonlinear solve for each single-phase cell.
     void allocate(const unsigned bufferSize,
                   std::map<std::string, int>& rstKeywords,
                   RestartOutput restartOutput);

--- a/opm/simulators/flow/CompositionalContainer.hpp
+++ b/opm/simulators/flow/CompositionalContainer.hpp
@@ -53,12 +53,14 @@ class CompositionalContainer
     static constexpr int waterPhaseIdx = FluidSystem::waterPhaseIdx;
 
 public:
+    enum class RestartOutput { Disabled, Enabled };
+
     /// Allocate compositional restart fields requested by \p rstKeywords.
     /// PSAT is allocated only for restart output because computing it requires
     /// a nonlinear saturation-pressure solve in each cell.
     void allocate(const unsigned bufferSize,
                   std::map<std::string, int>& rstKeywords,
-                  const bool isRestartOutput);
+                  RestartOutput restartOutput);
 
     using AssignFunction = std::function<Scalar(const unsigned)>;
 

--- a/opm/simulators/flow/DamarisWriter.hpp
+++ b/opm/simulators/flow/DamarisWriter.hpp
@@ -442,7 +442,8 @@ private:
         const bool log = this->collectOnIORank_.isIORank();
 
         damarisOutputModule_->allocBuffers(num_interior, reportStepNum,
-                                      isSubStep, log, /*isRestart*/ false);
+                                           isSubStep, log,
+                                           /*forceRestartFieldAllocation=*/false);
 
         ElementContext elemCtx(simulator_);
         OPM_BEGIN_PARALLEL_TRY_CATCH();
@@ -476,8 +477,11 @@ private:
                 damarisOutputModule_->updateFluidInPlace(dofIdx, intQuants, totVolume);
         }
         }
+        OPM_END_PARALLEL_TRY_CATCH("DamarisWriter::prepareLocalCellData() failed: ",
+                                   simulator_.vanguard().grid().comm());
+
+        // Keep collective validation outside rank-local exception handling.
         damarisOutputModule_->validateLocalData();
-        OPM_END_PARALLEL_TRY_CATCH("DamarisWriter::prepareLocalCellData() failed: ", simulator_.vanguard().grid().comm());
     }
 
 };

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -863,8 +863,6 @@ private:
                 this->outputModule_->processElementBlockData(elemCtx);
             }
             this->outputModule_->clearExtractors();
-
-            this->outputModule_->accumulateDensityParallel();
         }
 
         {
@@ -881,10 +879,12 @@ private:
             }
         }
 
-        this->outputModule_->validateLocalData();
-
         OPM_END_PARALLEL_TRY_CATCH("EclWriter::prepareLocalCellData() failed: ",
                                    this->simulator_.vanguard().grid().comm());
+
+        // Complete rank-wide exception handling before entering output collectives.
+        this->outputModule_->accumulateDensityParallel();
+        this->outputModule_->validateLocalData();
     }
 
     void captureLocalFluxData()

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -406,7 +406,8 @@ public:
             countLocalInteriorCellsGridView(gridView);
 
         this->outputModule_->
-            allocBuffers(num_interior, 0, false, false, /*isRestart*/ false);
+            allocBuffers(num_interior, 0, false, false,
+                         /*forceRestartFieldAllocation=*/false);
 
 #ifdef _OPENMP
 #pragma omp parallel for
@@ -639,7 +640,7 @@ public:
                                               0,
                                               /*isSubStep = */false,
                                               /*log = */      false,
-                                              /*isRestart = */true);
+                                              /*forceRestartFieldAllocation = */true);
 
             const auto restartSolution =
                 loadParallelRestartSolution(this->eclIO_.get(),
@@ -676,7 +677,7 @@ public:
                                               restartStepIdx,
                                               /*isSubStep = */false,
                                               /*log = */      false,
-                                              /*isRestart = */true);
+                                              /*forceRestartFieldAllocation = */true);
         }
 
         {
@@ -844,7 +845,8 @@ private:
         const bool writeAllSolutions =
             Parameters::Get<Parameters::EnableWriteAllSolutions>();
 
-        // EclipseIO forces restart output for positive time-step indices in write-all mode.
+        // EclipseIO writes restart output for every positive time-step index in
+        // write-all mode, independently of the schedule's BASIC/FREQ settings.
         const bool forceRestartFieldAllocation =
             writeAllSolutions && (simulator_.timeStepIndex() > 0);
         this->outputModule_->
@@ -888,7 +890,7 @@ private:
         OPM_END_PARALLEL_TRY_CATCH("EclWriter::prepareLocalCellData() failed: ",
                                    this->simulator_.vanguard().grid().comm());
 
-        // Complete rank-wide exception handling before entering output collectives.
+        // Propagate rank-local exceptions before entering output collectives.
         this->outputModule_->accumulateDensityParallel();
         this->outputModule_->validateLocalData();
     }

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -841,10 +841,16 @@ private:
 
         const int num_interior = detail::
             countLocalInteriorCellsGridView(gridView);
+        const bool writeAllSolutions =
+            Parameters::Get<Parameters::EnableWriteAllSolutions>();
+
+        // EclipseIO forces restart output for positive time-step indices in write-all mode.
+        const bool forceRestartFieldAllocation =
+            writeAllSolutions && (simulator_.timeStepIndex() > 0);
         this->outputModule_->
             allocBuffers(num_interior, reportStepNum,
-                         isSubStep && !Parameters::Get<Parameters::EnableWriteAllSolutions>(),
-                         log, /*isRestart*/ false);
+                         isSubStep && !writeAllSolutions,
+                         log, forceRestartFieldAllocation);
 
         ElementContext elemCtx(simulator_);
 

--- a/opm/simulators/flow/GenericOutputModule.cpp
+++ b/opm/simulators/flow/GenericOutputModule.cpp
@@ -637,7 +637,7 @@ doAllocBuffers(const unsigned bufferSize,
                const unsigned reportStepNum,
                const bool     substep,
                const bool     log,
-               const bool     isRestart,
+               const bool     forceRestartFieldAllocation,
                const EclHysteresisConfig* hysteresisConfig,
                const unsigned numOutputNnc,
                std::map<std::string, int> rstKeywords)
@@ -706,7 +706,8 @@ doAllocBuffers(const unsigned bufferSize,
         this->rftC_.allocate(reportStepNum);
     }
 
-    const bool alloc_fields = isRestart || (schedule_.write_rst_file(reportStepNum) && !substep);
+    const bool alloc_fields = forceRestartFieldAllocation ||
+        (schedule_.write_rst_file(reportStepNum) && !substep);
     this->flowsC_.allocate(bufferSize, summaryConfig_, numOutputNnc, alloc_fields, rstKeywords);
 
     // Field data should be allocated

--- a/opm/simulators/flow/GenericOutputModule.cpp
+++ b/opm/simulators/flow/GenericOutputModule.cpp
@@ -710,10 +710,9 @@ doAllocBuffers(const unsigned bufferSize,
         (schedule_.write_rst_file(reportStepNum) && !substep);
     this->flowsC_.allocate(bufferSize, summaryConfig_, numOutputNnc, alloc_fields, rstKeywords);
 
-    // Field data should be allocated
-    // 1) When we want to restart
-    // 2) When it is ask for by the user via restartConfig
-    // 3) When it is not a substep
+    // Allocate cell-based restart fields when the schedule requests a restart
+    // file, or when a caller needs them independently of the output schedule
+    // (while loading restart data or producing write-all snapshots).
     if (!alloc_fields) {
         return;
     }

--- a/opm/simulators/flow/GenericOutputModule.hpp
+++ b/opm/simulators/flow/GenericOutputModule.hpp
@@ -286,7 +286,10 @@ public:
         local_data_valid_ = false;
     }
 
-    void validateLocalData(){
+    /// Mark per-cell output data valid. All ranks must call this method,
+    /// since overrides may reduce per-rank data.
+    virtual void validateLocalData()
+    {
         local_data_valid_ = true;
     }
 

--- a/opm/simulators/flow/GenericOutputModule.hpp
+++ b/opm/simulators/flow/GenericOutputModule.hpp
@@ -286,8 +286,8 @@ public:
         local_data_valid_ = false;
     }
 
-    /// Mark per-cell output data valid. All ranks must call this method,
-    /// since overrides may reduce per-rank data.
+    /// Finalize per-cell output and mark it valid. Call this method on every
+    /// rank because overrides may perform collectives.
     virtual void validateLocalData()
     {
         local_data_valid_ = true;

--- a/opm/simulators/flow/GenericOutputModule.hpp
+++ b/opm/simulators/flow/GenericOutputModule.hpp
@@ -467,7 +467,7 @@ protected:
                         unsigned reportStepNum,
                         const bool substep,
                         const bool log,
-                        const bool isRestart,
+                        const bool forceRestartFieldAllocation,
                         const EclHysteresisConfig* hysteresisConfig,
                         unsigned numOutputNnc = 0,
                         std::map<std::string, int> rstKeywords = {});

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -269,7 +269,7 @@ public:
                  const unsigned reportStepNum,
                  const bool     substep,
                  const bool     log,
-                 const bool     isRestart)
+                 const bool     forceRestartFieldAllocation)
     {
         if (! std::is_same<Discretization, EcfvDiscretization<TypeTag>>::value) {
             return;
@@ -281,7 +281,7 @@ public:
                              reportStepNum,
                              substep,
                              log,
-                             isRestart,
+                             forceRestartFieldAllocation,
                              &problem.materialLawManager()->hysteresisConfig(),
                              problem.eclWriter().getOutputNnc().front().size());
     }

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -195,7 +195,7 @@ public:
             ? RestartOutput::Enabled
             : RestartOutput::Disabled;
         this->compC_.allocate(bufferSize, rstKeywords, restartOutput);
-        this->numFailedSaturationPressures_ = 0;
+        this->numUnresolvedSaturationPressures_ = 0;
 
         this->doAllocBuffers(bufferSize, reportStepNum, substep, log,
                              forceRestartFieldAllocation,
@@ -732,22 +732,26 @@ public:
         this->assignSaturationPressure_(globalDofIdx, intQuants.fluidState());
     }
 
-    /// When PSAT is requested, reduce failures across all ranks before marking
-    /// the output data valid.
+    /// When PSAT is requested, reduce the count of unresolved cells across all
+    /// ranks before marking the output data valid.
     void validateLocalData() override
     {
         if (this->compC_.saturationPressureRequested()) {
             const auto& comm = this->simulator_.gridView().comm();
-            const auto totalFailures = comm.sum(this->numFailedSaturationPressures_);
-            if (totalFailures > 0 && comm.rank() == 0) {
-                const auto* const cell = totalFailures == 1 ? "cell" : "cells";
-                OpmLog::info(fmt::format("Could not determine saturation pressure in {} {}; "
-                                         "PSAT is written as zero for every affected cell.",
-                                         totalFailures,
+            const auto totalUnresolved = comm.sum(this->numUnresolvedSaturationPressures_);
+            if (totalUnresolved > 0 && comm.rank() == 0) {
+                const std::string_view cell = totalUnresolved == 1 ? "cell" : "cells";
+                // Some unresolved searches correspond to states with no saturation
+                // boundary at this composition and temperature, so report the aggregate
+                // informationally rather than treating every result as a solver failure.
+                OpmLog::info(fmt::format("No saturation pressure was resolved in {} {}; "
+                                         "PSAT is written as zero there. This includes "
+                                         "mixtures that have none.",
+                                         totalUnresolved,
                                          cell));
             }
         }
-        this->numFailedSaturationPressures_ = 0;
+        this->numUnresolvedSaturationPressures_ = 0;
         BaseType::validateLocalData();
     }
 
@@ -815,7 +819,7 @@ private:
     }
 
     /// Store the cell's saturation pressure, using zero for an unsuccessful solve.
-    /// Concurrent calls must use distinct cell indices; the failure count is atomic.
+    /// Concurrent calls must use distinct cell indices; the unresolved count is atomic.
     template<class FluidState>
     void assignSaturationPressure_(const unsigned globalDofIdx, const FluidState& fluidState)
     {
@@ -834,12 +838,13 @@ private:
             getValue(fluidState.temperature(oilPhaseIdx)),
             this->eosType_);
         if (!psat) {
-            // Failure includes supercritical mixtures; it does not establish
-            // whether a saturation pressure exists.
+            // A false result means only that no saturation pressure was resolved;
+            // it does not distinguish a physically absent boundary from numerical
+            // nonconvergence.
 #ifdef _OPENMP
 #pragma omp atomic
 #endif
-            ++this->numFailedSaturationPressures_;
+            ++this->numUnresolvedSaturationPressures_;
         }
 
         this->compC_.assignSaturationPressure(globalDofIdx, psat.value_or(Scalar{0}));
@@ -848,7 +853,7 @@ private:
     const Simulator& simulator_;
     CompositionalContainer<FluidSystem> compC_;
     CompositionalConfig::EOSType eosType_;
-    std::size_t numFailedSaturationPressures_{};
+    std::size_t numUnresolvedSaturationPressures_{};
     std::vector<typename Extractor::Entry> extractors_;
     typename BlockExtractor::ExecMap blockExtractors_;
 };

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -88,6 +88,7 @@ class OutputCompositionalModule : public GenericOutputModule<GetPropType<TypeTag
     using IntensiveQuantities = GetPropType<TypeTag, Properties::IntensiveQuantities>;
     using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
     using BaseType = GenericOutputModule<FluidSystem>;
+    using RestartOutput = typename CompositionalContainer<FluidSystem>::RestartOutput;
     using Extractor = detail::Extractor<TypeTag>;
     using BlockExtractor = detail::BlockExtractor<TypeTag>;
 
@@ -188,10 +189,12 @@ public:
         }
 
         auto rstKeywords = this->schedule_.rst_keywords(reportStepNum);
-        const bool isRestartOutput =
-            forceRestartFieldAllocation ||
+        const bool isRestartOutput = forceRestartFieldAllocation ||
             (!substep && this->schedule_.write_rst_file(reportStepNum));
-        this->compC_.allocate(bufferSize, rstKeywords, isRestartOutput);
+        const auto restartOutput = isRestartOutput
+            ? RestartOutput::Enabled
+            : RestartOutput::Disabled;
+        this->compC_.allocate(bufferSize, rstKeywords, restartOutput);
         this->numFailedSaturationPressures_ = 0;
 
         this->doAllocBuffers(bufferSize, reportStepNum, substep, log,
@@ -820,7 +823,7 @@ private:
             return;
         }
 
-        std::array<Scalar, numComponents> moleFractions;
+        std::array<Scalar, numComponents> moleFractions{};
         for (int c = 0; c < numComponents; ++c) {
             moleFractions[c] = getValue(fluidState.moleFraction(c));
         }

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -181,7 +181,7 @@ public:
                  const unsigned reportStepNum,
                  const bool     substep,
                  const bool     log,
-                 const bool     isRestart)
+                 const bool     forceRestartFieldAllocation)
     {
         if (! std::is_same<Discretization, EcfvDiscretization<TypeTag>>::value) {
             return;
@@ -189,11 +189,13 @@ public:
 
         auto rstKeywords = this->schedule_.rst_keywords(reportStepNum);
         const bool isRestartOutput =
-            isRestart || (!substep && this->schedule_.write_rst_file(reportStepNum));
+            forceRestartFieldAllocation ||
+            (!substep && this->schedule_.write_rst_file(reportStepNum));
         this->compC_.allocate(bufferSize, rstKeywords, isRestartOutput);
         this->numFailedSaturationPressures_ = 0;
 
-        this->doAllocBuffers(bufferSize, reportStepNum, substep, log, isRestart,
+        this->doAllocBuffers(bufferSize, reportStepNum, substep, log,
+                             forceRestartFieldAllocation,
                              /* hysteresisConfig = */ nullptr,
                              /* numOutputNnc =*/ 0,
                              std::move(rstKeywords));

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -724,24 +724,27 @@ public:
                                               totVolume,
                                               referencePorosity);
 
-        // Run the nonlinear PSAT solve in the caller's OpenMP loop.
-        // The assignment skips cells when no restart buffer is allocated.
+        // Run the nonlinear PSAT solve in the caller's OpenMP loop. The
+        // assignment is a no-op unless a PSAT restart buffer is allocated.
         this->assignSaturationPressure_(globalDofIdx, intQuants.fluidState());
     }
 
-    /// Reduce PSAT failures across all ranks before marking the output data valid.
+    /// When PSAT is requested, reduce failures across all ranks before marking
+    /// the output data valid.
     void validateLocalData() override
     {
-        const auto& comm = this->simulator_.gridView().comm();
-        const auto totalFailures = comm.sum(this->numFailedSaturationPressures_);
-        this->numFailedSaturationPressures_ = 0;
-        if (totalFailures > 0 && comm.rank() == 0) {
-            const auto* const cell = totalFailures == 1 ? "cell" : "cells";
-            OpmLog::info(fmt::format("Could not determine saturation pressure in {} {}; "
-                                     "PSAT is written as zero for every affected cell.",
-                                     totalFailures,
-                                     cell));
+        if (this->compC_.saturationPressureRequested()) {
+            const auto& comm = this->simulator_.gridView().comm();
+            const auto totalFailures = comm.sum(this->numFailedSaturationPressures_);
+            if (totalFailures > 0 && comm.rank() == 0) {
+                const auto* const cell = totalFailures == 1 ? "cell" : "cells";
+                OpmLog::info(fmt::format("Could not determine saturation pressure in {} {}; "
+                                         "PSAT is written as zero for every affected cell.",
+                                         totalFailures,
+                                         cell));
+            }
         }
+        this->numFailedSaturationPressures_ = 0;
         BaseType::validateLocalData();
     }
 

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -36,6 +36,7 @@
 #include <opm/common/TimingMacros.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
 
+#include <opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp>
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 #include <opm/material/common/Valgrind.hpp>
@@ -52,6 +53,7 @@
 #include <opm/simulators/flow/OutputExtractor.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <fstream>
 #include <memory>
@@ -62,6 +64,7 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/format.h>
 
 namespace Opm {
 
@@ -127,6 +130,7 @@ public:
                    getPropValue<TypeTag, Properties::EnableBioeffects>(),
                    getPropValue<TypeTag, Properties::EnableGeochemistry>())
         , simulator_(simulator)
+        , eosType_(simulator.vanguard().eclState().compositionalConfig().eosType(0))
     {
         for (auto& region_pair : this->regions_) {
             this->createLocalRegion_(region_pair.second);
@@ -184,7 +188,10 @@ public:
         }
 
         auto rstKeywords = this->schedule_.rst_keywords(reportStepNum);
-        this->compC_.allocate(bufferSize, rstKeywords);
+        const bool isRestartOutput =
+            isRestart || (!substep && this->schedule_.write_rst_file(reportStepNum));
+        this->compC_.allocate(bufferSize, rstKeywords, isRestartOutput);
+        this->numFailedSaturationPressures_ = 0;
 
         this->doAllocBuffers(bufferSize, reportStepNum, substep, log, isRestart,
                              /* hysteresisConfig = */ nullptr,
@@ -714,6 +721,26 @@ public:
                                               intQuants,
                                               totVolume,
                                               referencePorosity);
+
+        // Run the nonlinear PSAT solve in the caller's OpenMP loop.
+        // The assignment skips cells when no restart buffer is allocated.
+        this->assignSaturationPressure_(globalDofIdx, intQuants.fluidState());
+    }
+
+    /// Reduce PSAT failures across all ranks before marking the output data valid.
+    void validateLocalData() override
+    {
+        const auto& comm = this->simulator_.gridView().comm();
+        const auto totalFailures = comm.sum(this->numFailedSaturationPressures_);
+        this->numFailedSaturationPressures_ = 0;
+        if (totalFailures > 0 && comm.rank() == 0) {
+            const auto* const cell = totalFailures == 1 ? "cell" : "cells";
+            OpmLog::info(fmt::format("Could not determine saturation pressure in {} {}; "
+                                     "PSAT is written as zero for every affected cell.",
+                                     totalFailures,
+                                     cell));
+        }
+        BaseType::validateLocalData();
     }
 
 protected:
@@ -779,8 +806,41 @@ private:
         }
     }
 
+    /// Store the cell's saturation pressure, using zero for an unsuccessful solve.
+    /// Concurrent calls must use distinct cell indices; the failure count is atomic.
+    template<class FluidState>
+    void assignSaturationPressure_(const unsigned globalDofIdx, const FluidState& fluidState)
+    {
+        if (!this->compC_.saturationPressureAllocated()) {
+            return;
+        }
+
+        std::array<Scalar, numComponents> moleFractions;
+        for (int c = 0; c < numComponents; ++c) {
+            moleFractions[c] = getValue(fluidState.moleFraction(c));
+        }
+        const auto psat = CompositionalContainer<FluidSystem>::cellSaturationPressure(
+            getValue(fluidState.L()),
+            getValue(fluidState.pressure(oilPhaseIdx)),
+            moleFractions,
+            getValue(fluidState.temperature(oilPhaseIdx)),
+            this->eosType_);
+        if (!psat) {
+            // Failure includes supercritical mixtures; it does not establish
+            // whether a saturation pressure exists.
+#ifdef _OPENMP
+#pragma omp atomic
+#endif
+            ++this->numFailedSaturationPressures_;
+        }
+
+        this->compC_.assignSaturationPressure(globalDofIdx, psat.value_or(Scalar{0}));
+    }
+
     const Simulator& simulator_;
     CompositionalContainer<FluidSystem> compC_;
+    CompositionalConfig::EOSType eosType_;
+    std::size_t numFailedSaturationPressures_{};
     std::vector<typename Extractor::Entry> extractors_;
     typename BlockExtractor::ExecMap blockExtractors_;
 };

--- a/tests/test_compositionalcontainer.cpp
+++ b/tests/test_compositionalcontainer.cpp
@@ -1,0 +1,183 @@
+/*
+  Copyright 2026 SINTEF Digital
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#define BOOST_TEST_MODULE CompositionalContainer
+#include <boost/test/unit_test.hpp>
+
+#include <opm/simulators/flow/CompositionalContainer.hpp>
+
+#include <opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp>
+
+#include <opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp>
+#include <opm/output/data/Solution.hpp>
+
+#include <algorithm>
+#include <array>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace {
+using FluidSystem = Opm::GenericOilGasWaterFluidSystem<double, 3, false>;
+using Container = Opm::CompositionalContainer<FluidSystem>;
+
+// The three-component CO2/methane/decane fluid of the saturation-pressure
+// solver's own tests, so their reference values can be reused here.
+struct Fixture
+{
+    Fixture()
+    {
+        using CompParam = FluidSystem::ComponentParam;
+        FluidSystem::init();
+        FluidSystem::addComponent(CompParam{"CO2", 44.0, 304.128, 73.773e5, 0.09412, 0.22394});
+        FluidSystem::addComponent(CompParam{"C1", 16.04, 190.564, 45.992e5, 0.09863, 0.01142});
+        FluidSystem::addComponent(CompParam{"C10", 142.28, 617.7, 21.03e5, 0.60980, 0.4884});
+    }
+};
+} // anonymous namespace
+
+BOOST_GLOBAL_FIXTURE(Fixture);
+
+BOOST_AUTO_TEST_CASE(SaturationPressureRequiresRestartOutput)
+{
+    Container container;
+    std::map<std::string, int> keywords{{"PSAT", 1}};
+    container.allocate(2, keywords, /*isRestartOutput=*/false);
+    BOOST_CHECK(!container.saturationPressureAllocated());
+    BOOST_CHECK_EQUAL(keywords.at("PSAT"), 0);
+
+    keywords["PSAT"] = 1;
+    container.allocate(2, keywords, /*isRestartOutput=*/true);
+    BOOST_REQUIRE(container.saturationPressureAllocated());
+    container.assignSaturationPressure(0, 100.0e5);
+
+    // A summary-only pass must discard the old buffer, even before export.
+    keywords["PSAT"] = 1;
+    container.allocate(2, keywords, /*isRestartOutput=*/false);
+    BOOST_CHECK(!container.saturationPressureAllocated());
+    Opm::data::Solution substep;
+    std::vector<double> oilSaturation;
+    container.outputRestart(substep, oilSaturation);
+    BOOST_CHECK(!substep.has("PSAT"));
+
+    // Re-enable the request on a later restart snapshot.
+    keywords["PSAT"] = 1;
+    container.allocate(2, keywords, /*isRestartOutput=*/true);
+    BOOST_REQUIRE(container.saturationPressureAllocated());
+    container.assignSaturationPressure(0, 150.0e5);
+    container.assignSaturationPressure(1, 200.0e5);
+    Opm::data::Solution restart;
+    container.outputRestart(restart, oilSaturation);
+    BOOST_REQUIRE(restart.has("PSAT"));
+    const auto& pressure = restart.data<double>("PSAT");
+    BOOST_REQUIRE_EQUAL(pressure.size(), 2);
+    BOOST_CHECK_EQUAL(pressure[0], 150.0e5);
+    BOOST_CHECK_EQUAL(pressure[1], 200.0e5);
+    BOOST_CHECK(restart.at("PSAT").dim == Opm::UnitSystem::measure::pressure);
+    BOOST_CHECK(!container.saturationPressureAllocated());
+}
+
+BOOST_AUTO_TEST_CASE(DisabledSaturationPressureClearsPreviousRequest)
+{
+    Container container;
+    std::map<std::string, int> keywords{{"PSAT", 1}};
+    container.allocate(2, keywords, /*isRestartOutput=*/true);
+    BOOST_REQUIRE(container.saturationPressureAllocated());
+    keywords["PSAT"] = 0;
+    container.allocate(2, keywords, /*isRestartOutput=*/true);
+    BOOST_CHECK(!container.saturationPressureAllocated());
+}
+
+BOOST_AUTO_TEST_CASE(CellSaturationPressureSelectsThePhaseAndTheBranch)
+{
+    // 100 degC with Peng-Robinson, as in the solver's tests.  Phase presence
+    // comes from the flash liquid fraction L, not from the saturations.
+    constexpr double temperature = 373.15;
+    constexpr auto eos = Opm::CompositionalConfig::EOSType::PR;
+    using CompVec = std::array<double, 3>;
+
+    // Both hydrocarbon phases present: the cell is at its saturation pressure
+    // and the solver is not consulted.
+    {
+        const auto psat = Container::cellSaturationPressure(
+            0.3, 75.0e5, CompVec{0.0, 0.5, 0.5}, temperature, eos);
+        BOOST_REQUIRE(psat.has_value());
+        BOOST_CHECK_CLOSE(*psat, 75.0e5, 1.0e-12);
+    }
+
+    // Liquid only (L == 1): the bubble point of the total composition.  The
+    // reference simulator puts this liquid at 160.5601 bar.
+    {
+        const auto psat = Container::cellSaturationPressure(
+            1.0, 150.0e5, CompVec{0.0, 0.5, 0.5}, temperature, eos);
+        BOOST_REQUIRE(psat.has_value());
+        BOOST_CHECK_CLOSE(*psat / 1.0e5, 160.56010, 1.0e-3);
+    }
+
+    // Vapour only (L == 0): the retrograde dew point of that liquid's
+    // equilibrium vapour, which recovers the same pressure.  The vapour is
+    // known to single precision, hence the tolerance.
+    {
+        const auto psat = Container::cellSaturationPressure(
+            0.0, 150.0e5, CompVec{0.0, 0.987784, 0.012216}, temperature, eos);
+        BOOST_REQUIRE(psat.has_value());
+        BOOST_CHECK_CLOSE(*psat / 1.0e5, 160.56010, 1.0e-2);
+    }
+
+    // Pure methane far above its critical temperature has no saturation
+    // pressure, and the cell pressure must not stand in for one.
+    {
+        const auto psat = Container::cellSaturationPressure(
+            0.0, 150.0e5, CompVec{0.0, 1.0, 0.0}, temperature, eos);
+        BOOST_CHECK(!psat.has_value());
+    }
+
+    // Rachford-Rice values near the exact single-phase labels still denote
+    // two phases, even when round-off puts them slightly outside (0, 1).
+    for (const double liquidFraction : {1.0 + 2.0e-16, -1.0e-16, 1.0 - 1.0e-12, 1.0e-12}) {
+        const auto psat = Container::cellSaturationPressure(
+            liquidFraction, 75.0e5, CompVec{0.0, 0.5, 0.5}, temperature, eos);
+        BOOST_REQUIRE_MESSAGE(psat.has_value(), "L = " << liquidFraction);
+        BOOST_CHECK_CLOSE(*psat, 75.0e5, 1.0e-12);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(RoundOffInTheGasSaturationDoesNotHideTheBubblePoint)
+{
+    // Sg = max(1 - So - Sw, 0) leaves a positive round-off residual at Sw = 0.3.
+    // Classifying this liquid-only cell by saturation would return the cell
+    // pressure instead of the bubble point.
+    constexpr double temperature = 373.15;
+    constexpr auto eos = Opm::CompositionalConfig::EOSType::PR;
+    const std::array<double, 3> liquid{0.0, 0.5, 0.5};
+
+    constexpr double waterSaturation = 0.3;
+    const double oilSaturation = 1.0 - waterSaturation;
+    const double gasSaturation = std::max(1.0 - oilSaturation - waterSaturation, 0.0);
+    BOOST_REQUIRE_GT(gasSaturation, 0.0);
+    BOOST_REQUIRE_LT(gasSaturation, 1.0e-15);
+
+    // The flash's liquid-only label must select the bubble point.
+    const auto psat = Container::cellSaturationPressure(
+        1.0, 200.0e5, liquid, temperature, eos);
+    BOOST_REQUIRE(psat.has_value());
+    BOOST_CHECK_CLOSE(*psat / 1.0e5, 160.56010, 1.0e-3);
+}

--- a/tests/test_compositionalcontainer.cpp
+++ b/tests/test_compositionalcontainer.cpp
@@ -62,17 +62,21 @@ BOOST_AUTO_TEST_CASE(SaturationPressureRequiresRestartOutput)
     std::map<std::string, int> keywords{{"PSAT", 1}};
     container.allocate(2, keywords, /*isRestartOutput=*/false);
     BOOST_CHECK(!container.saturationPressureAllocated());
-    BOOST_CHECK_EQUAL(keywords.at("PSAT"), 0);
+    BOOST_CHECK(!container.saturationPressureRequested());
+    BOOST_CHECK_EQUAL(keywords.at("PSAT"), 1);
 
-    keywords["PSAT"] = 1;
     container.allocate(2, keywords, /*isRestartOutput=*/true);
     BOOST_REQUIRE(container.saturationPressureAllocated());
+    BOOST_CHECK(container.saturationPressureRequested());
+    BOOST_CHECK_EQUAL(keywords.at("PSAT"), 0);
     container.assignSaturationPressure(0, 100.0e5);
 
     // A summary-only pass must discard the old buffer, even before export.
     keywords["PSAT"] = 1;
     container.allocate(2, keywords, /*isRestartOutput=*/false);
     BOOST_CHECK(!container.saturationPressureAllocated());
+    BOOST_CHECK(!container.saturationPressureRequested());
+    BOOST_CHECK_EQUAL(keywords.at("PSAT"), 1);
     Opm::data::Solution substep;
     std::vector<double> oilSaturation;
     container.outputRestart(substep, oilSaturation);
@@ -82,6 +86,7 @@ BOOST_AUTO_TEST_CASE(SaturationPressureRequiresRestartOutput)
     keywords["PSAT"] = 1;
     container.allocate(2, keywords, /*isRestartOutput=*/true);
     BOOST_REQUIRE(container.saturationPressureAllocated());
+    BOOST_CHECK(container.saturationPressureRequested());
     container.assignSaturationPressure(0, 150.0e5);
     container.assignSaturationPressure(1, 200.0e5);
     Opm::data::Solution restart;
@@ -104,6 +109,18 @@ BOOST_AUTO_TEST_CASE(DisabledSaturationPressureClearsPreviousRequest)
     keywords["PSAT"] = 0;
     container.allocate(2, keywords, /*isRestartOutput=*/true);
     BOOST_CHECK(!container.saturationPressureAllocated());
+    BOOST_CHECK(!container.saturationPressureRequested());
+}
+
+BOOST_AUTO_TEST_CASE(SaturationPressureRequestIsIndependentOfLocalBufferSize)
+{
+    Container container;
+    std::map<std::string, int> keywords{{"PSAT", 1}};
+    container.allocate(0, keywords, /*isRestartOutput=*/true);
+
+    BOOST_CHECK(container.saturationPressureRequested());
+    BOOST_CHECK(!container.saturationPressureAllocated());
+    BOOST_CHECK_EQUAL(keywords.at("PSAT"), 0);
 }
 
 BOOST_AUTO_TEST_CASE(CellSaturationPressureSelectsThePhaseAndTheBranch)
@@ -123,8 +140,8 @@ BOOST_AUTO_TEST_CASE(CellSaturationPressureSelectsThePhaseAndTheBranch)
         BOOST_CHECK_CLOSE(*psat, 75.0e5, 1.0e-12);
     }
 
-    // Liquid only (L == 1): the bubble point of the total composition.  The
-    // reference simulator puts this liquid at 160.5601 bar.
+    // Liquid only (L == 1): the bubble point of the total composition. The
+    // reference bubble pressure is 160.5601 bar.
     {
         const auto psat = Container::cellSaturationPressure(
             1.0, 150.0e5, CompVec{0.0, 0.5, 0.5}, temperature, eos);

--- a/tests/test_compositionalcontainer.cpp
+++ b/tests/test_compositionalcontainer.cpp
@@ -38,6 +38,7 @@
 namespace {
 using FluidSystem = Opm::GenericOilGasWaterFluidSystem<double, 3, false>;
 using Container = Opm::CompositionalContainer<FluidSystem>;
+using RestartOutput = Container::RestartOutput;
 
 // The three-component CO2/methane/decane fluid of the saturation-pressure
 // solver's own tests, so their reference values can be reused here.
@@ -60,12 +61,12 @@ BOOST_AUTO_TEST_CASE(SaturationPressureRequiresRestartOutput)
 {
     Container container;
     std::map<std::string, int> keywords{{"PSAT", 1}};
-    container.allocate(2, keywords, /*isRestartOutput=*/false);
+    container.allocate(2, keywords, RestartOutput::Disabled);
     BOOST_CHECK(!container.saturationPressureAllocated());
     BOOST_CHECK(!container.saturationPressureRequested());
     BOOST_CHECK_EQUAL(keywords.at("PSAT"), 1);
 
-    container.allocate(2, keywords, /*isRestartOutput=*/true);
+    container.allocate(2, keywords, RestartOutput::Enabled);
     BOOST_REQUIRE(container.saturationPressureAllocated());
     BOOST_CHECK(container.saturationPressureRequested());
     BOOST_CHECK_EQUAL(keywords.at("PSAT"), 0);
@@ -73,7 +74,7 @@ BOOST_AUTO_TEST_CASE(SaturationPressureRequiresRestartOutput)
 
     // A summary-only pass must discard the old buffer, even before export.
     keywords["PSAT"] = 1;
-    container.allocate(2, keywords, /*isRestartOutput=*/false);
+    container.allocate(2, keywords, RestartOutput::Disabled);
     BOOST_CHECK(!container.saturationPressureAllocated());
     BOOST_CHECK(!container.saturationPressureRequested());
     BOOST_CHECK_EQUAL(keywords.at("PSAT"), 1);
@@ -84,7 +85,7 @@ BOOST_AUTO_TEST_CASE(SaturationPressureRequiresRestartOutput)
 
     // Re-enable the request on a later restart snapshot.
     keywords["PSAT"] = 1;
-    container.allocate(2, keywords, /*isRestartOutput=*/true);
+    container.allocate(2, keywords, RestartOutput::Enabled);
     BOOST_REQUIRE(container.saturationPressureAllocated());
     BOOST_CHECK(container.saturationPressureRequested());
     container.assignSaturationPressure(0, 150.0e5);
@@ -104,10 +105,10 @@ BOOST_AUTO_TEST_CASE(DisabledSaturationPressureClearsPreviousRequest)
 {
     Container container;
     std::map<std::string, int> keywords{{"PSAT", 1}};
-    container.allocate(2, keywords, /*isRestartOutput=*/true);
+    container.allocate(2, keywords, RestartOutput::Enabled);
     BOOST_REQUIRE(container.saturationPressureAllocated());
     keywords["PSAT"] = 0;
-    container.allocate(2, keywords, /*isRestartOutput=*/true);
+    container.allocate(2, keywords, RestartOutput::Enabled);
     BOOST_CHECK(!container.saturationPressureAllocated());
     BOOST_CHECK(!container.saturationPressureRequested());
 }
@@ -116,7 +117,7 @@ BOOST_AUTO_TEST_CASE(SaturationPressureRequestIsIndependentOfLocalBufferSize)
 {
     Container container;
     std::map<std::string, int> keywords{{"PSAT", 1}};
-    container.allocate(0, keywords, /*isRestartOutput=*/true);
+    container.allocate(0, keywords, RestartOutput::Enabled);
 
     BOOST_CHECK(container.saturationPressureRequested());
     BOOST_CHECK(!container.saturationPressureAllocated());


### PR DESCRIPTION
Adds `PSAT` to compositional restart output with the documented semantics:

- two-phase hydrocarbon cells use the oil-phase pressure;
- liquid-only and gas-only cells use the bubble and dew pressure of the total composition;
- when no saturation pressure is resolved, `PSAT` is zero and the cell contributes to one aggregated MPI informational message. The solver API does not distinguish numerical nonconvergence from a physically absent boundary, so this is not logged as a warning.

Phase selection uses the flash liquid fraction rather than computed saturations, avoiding misclassification from saturation round-off. The per-cell calculation runs in the existing OpenMP fluid-in-place loop.

The `PSAT` buffer is allocated only for requested restart snapshots, including `--enable-write-all-solutions`, so summary-only substeps do not incur the calculation cost. The write-all allocation correction also touches the shared black-oil `GenericOutputModule` path.

### Testing

- `test_compositionalcontainer`: 5 cases and 43 assertions covering allocation, phase selection, bubble/dew selection, two-phase pressure, empty MPI ranks, and unresolved-result handling.
- `1D_COMP` and `SIMPLE_COMP_SSHIFT`: completed with one and eight OpenMP threads and produced byte-identical restart files. `PSAT` is present at every restart step; two-phase values equal cell pressure, solved single-phase values are lower, and no values are negative.

### Known limitations

- The EOS type is taken from region 0, consistent with `FlowProblemComp`.
- Thermal water saturation pressure for rock-filled and water-filled cells is not implemented.

Depends on the saturation-pressure solver merged in [OPM/opm-common#5283](https://github.com/OPM/opm-common/pull/5283). Regression coverage is proposed in [OPM/opm-tests#1593](https://github.com/OPM/opm-tests/pull/1593).