### PR TITLE
TPSA: Thermoelastic effects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -706,6 +706,7 @@ macro(opm-simulators_targets_hook)
     brine_precsalt_vapwat
     brine_saltprecipitation
     energy
+    energy_tpsa
     extbo
     foam
     gasoil
@@ -717,6 +718,7 @@ macro(opm-simulators_targets_hook)
     gaswater_dissolution_diffuse
     gaswater_dissolution_tpsa
     gaswater_energy
+    gaswater_energy_tpsa
     gaswater_saltprec_energy
     gaswater_saltprec_vapwat
     gaswater_solvent
@@ -727,6 +729,7 @@ macro(opm-simulators_targets_hook)
     oilwater_polymer_injectivity
     onephase
     onephase_energy
+    onephase_energy_tpsa
     onephase_tpsa
     polymer
     solvent

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -519,6 +519,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_stoppedwells.cpp
   tests/test_ThreePointHorizontalSatfuncConsistencyChecks.cpp
   tests/test_timer.cpp
+  tests/test_tpsa_conversions.cpp
   tests/test_tpsa_face_properties.cpp
   tests/test_tpsa_localresidual.cpp
   tests/test_tpsa_matrix.cpp

--- a/flow/flow_energy_tpsa.cpp
+++ b/flow/flow_energy_tpsa.cpp
@@ -1,0 +1,105 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2025, NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#include <flow/flow_energy_tpsa.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+#include <opm/models/blackoil/blackoildiffusionmodule.hh>
+#include <opm/models/blackoil/blackoilenergymodules.hh>
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+#include <opm/models/discretization/common/tpfalinearizer.hh>
+
+#include <opm/simulators/flow/BlackoilModelProperties.hpp>
+#include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/TTagFlowProblemTPSA.hpp>
+
+#include <tuple>
+
+
+namespace Opm::Properties {
+
+namespace TTag {
+
+struct FlowEnergyProblemTPSA
+{
+    using InheritsFrom = std::tuple<FlowProblem, FlowProblemTpsa>;
+};
+
+}  // namespace Opm::Properties::TTag
+
+// ///
+// Flow related properties
+// ///
+template<class TypeTag>
+struct Linearizer<TypeTag, TTag::FlowEnergyProblemTPSA>
+{ using type = TpfaLinearizer<TypeTag>; };
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::FlowEnergyProblemTPSA>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
+
+template<class TypeTag>
+struct EnergyModuleType<TypeTag, TTag::FlowEnergyProblemTPSA>
+{ static constexpr EnergyModules value = EnergyModules::FullyImplicitThermal; };
+
+// ///
+// TPSA related properties
+// ///
+template <class TypeTag>
+struct EnableMech<TypeTag, TTag::FlowEnergyProblemTPSA>
+{ static constexpr bool value = true; };
+
+template <class TypeTag>
+struct Problem<TypeTag, TTag::FlowEnergyProblemTPSA>
+{ using type = FlowProblemTPSA<TypeTag>; };
+
+template <class TypeTag>
+struct NonlinearSystem<TypeTag, TTag::FlowEnergyProblemTPSA>
+{ using type = NonlinearSystemBlackOilReservoirTPSA<TypeTag>; };
+
+}  // namespace Opm::Properties
+
+namespace Opm {
+
+// ----------------- Main program -----------------
+int flowEnergyTpsaMain(int argc, char** argv, bool outputCout, bool outputFiles)
+{
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    resetLocale();
+
+    FlowMain<Properties::TTag::FlowEnergyProblemTPSA>
+        mainfunc {argc, argv, outputCout, outputFiles};
+    return mainfunc.execute();
+}
+
+int flowEnergyTpsaMainStandalone(int argc, char** argv)
+{
+    using TypeTag = Properties::TTag::FlowEnergyProblemTPSA;
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
+}
+
+}  // namespace Opm

--- a/flow/flow_energy_tpsa.hpp
+++ b/flow/flow_energy_tpsa.hpp
@@ -1,0 +1,30 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef FLOW_ENERGY_TPSA_HPP
+#define FLOW_ENERGY_TPSA_HPP
+
+namespace Opm {
+
+//! \brief Main function used in flow binary.
+int flowEnergyTpsaMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
+//! \brief Main function used in flow_energy_tpsa binary.
+int flowEnergyTpsaMainStandalone(int argc, char** argv);
+
+}
+
+#endif // FLOW_ENERGY_TPSA_HPP

--- a/flow/flow_energy_tpsa_main.cpp
+++ b/flow/flow_energy_tpsa_main.cpp
@@ -1,0 +1,24 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+#include <flow/flow_energy_tpsa.hpp>
+
+
+int main(int argc, char** argv)
+{
+    return Opm::flowEnergyTpsaMainStandalone(argc, argv);
+}

--- a/flow/flow_gaswater_energy_tpsa.cpp
+++ b/flow/flow_gaswater_energy_tpsa.cpp
@@ -1,0 +1,88 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2026, NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#include <flow/flow_gaswater_energy_tpsa.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+#include <opm/models/blackoil/blackoildiffusionmodule.hh>
+#include <opm/models/blackoil/blackoildispersionmodule.hh>
+#include <opm/models/blackoil/blackoilenergymodules.hh>
+
+#include <opm/simulators/flow/BlackoilModelProperties.hpp>
+#include <opm/simulators/flow/FlowGasWaterEnergyTypeTag.hpp>
+#include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/TTagFlowProblemTPSA.hpp>
+
+#include <tuple>
+
+
+namespace Opm::Properties {
+
+namespace TTag {
+
+struct FlowGasWaterEnergyProblemTPSA
+{ using InheritsFrom = std::tuple<FlowGasWaterEnergyProblem, FlowProblemTpsa>; };
+
+}  // namespace Opm::Properties::TTag
+
+// ///
+// TPSA related properties
+// ///
+template <class TypeTag>
+struct EnableMech<TypeTag, TTag::FlowGasWaterEnergyProblemTPSA>
+{ static constexpr bool value = true; };
+
+template <class TypeTag>
+struct Problem<TypeTag, TTag::FlowGasWaterEnergyProblemTPSA>
+{ using type = FlowProblemTPSA<TypeTag>; };
+
+template <class TypeTag>
+struct NonlinearSystem<TypeTag, TTag::FlowGasWaterEnergyProblemTPSA>
+{ using type = NonlinearSystemBlackOilReservoirTPSA<TypeTag>; };
+
+}  // namespace Opm::Properties
+
+namespace Opm {
+
+// ----------------- Main program -----------------
+int flowGasWaterEnergyTpsaMain(int argc, char** argv, bool outputCout, bool outputFiles)
+{
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    resetLocale();
+
+    FlowMain<Properties::TTag::FlowGasWaterEnergyProblemTPSA>
+        mainfunc {argc, argv, outputCout, outputFiles};
+    return mainfunc.execute();
+}
+
+int flowGasWaterEnergyTpsaMainStandalone(int argc, char** argv)
+{
+    using TypeTag = Properties::TTag::FlowGasWaterEnergyProblemTPSA;
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
+}
+
+}  // namespace Opm

--- a/flow/flow_gaswater_energy_tpsa.hpp
+++ b/flow/flow_gaswater_energy_tpsa.hpp
@@ -1,0 +1,34 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2026, NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef FLOW_GASWATER_ENERGY_TPSA_HPP
+#define FLOW_GASWATER_ENERGY_TPSA_HPP
+
+namespace Opm {
+
+//! \brief Main function used in flow binary.
+int flowGasWaterEnergyTpsaMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
+//! \brief Main function used in flow_gaswater_energy_tpsa binary.
+int flowGasWaterEnergyTpsaMainStandalone(int argc, char** argv);
+
+}  // namespace Opm
+
+#endif

--- a/flow/flow_gaswater_energy_tpsa_main.cpp
+++ b/flow/flow_gaswater_energy_tpsa_main.cpp
@@ -1,0 +1,28 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2026, NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+#include <flow/flow_gaswater_energy_tpsa.hpp>
+
+
+int main(int argc, char** argv)
+{
+    return Opm::flowGasWaterEnergyTpsaMainStandalone(argc, argv);
+}

--- a/flow/flow_onephase_energy_tpsa.cpp
+++ b/flow/flow_onephase_energy_tpsa.cpp
@@ -1,0 +1,134 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2025, NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#include <opm/material/thermal/EnergyModuleType.hpp>
+
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
+#include <opm/models/blackoil/blackoildiffusionmodule.hh>
+#include <opm/models/blackoil/blackoilenergymodules.hh>
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+#include <opm/models/blackoil/blackoilonephaseindices.hh>
+#include <opm/models/discretization/common/tpfalinearizer.hh>
+
+#include <opm/simulators/flow/BlackoilModelProperties.hpp>
+#include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/TTagFlowProblemTPSA.hpp>
+
+#include <tuple>
+
+
+namespace Opm::Properties {
+
+namespace TTag {
+
+struct FlowWaterOnlyEnergyProblemTPSA
+{
+    using InheritsFrom = std::tuple<FlowProblem, FlowProblemTpsa>;
+};
+
+}  // namespace Opm::Properties::TTag
+
+// ///
+// Flow related properties
+// ///
+template<class TypeTag>
+struct Linearizer<TypeTag, TTag::FlowWaterOnlyEnergyProblemTPSA>
+{ using type = TpfaLinearizer<TypeTag>; };
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::FlowWaterOnlyEnergyProblemTPSA>
+{ using type = BlackOilLocalResidualTPFA<TypeTag>; };
+
+template<class TypeTag>
+struct EnableDiffusion<TypeTag, TTag::FlowWaterOnlyEnergyProblemTPSA>
+{ static constexpr bool value = false; };
+
+template<class TypeTag>
+struct EnergyModuleType<TypeTag, TTag::FlowWaterOnlyEnergyProblemTPSA>
+{ static constexpr EnergyModules value = EnergyModules::FullyImplicitThermal; };
+
+template<class TypeTag>
+struct Indices<TypeTag, TTag::FlowWaterOnlyEnergyProblemTPSA>
+{
+private:
+    // it is unfortunately not possible to simply use 'TypeTag' here because this leads
+    // to cyclic definitions of some properties. if this happens the compiler error
+    // messages unfortunately are *really* confusing and not really helpful.
+    using BaseTypeTag = TTag::FlowProblem;
+    using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
+    static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
+
+public:
+    using type = BlackOilOnePhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
+                                         getPropValue<TypeTag, Properties::EnableExtbo>(),
+                                         getPropValue<TypeTag, Properties::EnablePolymer>(),
+                                         numEnergyVars,
+                                         getPropValue<TypeTag, Properties::EnableFoam>(),
+                                         getPropValue<TypeTag, Properties::EnableBrine>(),
+                                         /*PVOffset=*/0,
+                                         /*enabledCompIdx=*/FluidSystem::waterCompIdx,
+                                         getPropValue<TypeTag, Properties::EnableBioeffects>()>;
+};
+
+// ///
+// TPSA related properties
+// ///
+template <class TypeTag>
+struct EnableMech<TypeTag, TTag::FlowWaterOnlyEnergyProblemTPSA>
+{ static constexpr bool value = true; };
+
+template <class TypeTag>
+struct Problem<TypeTag, TTag::FlowWaterOnlyEnergyProblemTPSA>
+{ using type = FlowProblemTPSA<TypeTag>; };
+
+template <class TypeTag>
+struct NonlinearSystem<TypeTag, TTag::FlowWaterOnlyEnergyProblemTPSA>
+{ using type = NonlinearSystemBlackOilReservoirTPSA<TypeTag>; };
+
+}  // namespace Opm::Properties
+
+namespace Opm {
+
+// ----------------- Main program -----------------
+int flowWaterOnlyEnergyTpsaMain(int argc, char** argv, bool outputCout, bool outputFiles)
+{
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    resetLocale();
+
+    FlowMain<Properties::TTag::FlowWaterOnlyEnergyProblemTPSA>
+        mainfunc {argc, argv, outputCout, outputFiles};
+    return mainfunc.execute();
+}
+
+int flowWaterOnlyEnergyTpsaMainStandalone(int argc, char** argv)
+{
+    using TypeTag = Opm::Properties::TTag::FlowWaterOnlyEnergyProblemTPSA;
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
+}
+
+}  // namespace Opm

--- a/flow/flow_onephase_energy_tpsa.hpp
+++ b/flow/flow_onephase_energy_tpsa.hpp
@@ -1,0 +1,34 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2025, NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef FLOW_ONEPHASE_ENERGY_TPSA_HPP
+#define FLOW_ONEPHASE_ENERGY_TPSA_HPP
+
+namespace Opm {
+
+//! \brief Main function used in main flow binary.
+int flowWaterOnlyEnergyTpsaMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
+//! \brief Main function used in flow_onephase_energy_tpsa binary.
+int flowWaterOnlyEnergyTpsaMainStandalone(int argc, char** argv);
+
+}  // namespace Opm
+
+#endif

--- a/flow/flow_onephase_energy_tpsa_main.cpp
+++ b/flow/flow_onephase_energy_tpsa_main.cpp
@@ -1,0 +1,28 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2025, NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+#include <flow/flow_onephase_energy_tpsa.hpp>
+
+
+int main(int argc, char** argv)
+{
+    return Opm::flowWaterOnlyEnergyTpsaMainStandalone(argc, argv);
+}

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -667,6 +667,16 @@ public:
                     porosity_ += rockBiot * active_pressure;
                 }
 
+                if constexpr (energyModuleType == EnergyModules::FullyImplicitThermal) {
+                    const Scalar rockBiotTemp = problem.rockBiotTemp(globalSpaceIdx);
+                    if (rockBiotTemp != 0.0) {
+                        const Scalar rockRefTemp = problem.rockReferenceTemperature();
+                        Evaluation active_temp = fluidState_.temperature(/*phaseIdx=*/0) -
+                            rockRefTemp;
+                        porosity_ += rockBiotTemp * active_temp;
+                    }
+                }
+
                 // TPSA coupling term, pore volume changes due to mechanics
                 porosity_ += problem.rockMechPoroChange(globalSpaceIdx, /*timeIdx=*/timeIdx);
             }

--- a/opm/models/blackoil/blackoilproblem.hh
+++ b/opm/models/blackoil/blackoilproblem.hh
@@ -170,6 +170,25 @@ public:
     { return 0.0; }
 
     /*!
+     * \brief Returns the additional compressibility of a cell due to thermoelasticity
+     */
+    template <class Context>
+    Scalar rockBiotTemp(const Context&,
+                        unsigned,
+                        unsigned) const
+    {
+        return 0.0;
+    }
+
+    /*!
+     * \brief Returns the additional compressibility of a cell due to thermoelasticity
+     */
+    Scalar rockBiotTemp(unsigned) const
+    {
+        return 0.0;
+    }
+
+    /*!
      * \brief Returns Lame's first parameter of a cell
      */
     template <class Context>
@@ -197,7 +216,28 @@ public:
      * \brief Returns Biot coefficient of a cell
      */
     Scalar biotCoeff(unsigned) const
-    { return 0.0; }
+    {
+        return 0.0;
+    }
+
+    /*!
+     * \brief Returns Biot temperature coefficient of a cell
+     */
+    template <class Context>
+    Scalar biotTemp(const Context&,
+                    unsigned,
+                    unsigned) const
+    {
+        return 0.0;
+    }
+
+    /*!
+     * \brief Returns Biot temperature coefficient of a cell
+     */
+    Scalar biotTemp(unsigned) const
+    {
+        return 0.0;
+    }
 
     /*!
      * \brief Returns the reference pressure for rock the compressibility of a cell

--- a/opm/models/tpsa/tpsamodel.hpp
+++ b/opm/models/tpsa/tpsamodel.hpp
@@ -185,6 +185,7 @@ public:
 
         // Initialize potential force vectors
         mechPotPresForce_.resize(numDof);
+        mechPotTempForce_.resize(numDof);
     }
 
     /*!
@@ -639,14 +640,16 @@ public:
     }
 
     /*!
-    * \brief Output potential forces
+    * \brief Output total potential forces
+    *
+    * This is the sum of pressure and temperature potential forces
     *
     * \param globalIdx Cell index
     * \returns Potential forces at grid cell
     */
     Scalar mechPotentialForce(unsigned globalIdx) const
     {
-        return mechPotentialPressForce(globalIdx);
+        return mechPotentialPressForce(globalIdx) + mechPotentialTempForce(globalIdx);
     }
 
     /*!
@@ -660,6 +663,12 @@ public:
         return mechPotPresForce_[globalIdx];
     }
 
+    /*!
+    * \brief Sets potential pressure force
+    *
+    * \param globalIdx Cell index
+    * \param val Potential pressure force at grid cell
+    */
     void setMechPotentialPressForce(unsigned globalIdx, Scalar val)
     {
         mechPotPresForce_[globalIdx] = val;
@@ -670,12 +679,21 @@ public:
     *
     * \param globalIdx Cell index
     * \returns Potential temperature forces at grid cell
-    *
-    * \note Needed in OutputBlackOilModule, but zero for now!
     */
-    Scalar mechPotentialTempForce(unsigned /*globalIdx*/) const
+    Scalar mechPotentialTempForce(unsigned globalIdx) const
     {
-        return Scalar(0.0);
+        return mechPotTempForce_[globalIdx];
+    }
+
+    /*!
+    * \brief Sets potential temperature force
+    *
+    * \param globalIdx Cell index
+    * \param val Potential temperature force at grid cell
+    */
+    void setMechPotentialTempForce(unsigned globalIdx, Scalar val)
+    {
+        mechPotTempForce_[globalIdx] = val;
     }
 
 protected:
@@ -725,6 +743,7 @@ private:
     std::vector<Scalar> eqWeights_;
     std::vector<MaterialState> materialState_;
     PotForceVector mechPotPresForce_;
+    PotForceVector mechPotTempForce_;
 };  // class TpsaModel
 
 }  // namespace Opm

--- a/opm/simulators/flow/FlowGenericProblem.hpp
+++ b/opm/simulators/flow/FlowGenericProblem.hpp
@@ -156,6 +156,11 @@ public:
     Scalar rockBiotComp(unsigned elementIdx) const;
 
     /*!
+     * \brief Returns the rock compressibility of an element due to thermoelasticity
+     */
+    Scalar rockBiotTemp(unsigned elementIdx) const;
+
+    /*!
     * \brief Direct access to Lame's second parameter in an element
     */
     Scalar lame(unsigned elementIdx) const;
@@ -164,6 +169,11 @@ public:
     * \brief Direct access to Biot coefficient in an element
     */
     Scalar biotCoeff(unsigned elementIdx) const;
+
+    /*!
+    * \brief Direct access to Biot temperature coefficient in an element
+    */
+    Scalar biotTemp(unsigned elementIdx) const;
 
     /*!
      * \brief Sets the porosity of an element

--- a/opm/simulators/flow/FlowGenericProblem_impl.hpp
+++ b/opm/simulators/flow/FlowGenericProblem_impl.hpp
@@ -30,6 +30,8 @@
 
 #include <dune/common/parametertree.hh>
 
+#include <opm/common/ErrorMacros.hpp>
+
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/OverburdTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/RockwnodTable.hpp>
@@ -362,9 +364,21 @@ FlowGenericProblem<GridView,FluidSystem>::
 rockBiotComp(unsigned elementIdx) const
 {
     // Additional compressibility of the rock due to Biot poroelasticity
-    auto biot = biotCoeff(elementIdx);
-    auto lameParam = lame(elementIdx);
+    const auto biot = biotCoeff(elementIdx);
+    const auto lameParam = lame(elementIdx);
     return biot * biot / lameParam;
+}
+
+template <class GridView, class FluidSystem>
+typename FlowGenericProblem<GridView, FluidSystem>::Scalar
+FlowGenericProblem<GridView, FluidSystem>::
+rockBiotTemp(unsigned elementIdx) const
+{
+    // Additional compressibility due to Biot thermoelasticity
+    const auto biotT = biotTemp(elementIdx);
+    const auto biotC = biotCoeff(elementIdx);
+    const auto lameParam = lame(elementIdx);
+    return biotC * biotT / lameParam;
 }
 
 template<class GridView, class FluidSystem>
@@ -419,6 +433,81 @@ biotCoeff(unsigned elementIdx) const
     return biotC;
 }
 
+template <class GridView, class FluidSystem>
+typename FlowGenericProblem<GridView, FluidSystem>::Scalar
+FlowGenericProblem<GridView, FluidSystem>::
+biotTemp(unsigned elementIdx) const
+{
+    const auto& fp = eclState_.fieldProps();
+
+    // Return early if deck does not have necessary parameters
+    if (!fp.has_double("THERMEXR") && !fp.has_double("THELCOEF")) {
+        return 0.0;
+    }
+
+    // Calculate from THERMEXR or THELCOEF
+    // OBS: Only accept (YMODULE, PRATIO) or (LAME, SMODULUS) conversions for now
+    Scalar biotT = 0.0;
+    if (fp.has_double("THERMEXR") && !fp.has_double("THELCOEF")) {
+        const auto thermexr = this->lookUpData_.fieldPropDouble(fp, "THERMEXR", elementIdx);
+
+        if (fp.has_double("LAME") && fp.has_double("SMODULUS")) {
+            const auto lamParam = lame(elementIdx);
+            const auto sMod = this->lookUpData_.fieldPropDouble(fp, "SMODULUS", elementIdx);
+            biotT = thermexr * (3.0 * lamParam + 2.0 * sMod);
+        } else if (fp.has_double("YMODULE") && fp.has_double("PRATIO")) {
+            const auto yMod = this->lookUpData_.fieldPropDouble(fp, "YMODULE", elementIdx);
+            const auto pRatio = this->lookUpData_.fieldPropDouble(fp, "PRATIO", elementIdx);
+            biotT = thermexr * yMod / (1.0 - 2.0 * pRatio);
+        } else if (fp.has_double("LAME") && fp.has_double("PRATIO")) {
+            const auto lamParam = lame(elementIdx);
+            const auto pRatio = this->lookUpData_.fieldPropDouble(fp, "PRATIO", elementIdx);
+            biotT =
+                thermexr * lamParam * (1.0 / pRatio - 2.0 * pRatio - 1.0) / (1.0 - 2.0 * pRatio);
+        } else if (fp.has_double("SMODULUS") && fp.has_double("PRATIO")) {
+            const auto sMod = this->lookUpData_.fieldPropDouble(fp, "SMODULUS", elementIdx);
+            const auto pRatio = this->lookUpData_.fieldPropDouble(fp, "PRATIO", elementIdx);
+            biotT = thermexr * 2.0 * sMod * (1 + pRatio) / (1.0 - 2.0 * pRatio);
+        } else if (fp.has_double("YMODULE") && fp.has_double("SMODULUS")) {
+            const auto yMod = this->lookUpData_.fieldPropDouble(fp, "YMODULE", elementIdx);
+            const auto sMod = this->lookUpData_.fieldPropDouble(fp, "SMODULUS", elementIdx);
+            biotT = thermexr * yMod * sMod / (3.0 * sMod - yMod);
+        } else {
+            OPM_THROW(std::runtime_error,
+                      "THERMEXR requires one of (LAME, SMODULUS), (YMODULE, PRATIO), "
+                      "(LAME, PRATIO), (SMODULUS, PRATIO) or (YMODULE, SMODULUS) "
+                      "to compute the Biot temperature coefficient. "
+                      "(YMODULE, LAME) is not supported.");
+        }
+
+    } else if (!fp.has_double("THERMEXR") && fp.has_double("THELCOEF")) {
+        const auto thelcoef = this->lookUpData_.fieldPropDouble(fp, "THELCOEF", elementIdx);
+
+        if (fp.has_double("LAME") && fp.has_double("SMODULUS")) {
+            const auto lamParam = lame(elementIdx);
+            const auto sMod = this->lookUpData_.fieldPropDouble(fp, "SMODULUS", elementIdx);
+            biotT = thelcoef * (lamParam + 2 * sMod) / (2 * sMod);
+        } else if (fp.has_double("PRATIO")) {
+            const auto pRatio = this->lookUpData_.fieldPropDouble(fp, "PRATIO", elementIdx);
+            biotT = thelcoef * (1 - pRatio) / (1 - 2 * pRatio);
+        } else if (fp.has_double("YMODULE") && fp.has_double("SMODULUS")) {
+            const auto yMod = this->lookUpData_.fieldPropDouble(fp, "YMODULE", elementIdx);
+            const auto sMod = this->lookUpData_.fieldPropDouble(fp, "SMODULUS", elementIdx);
+            biotT = thelcoef * (4.0 * sMod - yMod) / (6.0 * sMod - 2.0 * yMod);
+        } else {
+            OPM_THROW(std::runtime_error,
+                      "THELCOEF requires one of (LAME, SMODULUS), (YMODULE, SMODULUS) "
+                      "to compute the Biot temperature coefficient. "
+                      "(YMODULE, LAME) is not supported.");
+        }
+    } else {
+        OPM_THROW(std::runtime_error,
+                  "THERMEXR and THELCOEF cannot both be specified for the "
+                  "Biot temperature coefficient");
+    }
+
+    return biotT;
+}
 
 template<class GridView, class FluidSystem>
 template<class T>

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -180,8 +180,10 @@ public:
     using BaseType::shouldWriteOutput;
     using BaseType::shouldWriteRestartFile;
     using BaseType::rockBiotComp;
+    using BaseType::rockBiotTemp;
     using BaseType::lame;
     using BaseType::biotCoeff;
+    using BaseType::biotTemp;
     using BaseType::rockCompressibility;
     using BaseType::porosity;
 
@@ -754,6 +756,16 @@ public:
     }
 
     /*!
+     * \copydoc BlackoilProblem::rockBiotTemp
+     */
+    template <class Context>
+    Scalar rockBiotTemp(const Context& context, unsigned spaceIdx, unsigned timeIdx) const
+    {
+        unsigned globalSpaceIdx = context.globalSpaceIndex(spaceIdx, timeIdx);
+        return this->rockBiotTemp(globalSpaceIdx);
+    }
+
+    /*!
      * \copydoc BlackoilProblem::lame
      */
     template <class Context>
@@ -771,6 +783,16 @@ public:
     {
         unsigned globalSpaceIdx = context.globalSpaceIndex(spaceIdx, timeIdx);
         return this->biotCoeff(globalSpaceIdx);
+    }
+
+    /*!
+     * \copydoc BlackoilProblem::biotTemp
+     */
+    template <class Context>
+    Scalar biotTemp(const Context& context, unsigned spaceIdx, unsigned timeIdx) const
+    {
+        unsigned globalSpaceIdx = context.globalSpaceIndex(spaceIdx, timeIdx);
+        return this->biotTemp(globalSpaceIdx);
     }
 
     /*!

--- a/opm/simulators/flow/FlowProblemTPSA.hpp
+++ b/opm/simulators/flow/FlowProblemTPSA.hpp
@@ -35,6 +35,7 @@
 
 #include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/materialstates/MaterialStateTPSA.hpp>
+#include <opm/material/thermal/EnergyModuleType.hpp>
 
 #include <opm/models/io/vtktpsamodule.hpp>
 #include <opm/models/tpsa/tpsabaseproperties.hpp>
@@ -81,6 +82,9 @@ public:
     enum { historySize = getPropValue<TypeTag, Properties::SolutionHistorySizeTPSA>() };
     enum { numEq = getPropValue<TypeTag, Properties::NumEqTPSA>() };
     enum { numPhases = FluidSystem::numPhases };
+
+    static constexpr EnergyModules energyModuleType =
+        getPropValue<TypeTag, Properties::EnergyModuleType>();
 
     enum { contiRotEqIdx = Indices::contiRotEqIdx };
     enum { contiSolidPresEqIdx = Indices::contiSolidPresEqIdx };
@@ -330,6 +334,19 @@ public:
         const auto dPres = biot * (pres - initPres);
 
         auto sourceFromFlow = -dPres / lameParam;
+
+        if constexpr (energyModuleType == EnergyModules::FullyImplicitThermal) {
+            const auto biotTemp = this->biotTemp(globalSpaceIdx);
+            const auto temp = decay<Scalar>(fs.temperature(0));
+            const auto initTemp = this->initialFluidState(globalSpaceIdx).temperature(0);
+            const auto dTemp = biotTemp * (temp - initTemp);
+            sourceFromFlow += -dTemp / lameParam;
+
+            // Store potential temperature force for output
+            geoMechModel_.setMechPotentialTempForce(globalSpaceIdx, dTemp);
+        }
+
+        // Add calculated source terms to output
         sourceTerm[contiSolidPresEqIdx] += sourceFromFlow;
 
         // Store potential pressure force for output
@@ -356,6 +373,16 @@ public:
         const auto lameParam = this->lame(elementIdx);
 
         return biot / lameParam * solidPres;
+    }
+
+    /*!
+    * \brief Reference temperature for thermoelasticity
+    *
+    * \returns Standard condition temperature (STCOND), in Kelvin
+    */
+    Scalar rockReferenceTemperature() const
+    {
+        return this->simulator().vanguard().eclState().getTableManager().stCond().temperature;
     }
 
     // ///

--- a/opm/simulators/flow/MainDispatchDynamic.cpp
+++ b/opm/simulators/flow/MainDispatchDynamic.cpp
@@ -35,6 +35,7 @@
 #include <flow/flow_brine_precsalt_vapwat.hpp>
 #include <flow/flow_brine_saltprecipitation.hpp>
 #include <flow/flow_energy.hpp>
+#include <flow/flow_energy_tpsa.hpp>
 #include <flow/flow_extbo.hpp>
 #include <flow/flow_foam.hpp>
 #include <flow/flow_gasoil.hpp>
@@ -46,6 +47,7 @@
 #include <flow/flow_gaswater_dissolution_diffuse.hpp>
 #include <flow/flow_gaswater_dissolution_tpsa.hpp>
 #include <flow/flow_gaswater_energy.hpp>
+#include <flow/flow_gaswater_energy_tpsa.hpp>
 #include <flow/flow_gaswater_saltprec_energy.hpp>
 #include <flow/flow_gaswater_saltprec_vapwat.hpp>
 #include <flow/flow_gaswater_solvent.hpp>
@@ -56,6 +58,7 @@
 #include <flow/flow_oilwater_polymer_injectivity.hpp>
 #include <flow/flow_onephase.hpp>
 #include <flow/flow_onephase_energy.hpp>
+#include <flow/flow_onephase_energy_tpsa.hpp>
 #include <flow/flow_onephase_tpsa.hpp>
 #include <flow/flow_polymer.hpp>
 #include <flow/flow_solvent.hpp>
@@ -314,6 +317,8 @@ int Opm::Main::runWaterOnly(const Phases& phases)
 
 int Opm::Main::runWaterOnlyEnergy(const Phases& phases)
 {
+    const auto& rspec = this->eclipseState_->runspec();
+
     if (!phases.active(Phase::WATER) || phases.size() != 2) {
         if (outputCout_) {
             std::cerr << "No valid configuration is found for water-only "
@@ -322,6 +327,10 @@ int Opm::Main::runWaterOnlyEnergy(const Phases& phases)
         }
 
         return EXIT_FAILURE;
+    }
+
+    if (rspec.mech() && rspec.mechSolver().tpsa()) {
+        return flowWaterOnlyEnergyTpsaMain(argc_, argv_, outputCout_, outputFiles_);
     }
 
     return flowWaterOnlyEnergyMain(argc_, argv_, outputCout_, outputFiles_);
@@ -415,6 +424,9 @@ int Opm::Main::runExtendedBlackOil()
 
 int Opm::Main::runThermal(const Phases& phases)
 {
+    const auto& rspec = this->eclipseState_->runspec();
+    const bool tpsa = rspec.mech() && rspec.mechSolver().tpsa();
+
     // oil-gas-thermal
     if (!phases.active(Phase::WATER) &&
         phases.active(Phase::OIL) &&
@@ -432,12 +444,20 @@ int Opm::Main::runThermal(const Phases& phases)
             return flowGasWaterSaltprecEnergyMain(argc_, argv_, outputCout_, outputFiles_);
         }
 
+        if (tpsa) {
+            return flowGasWaterEnergyTpsaMain(argc_, argv_, outputCout_, outputFiles_);
+        }
+
         return flowGasWaterEnergyMain(argc_, argv_, outputCout_, outputFiles_);
     }
 
     // brine-energy
     if (phases.active(Phase::BRINE)) {
         return flowBrineEnergyMain(argc_, argv_, outputCout_, outputFiles_);
+    }
+
+    if (tpsa) {
+        return flowEnergyTpsaMain(argc_, argv_, outputCout_, outputFiles_);
     }
 
     return flowEnergyMain(argc_, argv_, outputCout_, outputFiles_);

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -1766,6 +1766,28 @@ add_multiple_tests(
     --enable-opm-rst-file=1
 )
 
+set(_tpsa_energy
+    TPSA_THERMAL
+)
+
+add_multiple_tests(
+  _tpsa_energy
+  ""
+  SIMULATOR
+    flow
+  DEV_SIMULATOR
+    flow_onephase_energy_tpsa
+  ABS_TOL
+    ${abs_tol}
+  REL_TOL
+    ${rel_tol}
+  DIR
+    tpsa
+  TEST_ARGS
+    --enable-opm-rst-file=1
+    --initial-time-step-in-days=0.1
+)
+
 add_test_compareECLFiles(
   CASENAME
     ppcwmax

--- a/tests/test_tpsa_conversions.cpp
+++ b/tests/test_tpsa_conversions.cpp
@@ -1,0 +1,368 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2026 NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <config.h>
+
+#define BOOST_TEST_MODULE TestTpsaConversions
+#define BOOST_TEST_NO_MAIN
+
+#include <opm/models/common/multiphasebaseparameters.hh>
+#include <opm/models/discretization/common/fvbaseparameters.hh>
+#include <opm/models/nonlinear/newtonmethodparams.hpp>
+#include <opm/models/utils/basicparameters.hh>
+#include <opm/models/utils/parametersystem.hpp>
+#include <opm/simulators/flow/FlowGenericProblem_impl.hpp>
+#include <opm/simulators/flow/FlowProblemParameters.hpp>
+#include <opm/simulators/timestepping/EclTimeSteppingParams.hpp>
+
+#include <opm/grid/CpGrid.hpp>
+#include <opm/grid/LookUpData.hh>
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/Parser/Parser.hpp>
+#include <opm/input/eclipse/Python/Python.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Units/UnitSystem.hpp>
+#include <opm/material/fluidsystems/BlackOilDefaultFluidSystemIndices.hpp>
+#include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+#include <dune/common/parallel/mpihelper.hh>
+#include <dune/grid/common/defaultgridview.hh>
+#include <dune/grid/common/gridview.hh>
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#if HAVE_MPI
+struct MPIError
+{
+    MPIError(std::string s, int e) : errorstring(std::move(s)), errorcode(e){}
+    std::string errorstring;
+    int errorcode;
+};
+
+void MPI_err_handler(MPI_Comm*, int* err_code, ...)
+{
+    std::vector<char> err_string(MPI_MAX_ERROR_STRING);
+    int err_length;
+    MPI_Error_string(*err_code, err_string.data(), &err_length);
+    std::string s(err_string.data(), err_length);
+    std::cerr << "An MPI Error ocurred:" << std::endl << s << std::endl;
+    throw MPIError(s, *err_code);
+}
+#endif
+
+bool init_unit_test_func()
+{
+    return true;
+}
+
+using Grid = Dune::CpGrid;
+using GridView = Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>;
+using FluidSystem = Opm::BlackOilFluidSystem<double, Opm::BlackOilDefaultFluidSystemIndices>;
+using Problem = Opm::FlowGenericProblem<GridView, FluidSystem>;
+
+static Opm::Deck createDeck(const std::string& gridProps)
+{
+    // Single-cell deck; gridProps supplies the mechanical/thermal
+    // field-property keywords under test.
+    std::string deck_string = R"(
+RUNSPEC
+DIMENS
+1 1 1 /
+EQLDIMS
+/
+TABDIMS
+/
+WATER
+METRIC
+
+GRID
+DX
+10.0 /
+DY
+10.0 /
+DZ
+10.0 /
+TOPS
+1000.0 /
+PORO
+0.3 /
+PERMX
+100.0 /
+COPY
+PERMX PERMY /
+PERMX PERMZ /
+/
+)" + gridProps + R"(
+
+PROPS
+PVTW
+1.0 /
+ROCK
+1.0132  1.0E-6 /
+DENSITY
+859.5 1033.0 0.854 /
+
+SOLUTION
+EQUIL
+1000 100 /
+
+SUMMARY
+
+SCHEDULE
+)";
+    Opm::Parser parser;
+    return parser.parseString(deck_string);
+}
+
+#define MAKE_PROBLEM(problemVar, gridProps)                                               \
+    Opm::Deck deck = createDeck(gridProps);                                               \
+    Opm::EclipseState eclState(deck);                                                     \
+    auto python = std::make_shared<Opm::Python>();                                        \
+    Opm::Schedule schedule(deck, eclState, python);                                       \
+    Grid grid;                                                                            \
+    grid.processEclipseFormat(&eclState.getInputGrid(), &eclState, false, false, false);  \
+    auto gridView = grid.leafGridView();                                                  \
+    Problem problemVar(eclState, schedule, gridView)
+
+namespace {
+// Unit conversions
+const Opm::UnitSystem metricUnits(Opm::UnitSystem::UnitType::UNIT_TYPE_METRIC);
+const double yModuleUnitFactor = metricUnits.to_si("Ymodule", 1.0);
+const double pressureUnitFactor = metricUnits.to_si("Pressure", 1.0);
+
+// Input parameters
+constexpr double lameVal = 3.5;
+constexpr double sModVal = 3.5;
+constexpr double yModVal = 8.75;   // = 2*sModVal*(1+pRatioVal)
+constexpr double pRatioVal = 0.25;
+
+constexpr double biotCoeffVal = 0.9;
+constexpr double poelCoefVal = 0.6;  // biotCoeffVal = poelCoefVal*(1-nu)/(1-2*nu)
+
+constexpr double thermexrVal = 2.0;
+constexpr double thelcoefVal = 4.0;
+
+const double lameExpected = lameVal * yModuleUnitFactor;
+
+// Expected THERMEXR and THELCOEF
+const double biotTempThermexrExpected = thermexrVal * 17.5 * yModuleUnitFactor;
+const double biotTempThelcoefExpected = thelcoefVal * pressureUnitFactor * 1.5;
+
+constexpr double tol = 1.0e-8;
+}
+
+// ///
+// lame() conversions
+// ///
+
+BOOST_AUTO_TEST_CASE(Lame_Direct)
+{
+    MAKE_PROBLEM(problem, "LAME\n" + std::to_string(lameVal) + " /\n");
+    BOOST_CHECK_CLOSE(problem.lame(0), lameExpected, tol);
+}
+
+BOOST_AUTO_TEST_CASE(Lame_YmoduleSmodulus)
+{
+    MAKE_PROBLEM(problem,
+                 "YMODULE\n" + std::to_string(yModVal) + " /\n" +
+                 "SMODULUS\n" + std::to_string(sModVal) + " /\n");
+    BOOST_CHECK_CLOSE(problem.lame(0), lameExpected, tol);
+}
+
+BOOST_AUTO_TEST_CASE(Lame_YmodulePratio)
+{
+    MAKE_PROBLEM(problem,
+                 "YMODULE\n" + std::to_string(yModVal) + " /\n" +
+                 "PRATIO\n" + std::to_string(pRatioVal) + " /\n");
+    BOOST_CHECK_CLOSE(problem.lame(0), lameExpected, tol);
+}
+
+BOOST_AUTO_TEST_CASE(Lame_SmodulusPratio)
+{
+    MAKE_PROBLEM(problem,
+                 "SMODULUS\n" + std::to_string(sModVal) + " /\n" +
+                 "PRATIO\n" + std::to_string(pRatioVal) + " /\n");
+    BOOST_CHECK_CLOSE(problem.lame(0), lameExpected, tol);
+}
+
+// ///
+// biotCoeff() conversions
+// ///
+
+BOOST_AUTO_TEST_CASE(BiotCoeff_Direct)
+{
+    MAKE_PROBLEM(problem, "BIOTCOEF\n" + std::to_string(biotCoeffVal) + " /\n");
+    BOOST_CHECK_CLOSE(problem.biotCoeff(0), biotCoeffVal, tol);
+}
+
+BOOST_AUTO_TEST_CASE(BiotCoeff_PoelcoefPratio)
+{
+    MAKE_PROBLEM(problem,
+                 "POELCOEF\n" + std::to_string(poelCoefVal) + " /\n" +
+                 "PRATIO\n" + std::to_string(pRatioVal) + " /\n");
+    BOOST_CHECK_CLOSE(problem.biotCoeff(0), biotCoeffVal, tol);
+}
+
+// ///
+// biotTemp() conversions: THERMEXR
+// ///
+
+BOOST_AUTO_TEST_CASE(BiotTemp_Thermexr_LameSmodulus)
+{
+    MAKE_PROBLEM(problem,
+                 "THERMEXR\n" + std::to_string(thermexrVal) + " /\n" +
+                 "LAME\n" + std::to_string(lameVal) + " /\n" +
+                 "SMODULUS\n" + std::to_string(sModVal) + " /\n");
+    BOOST_CHECK_CLOSE(problem.biotTemp(0), biotTempThermexrExpected, tol);
+}
+
+BOOST_AUTO_TEST_CASE(BiotTemp_Thermexr_YmodulePratio)
+{
+    MAKE_PROBLEM(problem,
+                 "THERMEXR\n" + std::to_string(thermexrVal) + " /\n" +
+                 "YMODULE\n" + std::to_string(yModVal) + " /\n" +
+                 "PRATIO\n" + std::to_string(pRatioVal) + " /\n");
+    BOOST_CHECK_CLOSE(problem.biotTemp(0), biotTempThermexrExpected, tol);
+}
+
+BOOST_AUTO_TEST_CASE(BiotTemp_Thermexr_LamePratio)
+{
+    MAKE_PROBLEM(problem,
+                 "THERMEXR\n" + std::to_string(thermexrVal) + " /\n" +
+                 "LAME\n" + std::to_string(lameVal) + " /\n" +
+                 "PRATIO\n" + std::to_string(pRatioVal) + " /\n");
+    BOOST_CHECK_CLOSE(problem.biotTemp(0), biotTempThermexrExpected, tol);
+}
+
+BOOST_AUTO_TEST_CASE(BiotTemp_Thermexr_SmodulusPratio)
+{
+    MAKE_PROBLEM(problem,
+                 "THERMEXR\n" + std::to_string(thermexrVal) + " /\n" +
+                 "SMODULUS\n" + std::to_string(sModVal) + " /\n" +
+                 "PRATIO\n" + std::to_string(pRatioVal) + " /\n");
+    BOOST_CHECK_CLOSE(problem.biotTemp(0), biotTempThermexrExpected, tol);
+}
+
+BOOST_AUTO_TEST_CASE(BiotTemp_Thermexr_YmoduleSmodulus)
+{
+    MAKE_PROBLEM(problem,
+                 "THERMEXR\n" + std::to_string(thermexrVal) + " /\n" +
+                 "YMODULE\n" + std::to_string(yModVal) + " /\n" +
+                 "SMODULUS\n" + std::to_string(sModVal) + " /\n");
+    BOOST_CHECK_CLOSE(problem.biotTemp(0), biotTempThermexrExpected, tol);
+}
+
+// ///
+// biotTemp() conversions: THELCOEF
+// ///
+
+BOOST_AUTO_TEST_CASE(BiotTemp_Thelcoef_LameSmodulus)
+{
+    MAKE_PROBLEM(problem,
+                 "THELCOEF\n" + std::to_string(thelcoefVal) + " /\n" +
+                 "LAME\n" + std::to_string(lameVal) + " /\n" +
+                 "SMODULUS\n" + std::to_string(sModVal) + " /\n");
+    BOOST_CHECK_CLOSE(problem.biotTemp(0), biotTempThelcoefExpected, tol);
+}
+
+BOOST_AUTO_TEST_CASE(BiotTemp_Thelcoef_PratioOnly)
+{
+    MAKE_PROBLEM(problem,
+                 "THELCOEF\n" + std::to_string(thelcoefVal) + " /\n" +
+                 "PRATIO\n" + std::to_string(pRatioVal) + " /\n");
+    BOOST_CHECK_CLOSE(problem.biotTemp(0), biotTempThelcoefExpected, tol);
+}
+
+BOOST_AUTO_TEST_CASE(BiotTemp_Thelcoef_YmoduleSmodulus)
+{
+    MAKE_PROBLEM(problem,
+                 "THELCOEF\n" + std::to_string(thelcoefVal) + " /\n" +
+                 "YMODULE\n" + std::to_string(yModVal) + " /\n" +
+                 "SMODULUS\n" + std::to_string(sModVal) + " /\n");
+    BOOST_CHECK_CLOSE(problem.biotTemp(0), biotTempThelcoefExpected, tol);
+}
+
+// ///
+// biotTemp() error handling
+// ///
+
+BOOST_AUTO_TEST_CASE(BiotTemp_Thermexr_InsufficientParams_Throws)
+{
+    // THERMEXR alone with only PRATIO available does not match any of the
+    // supported (LAME,SMODULUS) / (YMODULE,PRATIO) / (LAME,PRATIO) /
+    // (SMODULUS,PRATIO) / (YMODULE,SMODULUS) combinations.
+    MAKE_PROBLEM(problem,
+                 "THERMEXR\n" + std::to_string(thermexrVal) + " /\n" +
+                 "PRATIO\n" + std::to_string(pRatioVal) + " /\n");
+    BOOST_CHECK_THROW(problem.biotTemp(0), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(BiotTemp_BothKeywordsGiven_Throws)
+{
+    MAKE_PROBLEM(problem,
+                 "THERMEXR\n" + std::to_string(thermexrVal) + " /\n" +
+                 "THELCOEF\n" + std::to_string(thelcoefVal) + " /\n" +
+                 "LAME\n" + std::to_string(lameVal) + " /\n" +
+                 "SMODULUS\n" + std::to_string(sModVal) + " /\n");
+    BOOST_CHECK_THROW(problem.biotTemp(0), std::runtime_error);
+}
+
+int main(int argc, char** argv)
+{
+    Dune::MPIHelper::instance(argc, argv);
+#if HAVE_MPI
+    // register a throwing error handler to allow for
+    // debugging with "catch throw" in gdb
+    MPI_Errhandler handler;
+    MPI_Comm_create_errhandler(MPI_err_handler, &handler);
+    MPI_Comm_set_errhandler(MPI_COMM_WORLD, handler);
+#endif
+
+    // FlowProblemParameters.cpp's registerFlowProblemParameters() calls
+    // SetDefault() on several parameters that are normally registered by
+    // Simulator<TypeTag>::registerParameters() (which we don't instantiate
+    // here, to avoid pulling in the whole type-tag/property system) -
+    // register them manually instead.
+    Opm::Parameters::Register<Opm::Parameters::EndTime<double>>
+        ("The simulation time at which the simulation is finished [s]");
+    Opm::Parameters::Register<Opm::Parameters::InitialTimeStepSize<double>>
+        ("The size of the initial time step [s]");
+    Opm::Parameters::Register<Opm::Parameters::EnableVtkOutput>
+        ("Write VTK output files");
+    Opm::Parameters::Register<Opm::Parameters::EnableIntensiveQuantityCache>
+        ("Cache intensive quantities");
+    Opm::Parameters::Register<Opm::Parameters::EnableStorageCache>
+        ("Cache storage terms");
+    Opm::Parameters::Register<Opm::Parameters::NewtonTolerance<double>>
+        ("Newton convergence tolerance");
+    Opm::Parameters::Register<Opm::Parameters::EnableGravity>
+        ("Enable gravity");
+
+    Opm::registerFlowProblemParameters<double>();
+    Opm::registerEclTimeSteppingParameters<double>();
+    Opm::Parameters::endRegistration();
+
+    return boost::unit_test::unit_test_main(&init_unit_test_func, argc, argv);
+}


### PR DESCRIPTION
This PR adds the possibility to run TPSA with THERMAL activated, i.e. simulating thermoelastic effects. The thermal effects on TPSA is an additional temperature-dependent source term. Mechanical effects on thermal simulations are given through pore volume changes (similar to pressure effects), with an additional compressibility term. The coupling parameter (the new `biotTemp` function) is calculated from existing deck inputs, `THERMEXR` or `THELCOEF`. Temperature-dependent output variables are given. Binaries produced for blackoil, one-phase (water), and gas-water simulators, which are also added to flow binary. New regression test with TPSA_THERMAL deck, https://github.com/OPM/opm-tests/pull/1598. 

Note that the implementation is only with the fully-implicit thermal simulator (`EnergyModules::FullyImplicitThermal`). It's possible that it can easily be extended to the sequential simulator (`TEMP` option), but have not tested this yet.