### PR TITLE
Chase Satellite Production Rate API Change

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelNetworkPressureComputation.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetworkPressureComputation.hpp
@@ -22,8 +22,10 @@
 
 #include <opm/common/TimingMacros.hpp>
 
+#include <opm/input/eclipse/Schedule/Group/GSatProd.hpp>
 #include <opm/input/eclipse/Schedule/Network/ExtNetwork.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/ScheduleState.hpp>
 #include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
 
 #include <opm/output/data/Groups.hpp>
@@ -256,8 +258,12 @@ private:
         // Only add satellite production once for parallel runs
         // (i.e. add after communication)
         if (group.hasSatelliteProduction()) {
-            const auto& gsat_prod = well_model_.schedule()[report_step_idx_].gsatprod().get(node, well_model_.summaryState());
-            alq += gsat_prod.rate[GSatProd::GSatProdGroupProp::Rate::GLift];
+            const auto gsrate = this->well_model_
+                .schedule()[this->report_step_idx_]
+                .satelliteProduction(node)
+                .getRate(GSatProd::Rate::GLift, this->well_model_.summaryState());
+
+            alq += static_cast<Scalar>(gsrate);
         }
 
         rates[IndexTraits::gasPhaseIdx] += alq;

--- a/opm/simulators/wells/GasLiftGroupInfo.cpp
+++ b/opm/simulators/wells/GasLiftGroupInfo.cpp
@@ -23,9 +23,10 @@
 #include <opm/material/fluidsystems/BlackOilDefaultFluidSystemIndices.hpp>
 
 #include <opm/input/eclipse/Schedule/GasLiftOpt.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
-#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Group/GSatProd.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/ScheduleState.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 
 #include <opm/simulators/wells/WellInterfaceGeneric.hpp>
 #include <opm/simulators/wells/WellState.hpp>
@@ -599,16 +600,24 @@ initializeGroupRatesRecursive_(const Group& group)
     auto& [oil_rate, water_rate, gas_rate, oil_potential, water_potential, gas_potential, alq] = rates;
 
     if (group.hasSatelliteProduction()) {
-        using RateProp = GSatProd::GSatProdGroupProp::Rate;
-        const auto& gsat_prod = this->schedule_[this->report_step_idx_].gsatprod().get(group.name(), this->summary_state_);
-        oil_rate += gsat_prod.rate[RateProp::Oil];
-        water_rate += gsat_prod.rate[RateProp::Water];
-        gas_rate += gsat_prod.rate[RateProp::Gas];
-        oil_potential += gsat_prod.rate[RateProp::Oil];
-        water_potential += gsat_prod.rate[RateProp::Water];
-        gas_potential += gsat_prod.rate[RateProp::Gas];
-        alq += gsat_prod.rate[RateProp::GLift];
-        // We don't support reservoir rates for satellite production groups
+        using RateProp = GSatProd::Rate;
+
+        const auto gsat_prod = this->schedule_[this->report_step_idx_]
+            .satelliteProduction(group.name())
+            .getRates(this->summary_state_);
+
+        // Note: We don't support reservoir production rates for satellite
+        // groups.
+
+        oil_rate        += gsat_prod[RateProp::Oil];
+        water_rate      += gsat_prod[RateProp::Water];
+        gas_rate        += gsat_prod[RateProp::Gas];
+
+        oil_potential   += gsat_prod[RateProp::Oil];
+        water_potential += gsat_prod[RateProp::Water];
+        gas_potential   += gsat_prod[RateProp::Gas];
+
+        alq             += gsat_prod[RateProp::GLift];
     }
 
     if (group.wellgroup()) {

--- a/opm/simulators/wells/GroupStateHelper.cpp
+++ b/opm/simulators/wells/GroupStateHelper.cpp
@@ -2598,33 +2598,34 @@ GroupStateHelper<Scalar, IndexTraits>::satelliteInjectionRate_(const ScheduleSta
 // - Returns the satellite production rate for the given rate component from GSATPROD data.
 template <typename Scalar, typename IndexTraits>
 Scalar
-GroupStateHelper<Scalar, IndexTraits>::satelliteProductionRate_(
-    const ScheduleState& sched,
-    const Group& group,
-    const GSatProd::GSatProdGroupProp::Rate rate_comp,
-    bool res_rates) const
+GroupStateHelper<Scalar, IndexTraits>::
+satelliteProductionRate_(const ScheduleState& sched,
+                         const Group&         group,
+                         const GSatProd::Rate rate_comp,
+                         const bool           res_rates) const
 {
-    Scalar rate = 0.0;
-    if (group.hasSatelliteProduction()) {
-        const auto& gsat_prod = sched.gsatprod();
-        if (!res_rates) {
-            rate = gsat_prod.get(group.name(), this->summary_state_).rate[rate_comp];
-        }
-        // We don't support reservoir rates for satellite production groups
+    if (res_rates || !group.hasSatelliteProduction()) {
+        // Note: We explicitly exclude reservoir condition production rates
+        // ("res_rates") since we don't support those for satellite groups.
+        return Scalar{};
     }
-    return rate;
+
+    const auto gsrate = sched.satelliteProduction(group.name())
+        .getRate(rate_comp, this->summary_state_);
+
+    return static_cast<Scalar>(gsrate);
 }
 
 // Called from getSatelliteRate_().
 // - Maps an active phase index to the corresponding GSatProd rate component enum.
 template <typename Scalar, typename IndexTraits>
-std::optional<GSatProd::GSatProdGroupProp::Rate>
+std::optional<GSatProd::Rate>
 GroupStateHelper<Scalar, IndexTraits>::selectRateComponent_(const int phase_pos) const
 {
     // TODO: this function can be wrong, phase_pos is not used anymore, this function requries checking and
     // refactoring.
     const auto& pu = this->phase_usage_info_;
-    using Rate = GSatProd::GSatProdGroupProp::Rate;
+    using Rate = GSatProd::Rate;
 
     for (const auto& [phase, rate_comp] : std::array {std::pair {IndexTraits::waterPhaseIdx, Rate::Water},
                                                       std::pair {IndexTraits::oilPhaseIdx, Rate::Oil},

--- a/opm/simulators/wells/GroupStateHelper.hpp
+++ b/opm/simulators/wells/GroupStateHelper.hpp
@@ -658,10 +658,10 @@ private:
 
     Scalar satelliteProductionRate_(const ScheduleState& sched,
                                     const Group& group,
-                                    const GSatProd::GSatProdGroupProp::Rate rate_comp,
+                                    const GSatProd::Rate rate_comp,
                                     bool res_rates) const;
 
-    std::optional<GSatProd::GSatProdGroupProp::Rate> selectRateComponent_(const int phase_pos) const;
+    std::optional<GSatProd::Rate> selectRateComponent_(const int phase_pos) const;
 
     //! \brief Subtract other-phase reservoir injection rates from a base rate.
     //!

--- a/tests/test_networkpressure.cpp
+++ b/tests/test_networkpressure.cpp
@@ -42,11 +42,14 @@
 #include <algorithm>
 #include <cstddef>
 #include <filesystem>
-#include <memory>
-#include <map>
-#include <sstream>
 #include <limits>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <optional>
+#include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 using namespace Opm;
@@ -197,13 +200,12 @@ struct MockWellModel
             }
             bool hasSatelliteProduction() const { return false; }
         };
-        struct MockGSatProdValue { std::vector<double> rate {0.0}; };
         struct MockGSatProd
         {
-            template <typename SummaryState>
-            MockGSatProdValue get(const std::string&, const SummaryState&) const { return {}; }
+            template <typename GSatProdRateType, typename SummaryState>
+            double getRate(const GSatProdRateType, const SummaryState&) const { return 0.0; }
         };
-        struct MockScheduleStep { MockGSatProd gsatprod() const { return {}; } };
+        struct MockScheduleStep { MockGSatProd satelliteProduction(std::string_view) const { return {}; } };
         const MockGroup& getGroup(const std::string&, int) const
         {
             static const MockGroup group {};


### PR DESCRIPTION
The satellite production rates are now (OPM/opm-common#5357) stored in a `map_member<>` within the `ScheduleState` type so accessing the values requires slightly different syntax.

While here, also switch to accessing individual rates only where applicable.  This avoids calculating all rates only to throw away most of those rate values in certain contexts.